### PR TITLE
fix: Use lexically_relative instead of fs::relative

### DIFF
--- a/vicinae/src/services/app-service/xdg/xdg-app-database.cpp
+++ b/vicinae/src/services/app-service/xdg/xdg-app-database.cpp
@@ -85,12 +85,11 @@ bool XdgAppDatabase::scan(const std::vector<std::filesystem::path> &paths) {
       if (entry.path().extension() != ".desktop") continue;
 
       try {
-        XdgDesktopEntry desktopEntry(dir, fs::relative(entry.path(), dir));
-        QString filename = entry.path().filename().c_str();
+        XdgDesktopEntry desktopEntry(dir, entry.path().lexically_relative(dir));
 
-        if (std::ranges::contains(processedIds, filename)) continue;
+        if (processedIds.contains(desktopEntry.id)) continue;
+        processedIds.insert(desktopEntry.id);
 
-        processedIds.insert(filename);
         addDesktopFile(entry.path(), desktopEntry);
       } catch (std::exception &except) {
         qWarning() << "Failed to parse app at" << entry.path() << except.what();


### PR DESCRIPTION
Fixes desktop ids being like `..-..-..-path-to-non-hardlink-file` when the `.desktop` file is a hard link.

Also undoes #187.