### PR TITLE
fix(clipboard): Choose preferred mimeType for copy selection

### DIFF
--- a/vicinae/src/services/clipboard/clipboard-service.cpp
+++ b/vicinae/src/services/clipboard/clipboard-service.cpp
@@ -8,7 +8,6 @@
 #include <qt6keychain/keychain.h>
 #include <QtConcurrent/QtConcurrent>
 #include <QFutureWatcher>
-#include <QTextDocument>
 #include "clipboard-server-factory.hpp"
 #include "crypto.hpp"
 #include "services/app-service/app-service.hpp"
@@ -200,44 +199,46 @@ ClipboardOfferKind ClipboardService::getKind(const ClipboardDataOffer &offer) {
 }
 
 QString ClipboardService::getSelectionPreferredMimeType(const ClipboardSelection &selection) {
-  enum SelectionPriority {
-    Invalid = 0,
-    Other = 1,
-    HtmlText = 2,
-    Text = 3,
-    GenericImage = 4,
-    ImageJpeg = 5,
-    ImagePng = 6,
-    ImageSvg = 7
+  // List of preferred plain text MIME types in order
+  static const std::vector<QString> plainTextMimeTypes = {
+    "text/plain",
+    "text/plain;charset=utf-8",
+    "UTF8_STRING",
+    "STRING",
+    "TEXT",
+    "COMPOUND_TEXT"
   };
-  int priority = Invalid;
-  QString preferredMimeType;
-  for (const auto &offer : selection.offers) {
-    if (offer.mimeType.startsWith("text/_moz_html")) continue;
-    int mimePriority = Other;
-    if (offer.mimeType.startsWith("text/")) {
-      if (offer.mimeType == "text/plain") {
-        mimePriority = Text;
-      } else if (offer.mimeType == "text/html") {
-        mimePriority = HtmlText;
-      } else if (offer.mimeType == "text/svg") {
-        mimePriority = ImageSvg;
-      } else {
-        mimePriority = Text;
-      }
-    } else if (offer.mimeType == "image/jpeg") {
-      mimePriority = ImageJpeg;
-    } else if (offer.mimeType == "image/png") {
-      mimePriority = ImagePng;
-    } else if (offer.mimeType == "image/svg+xml") {
-      mimePriority = ImageSvg;
-    }
-    if (mimePriority > priority) {
-      priority = mimePriority;
-      preferredMimeType = offer.mimeType;
-    }
+
+  // 1. Prefer plain text
+  for (const auto &mime : plainTextMimeTypes) {
+    auto it = std::ranges::find_if(selection.offers, [&](const auto &offer) {
+      return offer.mimeType == mime;
+    });
+    if (it != selection.offers.end()) return it->mimeType;
   }
-  return preferredMimeType;
+
+  // 2. Then image types
+  auto imageIt = std::ranges::find_if(selection.offers, [](const auto &offer) {
+    return offer.mimeType.startsWith("image/");
+  });
+  if (imageIt != selection.offers.end()) return imageIt->mimeType;
+
+  // 3. Then HTML
+  auto htmlIt = std::ranges::find_if(selection.offers, [](const auto &offer) {
+    return offer.mimeType == "text/html";
+  });
+  if (htmlIt != selection.offers.end()) return htmlIt->mimeType;
+
+  // 4. Otherwise, fallback to first non-Firefox/Zen custom type
+  auto fallbackIt = std::ranges::find_if(selection.offers, [](const auto &offer) {
+    return !offer.mimeType.startsWith("text/_moz_html");
+  });
+  if (fallbackIt != selection.offers.end()) return fallbackIt->mimeType;
+
+  // 5. If nothing else, fallback to first offer
+  if (!selection.offers.empty()) return selection.offers.front().mimeType;
+
+  return {};
 }
 
 bool ClipboardService::removeSelection(const QString &selectionId) {
@@ -342,7 +343,6 @@ bool ClipboardService::setKeywords(const QString &id, const QString &keywords) {
 void ClipboardService::saveSelection(ClipboardSelection selection) {
   if (!m_monitoring || !m_isEncryptionReady) return;
 
-  std::erase_if(selection.offers, [](const auto& offer) { return offer.data.isEmpty(); });
   std::ranges::unique(selection.offers, [](auto &&a, auto &&b) { return a.mimeType == b.mimeType; });
 
   if (isClearSelection(selection)) { return; }
@@ -355,98 +355,86 @@ void ClipboardService::saveSelection(ClipboardSelection selection) {
     return;
   }
 
-  // Prefer text/plain, then image/*, then text/html
-  QByteArray offerData;
-  QString mimeTypeToSave;
+  auto selectionHash = QString::fromUtf8(computeSelectionHash(selection).toHex());
+  QString preferredMimeType = getSelectionPreferredMimeType(selection);
 
-  auto plainIt = std::ranges::find_if(selection.offers, [](const auto& offer){ return offer.mimeType == "text/plain"; });
-  auto imageIt = std::ranges::find_if(selection.offers, [](const auto& offer){ return offer.mimeType.startsWith("image/"); });
-  auto htmlIt = std::ranges::find_if(selection.offers, [](const auto& offer){ return offer.mimeType == "text/html"; });
-
-  if (plainIt != selection.offers.end()) {
-    offerData = plainIt->data;
-    mimeTypeToSave = "text/plain";
-  } else if (imageIt != selection.offers.end()) {
-    offerData = imageIt->data;
-    mimeTypeToSave = imageIt->mimeType;
-  } else if (htmlIt != selection.offers.end()) {
-    // Extract plain text from HTML
-    QTextDocument doc;
-    doc.setHtml(QString::fromUtf8(htmlIt->data));
-    offerData = doc.toPlainText().toUtf8();
-    mimeTypeToSave = "text/plain";
-  } else {
-    // No supported mime type
-    return;
-  }
-
-  auto selectionHash = QString::fromUtf8(QCryptographicHash::hash(offerData, QCryptographicHash::Md5).toHex());
-
+  // capturing this inside this lambda is safe because we only read data
   ClipboardHistoryEntry insertedEntry;
   ClipboardDatabase cdb;
 
+  auto &preferredOffer =
+      *std::ranges::find_if(selection.offers, [&](auto &&o) { return o.mimeType == preferredMimeType; });
+
   cdb.transaction([&](ClipboardDatabase &db) {
+    // selection already exists, stop here
     if (db.tryBubbleUpSelection(selectionHash)) return true;
 
     QString selectionId = Crypto::UUID::v4();
-    ClipboardOfferKind kind = getKind({mimeTypeToSave, offerData});
+    ClipboardOfferKind kind = getKind(preferredOffer);
 
     if (!db.insertSelection({.id = selectionId,
-                             .offerCount = 1,
+                             .offerCount = static_cast<int>(selection.offers.size()),
                              .hash = selectionHash,
-                             .preferredMimeType = mimeTypeToSave,
+                             .preferredMimeType = preferredMimeType,
                              .kind = kind,
                              .source = selection.sourceApp})) {
       qWarning() << "failed to insert selection";
       return false;
     }
 
-    QString textPreview = getOfferTextPreview({mimeTypeToSave, offerData});
+    for (const auto &offer : selection.offers) {
+      ClipboardOfferKind kind = getKind(offer);
+      bool isIndexableText = kind == ClipboardOfferKind::Text || kind == ClipboardOfferKind::Link;
+      QString textPreview = getOfferTextPreview(offer);
 
-    if (kind == ClipboardOfferKind::Text || kind == ClipboardOfferKind::Link) {
-      if (!db.indexSelectionContent(selectionId, offerData)) return false;
+      if (isIndexableText) {
+        if (!db.indexSelectionContent(selectionId, offer.data)) return false;
+      }
+
+      auto md5sum = QCryptographicHash::hash(offer.data, QCryptographicHash::Md5).toHex();
+      auto offerId = Crypto::UUID::v4();
+      ClipboardEncryptionType encryption = ClipboardEncryptionType::None;
+
+      if (m_localEncryptionKey) encryption = ClipboardEncryptionType::Local;
+
+      InsertClipboardOfferPayload dto{
+          .id = offerId,
+          .selectionId = selectionId,
+          .mimeType = offer.mimeType,
+          .textPreview = textPreview,
+          .md5sum = md5sum,
+          .encryption = encryption,
+          .size = static_cast<quint64>(offer.data.size()),
+      };
+
+      if (kind == ClipboardOfferKind::Link) {
+        auto url = QUrl::fromEncoded(offer.data, QUrl::StrictMode);
+
+        if (url.scheme().startsWith("http")) { dto.urlHost = url.host(); }
+      }
+
+      db.insertOffer(dto);
+
+      fs::path targetPath = m_dataDir / offerId.toStdString();
+      QFile targetFile(targetPath);
+
+      if (!targetFile.open(QIODevice::WriteOnly)) { continue; }
+
+      if (m_localEncryptionKey) {
+        targetFile.write(Crypto::AES256GCM::encrypt(offer.data, *m_localEncryptionKey));
+      } else {
+        targetFile.write(offer.data);
+      }
+
+      if (offer.mimeType == preferredMimeType) {
+        insertedEntry.id = selectionId;
+        insertedEntry.pinnedAt = 0;
+        insertedEntry.updatedAt = {};
+        insertedEntry.mimeType = offer.mimeType;
+        insertedEntry.md5sum = md5sum;
+        insertedEntry.textPreview = textPreview;
+      }
     }
-
-    auto md5sum = QCryptographicHash::hash(offerData, QCryptographicHash::Md5).toHex();
-    auto offerId = Crypto::UUID::v4();
-    ClipboardEncryptionType encryption = ClipboardEncryptionType::None;
-
-    if (m_localEncryptionKey) encryption = ClipboardEncryptionType::Local;
-
-    InsertClipboardOfferPayload dto{
-        .id = offerId,
-        .selectionId = selectionId,
-        .mimeType = mimeTypeToSave,
-        .textPreview = textPreview,
-        .md5sum = md5sum,
-        .encryption = encryption,
-        .size = static_cast<quint64>(offerData.size()),
-    };
-
-    if (kind == ClipboardOfferKind::Link) {
-      auto url = QUrl::fromEncoded(offerData, QUrl::StrictMode);
-      if (url.scheme().startsWith("http")) { dto.urlHost = url.host(); }
-    }
-
-    db.insertOffer(dto);
-
-    fs::path targetPath = m_dataDir / offerId.toStdString();
-    QFile targetFile(targetPath);
-
-    if (!targetFile.open(QIODevice::WriteOnly)) { return false; }
-
-    if (m_localEncryptionKey) {
-      targetFile.write(Crypto::AES256GCM::encrypt(offerData, *m_localEncryptionKey));
-    } else {
-      targetFile.write(offerData);
-    }
-
-    insertedEntry.id = selectionId;
-    insertedEntry.pinnedAt = 0;
-    insertedEntry.updatedAt = {};
-    insertedEntry.mimeType = mimeTypeToSave;
-    insertedEntry.md5sum = md5sum;
-    insertedEntry.textPreview = textPreview;
 
     return true;
   });

--- a/vicinae/src/services/clipboard/clipboard-service.cpp
+++ b/vicinae/src/services/clipboard/clipboard-service.cpp
@@ -383,6 +383,8 @@ void ClipboardService::saveSelection(ClipboardSelection selection) {
     }
 
     for (const auto &offer : selection.offers) {
+      if (offer.data.isEmpty()) continue;
+
       ClipboardOfferKind kind = getKind(offer);
       bool isIndexableText = kind == ClipboardOfferKind::Text || kind == ClipboardOfferKind::Link;
       QString textPreview = getOfferTextPreview(offer);


### PR DESCRIPTION
**UPDATE**

With less code I was trying to just choose the preferred mime type to show the copied text as discussed in the reactions on this merge request, which seems like the better way to do. 

I now have the following working.

<img width="1650" height="1406" alt="image" src="https://github.com/user-attachments/assets/d4e47d98-daf0-49f6-a70d-fb338be9e041" />


<hr />

<details>
<summary>Original issue</summary>

When you now try to copy text from a firefox/zen browser window it shows up as text and not as a bunch of null characters. _See screenshot_

<img width="1740" height="1312" alt="image" src="https://github.com/user-attachments/assets/24ebac62-fb9e-4103-9b83-ac8a9f2f9968" />

The selection text in the screenshot is what is being shown in the clipboard history. The output of `wl-paste` is the following 

```bash
text/html
text/_moz_htmlcontext
text/_moz_htmlinfo
text/plain;charset=utf-8
UTF8_STRING
COMPOUND_TEXT
TEXT
text/plain
STRING
text/plain;charset=utf-8
text/plain
text/x-moz-url-priv
```

I changed the priority of formats since it struggled with saving multiple versions of the same text. Its my first C++ contribution so please let me know or change if this is not needed and can be done differently. 
</details>