### PR TITLE
fix: extension registry null pointer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .cache
 build
-/home/aurelle/Downloads/wireguard.png
 /src
 .tmp
 extension-manager/runtime/node_modules
@@ -12,3 +11,5 @@ vicinae/assets/extension-runtime.js
 
 *.tar.gz
 /dist
+
+__cmake*

--- a/vicinae/src/main.cpp
+++ b/vicinae/src/main.cpp
@@ -165,7 +165,7 @@ int startDaemon() {
       ServiceRegistry::instance()->commandDb()->removeRepository(id);
     });
 
-    for (const auto &manifest : extensionRegistry->scanAll()) {
+    for (const auto &manifest : reg->scanAll()) {
       auto extension = std::make_shared<Extension>(manifest);
 
       ServiceRegistry::instance()->commandDb()->registerRepository(extension);


### PR DESCRIPTION
fixes this compilation error:

``` [81/222] Building CXX object
vicinae/CMakeFiles/vicinae.dir/src/main.cpp.o
/home/kainoa/.cache/yay/vicinae-git/src/vicinae/vicinae/src/main.cpp: In
function ‘int startDaemon()’:
/home/kainoa/.cache/yay/vicinae-git/src/vicinae/vicinae/src/main.cpp:168:60:
warning: ‘this’ pointer is null [-Wnonnull] 168 | for (const auto
&manifest : extensionRegistry->scanAll()) { | ^ In file included from
/home/kainoa/.cache/yay/vicinae-git/src/vicinae/vicinae/include/extension/extension.hpp:5,
from
/home/kainoa/.cache/yay/vicinae-git/src/vicinae/vicinae/src/extension/manager/extension-manager.hpp:9,
from
/home/kainoa/.cache/yay/vicinae-git/src/vicinae/vicinae/src/main.cpp:46:
/home/kainoa/.cache/yay/vicinae-git/src/vicinae/vicinae/src/services/extension-registry/extension-registry.hpp:61:34:
note: in a call to non-static member function
‘std::vector<ExtensionManifest> ExtensionRegistry::scanAll()’ 61 |
std::vector<ExtensionManifest> scanAll(); | ^~~~~~~
```

by using the `extensionRegistry`'s service instead of the
`extensionRegistry` variable (after `std::move` the variable is null)