### PR TITLE
feat(extension): add uninstall action from within extension views

### DIFF
--- a/vicinae/CMakeLists.txt
+++ b/vicinae/CMakeLists.txt
@@ -125,6 +125,8 @@ set(SRCS
 	src/actions/root-search/root-search-actions.hpp
 	src/actions/root-search/root-search-actions.cpp
 
+	src/actions/extension/extension-actions.cpp
+
 	src/actions/app/app-actions.hpp
 	src/actions/app/app-actions.cpp
 	

--- a/vicinae/include/extend/action-model.hpp
+++ b/vicinae/include/extend/action-model.hpp
@@ -8,6 +8,8 @@ struct KeyboardShortcutModel {
   QStringList modifiers;
 
   static KeyboardShortcutModel submit() { return {.key = "return", .modifiers = {"shift"}}; }
+  static KeyboardShortcutModel cut() { return {.key = "X", .modifiers = {"ctrl"}}; }
+  static KeyboardShortcutModel enter() { return {.key = "return"}; }
 };
 
 struct ActionModel {

--- a/vicinae/src/actions/extension/extension-actions.cpp
+++ b/vicinae/src/actions/extension/extension-actions.cpp
@@ -1,0 +1,26 @@
+#include "extension-actions.hpp"
+#include "ui/alert/alert.hpp"
+#include "service-registry.hpp"
+#include "services/extension-registry/extension-registry.hpp"
+#include "services/toast/toast-service.hpp"
+#include "navigation-controller.hpp"
+
+void UninstallExtensionAction::execute(ApplicationContext *ctx) {
+  auto alert = new CallbackAlertWidget();
+
+  alert->setTitle("Are you sure?");
+  alert->setMessage(
+      "All this extension data will be permanently lost. If you "
+      "just want the extension to not appear in the root search anymore, consider disabling it instead.");
+  alert->setConfirmText("Uninstall", SemanticColor::Red);
+  alert->setCallback([ctx, id = m_id](bool ok) {
+    if (!ok) return;
+    if (ctx->services->extensionRegistry()->uninstall(id)) {
+      ctx->services->toastService()->setToast("Extension uninstalled");
+    } else {
+      ctx->services->toastService()->setToast("Failed to uninstall extension", ToastPriority::Danger);
+    }
+  });
+
+  ctx->navigation->setDialog(alert);
+}

--- a/vicinae/src/actions/extension/extension-actions.hpp
+++ b/vicinae/src/actions/extension/extension-actions.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#include <qstring.h>
+#include "ui/action-pannel/action.hpp"
+#include "ui/image/url.hpp"
+
+class UninstallExtensionAction : public AbstractAction {
+  QString m_id;
+
+  ImageURL icon() const override { return ImageURL::builtin("computer-chip"); }
+  void execute(ApplicationContext *ctx) override;
+  QString title() const override { return "Uninstall Extension"; }
+
+public:
+  UninstallExtensionAction(const QString &id) : m_id(id) { setStyle(AbstractAction::Danger); }
+};

--- a/vicinae/src/actions/root-search/root-search-actions.cpp
+++ b/vicinae/src/actions/root-search/root-search-actions.cpp
@@ -125,23 +125,3 @@ DisableItemAction::DisableItemAction(const QString &id)
     : AbstractAction("Disable item", ImageURL::builtin("trash")), m_id(id) {
   setStyle(AbstractAction::Danger);
 }
-
-void UninstallExtensionAction::execute(ApplicationContext *ctx) {
-  auto alert = new CallbackAlertWidget();
-
-  alert->setTitle("Are you sure?");
-  alert->setMessage(
-      "All this extension data will be permanently lost. If you "
-      "just want the extension to not appear in the root search anymore, consider disabling it instead.");
-  alert->setConfirmText("Uninstall", SemanticColor::Red);
-  alert->setCallback([ctx, id = m_id](bool ok) {
-    if (!ok) return;
-    if (ctx->services->extensionRegistry()->uninstall(id)) {
-      ctx->services->toastService()->setToast("Extension uninstalled");
-    } else {
-      ctx->services->toastService()->setToast("Failed to uninstall extension", ToastPriority::Danger);
-    }
-  });
-
-  ctx->navigation->setDialog(alert);
-}

--- a/vicinae/src/actions/root-search/root-search-actions.hpp
+++ b/vicinae/src/actions/root-search/root-search-actions.hpp
@@ -47,17 +47,6 @@ public:
   DisableApplication(const QString &itemId) : DisableItemAction(itemId) {}
 };
 
-class UninstallExtensionAction : public AbstractAction {
-  QString m_id;
-
-  ImageURL icon() const override { return ImageURL::builtin("computer-chip"); }
-  void execute(ApplicationContext *ctx) override;
-  QString title() const override { return "Uninstall Extension"; }
-
-public:
-  UninstallExtensionAction(const QString &id) : m_id(id) { setStyle(AbstractAction::Danger); }
-};
-
 /**
  * Wrapper for the main action of a root item, automatically recording execution.
  */

--- a/vicinae/src/extensions/raycast/store/store-detail-view.hpp
+++ b/vicinae/src/extensions/raycast/store/store-detail-view.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "actions/root-search/root-search-actions.hpp"
+#include "actions/extension/extension-actions.hpp"
 #include "ui/views/base-view.hpp"
 #include "common.hpp"
 #include "ui/action-pannel/action.hpp"

--- a/vicinae/src/extensions/raycast/store/store-detail-view.hpp
+++ b/vicinae/src/extensions/raycast/store/store-detail-view.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "actions/root-search/root-search-actions.hpp"
 #include "ui/views/base-view.hpp"
 #include "common.hpp"
 #include "ui/action-pannel/action.hpp"
@@ -237,6 +238,10 @@ class RaycastStoreDetailView : public BaseView {
     return VStack().add(createPresentationSection()).add(createContentSection()).divided(1).buildWidget();
   }
 
+  void extensionInstalled() { m_installedAccessory->show(); }
+
+  void extensionUninstalled() { m_installedAccessory->hide(); }
+
   void createActions() {
     auto panel = std::make_unique<ActionPanelState>();
     auto install = new StaticAction(
@@ -262,31 +267,46 @@ class RaycastStoreDetailView : public BaseView {
 
           watcher->setFuture(downloadResult);
         });
+    auto uninstall = new UninstallExtensionAction(m_ext.id);
 
     install->setShortcut({.key = "return"});
 
     auto main = panel->createSection();
+    auto danger = panel->createSection();
 
     main->addAction(install);
     install->setPrimary(true);
+    danger->addAction(uninstall);
+    uninstall->setShortcut(KeyboardShortcutModel::cut());
 
     setActions(std::move(panel));
   }
 
   void initialize() override {
-    bool isInstalled = context()->services->extensionRegistry()->isInstalled(m_ext.id);
+    auto registry = context()->services->extensionRegistry();
+    bool isInstalled = registry->isInstalled(m_ext.id);
+
+    if (isInstalled) {
+      extensionInstalled();
+    } else {
+      extensionUninstalled();
+    }
 
     createActions();
-    m_installedAccessory->setVisible(isInstalled);
+    connect(registry, &ExtensionRegistry::extensionAdded, this, [this](const QString &id) {
+      if (id != m_ext.id) return;
+      extensionInstalled();
+    });
+
+    connect(registry, &ExtensionRegistry::extensionUninstalled, this, [this](const QString &id) {
+      if (id != m_ext.id) return;
+      extensionUninstalled();
+    });
   }
 
   void setupUI(const Raycast::Extension &extension) {
-    auto layout = new QVBoxLayout;
-
     m_scrollArea->setWidget(createUI(extension));
-    layout->addWidget(m_scrollArea);
-    layout->setContentsMargins(0, 0, 0, 0);
-    setLayout(layout);
+    VStack().add(m_scrollArea).imbue(this);
   }
 
 public:

--- a/vicinae/src/extensions/raycast/store/store-listing-view.hpp
+++ b/vicinae/src/extensions/raycast/store/store-listing-view.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "actions/root-search/root-search-actions.hpp"
 #include "ui/views/base-view.hpp"
 #include "extensions/raycast/store/store-detail-view.hpp"
 #include "navigation-controller.hpp"
@@ -10,6 +11,7 @@
 #include "ui/action-pannel/action.hpp"
 #include "ui/list-accessory/list-accessory.hpp"
 #include "ui/toast/toast.hpp"
+#include "ui/views/list-view.hpp"
 #include <chrono>
 #include <memory>
 #include <qboxlayout.h>
@@ -93,6 +95,7 @@ public:
   std::unique_ptr<ActionPanelState> newActionPanel(ApplicationContext *ctx) const override {
     auto panel = std::make_unique<ActionPanelState>();
     auto section = panel->createSection();
+    auto danger = panel->createSection();
     auto icon = m_extension.themedIcon();
     auto showExtension = new StaticAction(
         "Show details", ImageURL::builtin("computer-chip"), [ext = m_extension, icon, ctx]() {
@@ -101,9 +104,14 @@ public:
           ctx->navigation->setNavigationIcon(
               ImageURL::builtin("raycast").setBackgroundTint(Omnicast::ACCENT_COLOR));
         });
+    auto uninstall = new UninstallExtensionAction(m_extension.id);
+
+    showExtension->setShortcut(KeyboardShortcutModel::enter());
+    uninstall->setShortcut(KeyboardShortcutModel::cut());
 
     panel->setTitle(m_extension.name);
     section->addAction(showExtension);
+    danger->addAction(uninstall);
     showExtension->setPrimary(true);
 
     return panel;
@@ -119,6 +127,8 @@ class RaycastStoreListingView : public ListView {
   QFutureWatcher<Raycast::ListResult> m_queryResultWatcher;
   QString lastQueryText;
   QTimer m_debounce;
+
+  void refresh() { setSearchText(searchText()); }
 
   void handleDebounce() {
     if (searchText().isEmpty()) return;
@@ -190,6 +200,8 @@ class RaycastStoreListingView : public ListView {
 
 public:
   void initialize() override {
+    auto registry = context()->services->extensionRegistry();
+
     m_store = context()->services->raycastStore();
     setLoading(true);
     setSearchPlaceholderText("Browse Raycast extensions");
@@ -197,6 +209,8 @@ public:
     auto result = m_store->fetchExtensions();
 
     m_listResultWatcher.setFuture(result);
+
+    connect(registry, &ExtensionRegistry::extensionsChanged, this, &RaycastStoreListingView::refresh);
   }
 
   RaycastStoreListingView() {

--- a/vicinae/src/extensions/raycast/store/store-listing-view.hpp
+++ b/vicinae/src/extensions/raycast/store/store-listing-view.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "actions/root-search/root-search-actions.hpp"
+#include "actions/extension/extension-actions.hpp"
 #include "ui/views/base-view.hpp"
 #include "extensions/raycast/store/store-detail-view.hpp"
 #include "navigation-controller.hpp"

--- a/vicinae/src/root-search/extensions/extension-root-provider.cpp
+++ b/vicinae/src/root-search/extensions/extension-root-provider.cpp
@@ -1,4 +1,5 @@
 #include "root-search/extensions/extension-root-provider.hpp"
+#include "actions/extension/extension-actions.hpp"
 #include "action-panel/action-panel.hpp"
 #include "actions/fallback-actions.hpp"
 #include "actions/root-search/root-search-actions.hpp"
@@ -7,7 +8,6 @@
 #include "extension/extension-command.hpp"
 #include "navigation-controller.hpp"
 #include "services/root-item-manager/root-item-manager.hpp"
-#include "services/toast/toast-service.hpp"
 #include "ui/action-pannel/action.hpp"
 
 QString CommandRootItem::displayName() const { return m_command->name(); }
@@ -18,32 +18,6 @@ QString CommandRootItem::providerId() const { return "command"; }
 bool CommandRootItem::isSuitableForFallback() const { return m_command->isFallback(); }
 double CommandRootItem::baseScoreWeight() const { return 1.1; }
 QString CommandRootItem::typeDisplayName() const { return "Command"; }
-
-ActionPanelView *CommandRootItem::actionPanel(const RootItemMetadata &metadata) const {
-  auto panel = new ActionPanelStaticListView;
-  auto open = new OpenBuiltinCommandAction(m_command, "Open command");
-  auto resetRanking = new ResetItemRanking(uniqueId());
-  auto markAsFavorite = new ToggleItemAsFavorite(uniqueId(), metadata.favorite);
-
-  panel->setTitle(m_command->name());
-  panel->addAction(new DefaultActionWrapper(uniqueId(), open));
-  panel->addSection();
-  panel->addAction(resetRanking);
-  panel->addAction(markAsFavorite);
-
-  auto deeplink = QString("omnicast://extensions/%1/%2/%3")
-                      .arg(m_command->author())
-                      .arg(m_command->extensionId())
-                      .arg(m_command->commandId());
-  auto action = new CopyToClipboardAction(Clipboard::Text(deeplink), "Copy to deeplink");
-
-  panel->addAction(action);
-
-  panel->addSection();
-  panel->addAction(new DisableApplication(uniqueId()));
-
-  return panel;
-}
 
 std::unique_ptr<ActionPanelState> CommandRootItem::newActionPanel(ApplicationContext *ctx,
                                                                   const RootItemMetadata &metadata) {

--- a/vicinae/src/root-search/extensions/extension-root-provider.hpp
+++ b/vicinae/src/root-search/extensions/extension-root-provider.hpp
@@ -17,7 +17,6 @@ public:
   QString providerId() const override;
   bool isSuitableForFallback() const override;
   double baseScoreWeight() const override;
-  ActionPanelView *actionPanel(const RootItemMetadata &metadata) const override;
   std::unique_ptr<ActionPanelState> newActionPanel(ApplicationContext *ctx,
                                                    const RootItemMetadata &metadata) override;
   ActionPanelView *fallbackActionPanel() const override;

--- a/vicinae/src/ui/views/base-view.cpp
+++ b/vicinae/src/ui/views/base-view.cpp
@@ -1,6 +1,8 @@
 #include "ui/views/base-view.hpp"
 #include "common.hpp"
 #include "navigation-controller.hpp"
+#include <qlogging.h>
+#include <stdexcept>
 
 void BaseView::createInitialize() {
   if (m_initialized) return;
@@ -63,7 +65,17 @@ void BaseView::onDeactivate() {}
 
 void BaseView::setContext(ApplicationContext *ctx) { m_ctx = ctx; }
 
-ApplicationContext *BaseView::context() const { return m_ctx; }
+ApplicationContext *BaseView::context() const {
+  if (!m_ctx) {
+    qCritical()
+        << "BaseView::context() was called before the view was registered by the navigation controller. "
+           "This is not supported and will most "
+           "likely cause a crash. If you need to access the application context when a view is first "
+           "shown, you should implement the `initialize` method and do what you need in there.";
+  }
+
+  return m_ctx;
+}
 
 void BaseView::destroyCompleter() { /*m_uiController->destroyCompleter();*/ }
 


### PR DESCRIPTION
Implements #154 
Extensions can now be uninstalled from the extension list and detail pages.