### PR TITLE
fix: use filename to keep track of overriden desktop files

### DIFF
--- a/vicinae/src/services/app-service/xdg/xdg-app-database.cpp
+++ b/vicinae/src/services/app-service/xdg/xdg-app-database.cpp
@@ -86,10 +86,11 @@ bool XdgAppDatabase::scan(const std::vector<std::filesystem::path> &paths) {
 
       try {
         XdgDesktopEntry desktopEntry(dir, fs::relative(entry.path(), dir));
+        QString filename = entry.path().filename().c_str();
 
-        if (processedIds.find(desktopEntry.id) != processedIds.end()) continue;
-        processedIds.insert(desktopEntry.id);
+        if (std::ranges::contains(processedIds, filename)) continue;
 
+        processedIds.insert(filename);
         addDesktopFile(entry.path(), desktopEntry);
       } catch (std::exception &except) {
         qWarning() << "Failed to parse app at" << entry.path() << except.what();


### PR DESCRIPTION
There is something fishy going on with the id computation.
For now this should fix #183 

@quadratech188 this is the kind of output I get when logging the ids during scanning. Notice the few outliers here. I wasn't able to fully reproduce by duplicating a desktop file, but there is a problem.
I'm guessing the `fs::relative` stuff might be responsible.

```
 desktop.id "mupdf.desktop" for path /usr/share/applications/mupdf.desktop (xdg-app-database.cpp:91)
[01:25:37.047] DEBUG  -  desktop.id "zzz-gimp.desktop" for path /usr/share/applications/zzz-gimp.desktop (xdg-app-database.cpp:91)
[01:25:37.047] DEBUG  -  desktop.id "xdg-desktop-portal-gtk.desktop" for path /usr/share/applications/xdg-desktop-portal-gtk.desktop (xdg-app-database.cpp:91)
[01:25:37.047] DEBUG  -  desktop.id "xsane.desktop" for path /usr/share/applications/xsane.desktop (xdg-app-database.cpp:91)
[01:25:37.047] DEBUG  -  desktop.id "org.fcitx.fcitx5-config-qt.desktop" for path /usr/share/applications/org.fcitx.fcitx5-config-qt.desktop (xdg-app-database.cpp:91)
[01:25:37.047] DEBUG  -  desktop.id "swayimg.desktop" for path /usr/share/applications/swayimg.desktop (xdg-app-database.cpp:91)
[01:25:37.048] DEBUG  -  desktop.id "htop.desktop" for path /usr/share/applications/htop.desktop (xdg-app-database.cpp:91)
[01:25:37.048] DEBUG  -  desktop.id "thunderbird-esr.desktop" for path /usr/share/applications/thunderbird-esr.desktop (xdg-app-database.cpp:91)
[01:25:37.048] DEBUG  -  desktop.id "kcm_filetypes.desktop" for path /usr/share/applications/kcm_filetypes.desktop (xdg-app-database.cpp:91)
[01:25:37.048] DEBUG  -  desktop.id "..-..-lib64-libreoffice-share-xdg-writer.desktop" for path /usr/share/applications/libreoffice-writer.desktop (xdg-app-database.cpp:91)
[01:25:37.048] DEBUG  -  desktop.id "codium-open-in-new-window.desktop" for path /usr/share/applications/codium-open-in-new-window.desktop (xdg-app-database.cpp:91)
[01:25:37.048] DEBUG  -  desktop.id "kitty.desktop" for path /usr/share/applications/kitty.desktop (xdg-app-database.cpp:91)
[01:25:37.048] DEBUG  -  desktop.id "gcr-viewer.desktop" for path /usr/share/applications/gcr-viewer.desktop (xdg-app-database.cpp:91)
[01:25:37.048] DEBUG  -  desktop.id "compton.desktop" for path /usr/share/applications/compton.desktop (xdg-app-database.cpp:91)
[01:25:37.048] DEBUG  -  desktop.id "javaws.desktop" for path /usr/share/applications/javaws.desktop (xdg-app-database.cpp:91)
[01:25:37.048] DEBUG  -  desktop.id "org.pulseaudio.pavucontrol.desktop" for path /usr/share/applications/org.pulseaudio.pavucontrol.desktop (xdg-app-database.cpp:91)
[01:25:37.049] DEBUG  -  desktop.id "org.fcitx.Fcitx5.desktop" for path /usr/share/applications/org.fcitx.Fcitx5.desktop (xdg-app-database.cpp:91)
[01:25:37.049] DEBUG  -  desktop.id "org.kde.knewstuff-dialog6.desktop" for path /usr/share/applications/org.kde.knewstuff-dialog6.desktop (xdg-app-database.cpp:91)
[01:25:37.049] DEBUG  -  desktop.id "org.gnome.Nautilus.desktop" for path /usr/share/applications/org.gnome.Nautilus.desktop (xdg-app-database.cpp:91)
[01:25:37.049] DEBUG  -  desktop.id "org.wireshark.Wireshark.desktop" for path /usr/share/applications/org.wireshark.Wireshark.desktop (xdg-app-database.cpp:91)
[01:25:37.049] DEBUG  -  desktop.id "calibre-ebook-viewer.desktop" for path /usr/share/applications/calibre-ebook-viewer.desktop (xdg-app-database.cpp:91)
[01:25:37.050] DEBUG  -  desktop.id "org.remmina.Remmina.desktop" for path /usr/share/applications/org.remmina.Remmina.desktop (xdg-app-database.cpp:91)
[01:25:37.050] DEBUG  -  desktop.id "calibre-gui.desktop" for path /usr/share/applications/calibre-gui.desktop (xdg-app-database.cpp:91)
[01:25:37.050] DEBUG  -  desktop.id "avahi-discover.desktop" for path /usr/share/applications/avahi-discover.desktop (xdg-app-database.cpp:91)
[01:25:37.050] DEBUG  -  desktop.id "org.qt-project.qtcreator.desktop" for path /usr/share/applications/org.qt-project.qtcreator.desktop (xdg-app-database.cpp:91)
[01:25:37.050] DEBUG  -  desktop.id "com.obsproject.Studio.desktop" for path /usr/share/applications/com.obsproject.Studio.desktop (xdg-app-database.cpp:91)
[01:25:37.050] DEBUG  -  desktop.id "cups.desktop" for path /usr/share/applications/cups.desktop (xdg-app-database.cpp:91)
[01:25:37.051] DEBUG  -  desktop.id "librewolf.desktop" for path /usr/share/applications/librewolf.desktop (xdg-app-database.cpp:91)
[01:25:37.051] DEBUG  -  desktop.id "..-..-lib64-libreoffice-share-xdg-base.desktop" for path /usr/share/applications/libreoffice-base.desktop (xdg-app-database.cpp:91)
[01:25:37.051] DEBUG  -  desktop.id "rofi-theme-selector.desktop" for path /usr/share/applications/rofi-theme-selector.desktop (xdg-app-database.cpp:91)
[01:25:37.051] DEBUG  -  desktop.id "org.gnupg.pinentry-qt.desktop" for path /usr/share/applications/org.gnupg.pinentry-qt.desktop (xdg-app-database.cpp:91)
[01:25:37.051] DEBUG  -  desktop.id "org.kde.kded6.desktop" for path /usr/share/applications/org.kde.kded6.desktop (xdg-app-database.cpp:91)
```
