### PR TITLE
fix: do not hardcode emoji font and add explicit customization via en…

### DIFF
--- a/vicinae/src/font-service.cpp
+++ b/vicinae/src/font-service.cpp
@@ -1,6 +1,10 @@
 #include "font-service.hpp"
+#include <qfontdatabase.h>
+#include <qlogging.h>
+#include <qnamespace.h>
+#include <qprocess.h>
 
-static const std::vector<QString> unixEmojiFontCandidates = {
+static const std::vector<QString> UNIX_EMOJI_FONT_CANDIDATES = {
     "Twemoji",
     "Noto Color Emoji",
     "JoyPixels",
@@ -15,9 +19,24 @@ QFont FontService::findEmojiFont() {
   return QFont("Apple Color Emoji");
 #endif
 
-  auto it = std::ranges::find_if(unixEmojiFontCandidates, QFontDatabase::hasFamily);
+  auto environ = QProcessEnvironment::systemEnvironment();
 
-  if (it != unixEmojiFontCandidates.end()) return *it;
+  if (auto emojiFont = environ.value("EMOJI_FONT"); !emojiFont.isEmpty()) {
+    if (!QFontDatabase::hasFamily(emojiFont)) {
+      qWarning() << "EMOJI_FONT environment variable was set to" << emojiFont
+                 << "but there is no such family installed.";
+    }
+
+    return QFont(emojiFont);
+  }
+
+  auto it = std::ranges::find_if(UNIX_EMOJI_FONT_CANDIDATES, QFontDatabase::hasFamily);
+
+  if (it != UNIX_EMOJI_FONT_CANDIDATES.end()) return *it;
+
+  for (const auto &font : QFontDatabase::families()) {
+    if (font.contains("emoji", Qt::CaseInsensitive)) return font;
+  }
 
   return {};
 }

--- a/vicinae/src/ui/image/emoji-image-loader.cpp
+++ b/vicinae/src/ui/image/emoji-image-loader.cpp
@@ -1,7 +1,9 @@
 #include "emoji-image-loader.hpp"
+#include "service-registry.hpp"
+#include "font-service.hpp"
 
 void EmojiImageLoader::render(const RenderConfig &config) {
-  auto font = QFont("Twemoji");
+  auto font = ServiceRegistry::instance()->fontService()->emojiFont();
   QPixmap canva(config.size * config.devicePixelRatio);
 
   font.setStyleStrategy(QFont::StyleStrategy::NoFontMerging);


### PR DESCRIPTION
The emoji font used to render emojis was left hardcoded to `Twemoji` which obviously didn't make much sense.
This now uses the font service to get the best emoji font available (although that's a tricky thing to figure out).
To work around some of the limitations of this selection logic the `EMOJI_FONT` environment variable can be used to select the emoji font to use explicitly.
Fixes #17 