### PR TITLE
fix(extension): let QProcess infer node path

### DIFF
--- a/vicinae/src/extension/manager/extension-manager.cpp
+++ b/vicinae/src/extension/manager/extension-manager.cpp
@@ -138,6 +138,7 @@ ExtensionManager::ExtensionManager(OmniCommandDatabase &commandDb) : commandDb(c
 }
 
 bool ExtensionManager::start() {
+  int maxWaitForStart = 5000;
   QFile file(":bin/extension-manager");
 
   if (!file.exists()) {
@@ -157,10 +158,15 @@ bool ExtensionManager::start() {
     return false;
   }
 
-  qInfo() << "Started extension manager" << runtimeFile->fileName();
-
   runtimeFile->write(file.readAll());
   process.start("node", {runtimeFile->fileName()});
+
+  if (!process.waitForStarted(maxWaitForStart)) {
+    qCritical() << "Failed to start extension manager" << process.errorString();
+    return false;
+  }
+
+  qInfo() << "Started extension manager" << runtimeFile->fileName();
 
   return true;
 }

--- a/vicinae/src/extension/manager/extension-manager.cpp
+++ b/vicinae/src/extension/manager/extension-manager.cpp
@@ -160,7 +160,7 @@ bool ExtensionManager::start() {
   qInfo() << "Started extension manager" << runtimeFile->fileName();
 
   runtimeFile->write(file.readAll());
-  process.start("/bin/node", {runtimeFile->fileName()});
+  process.start("node", {runtimeFile->fileName()});
 
   return true;
 }


### PR DESCRIPTION
The hardcoded /bin/node path was creating packaging issues.