### PR TITLE
.desktop entry loading fixes

### DIFF
--- a/vicinae/src/main.cpp
+++ b/vicinae/src/main.cpp
@@ -257,6 +257,9 @@ int startDaemon() {
 
     registry->rootItemManager()->addProvider(std::make_unique<AppRootProvider>(*registry->appDb()));
     registry->rootItemManager()->addProvider(std::make_unique<ShortcutRootProvider>(*registry->shortcuts()));
+
+    // Force reload providers to make sure items that depend on them are shown
+    registry->rootItemManager()->reloadProviders();
   }
 
   FaviconService::initialize(new FaviconService(Omnicast::dataDir() / "favicon"));

--- a/vicinae/src/services/app-service/app-service.cpp
+++ b/vicinae/src/services/app-service/app-service.cpp
@@ -11,8 +11,10 @@ std::vector<std::filesystem::path> AppService::mergedPaths() const {
   auto defaultPaths = defaultSearchPaths();
 
   paths.reserve(defaultPaths.size() + m_additionalSearchPaths.size());
-  paths.insert(paths.end(), defaultPaths.begin(), defaultPaths.end());
+  // Manually added paths have highest priority, so they come first
   paths.insert(paths.end(), m_additionalSearchPaths.begin(), m_additionalSearchPaths.end());
+  // Then add default system paths (XDG_DATA_HOME, XDG_DATA_DIRS)
+  paths.insert(paths.end(), defaultPaths.begin(), defaultPaths.end());
 
   return paths;
 }

--- a/vicinae/src/services/root-item-manager/root-item-manager.hpp
+++ b/vicinae/src/services/root-item-manager/root-item-manager.hpp
@@ -219,7 +219,6 @@ private:
   RootItemMetadata loadMetadata(const QString &id);
   bool upsertProvider(const RootProvider &provider);
   bool upsertItem(const QString &providerId, const RootItem &item);
-  void reloadProviders();
   RootItem *findItemById(const QString &id) const;
   RootProvider *findProviderById(const QString &id) const;
   bool pruneProvider(const QString &id);
@@ -270,6 +269,7 @@ public:
 
   std::vector<RootProvider *> providers() const;
 
+  void reloadProviders();
   void removeProvider(const QString &id);
   void addProvider(std::unique_ptr<RootProvider> provider);
   RootProvider *provider(const QString &id) const;


### PR DESCRIPTION
This PR prevents duplicate .desktop entries from loading by prioritizing according to their order in XDG_DATA_DIRS. It also adds XDG_DATA_HOME to the default search paths, and fixes additional search paths not being automatically loaded on daemon start.


Closes #33
Closes #57 
Closes #46 