### PR TITLE
Nix module changes

### DIFF
--- a/extra/vicinae.service
+++ b/extra/vicinae.service
@@ -10,6 +10,7 @@ ExecStart=vicinae server
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 RestartSec=5
+KillMode=process
 
 [Install]
 WantedBy=graphical-session.target

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,9 @@
         packages.default = vicinaePkg;
       }
     ) // {
+      overlays.default = final: prev: {
+        vicinae = self.packages.${final.system}.default;
+      };
       homeManagerModules.default = {config,pkgs,lib,...}: import ./module.nix {inherit config pkgs lib self;};
     };
 }

--- a/module.nix
+++ b/module.nix
@@ -41,15 +41,17 @@ in {
       };
       Unit = {
         Description = "Vicinae server daemon";
+        Documentation = ["https://docs.vicinae.com"];
         After = ["graphical-session.target"];
         PartOf = ["graphical-session.target"];
         BindsTo = ["graphical-session.target"];
       };
       Service = {
         Type = "simple";
-        ExecStart = "${cfg.package}/bin/vicinae server";
-        Restart = "on-failure";
-        RestartSec = 3;
+        ExecStart = "${lib.getExe cfg.package} server";
+        Restart = "always";
+        RestartSec = 5;
+        KillMode = "process";
       };
       Install = lib.mkIf cfg.autoStart {
         WantedBy = ["graphical-session.target"];

--- a/module.nix
+++ b/module.nix
@@ -48,7 +48,7 @@ in {
       };
       Service = {
         Type = "simple";
-        ExecStart = "${lib.getExe cfg.package} server";
+        ExecStart = "${lib.getExe' cfg.package "vicinae"} server";
         Restart = "always";
         RestartSec = 5;
         KillMode = "process";

--- a/module.nix
+++ b/module.nix
@@ -36,10 +36,10 @@ in {
     home.packages = [cfg.package];
 
     systemd.user.services.vicinae = {
-      environment = {
-        USE_LAYER_SHELL = if cfg.useLayerShell then 1 else 0;
-      };
       Unit = {
+        EnvironmentFile = pkgs.writeText "vicinae-env" ''
+          USE_LAYER_SHELL=${if cfg.useLayerShell then 1 else 0}
+        '';
         Description = "Vicinae server daemon";
         Documentation = ["https://docs.vicinae.com"];
         After = ["graphical-session.target"];

--- a/module.nix
+++ b/module.nix
@@ -37,9 +37,6 @@ in {
 
     systemd.user.services.vicinae = {
       Unit = {
-        EnvironmentFile = pkgs.writeText "vicinae-env" ''
-          USE_LAYER_SHELL=${if cfg.useLayerShell then builtins.toString 1 else builtins.toString 0}
-        '';
         Description = "Vicinae server daemon";
         Documentation = ["https://docs.vicinae.com"];
         After = ["graphical-session.target"];
@@ -47,6 +44,9 @@ in {
         BindsTo = ["graphical-session.target"];
       };
       Service = {
+        EnvironmentFile = pkgs.writeText "vicinae-env" ''
+          USE_LAYER_SHELL=${if cfg.useLayerShell then builtins.toString 1 else builtins.toString 0}
+        '';
         Type = "simple";
         ExecStart = "${lib.getExe' cfg.package "vicinae"} server";
         Restart = "always";

--- a/module.nix
+++ b/module.nix
@@ -38,7 +38,7 @@ in {
     systemd.user.services.vicinae = {
       Unit = {
         EnvironmentFile = pkgs.writeText "vicinae-env" ''
-          USE_LAYER_SHELL=${if cfg.useLayerShell then 1 else 0}
+          USE_LAYER_SHELL=${if cfg.useLayerShell then builtins.toString 1 else builtins.toString 0}
         '';
         Description = "Vicinae server daemon";
         Documentation = ["https://docs.vicinae.com"];

--- a/module.nix
+++ b/module.nix
@@ -25,11 +25,20 @@ in {
       default = true;
       description = "If the vicinae daemon should be started automatically";
     };
+
+    useLayerShell = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "If vicinae should use the layer shell";
+    };
   };
   config = lib.mkIf cfg.enable {
     home.packages = [cfg.package];
 
     systemd.user.services.vicinae = {
+      environment = {
+        USE_LAYER_SHELL = if cfg.useLayerShell then 1 else 0;
+      };
       Unit = {
         Description = "Vicinae server daemon";
         After = ["graphical-session.target"];


### PR DESCRIPTION
A couple of changes to the nix module.

1. Added the package as an overlay, this allows adding vinicae to pkgs which is useful for making overrides (and makes it possible to actually use the `package` option in the module).
2. Added killmode to the systemd service, this fixes #179 
3. Brought the systemd service in nix, and the example systemd service in line with eachother
4. Added useLayerShell option to nix module
5. Changed ExecStart to use lib.getExe'