### PR TITLE
refactor: Clean up file scanners

### DIFF
--- a/vicinae/CMakeLists.txt
+++ b/vicinae/CMakeLists.txt
@@ -433,6 +433,10 @@ set(SRCS
 	src/services/files-service/file-indexer/file-indexer-db.cpp
 	src/services/files-service/file-indexer/writer-worker.hpp
 	src/services/files-service/file-indexer/writer-worker.cpp
+        src/services/files-service/file-indexer/scan-dispatcher.hpp
+	src/services/files-service/file-indexer/scan-dispatcher.cpp
+        src/services/files-service/file-indexer/abstract-scanner.hpp
+	src/services/files-service/file-indexer/abstract-scanner.cpp
 
 	src/services/extension-registry/extension-registry.hpp
 	src/services/extension-registry/extension-registry.cpp

--- a/vicinae/CMakeLists.txt
+++ b/vicinae/CMakeLists.txt
@@ -433,9 +433,9 @@ set(SRCS
 	src/services/files-service/file-indexer/file-indexer-db.cpp
 	src/services/files-service/file-indexer/writer-worker.hpp
 	src/services/files-service/file-indexer/writer-worker.cpp
-        src/services/files-service/file-indexer/scan-dispatcher.hpp
 	src/services/files-service/file-indexer/scan-dispatcher.cpp
-        src/services/files-service/file-indexer/abstract-scanner.hpp
+	src/services/files-service/file-indexer/scan-dispatcher.cpp
+	src/services/files-service/file-indexer/abstract-scanner.hpp
 	src/services/files-service/file-indexer/abstract-scanner.cpp
 
 	src/services/extension-registry/extension-registry.hpp

--- a/vicinae/CMakeLists.txt
+++ b/vicinae/CMakeLists.txt
@@ -431,6 +431,8 @@ set(SRCS
 	src/services/files-service/file-indexer/indexer-scanner.cpp
 	src/services/files-service/file-indexer/home-directory-watcher.cpp
 	src/services/files-service/file-indexer/file-indexer-db.cpp
+	src/services/files-service/file-indexer/writer-worker.hpp
+	src/services/files-service/file-indexer/writer-worker.cpp
 
 	src/services/extension-registry/extension-registry.hpp
 	src/services/extension-registry/extension-registry.cpp

--- a/vicinae/src/services/files-service/file-indexer/abstract-scanner.cpp
+++ b/vicinae/src/services/files-service/file-indexer/abstract-scanner.cpp
@@ -1,0 +1,34 @@
+#include "abstract-scanner.hpp"
+#include <expected>
+#include <variant>
+
+std::expected<Scan, bool> AbstractScanner::awaitScan() {
+  if (!m_alive)
+    return std::unexpected<bool>(false);
+
+  std::unique_lock lock(m_scanLock);
+  m_scanCv.wait(lock, [&]() {return !m_scans.empty() || !m_alive;});
+  if (!m_alive) {
+    return std::unexpected<bool>(false);
+  }
+  Scan front = m_scans.front();
+  m_scans.pop();
+  return front;
+}
+
+void AbstractScanner::enqueue(const Scan& scan) {
+  m_scanLock.lock();
+  m_scans.push(scan);
+  m_scanLock.unlock();
+
+  m_scanCv.notify_one();
+}
+
+void AbstractScanner::run() {
+  m_alive = true;
+}
+
+void AbstractScanner::stop() {
+  m_alive = false;
+  m_scanCv.notify_one();
+}

--- a/vicinae/src/services/files-service/file-indexer/abstract-scanner.cpp
+++ b/vicinae/src/services/files-service/file-indexer/abstract-scanner.cpp
@@ -3,20 +3,17 @@
 #include <variant>
 
 std::expected<Scan, bool> AbstractScanner::awaitScan() {
-  if (!m_alive)
-    return std::unexpected<bool>(false);
+  if (!m_alive) return std::unexpected<bool>(false);
 
   std::unique_lock lock(m_scanLock);
-  m_scanCv.wait(lock, [&]() {return !m_scans.empty() || !m_alive;});
-  if (!m_alive) {
-    return std::unexpected<bool>(false);
-  }
+  m_scanCv.wait(lock, [&]() { return !m_scans.empty() || !m_alive; });
+  if (!m_alive) { return std::unexpected<bool>(false); }
   Scan front = m_scans.front();
   m_scans.pop();
   return front;
 }
 
-void AbstractScanner::enqueue(const Scan& scan) {
+void AbstractScanner::enqueue(const Scan &scan) {
   m_scanLock.lock();
   m_scans.push(scan);
   m_scanLock.unlock();
@@ -24,9 +21,7 @@ void AbstractScanner::enqueue(const Scan& scan) {
   m_scanCv.notify_one();
 }
 
-void AbstractScanner::run() {
-  m_alive = true;
-}
+void AbstractScanner::run() { m_alive = true; }
 
 void AbstractScanner::stop() {
   m_alive = false;

--- a/vicinae/src/services/files-service/file-indexer/abstract-scanner.hpp
+++ b/vicinae/src/services/files-service/file-indexer/abstract-scanner.hpp
@@ -14,7 +14,7 @@ class AbstractScanner {
 
 public:
   std::expected<Scan, bool> awaitScan();
-  void enqueue(const Scan& scan);
+  void enqueue(const Scan &scan);
   virtual void run();
   virtual void stop();
 };

--- a/vicinae/src/services/files-service/file-indexer/abstract-scanner.hpp
+++ b/vicinae/src/services/files-service/file-indexer/abstract-scanner.hpp
@@ -1,0 +1,20 @@
+#pragma once
+#include "services/files-service/file-indexer/scan.hpp"
+
+#include <condition_variable>
+#include <expected>
+#include <mutex>
+#include <queue>
+#include <variant>
+class AbstractScanner {
+  std::atomic<bool> m_alive;
+  std::queue<Scan> m_scans;
+  std::mutex m_scanLock;
+  std::condition_variable m_scanCv;
+
+public:
+  std::expected<Scan, bool> awaitScan();
+  void enqueue(const Scan& scan);
+  virtual void run();
+  virtual void stop();
+};

--- a/vicinae/src/services/files-service/file-indexer/file-indexer-db.hpp
+++ b/vicinae/src/services/files-service/file-indexer/file-indexer-db.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "services/files-service/abstract-file-indexer.hpp"
+#include "services/files-service/file-indexer/scan.hpp"
 #include <expected>
 #include <qdatetime.h>
 #include <qobject.h>
@@ -18,7 +19,6 @@ class FileIndexerDatabase : public QObject {
   QString m_connectionId;
 
 public:
-  enum class ScanType { Full, Incremental };
   enum class ScanStatus {
     Pending,
     Started,

--- a/vicinae/src/services/files-service/file-indexer/file-indexer.cpp
+++ b/vicinae/src/services/files-service/file-indexer/file-indexer.cpp
@@ -1,8 +1,11 @@
 #include <cstdlib>
 #include <filesystem>
+#include <memory>
 #include <mutex>
 #include <QtConcurrent/QtConcurrent>
 #include "services/files-service/abstract-file-indexer.hpp"
+#include "services/files-service/file-indexer/indexer-scanner.hpp"
+#include "services/files-service/file-indexer/incremental-scanner.hpp"
 #include "file-indexer-db.hpp"
 #include "file-indexer.hpp"
 #include "utils/utils.hpp"
@@ -110,6 +113,10 @@ QFuture<std::vector<IndexerFileResult>> FileIndexer::queryAsync(std::string_view
 }
 
 FileIndexer::FileIndexer():
-  m_dispatcher(m_scanner) {
+  m_dispatcher({
+      {ScanType::Full, std::make_shared<IndexerScanner>()},
+      {ScanType::Incremental, std::make_shared<IncrementalScanner>()}
+      }) {
+
   m_db.runMigrations();
 }

--- a/vicinae/src/services/files-service/file-indexer/file-indexer.cpp
+++ b/vicinae/src/services/files-service/file-indexer/file-indexer.cpp
@@ -112,11 +112,9 @@ QFuture<std::vector<IndexerFileResult>> FileIndexer::queryAsync(std::string_view
   return future;
 }
 
-FileIndexer::FileIndexer():
-  m_dispatcher({
-      {ScanType::Full, std::make_shared<IndexerScanner>()},
-      {ScanType::Incremental, std::make_shared<IncrementalScanner>()}
-      }) {
+FileIndexer::FileIndexer()
+    : m_dispatcher({{ScanType::Full, std::make_shared<IndexerScanner>()},
+                    {ScanType::Incremental, std::make_shared<IncrementalScanner>()}}) {
 
   m_db.runMigrations();
 }

--- a/vicinae/src/services/files-service/file-indexer/file-indexer.cpp
+++ b/vicinae/src/services/files-service/file-indexer/file-indexer.cpp
@@ -62,7 +62,7 @@ void FileIndexer::start() {
 
   if (startedScans.empty()) {
     for (const auto &entrypoint : m_entrypoints) {
-      m_scanner->enqueue(entrypoint.root, FileIndexerDatabase::ScanType::Incremental, 5);
+      m_scanner->enqueue(entrypoint.root, ScanType::Incremental, 5);
     }
   }
 }

--- a/vicinae/src/services/files-service/file-indexer/file-indexer.cpp
+++ b/vicinae/src/services/files-service/file-indexer/file-indexer.cpp
@@ -30,40 +30,6 @@ static const std::vector<fs::path> EXCLUDED_PATHS = {"/sys", "/run",     "/proc"
 
                                                      "/mnt", "/var/tmp", "/efi",  "/dev"};
 
-void WriterWorker::stop() {
-  m_alive = false;
-  m_batchCv.notify_one();
-}
-
-void WriterWorker::run() {
-  db = std::make_unique<FileIndexerDatabase>();
-
-  while (m_alive) {
-    std::deque<std::vector<std::filesystem::path>> batch;
-
-    {
-      std::unique_lock<std::mutex> lock(batchMutex);
-
-      m_batchCv.wait(lock, [&]() { return !batchQueue.empty(); });
-      batch = std::move(batchQueue);
-      batchQueue.clear();
-    }
-
-    for (const auto &paths : batch) {
-      batchWrite(paths);
-    }
-  }
-}
-
-void WriterWorker::batchWrite(const std::vector<fs::path> &paths) {
-  // Writing is happening in the writerThread
-  db->indexFiles(paths);
-}
-
-WriterWorker::WriterWorker(std::mutex &batchMutex, std::deque<std::vector<std::filesystem::path>> &batchQueue,
-                           std::condition_variable &batchCv)
-    : batchMutex(batchMutex), batchQueue(batchQueue), m_batchCv(batchCv) {}
-
 void FileIndexer::startFullscan() {
   for (const auto &entrypoint : m_entrypoints) {
     m_scanner->enqueueFull(entrypoint.root);

--- a/vicinae/src/services/files-service/file-indexer/file-indexer.hpp
+++ b/vicinae/src/services/files-service/file-indexer/file-indexer.hpp
@@ -4,11 +4,9 @@
 #include <qsqlquery.h>
 #include <qthread.h>
 #include "services/files-service/abstract-file-indexer.hpp"
-#include "services/files-service/file-indexer/indexer-scanner.hpp"
 #include "services/files-service/file-indexer/home-directory-watcher.hpp"
 #include "services/files-service/file-indexer/file-indexer-db.hpp"
 #include "services/files-service/file-indexer/scan-dispatcher.hpp"
-#include "services/files-service/file-indexer/scan.hpp"
 #include <malloc.h>
 #include <qdatetime.h>
 #include <qsqldatabase.h>
@@ -27,10 +25,10 @@ class FileIndexer : public AbstractFileIndexer {
 public:
   std::vector<Entrypoint> m_entrypoints;
   FileIndexerDatabase m_db;
-  std::shared_ptr<IndexerScanner> m_scanner = std::make_shared<IndexerScanner>();
-  std::unique_ptr<HomeDirectoryWatcher> m_homeWatcher;
 
   ScanDispatcher m_dispatcher;
+
+  std::unique_ptr<HomeDirectoryWatcher> m_homeWatcher;
 
   // move that somewhere else later
   QString preparePrefixSearchQuery(std::string_view query) const;

--- a/vicinae/src/services/files-service/file-indexer/file-indexer.hpp
+++ b/vicinae/src/services/files-service/file-indexer/file-indexer.hpp
@@ -1,14 +1,8 @@
 #pragma once
-#include <atomic>
-#include <condition_variable>
-#include <cstdlib>
-#include <filesystem>
-#include <mutex>
 #include <qfilesystemwatcher.h>
 #include <qobject.h>
 #include <qsqlquery.h>
 #include <qthread.h>
-#include "common.hpp"
 #include "services/files-service/abstract-file-indexer.hpp"
 #include "services/files-service/file-indexer/indexer-scanner.hpp"
 #include "services/files-service/file-indexer/home-directory-watcher.hpp"
@@ -17,23 +11,6 @@
 #include <qdatetime.h>
 #include <qsqldatabase.h>
 #include <qtmetamacros.h>
-
-class WriterWorker : public NonCopyable {
-  std::unique_ptr<FileIndexerDatabase> db;
-  std::mutex &batchMutex;
-  std::deque<std::vector<std::filesystem::path>> &batchQueue;
-  std::condition_variable &m_batchCv;
-  std::atomic<bool> m_alive = true;
-
-  void batchWrite(const std::vector<std::filesystem::path> &paths);
-
-public:
-  void run();
-  void stop();
-
-  WriterWorker(std::mutex &batchMutex, std::deque<std::vector<std::filesystem::path>> &batchQueue,
-               std::condition_variable &batchCv);
-};
 
 /**
  * Generic file indexer that should be usable in most linux environments.

--- a/vicinae/src/services/files-service/file-indexer/file-indexer.hpp
+++ b/vicinae/src/services/files-service/file-indexer/file-indexer.hpp
@@ -7,6 +7,7 @@
 #include "services/files-service/file-indexer/indexer-scanner.hpp"
 #include "services/files-service/file-indexer/home-directory-watcher.hpp"
 #include "services/files-service/file-indexer/file-indexer-db.hpp"
+#include "services/files-service/file-indexer/scan.hpp"
 #include <malloc.h>
 #include <qdatetime.h>
 #include <qsqldatabase.h>
@@ -22,6 +23,7 @@
 class FileIndexer : public AbstractFileIndexer {
   Q_OBJECT
 
+public:
   std::vector<Entrypoint> m_entrypoints;
   FileIndexerDatabase m_db;
   std::shared_ptr<IndexerScanner> m_scanner = std::make_shared<IndexerScanner>();

--- a/vicinae/src/services/files-service/file-indexer/file-indexer.hpp
+++ b/vicinae/src/services/files-service/file-indexer/file-indexer.hpp
@@ -7,6 +7,7 @@
 #include "services/files-service/file-indexer/indexer-scanner.hpp"
 #include "services/files-service/file-indexer/home-directory-watcher.hpp"
 #include "services/files-service/file-indexer/file-indexer-db.hpp"
+#include "services/files-service/file-indexer/scan-dispatcher.hpp"
 #include "services/files-service/file-indexer/scan.hpp"
 #include <malloc.h>
 #include <qdatetime.h>
@@ -27,8 +28,9 @@ public:
   std::vector<Entrypoint> m_entrypoints;
   FileIndexerDatabase m_db;
   std::shared_ptr<IndexerScanner> m_scanner = std::make_shared<IndexerScanner>();
-  std::thread m_scannerThread;
   std::unique_ptr<HomeDirectoryWatcher> m_homeWatcher;
+
+  ScanDispatcher m_dispatcher;
 
   // move that somewhere else later
   QString preparePrefixSearchQuery(std::string_view query) const;
@@ -42,5 +44,4 @@ public:
   void start() override;
 
   FileIndexer();
-  ~FileIndexer();
 };

--- a/vicinae/src/services/files-service/file-indexer/home-directory-watcher.cpp
+++ b/vicinae/src/services/files-service/file-indexer/home-directory-watcher.cpp
@@ -11,10 +11,7 @@ namespace fs = std::filesystem;
 void HomeDirectoryWatcher::directoryChanged(const QString &pathStr) {
   fs::path path(pathStr.toStdString());
 
-  m_dispatcher.enqueue({
-      .type = ScanType::Incremental,
-      .path = path,
-      .maxDepth = 1});
+  m_dispatcher.enqueue({.type = ScanType::Incremental, .path = path, .maxDepth = 1});
 
   if (path == homeDir()) { rebuildWatch(); }
 }
@@ -43,10 +40,8 @@ void HomeDirectoryWatcher::dispatchHourlyUpdate() {
   if (!m_allowsBackgroundUpdates) return;
 
   for (const auto &dir : m_watcher->directories()) {
-    m_dispatcher.enqueue({
-        .type = ScanType::Incremental,
-        .path = dir.toStdString(),
-        .maxDepth = BACKGROUND_UPDATE_DEPTH});
+    m_dispatcher.enqueue(
+        {.type = ScanType::Incremental, .path = dir.toStdString(), .maxDepth = BACKGROUND_UPDATE_DEPTH});
   }
 }
 
@@ -64,10 +59,7 @@ void HomeDirectoryWatcher::dispatchImportantUpdate() {
   for (const auto &dir : getImportantDirectories()) {
     if (m_watcher->directories().contains(dir.c_str())) {
       // 5 max depth
-      m_dispatcher.enqueue({
-          .type = ScanType::Incremental,
-          .path = dir,
-          .maxDepth = BACKGROUND_UPDATE_DEPTH});
+      m_dispatcher.enqueue({.type = ScanType::Incremental, .path = dir, .maxDepth = BACKGROUND_UPDATE_DEPTH});
     }
   }
 }

--- a/vicinae/src/services/files-service/file-indexer/home-directory-watcher.cpp
+++ b/vicinae/src/services/files-service/file-indexer/home-directory-watcher.cpp
@@ -9,7 +9,7 @@ namespace fs = std::filesystem;
 void HomeDirectoryWatcher::directoryChanged(const QString &pathStr) {
   fs::path path(pathStr.toStdString());
 
-  m_scanner.enqueue(path, FileIndexerDatabase::ScanType::Incremental, 1);
+  m_scanner.enqueue(path, ScanType::Incremental, 1);
 
   if (path == homeDir()) { rebuildWatch(); }
 }
@@ -38,7 +38,7 @@ void HomeDirectoryWatcher::dispatchHourlyUpdate() {
   if (!m_allowsBackgroundUpdates) return;
 
   for (const auto &dir : m_watcher->directories()) {
-    m_scanner.enqueue(dir.toStdString(), FileIndexerDatabase::ScanType::Incremental, BACKGROUND_UPDATE_DEPTH);
+    m_scanner.enqueue(dir.toStdString(), ScanType::Incremental, BACKGROUND_UPDATE_DEPTH);
   }
 }
 
@@ -56,7 +56,7 @@ void HomeDirectoryWatcher::dispatchImportantUpdate() {
   for (const auto &dir : getImportantDirectories()) {
     if (m_watcher->directories().contains(dir.c_str())) {
       // 5 max depth
-      m_scanner.enqueue(dir, FileIndexerDatabase::ScanType::Incremental, BACKGROUND_UPDATE_DEPTH);
+      m_scanner.enqueue(dir, ScanType::Incremental, BACKGROUND_UPDATE_DEPTH);
     }
   }
 }

--- a/vicinae/src/services/files-service/file-indexer/home-directory-watcher.hpp
+++ b/vicinae/src/services/files-service/file-indexer/home-directory-watcher.hpp
@@ -1,6 +1,7 @@
 #pragma once
-#include "services/files-service/file-indexer/indexer-scanner.hpp"
+#include "services/files-service/file-indexer/scan-dispatcher.hpp"
 #include <QTimer>
+#include <QFileSystemWatcher>
 #include <qobject.h>
 #include <qtimer.h>
 #include <qtmetamacros.h>
@@ -13,7 +14,7 @@
 class HomeDirectoryWatcher : public QObject {
   QTimer *m_hourlyUpdateTimer = new QTimer(this);
   QTimer *m_importantUpdateTimer = new QTimer(this);
-  IndexerScanner &m_scanner;
+  ScanDispatcher& m_dispatcher;
   QFileSystemWatcher *m_watcher = new QFileSystemWatcher(this);
   bool m_allowsBackgroundUpdates = true;
   static constexpr size_t BACKGROUND_UPDATE_DEPTH = 5;
@@ -29,5 +30,5 @@ class HomeDirectoryWatcher : public QObject {
   bool allowsBackgroundUpdates() const;
 
 public:
-  HomeDirectoryWatcher(IndexerScanner &scanner);
+  HomeDirectoryWatcher(ScanDispatcher& dispatcher);
 };

--- a/vicinae/src/services/files-service/file-indexer/home-directory-watcher.hpp
+++ b/vicinae/src/services/files-service/file-indexer/home-directory-watcher.hpp
@@ -14,7 +14,7 @@
 class HomeDirectoryWatcher : public QObject {
   QTimer *m_hourlyUpdateTimer = new QTimer(this);
   QTimer *m_importantUpdateTimer = new QTimer(this);
-  ScanDispatcher& m_dispatcher;
+  ScanDispatcher &m_dispatcher;
   QFileSystemWatcher *m_watcher = new QFileSystemWatcher(this);
   bool m_allowsBackgroundUpdates = true;
   static constexpr size_t BACKGROUND_UPDATE_DEPTH = 5;
@@ -30,5 +30,5 @@ class HomeDirectoryWatcher : public QObject {
   bool allowsBackgroundUpdates() const;
 
 public:
-  HomeDirectoryWatcher(ScanDispatcher& dispatcher);
+  HomeDirectoryWatcher(ScanDispatcher &dispatcher);
 };

--- a/vicinae/src/services/files-service/file-indexer/incremental-scanner.cpp
+++ b/vicinae/src/services/files-service/file-indexer/incremental-scanner.cpp
@@ -60,7 +60,7 @@ std::vector<fs::path> IncrementalScanner::getScannableDirectories(const fs::path
   return scannableDirs;
 }
 
-void IncrementalScanner::scan(const Scan& scan) {
+void IncrementalScanner::scan(const Scan &scan) {
   for (const auto &dir : getScannableDirectories(scan.path, scan.maxDepth)) {
     processDirectory(dir);
   }
@@ -75,7 +75,7 @@ void IncrementalScanner::run() {
     auto expected = awaitScan();
     if (!expected.has_value()) break;
 
-    const Scan& sc = *expected;
+    const Scan &sc = *expected;
 
     auto result = m_db->createScan(sc.path, sc.type);
 
@@ -93,6 +93,4 @@ void IncrementalScanner::run() {
   }
 }
 
-void IncrementalScanner::stop() {
-  AbstractScanner::stop();
-}
+void IncrementalScanner::stop() { AbstractScanner::stop(); }

--- a/vicinae/src/services/files-service/file-indexer/incremental-scanner.hpp
+++ b/vicinae/src/services/files-service/file-indexer/incremental-scanner.hpp
@@ -2,11 +2,12 @@
 #include "common.hpp"
 #include "services/files-service/file-indexer/file-indexer-db.hpp"
 #include "services/files-service/file-indexer/abstract-scanner.hpp"
+#include <memory>
 #include <qsqldatabase.h>
 #include <filesystem>
 
 class IncrementalScanner : public AbstractScanner, public NonCopyable {
-  FileIndexerDatabase m_db;
+  std::unique_ptr<FileIndexerDatabase> m_db;
 
   std::vector<std::filesystem::path> getScannableDirectories(const std::filesystem::path &path,
                                                              std::optional<size_t> maxDepth) const;

--- a/vicinae/src/services/files-service/file-indexer/incremental-scanner.hpp
+++ b/vicinae/src/services/files-service/file-indexer/incremental-scanner.hpp
@@ -1,17 +1,19 @@
 #pragma once
 #include "common.hpp"
 #include "services/files-service/file-indexer/file-indexer-db.hpp"
+#include "services/files-service/file-indexer/abstract-scanner.hpp"
 #include <qsqldatabase.h>
 #include <filesystem>
 
-class IncrementalScanner : public NonCopyable {
-  FileIndexerDatabase &m_db;
+class IncrementalScanner : public AbstractScanner, public NonCopyable {
+  FileIndexerDatabase m_db;
 
   std::vector<std::filesystem::path> getScannableDirectories(const std::filesystem::path &path,
                                                              std::optional<size_t> maxDepth) const;
   void processDirectory(const std::filesystem::path &path);
 
+  void scan(const Scan& scan);
 public:
-  void scan(const std::filesystem::path &path, std::optional<size_t> maxDepth);
-  IncrementalScanner(FileIndexerDatabase &db);
+  void run() override;
+  void stop() override;
 };

--- a/vicinae/src/services/files-service/file-indexer/incremental-scanner.hpp
+++ b/vicinae/src/services/files-service/file-indexer/incremental-scanner.hpp
@@ -13,7 +13,8 @@ class IncrementalScanner : public AbstractScanner, public NonCopyable {
                                                              std::optional<size_t> maxDepth) const;
   void processDirectory(const std::filesystem::path &path);
 
-  void scan(const Scan& scan);
+  void scan(const Scan &scan);
+
 public:
   void run() override;
   void stop() override;

--- a/vicinae/src/services/files-service/file-indexer/indexer-scanner.cpp
+++ b/vicinae/src/services/files-service/file-indexer/indexer-scanner.cpp
@@ -52,15 +52,10 @@ void IndexerScanner::scan(const std::filesystem::path &root) {
   enqueueBatch(batchedIndex);
 }
 
-void IndexerScanner::enqueueFull(const std::filesystem::path &path) {
-  enqueue(path, ScanType::Full);
-}
-
-void IndexerScanner::enqueue(const std::filesystem::path &path, ScanType type,
-                             std::optional<size_t> maxDepth) {
+void IndexerScanner::enqueue(const Scan &scan) {
   {
     std::lock_guard lock(m_scanMutex);
-    m_scanPaths.push(Scan{.type = type, .path = path, .maxDepth = maxDepth});
+    m_scanPaths.push(scan);
   }
   m_scanCv.notify_one();
 }

--- a/vicinae/src/services/files-service/file-indexer/indexer-scanner.cpp
+++ b/vicinae/src/services/files-service/file-indexer/indexer-scanner.cpp
@@ -61,7 +61,7 @@ void IndexerScanner::run() {
     const auto expected = awaitScan();
     if (!expected.has_value()) break;
 
-    const Scan& sc = *expected;
+    const Scan &sc = *expected;
 
     auto result = m_db->createScan(sc.path, sc.type);
 

--- a/vicinae/src/services/files-service/file-indexer/indexer-scanner.hpp
+++ b/vicinae/src/services/files-service/file-indexer/indexer-scanner.hpp
@@ -1,25 +1,19 @@
 #pragma once
 #include "common.hpp"
-#include "services/files-service/file-indexer/scan.hpp"
 #include "services/files-service/file-indexer/file-indexer-db.hpp"
 #include "services/files-service/file-indexer/writer-worker.hpp"
-#include <queue>
+#include "services/files-service/file-indexer/abstract-scanner.hpp"
 
-class IndexerScanner : public NonCopyable {
+class IndexerScanner : public AbstractScanner, public NonCopyable {
 private:
   static constexpr size_t INDEX_BATCH_SIZE = 10'000;
   static constexpr size_t MAX_PENDING_BATCH_COUNT = 10;
   static constexpr size_t BACKPRESSURE_WAIT_MS = 100;
   std::unique_ptr<FileIndexerDatabase> m_db;
 
-  std::atomic<bool> m_alive = true;
   std::deque<std::vector<std::filesystem::path>> m_writeBatches;
   std::mutex m_batchMutex;
   std::condition_variable m_batchCv;
-
-  std::queue<Scan> m_scanPaths;
-  std::mutex m_scanMutex;
-  std::condition_variable m_scanCv;
 
   std::unique_ptr<WriterWorker> m_writerWorker;
   std::thread m_writerThread;
@@ -28,7 +22,6 @@ private:
   void enqueueBatch(const std::vector<std::filesystem::path> &paths);
 
 public:
-  void enqueue(const Scan &scan);
-  void run();
-  void stop();
+  void run() override;
+  void stop() override;
 };

--- a/vicinae/src/services/files-service/file-indexer/indexer-scanner.hpp
+++ b/vicinae/src/services/files-service/file-indexer/indexer-scanner.hpp
@@ -28,10 +28,7 @@ private:
   void enqueueBatch(const std::vector<std::filesystem::path> &paths);
 
 public:
-  void enqueueFull(const std::filesystem::path &path);
-  void enqueue(const std::filesystem::path &path,
-               ScanType type = ScanType::Incremental,
-               std::optional<size_t> maxDepth = std::nullopt);
+  void enqueue(const Scan &scan);
   void run();
   void stop();
 };

--- a/vicinae/src/services/files-service/file-indexer/indexer-scanner.hpp
+++ b/vicinae/src/services/files-service/file-indexer/indexer-scanner.hpp
@@ -1,17 +1,11 @@
 #pragma once
 #include "common.hpp"
+#include "services/files-service/file-indexer/scan.hpp"
 #include "services/files-service/file-indexer/file-indexer-db.hpp"
 #include "services/files-service/file-indexer/writer-worker.hpp"
 #include <queue>
 
 class IndexerScanner : public NonCopyable {
-public:
-  struct EnqueuedScan {
-    FileIndexerDatabase::ScanType type;
-    std::filesystem::path path;
-    std::optional<size_t> maxDepth;
-  };
-
 private:
   static constexpr size_t INDEX_BATCH_SIZE = 10'000;
   static constexpr size_t MAX_PENDING_BATCH_COUNT = 10;
@@ -23,7 +17,7 @@ private:
   std::mutex m_batchMutex;
   std::condition_variable m_batchCv;
 
-  std::queue<EnqueuedScan> m_scanPaths;
+  std::queue<Scan> m_scanPaths;
   std::mutex m_scanMutex;
   std::condition_variable m_scanCv;
 
@@ -36,7 +30,7 @@ private:
 public:
   void enqueueFull(const std::filesystem::path &path);
   void enqueue(const std::filesystem::path &path,
-               FileIndexerDatabase::ScanType type = FileIndexerDatabase::ScanType::Incremental,
+               ScanType type = ScanType::Incremental,
                std::optional<size_t> maxDepth = std::nullopt);
   void run();
   void stop();

--- a/vicinae/src/services/files-service/file-indexer/indexer-scanner.hpp
+++ b/vicinae/src/services/files-service/file-indexer/indexer-scanner.hpp
@@ -1,9 +1,8 @@
 #pragma once
 #include "common.hpp"
 #include "services/files-service/file-indexer/file-indexer-db.hpp"
+#include "services/files-service/file-indexer/writer-worker.hpp"
 #include <queue>
-
-class WriterWorker;
 
 class IndexerScanner : public NonCopyable {
 public:

--- a/vicinae/src/services/files-service/file-indexer/scan-dispatcher.cpp
+++ b/vicinae/src/services/files-service/file-indexer/scan-dispatcher.cpp
@@ -3,18 +3,16 @@
 #include <map>
 #include <memory>
 
-void ScanDispatcher::enqueue(const Scan& scan) {
-  m_scannerMap[scan.type].first->enqueue(scan);
-}
+void ScanDispatcher::enqueue(const Scan &scan) { m_scannerMap[scan.type].first->enqueue(scan); }
 
 ScanDispatcher::ScanDispatcher(std::map<ScanType, std::shared_ptr<AbstractScanner>> scannerMap) {
-  for (const auto& [type, scanner]: scannerMap) {
-    m_scannerMap[type] = {scanner, std::thread([scanner]() {scanner->run();})};
+  for (const auto &[type, scanner] : scannerMap) {
+    m_scannerMap[type] = {scanner, std::thread([scanner]() { scanner->run(); })};
   }
 }
 
 ScanDispatcher::~ScanDispatcher() {
-  for (auto& [type, pair]: m_scannerMap) {
+  for (auto &[type, pair] : m_scannerMap) {
     pair.first->stop();
     pair.second.join();
   }

--- a/vicinae/src/services/files-service/file-indexer/scan-dispatcher.cpp
+++ b/vicinae/src/services/files-service/file-indexer/scan-dispatcher.cpp
@@ -1,0 +1,20 @@
+#include "scan-dispatcher.hpp"
+#include "file-indexer.hpp"
+#include <memory>
+
+void ScanDispatcher::enqueue(const Scan& scan) {
+  switch(scan.type) {
+    case ScanType::Full:
+    case ScanType::Incremental:
+      m_indexerScanner->enqueue(scan);
+  }
+}
+
+ScanDispatcher::ScanDispatcher(std::shared_ptr<IndexerScanner> indexerScanner):
+  m_indexerScanner(indexerScanner),
+  m_indexerThread([this](){ m_indexerScanner->run(); }) {}
+
+ScanDispatcher::~ScanDispatcher() {
+  m_indexerScanner->stop();
+  m_indexerThread.join();
+}

--- a/vicinae/src/services/files-service/file-indexer/scan-dispatcher.cpp
+++ b/vicinae/src/services/files-service/file-indexer/scan-dispatcher.cpp
@@ -1,20 +1,21 @@
 #include "scan-dispatcher.hpp"
 #include "file-indexer.hpp"
+#include <map>
 #include <memory>
 
 void ScanDispatcher::enqueue(const Scan& scan) {
-  switch(scan.type) {
-    case ScanType::Full:
-    case ScanType::Incremental:
-      m_indexerScanner->enqueue(scan);
+  m_scannerMap[scan.type].first->enqueue(scan);
+}
+
+ScanDispatcher::ScanDispatcher(std::map<ScanType, std::shared_ptr<AbstractScanner>> scannerMap) {
+  for (const auto& [type, scanner]: scannerMap) {
+    m_scannerMap[type] = {scanner, std::thread([scanner]() {scanner->run();})};
   }
 }
 
-ScanDispatcher::ScanDispatcher(std::shared_ptr<IndexerScanner> indexerScanner):
-  m_indexerScanner(indexerScanner),
-  m_indexerThread([this](){ m_indexerScanner->run(); }) {}
-
 ScanDispatcher::~ScanDispatcher() {
-  m_indexerScanner->stop();
-  m_indexerThread.join();
+  for (auto& [type, pair]: m_scannerMap) {
+    pair.first->stop();
+    pair.second.join();
+  }
 }

--- a/vicinae/src/services/files-service/file-indexer/scan-dispatcher.hpp
+++ b/vicinae/src/services/files-service/file-indexer/scan-dispatcher.hpp
@@ -9,7 +9,7 @@ class ScanDispatcher {
   std::map<ScanType, std::pair<std::shared_ptr<AbstractScanner>, std::thread>> m_scannerMap;
 
 public:
-  void enqueue(const Scan& scan);
+  void enqueue(const Scan &scan);
 
   ScanDispatcher(std::map<ScanType, std::shared_ptr<AbstractScanner>> scannerMap);
   ~ScanDispatcher();

--- a/vicinae/src/services/files-service/file-indexer/scan-dispatcher.hpp
+++ b/vicinae/src/services/files-service/file-indexer/scan-dispatcher.hpp
@@ -1,15 +1,16 @@
 #pragma once
 #include "services/files-service/file-indexer/scan.hpp"
-#include "services/files-service/file-indexer/indexer-scanner.hpp"
+#include "services/files-service/file-indexer/abstract-scanner.hpp"
+#include <map>
 #include <memory>
+#include <utility>
 
 class ScanDispatcher {
-  std::shared_ptr<IndexerScanner> m_indexerScanner;
-  std::thread m_indexerThread;
+  std::map<ScanType, std::pair<std::shared_ptr<AbstractScanner>, std::thread>> m_scannerMap;
 
 public:
   void enqueue(const Scan& scan);
 
-  ScanDispatcher(std::shared_ptr<IndexerScanner> indexerScanner);
+  ScanDispatcher(std::map<ScanType, std::shared_ptr<AbstractScanner>> scannerMap);
   ~ScanDispatcher();
 };

--- a/vicinae/src/services/files-service/file-indexer/scan-dispatcher.hpp
+++ b/vicinae/src/services/files-service/file-indexer/scan-dispatcher.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#include "services/files-service/file-indexer/scan.hpp"
+#include "services/files-service/file-indexer/indexer-scanner.hpp"
+#include <memory>
+
+class ScanDispatcher {
+  std::shared_ptr<IndexerScanner> m_indexerScanner;
+  std::thread m_indexerThread;
+
+public:
+  void enqueue(const Scan& scan);
+
+  ScanDispatcher(std::shared_ptr<IndexerScanner> indexerScanner);
+  ~ScanDispatcher();
+};

--- a/vicinae/src/services/files-service/file-indexer/scan.hpp
+++ b/vicinae/src/services/files-service/file-indexer/scan.hpp
@@ -1,0 +1,21 @@
+#pragma once
+#include <filesystem>
+#include <optional>
+
+enum ScanStatus {
+  Pending,
+  Started,
+  Failed,
+  Finished
+};
+
+enum ScanType {
+  Full,
+  Incremental
+};
+
+struct Scan {
+  ScanType type;
+  std::filesystem::path path;
+  std::optional<size_t> maxDepth;
+};

--- a/vicinae/src/services/files-service/file-indexer/scan.hpp
+++ b/vicinae/src/services/files-service/file-indexer/scan.hpp
@@ -3,10 +3,7 @@
 #include <optional>
 
 // Add new types here for new scanner types (e.g. watchers)
-enum ScanType {
-  Full,
-  Incremental
-};
+enum ScanType { Full, Incremental };
 
 // TODO: use unions for each ScanType
 struct Scan {

--- a/vicinae/src/services/files-service/file-indexer/scan.hpp
+++ b/vicinae/src/services/files-service/file-indexer/scan.hpp
@@ -2,18 +2,13 @@
 #include <filesystem>
 #include <optional>
 
-enum ScanStatus {
-  Pending,
-  Started,
-  Failed,
-  Finished
-};
-
+// Add new types here for new scanner types (e.g. watchers)
 enum ScanType {
   Full,
   Incremental
 };
 
+// TODO: use unions for each ScanType
 struct Scan {
   ScanType type;
   std::filesystem::path path;

--- a/vicinae/src/services/files-service/file-indexer/writer-worker.cpp
+++ b/vicinae/src/services/files-service/file-indexer/writer-worker.cpp
@@ -1,0 +1,37 @@
+#include "writer-worker.hpp"
+
+namespace fs = std::filesystem;
+
+void WriterWorker::stop() {
+  m_alive = false;
+  m_batchCv.notify_one();
+}
+
+void WriterWorker::run() {
+  db = std::make_unique<FileIndexerDatabase>();
+
+  while (m_alive) {
+    std::deque<std::vector<std::filesystem::path>> batch;
+
+    {
+      std::unique_lock<std::mutex> lock(batchMutex);
+
+      m_batchCv.wait(lock, [&]() { return !batchQueue.empty(); });
+      batch = std::move(batchQueue);
+      batchQueue.clear();
+    }
+
+    for (const auto &paths : batch) {
+      batchWrite(paths);
+    }
+  }
+}
+
+void WriterWorker::batchWrite(const std::vector<fs::path> &paths) {
+  // Writing is happening in the writerThread
+  db->indexFiles(paths);
+}
+
+WriterWorker::WriterWorker(std::mutex &batchMutex, std::deque<std::vector<std::filesystem::path>> &batchQueue,
+                           std::condition_variable &batchCv)
+    : batchMutex(batchMutex), batchQueue(batchQueue), m_batchCv(batchCv) {}

--- a/vicinae/src/services/files-service/file-indexer/writer-worker.hpp
+++ b/vicinae/src/services/files-service/file-indexer/writer-worker.hpp
@@ -1,0 +1,21 @@
+#include <atomic>
+#include <deque>
+#include "common.hpp"
+#include "services/files-service/file-indexer/file-indexer-db.hpp"
+
+class WriterWorker : public NonCopyable {
+  std::unique_ptr<FileIndexerDatabase> db;
+  std::mutex &batchMutex;
+  std::deque<std::vector<std::filesystem::path>> &batchQueue;
+  std::condition_variable &m_batchCv;
+  std::atomic<bool> m_alive = true;
+
+  void batchWrite(const std::vector<std::filesystem::path> &paths);
+
+public:
+  void run();
+  void stop();
+
+  WriterWorker(std::mutex &batchMutex, std::deque<std::vector<std::filesystem::path>> &batchQueue,
+               std::condition_variable &batchCv);
+};


### PR DESCRIPTION
Create the `ScanDispatcher` class to call the appropriate scanner - currently only `IncrementalScanner` and `IndexerScanner`, but easily extensible. It also manages the threads for these scanners.
This required creating `AbstractScanner` that all scanners derive from.
(I'm not completely satisfied about how both waiting for scans and scanning is in the same class, though)

Also moved `WriterWorker`, `Scan`, and `ScanType` to separate headers.