### PR TITLE
feat(config): make pop to root on window close configurable

### DIFF
--- a/vicinae/src/ipc-command-handler.cpp
+++ b/vicinae/src/ipc-command-handler.cpp
@@ -62,7 +62,18 @@ void IpcCommandHandler::handleUrl(const QUrl &url) {
   }
 
   if (url.host() == "close") {
-    m_ctx.navigation->closeWindow();
+    CloseWindowOptions opts;
+
+    if (auto text = query.queryItemValue("popToRootType"); !text.isEmpty()) {
+      if (text == "immediate") { opts.popToRootType = PopToRootType::Immediate; }
+      if (text == "suspended") { opts.popToRootType = PopToRootType::Suspended; }
+    }
+
+    if (auto text = query.queryItemValue("clearRootSearch"); !text.isEmpty()) {
+      opts.clearRootSearch = text == "true" || text == "1";
+    }
+
+    m_ctx.navigation->closeWindow(opts);
     return;
   }
 

--- a/vicinae/src/ipc-command-handler.cpp
+++ b/vicinae/src/ipc-command-handler.cpp
@@ -77,7 +77,13 @@ void IpcCommandHandler::handleUrl(const QUrl &url) {
   }
 
   if (url.host() == "pop_to_root") {
-    m_ctx.navigation->popToRoot();
+    PopToRootOptions opts;
+
+    if (auto text = query.queryItemValue("clearSearch"); !text.isEmpty()) {
+      opts.clearSearch = text == "true" || text == "1";
+    }
+
+    m_ctx.navigation->popToRoot(opts);
     return;
   }
 

--- a/vicinae/src/navigation-controller.cpp
+++ b/vicinae/src/navigation-controller.cpp
@@ -148,7 +148,7 @@ void NavigationController::popCurrentView() {
   selectSearchText();
 }
 
-void NavigationController::popToRoot(const PopToRootOptions opts) {
+void NavigationController::popToRoot(const PopToRootOptions &opts) {
   while (m_views.size() > 1) {
     popCurrentView();
   }

--- a/vicinae/src/navigation-controller.hpp
+++ b/vicinae/src/navigation-controller.hpp
@@ -21,6 +21,19 @@ struct ActionPanelSectionState {
   void addAction(AbstractAction *action) { m_actions.emplace_back(action); }
 };
 
+// matches raycast pop to root type policiy
+// https://developers.raycast.com/api-reference/window-and-search-bar#poptoroottype
+enum class PopToRootType { Default, Immediate, Suspended };
+
+struct CloseWindowOptions {
+  PopToRootType popToRootType = PopToRootType::Default;
+  bool clearRootSearch = true; // has no effect if we do not pop to root
+};
+
+struct PopToRootOptions {
+  bool clearSearch = true;
+};
+
 struct ActionPanelState : public NonCopyable {
   AbstractAction *findPrimaryAction() const {
     for (const auto &section : m_sections) {
@@ -88,18 +101,21 @@ public:
   };
 
   bool m_isPanelOpened = false;
+  bool m_popToRootOnClose = false;
 
-  void closeWindow();
+  void closeWindow(const CloseWindowOptions &settings = {});
   void showWindow();
   void toggleWindow();
   bool isWindowOpened() const;
+
+  void setPopToRootOnClose(bool value);
 
   void setSearchPlaceholderText(const QString &text, const BaseView *caller = nullptr);
   void setSearchText(const QString &text, const BaseView *caller = nullptr);
 
   void setLoading(bool value, const BaseView *caller = nullptr);
 
-  void popToRoot();
+  void popToRoot(const PopToRootOptions opts = {});
 
   QString searchText(const BaseView *caller = nullptr) const;
   QString navigationTitle(const BaseView *caller = nullptr) const;

--- a/vicinae/src/navigation-controller.hpp
+++ b/vicinae/src/navigation-controller.hpp
@@ -115,7 +115,7 @@ public:
 
   void setLoading(bool value, const BaseView *caller = nullptr);
 
-  void popToRoot(const PopToRootOptions opts = {});
+  void popToRoot(const PopToRootOptions &opts = {});
 
   QString searchText(const BaseView *caller = nullptr) const;
   QString navigationTitle(const BaseView *caller = nullptr) const;

--- a/vicinae/src/services/config/config-service.hpp
+++ b/vicinae/src/services/config/config-service.hpp
@@ -22,6 +22,7 @@ class ConfigService : public QObject {
 public:
   struct Value {
     QString faviconService = "google";
+    bool popToRootOnClose = false;
     struct {
       std::optional<QString> name;
       std::optional<QString> iconTheme;
@@ -58,6 +59,7 @@ private:
     Value cfg;
 
     cfg.faviconService = obj.value("faviconService").toString("google");
+    cfg.popToRootOnClose = obj.value("popToRootOnClose").toBool(false);
 
     {
       auto font = obj.value("font").toObject();
@@ -131,6 +133,7 @@ public:
     QJsonObject obj;
 
     obj["faviconService"] = value.faviconService;
+    obj["popToRootOnClose"] = value.popToRootOnClose;
 
     {
       QJsonObject font;

--- a/vicinae/src/settings/general-settings.hpp
+++ b/vicinae/src/settings/general-settings.hpp
@@ -19,6 +19,7 @@ class GeneralSettings : public VerticalScrollArea {
   FontSelector *m_fontSelector;
   QThemeSelector *m_qThemeSelector;
   FaviconServiceSelector *m_faviconSelector;
+  CheckboxInput *m_popToRootOnClose;
 
   void setupUI();
 
@@ -29,6 +30,7 @@ class GeneralSettings : public VerticalScrollArea {
   void handleOpacityChange(double opacity);
   void handleIconThemeChange(const QString &iconTheme);
   void handleFaviconServiceChange(const QString &service);
+  void handlePopToRootOnCloseChange(bool popToRootOnClose);
 
   void setConfig(const ConfigService::Value &value);
 


### PR DESCRIPTION
This adds a new setting allowing us to decide whether the navigation state should be reset or not when the window is closed.
This also allows for more customization through the use of query params when using the `vicinae://close` and `vicinae://pop_to_root` deeplinks.

Fixes #3 

<img width="782" height="308" alt="image" src="https://github.com/user-attachments/assets/e9f56e4b-9394-4426-893c-65d584fd3765" />