### PR TITLE
feat: always reset search text after a default root action executes

### DIFF
--- a/vicinae/src/actions/root-search/root-search-actions.cpp
+++ b/vicinae/src/actions/root-search/root-search-actions.cpp
@@ -89,6 +89,7 @@ void DefaultActionWrapper::execute(ApplicationContext *ctx) {
   }
 
   m_action->execute(ctx);
+  ctx->navigation->clearSearchText();
 }
 
 QString DefaultActionWrapper::title() const { return m_action->title(); }


### PR DESCRIPTION
implements #123 for all root search items: apps, shortcuts, no-view commands.