### PR TITLE
fix: Remove duplicates via ID, not by filename

### DIFF
--- a/vicinae/src/services/app-service/xdg/xdg-app-database.cpp
+++ b/vicinae/src/services/app-service/xdg/xdg-app-database.cpp
@@ -88,7 +88,7 @@ bool XdgAppDatabase::scan(const std::vector<std::filesystem::path> &paths) {
       // This ensures that the first occurrence (highest priority) wins
       if (processedFilenames.find(filename) == processedFilenames.end()) {
         processedFilenames.insert(filename);
-        addDesktopFile(entry.path().c_str());
+        addDesktopFile(dir, fs::relative(entry.path(), dir));
       }
     }
   }
@@ -345,11 +345,11 @@ AppPtr XdgAppDatabase::findByClass(const QString &name) const {
 
 std::vector<AppPtr> XdgAppDatabase::list() const { return {apps.begin(), apps.end()}; }
 
-bool XdgAppDatabase::addDesktopFile(const QString &path) {
-  QFileInfo info(path);
+bool XdgAppDatabase::addDesktopFile(fs::path parentPath, fs::path childPath) {
+  QFileInfo info(parentPath / childPath);
 
   try {
-    XdgDesktopEntry ent(path);
+    XdgDesktopEntry ent(parentPath, childPath);
 
     // we should not track hidden apps as they are explictly removed, unlike apps with NoDisplay
     // see: https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html
@@ -369,7 +369,7 @@ bool XdgAppDatabase::addDesktopFile(const QString &path) {
       appMap.insert({action->id(), action});
     }
   } catch (const std::exception &except) {
-    qWarning() << "Failed to parse app at" << path << except.what();
+    qWarning() << "Failed to parse app at" << (parentPath / childPath) << except.what();
     return false;
   }
 

--- a/vicinae/src/services/app-service/xdg/xdg-app-database.hpp
+++ b/vicinae/src/services/app-service/xdg/xdg-app-database.hpp
@@ -71,7 +71,7 @@ public:
   std::vector<QString> exec() const override { return {_data.exec.begin(), _data.exec.end()}; }
 
   XdgApplication(const QFileInfo &info, const XdgDesktopEntry &data)
-      : _path(info.filePath()), _id(info.fileName()), _data(data) {}
+      : _path(info.filePath()), _id(data.id), _data(data) {}
 };
 
 class XdgAppDatabase : public AbstractAppDatabase {
@@ -84,7 +84,7 @@ class XdgAppDatabase : public AbstractAppDatabase {
   std::vector<std::shared_ptr<XdgApplication>> apps;
 
   std::shared_ptr<Application> defaultForMime(const QString &mime) const;
-  bool addDesktopFile(const QString &path);
+  bool addDesktopFile(fs::path parentPath, fs::path childPath);
 
   AppPtr findBestTerminalEmulator() const;
 

--- a/vicinae/src/services/app-service/xdg/xdg-app-database.hpp
+++ b/vicinae/src/services/app-service/xdg/xdg-app-database.hpp
@@ -84,7 +84,7 @@ class XdgAppDatabase : public AbstractAppDatabase {
   std::vector<std::shared_ptr<XdgApplication>> apps;
 
   std::shared_ptr<Application> defaultForMime(const QString &mime) const;
-  bool addDesktopFile(fs::path parentPath, fs::path childPath);
+  void addDesktopFile(fs::path parentPath, fs::path childPath);
 
   AppPtr findBestTerminalEmulator() const;
 

--- a/vicinae/src/xdg/xdg-desktop.hpp
+++ b/vicinae/src/xdg/xdg-desktop.hpp
@@ -13,6 +13,8 @@
 #include <qstringliteral.h>
 #include <qstringview.h>
 
+namespace fs = std::filesystem;
+
 struct Locale {
   QStringView lang;
   QStringView country;
@@ -142,14 +144,20 @@ class XdgDesktopEntry {
   XdgDesktopEntry() {}
 
 public:
-  XdgDesktopEntry(const QString &path) {
-    QFile file(path);
+  XdgDesktopEntry(fs::path parentPath, fs::path childPath) {
+    QFile file(parentPath / childPath);
 
     file.open(QIODevice::ReadOnly);
 
     QString data = file.readAll();
 
     *this = XdgDesktopEntry::Parser(data).parse();
+
+    for (auto dir: childPath.parent_path()) {
+      id += dir.c_str();
+      id += '-';
+    }
+    id += childPath.stem().c_str();
   }
 
   struct Action {


### PR DESCRIPTION
This required actually generating the IDs properly according to [the XDG Desktop Entry spec](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html).