### PR TITLE
fix: prevent scroll area from taking focus on tab

### DIFF
--- a/vicinae/src/ui/vertical-scroll-area/vertical-scroll-area.cpp
+++ b/vicinae/src/ui/vertical-scroll-area/vertical-scroll-area.cpp
@@ -19,6 +19,7 @@ void VerticalScrollArea::resizeEvent(QResizeEvent *event) {
 }
 
 VerticalScrollArea::VerticalScrollArea(QWidget *parent) : QScrollArea(parent) {
+  setFocusPolicy(Qt::NoFocus);
   setWidgetResizable(true);
   setVerticalScrollBar(new OmniScrollBar);
   setHorizontalScrollBarPolicy(Qt::ScrollBarPolicy::ScrollBarAlwaysOff);


### PR DESCRIPTION
This was stealing focus in unexpected ways.