### PR TITLE
fix: Include .desktop extension in desktop entry ID

### DIFF
--- a/vicinae/src/services/app-service/xdg/xdg-app-database.cpp
+++ b/vicinae/src/services/app-service/xdg/xdg-app-database.cpp
@@ -90,7 +90,7 @@ bool XdgAppDatabase::scan(const std::vector<std::filesystem::path> &paths) {
         if (processedIds.find(desktopEntry.id) != processedIds.end()) continue;
         processedIds.insert(desktopEntry.id);
 
-        addDesktopFile(dir, fs::relative(entry.path(), dir));
+        addDesktopFile(entry.path(), desktopEntry);
       } catch(std::exception &except) {
         qWarning() << "Failed to parse app at" << entry.path() << except.what();
       }
@@ -349,16 +349,13 @@ AppPtr XdgAppDatabase::findByClass(const QString &name) const {
 
 std::vector<AppPtr> XdgAppDatabase::list() const { return {apps.begin(), apps.end()}; }
 
-void XdgAppDatabase::addDesktopFile(fs::path parentPath, fs::path childPath) {
-  QFileInfo info(parentPath / childPath);
-
-  XdgDesktopEntry ent(parentPath, childPath);
+void XdgAppDatabase::addDesktopFile(const fs::path &path, const XdgDesktopEntry &ent) {
   
   // we should not track hidden apps as they are explictly removed, unlike apps with NoDisplay
   // see: https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html
   if (ent.hidden) return;
   
-  auto entry = std::make_shared<XdgApplication>(info, ent);
+  auto entry = std::make_shared<XdgApplication>(path, ent);
   
   for (const auto &mimeName : ent.mimeType) {
   mimeToApps[mimeName].insert(entry->id());

--- a/vicinae/src/services/app-service/xdg/xdg-app-database.hpp
+++ b/vicinae/src/services/app-service/xdg/xdg-app-database.hpp
@@ -70,8 +70,8 @@ public:
 
   std::vector<QString> exec() const override { return {_data.exec.begin(), _data.exec.end()}; }
 
-  XdgApplication(const QFileInfo &info, const XdgDesktopEntry &data)
-      : _path(info.filePath()), _id(data.id), _data(data) {}
+  XdgApplication(const fs::path &path, const XdgDesktopEntry &data)
+      : _path(path.c_str()), _id(data.id), _data(data) {}
 };
 
 class XdgAppDatabase : public AbstractAppDatabase {
@@ -84,7 +84,7 @@ class XdgAppDatabase : public AbstractAppDatabase {
   std::vector<std::shared_ptr<XdgApplication>> apps;
 
   std::shared_ptr<Application> defaultForMime(const QString &mime) const;
-  void addDesktopFile(fs::path parentPath, fs::path childPath);
+  void addDesktopFile(const fs::path &path, const XdgDesktopEntry &ent);
 
   AppPtr findBestTerminalEmulator() const;
 

--- a/vicinae/src/xdg/xdg-desktop.hpp
+++ b/vicinae/src/xdg/xdg-desktop.hpp
@@ -146,7 +146,7 @@ class XdgDesktopEntry {
   XdgDesktopEntry() {}
 
 public:
-  XdgDesktopEntry(fs::path parentPath, fs::path childPath) {
+  XdgDesktopEntry(const fs::path &parentPath, const fs::path &childPath) {
     QFile file(parentPath / childPath);
 
     file.open(QIODevice::ReadOnly);


### PR DESCRIPTION
#140 would generate an ID of `foo-bar` for foo/bar.desktop, when it should be `foo-bar.desktop`.