### PR TITLE
feat: add  internal dev mode for extension manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,28 @@ set(PROJECT_NAME vicinae)
 project(${PROJECT_NAME} VERSION 1.0.0 LANGUAGES C CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+
+# Viciane build configuration options
+
+option(IGNORE_CCACHE "Always ignore ccache even if it is installed" OFF)
+option(LTO "Enable Link Time Optimization (LTO). This will result in better performance, but greatly increased compile time. (Gentoo chads can't live without this)" OFF)
+option(NOSTRIP "Never strip debug symbols from the binary, even in release mode. Note that symbols are never stripped for debug releases." OFF)
+
+option(WAYLAND_LAYER_SHELL "Enable support for the layer shell Wayland protocol" OFF)
+option(TYPESCRIPT_EXTENSIONS "Enable support for extensions built with React/Typescript (no browser involved)" ON)
+
+option(USE_SYSTEM_PROTOBUF "Use system protobuf instead of building it from source" ON)
+option(USE_SYSTEM_ABSEIL "Use system abseil (libabsl) instead of building it from source" ON)
+option(USE_SYSTEM_CMARK_GFM "Use system cmark-gfm (github's fork of cmark) instead of building it from source" ON)
+option(USE_SYSTEM_MINIZIP "Use system minizip instead of building it from source" ON)
+option(LIBQALCULATE_BACKEND "Compile in support for the Qalculate! calculator backend" ON)
+
+if (UNIX AND NOT APPLE)
+	set(WAYLAND_LAYER_SHELL ON)
+endif()
+
+# End of Vicinae build configuration options
+
 include(Git)
 include(Utils)
 
@@ -21,16 +43,6 @@ get_cxx_compiler_name(CXX_COMPILER_NAME)
 
 add_compile_definitions(VICINAE_GIT_TAG="${VICINAE_GIT_TAG}")
 add_compile_definitions(VICINAE_GIT_COMMIT_HASH="${VICINAE_GIT_COMMIT_HASH}")
-
-option(IGNORE_CCACHE "Always ignore ccache even if it is installed" OFF)
-option(LTO "Enable Link Time Optimization (LTO). This will result in better performance, but greatly increased compile time. (Gentoo chads can't live without this)" OFF)
-option(NOSTRIP "Never strip debug symbols from the binary, even in release mode. Note that symbols are never stripped for debug releases." OFF)
-
-option(USE_SYSTEM_PROTOBUF "Use system protobuf instead of building it from source" ON)
-option(USE_SYSTEM_ABSEIL "Use system abseil (libabsl) instead of building it from source" ON)
-option(USE_SYSTEM_CMARK_GFM "Use system cmark-gfm (github's fork of cmark) instead of building it from source" ON)
-option(USE_SYSTEM_MINIZIP "Use system minizip instead of building it from source" ON)
-option(LIBQALCULATE_BACKEND "Compile in support for the Qalculate! calculator backend" ON)
 
 set(CMARK_LIBRARY "cmark-gfm")
 
@@ -69,7 +81,7 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
 
 set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Debug Release ReleaseHost)
 
-if (NOT NOSTRIP)
+if (NOT NOSTRIP AND NOT ${CMAKE_BUILD_TYPE} MATCHES "Debug")
 	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -s")
 	message(STATUS "Built binaries will be stripped")
 endif()
@@ -96,7 +108,7 @@ if (LTO)
 endif()
 
 if (CCACHE AND NOT IGNORE_CCACHE) 
-	message(STATUS "Found ccache installed, changing CMAKE_CXX_COMPILER_LAUNCHER")
+	message(STATUS "ccache is installed, changing CMAKE_CXX_COMPILER_LAUNCHER")
 	set(CMAKE_CXX_COMPILER_LAUNCHER "ccache")
 endif()
 

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ portable:
 dev: debug
 .PHONY: dev
 
+extdev: debug
+	./scripts/vicinae-ext-dev.sh
+.PHONY: extdev
+
 runner:
 	cd ./scripts/runners/ && ./start.sh
 .PHONY:

--- a/cmake/Abseil.cmake
+++ b/cmake/Abseil.cmake
@@ -5,6 +5,7 @@ function(checkout_abseil)
 
 	FetchContent_Declare(
 	  abseil
+	  EXCLUDE_FROM_ALL
 	  GIT_REPOSITORY https://github.com/abseil/abseil-cpp
 	  GIT_TAG        20250814.0
 	)

--- a/cmake/CMark.cmake
+++ b/cmake/CMark.cmake
@@ -1,10 +1,12 @@
 include(FetchContent)
 
 function(checkout_cmark)
+	set(CMAKE_SKIP_INSTALL_RULES ON)
 	set(FETCHCONTENT_QUIET OFF)
 
 	FetchContent_Declare(
 	  cmark-gfm
+	  EXCLUDE_FROM_ALL
 	  GIT_REPOSITORY https://github.com/github/cmark-gfm
 	  GIT_TAG        0.29.0.gfm.13
 	)
@@ -13,6 +15,8 @@ function(checkout_cmark)
 	set(CMARK_TESTS OFF)
 	set(CMARK_STATIC ON)
 	set(CMARK_SHARED OFF)
+
 	
 	FetchContent_MakeAvailable(cmark-gfm)
+	set(CMAKE_SKIP_INSTALL_RULES OFF)
 endfunction()

--- a/cmake/ExtensionManager.cmake
+++ b/cmake/ExtensionManager.cmake
@@ -38,11 +38,11 @@ add_custom_command(
             ${EXT_MGR_SRC_DIR}/dist/runtime.js
             ${EXT_MGR_OUT}
     WORKING_DIRECTORY ${EXT_MGR_SRC_DIR}
-	DEPENDS ${FILTERED_TS_FILES} ${API_OUT}
+	DEPENDS ${FILTERED_TS_FILES} ${API_STAMP}
     COMMENT "Building extension manager JavaScript bundle"
 )
 
 add_custom_target(extension-manager ALL
-    DEPENDS api ${EXT_MGR_OUT}
+	DEPENDS ${EXT_MGR_OUT}
 )
 

--- a/cmake/Minizip.cmake
+++ b/cmake/Minizip.cmake
@@ -5,6 +5,7 @@ function(checkout_minizip)
 
 	FetchContent_Declare(
 	  minizip
+	  EXCLUDE_FROM_ALL
 	  GIT_REPOSITORY https://github.com/zlib-ng/minizip-ng
 	  GIT_TAG        4.0.10
 	)

--- a/cmake/Protobuf.cmake
+++ b/cmake/Protobuf.cmake
@@ -4,6 +4,7 @@ function(checkout_protobuf)
 	set(FETCHCONTENT_QUIET OFF)
 	FetchContent_Declare(
 	  protobuf
+	  EXCLUDE_FROM_ALL
 	  GIT_REPOSITORY https://github.com/protocolbuffers/protobuf.git
 	  GIT_TAG        v32.0  #
 	)

--- a/extension-manager/package-lock.json
+++ b/extension-manager/package-lock.json
@@ -18,6 +18,7 @@
         "@types/react": "^18.1.0",
         "@types/react-reconciler": "0.28.0",
         "esbuild": "^0.25.9",
+        "nodemon": "^3.1.10",
         "npm-run-all": "^4.1.5",
         "ts-proto": "^2.7.5",
         "typescript": "^5.8.2"
@@ -570,6 +571,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -642,6 +657,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -651,6 +679,19 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/call-bind": {
@@ -729,6 +770,31 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/color-convert": {
@@ -831,6 +897,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/define-data-property": {
@@ -1105,6 +1189,19 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -1119,6 +1216,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -1217,6 +1329,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/globalthis": {
@@ -1357,6 +1482,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -1431,6 +1563,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-boolean-object": {
@@ -1514,6 +1659,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-finalizationregistry": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
@@ -1549,6 +1704,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -1573,6 +1741,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-number-object": {
@@ -1824,12 +2002,61 @@
         "node": "*"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemon": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.10.tgz",
+      "integrity": "sha512-WDjw3pJ0/0jMFmyNDp3gvY2YizjLmmOUQo6DEBY+JgdvW/yQ9mEeSw6H5ythl5Ny2ytb7f9C2nIbjSxMNzbJXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^4",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^3.1.2",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/nodemon/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -1842,6 +2069,16 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/npm-run-all": {
@@ -1976,6 +2213,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/pidtree": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
@@ -2008,6 +2258,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -2051,6 +2308,19 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -2353,6 +2623,32 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-update-notifier/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -2517,6 +2813,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/touch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
+      }
+    },
     "node_modules/ts-poet": {
       "version": "6.12.0",
       "resolved": "https://registry.npmjs.org/ts-poet/-/ts-poet-6.12.0.tgz",
@@ -2663,6 +2982,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/extension-manager/package.json
+++ b/extension-manager/package.json
@@ -7,7 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "typecheck": "tsc --noEmit",
     "build-only": "node scripts/build.mjs",
-    "build": "run-p typecheck build-only"
+    "build": "run-p typecheck build-only",
+	"dev": "nodemon -e ts,tsx --watch src --watch ../api/src --exec \"node scripts/dev.mjs\""
   },
   "keywords": [
     "vicinae",
@@ -22,9 +23,10 @@
   "devDependencies": {
     "@bufbuild/protobuf": "^2.7.0",
     "@types/node": "^22.10.1",
-    "@types/react-reconciler": "0.28.0",
     "@types/react": "^18.1.0",
+    "@types/react-reconciler": "0.28.0",
     "esbuild": "^0.25.9",
+    "nodemon": "^3.1.10",
     "npm-run-all": "^4.1.5",
     "ts-proto": "^2.7.5",
     "typescript": "^5.8.2"

--- a/extension-manager/scripts/build.mjs
+++ b/extension-manager/scripts/build.mjs
@@ -2,31 +2,35 @@ import * as esbuild from 'esbuild'
 import { mkdirSync, rmSync } from 'fs'
 import { join } from 'path';
 
-const outDir = join(import.meta.dirname, '..', 'dist');
-const outFile = join(outDir, 'runtime.js');
+export const build = async () => {
+	const outDir = join(import.meta.dirname, '..', 'dist');
+	const outFile = join(outDir, 'runtime.js');
 
-rmSync(outDir, { recursive: true, force: true });
-mkdirSync(outDir, { recursive: true });
+	rmSync(outDir, { recursive: true, force: true });
+	mkdirSync(outDir, { recursive: true });
 
-const start = performance.now();
+	const start = performance.now();
 
-console.log(`Building runtime...`);
+	console.log(`Building runtime...`);
 
-await esbuild.build({
-  entryPoints: ['src/index.ts'],
-  bundle: true,
-  outfile: outFile,
-  format: 'cjs',
-  external: [], 
-  minify: true,
-  platform: 'node',
-	alias: {
-		'@vicinae/api': '../api/src/', // we bundle the local api directly
-		'react': '../api/node_modules/react' // we want the react version specified in the api package
-	}
-})
+	await esbuild.build({
+	  entryPoints: ['src/index.ts'],
+	  bundle: true,
+	  outfile: outFile,
+	  format: 'cjs',
+	  external: [], 
+	  minify: true,
+	  platform: 'node',
+		alias: {
+			'@vicinae/api': '../api/src/', // we bundle the local api directly
+			'react': '../api/node_modules/react' // we want the react version specified in the api package
+		}
+	})
 
-const end = performance.now();
-const buildTimeMs = end - start;
+	const end = performance.now();
+	const buildTimeMs = end - start;
 
-console.log(`Runtime built at ${outFile} in ${Math.round(buildTimeMs)}ms 🚀`);
+	console.log(`Runtime built at ${outFile} in ${Math.round(buildTimeMs)}ms 🚀`);
+}
+
+build();

--- a/extension-manager/scripts/dev.mjs
+++ b/extension-manager/scripts/dev.mjs
@@ -1,0 +1,9 @@
+import { spawnSync } from 'child_process';
+
+const notifyVicinae = () => {
+	spawnSync('vicinae', ['vicinae://internal/restart-extension-runtime']);
+}
+
+import './build.mjs'; 
+
+notifyVicinae();

--- a/extension-manager/src/index.ts
+++ b/extension-manager/src/index.ts
@@ -2,12 +2,11 @@ import { randomUUID } from 'crypto';
 import { isMainThread, Worker } from "worker_threads";
 import { main as workerMain } from './worker';
 import { isatty } from "tty";
-
 import * as ipc from './proto/ipc';
 import * as common from './proto/common';
 import * as manager from './proto/manager';
 import * as extension from './proto/extension';
-import { existsSync, mkdirSync } from 'fs';
+import { existsSync } from 'fs';
 import { appendFile, mkdir } from 'fs/promises';
 import { join } from 'path';
 

--- a/extension-manager/src/worker.tsx
+++ b/extension-manager/src/worker.tsx
@@ -56,10 +56,6 @@ const loadView = async () => {
 	const module = await import(workerData.entrypoint);
 	const Component = module.default.default;
 
-	process.on('uncaughtException', (error) => {
-		console.error('uncaught exception:', error);
-	});
-
 	let lastRender = performance.now();
 
 	const renderer = createRenderer({

--- a/scripts/vicinae-ext-dev.sh
+++ b/scripts/vicinae-ext-dev.sh
@@ -1,0 +1,14 @@
+#! /bin/sh
+# Wrapper to launch Vicinae with INTERNAL extension dev mode stuff on. 
+# Not sure how much we will use this, but it is there.
+#
+# Every time a change is made to the api or the extension the manager will be stopped
+# and restarted automatically to use the new bundle.
+#
+# Note: for changes made to `.proto` files, recompilation is still required.
+
+export PATH="./build/vicinae:${PATH}"
+export EXT_RECONCILER_LOG_PASSTHROUGH=1
+export EXT_MANAGER_PATH="${PWD}/extension-manager/dist/runtime.js"
+
+./build/vicinae/vicinae server

--- a/vicinae/CMakeLists.txt
+++ b/vicinae/CMakeLists.txt
@@ -4,17 +4,10 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(LIBS)
-
 set(TARGET vicinae)
 
 find_package(Qt6 REQUIRED COMPONENTS Widgets Sql Network Svg DBus Keychain)
 find_package(OpenSSL REQUIRED)
-
-
-option(WAYLAND_LAYER_SHELL "Enable support for the Wayland layer shell
-protocol, required for proper window positioning on most wlroots-based
-compositors." ON)
-option(TYPESCRIPT_EXTENSIONS "Enable support for extensions built using the React/Typescript stack (no browser involved)" ON)
 
 if (TYPESCRIPT_EXTENSIONS)
 	include(ExtensionManager)
@@ -23,12 +16,11 @@ endif()
 
 list(APPEND LIBS Qt6::Widgets Qt6::Sql Qt6::Network Qt6::Svg Qt6::DBus qt6keychain ${CMARK_LIBRARY} protobuf::libprotobuf minizip OpenSSL::Crypto)
 
-
 set(WLR_CLIP_BIN ${CMAKE_BINARY_DIR}/wlr-clip/wlr-clip${CMAKE_EXECUTABLE_SUFFIX})
 set(ASSET_PATH ${CMAKE_CURRENT_SOURCE_DIR}/assets)
 configure_file(resources.qrc.in resources.qrc)
 
-if (UNIX AND NOT APPLE)
+if (WAYLAND_LAYER_SHELL)
 	message(STATUS "Compiling with wayland layer shell support (for wlroots-like compositors)")
 	find_package(Qt6 REQUIRED COMPONENTS WaylandClient)
 	find_package(LayerShellQt REQUIRED)

--- a/vicinae/src/extension/manager/extension-manager.hpp
+++ b/vicinae/src/extension/manager/extension-manager.hpp
@@ -167,4 +167,6 @@ signals:
   void managerResponse(const proto::ext::ManagerResponse &res);
   void extensionRequest(ExtensionRequest *req);
   void extensionEvent(const ExtensionEvent &event);
+
+  void started() const;
 };

--- a/vicinae/src/ipc-command-handler.cpp
+++ b/vicinae/src/ipc-command-handler.cpp
@@ -228,6 +228,15 @@ void IpcCommandHandler::handleUrl(const QUrl &url) {
     }
   }
 
+  if (url.host() == "internal") {
+    if (url.path() == "/restart-extension-runtime") {
+      qInfo() << "Restarting extension runtime....";
+      m_ctx.navigation->popToRoot();
+      m_ctx.services->extensionManager()->start();
+      return;
+    }
+  }
+
   qWarning() << "No handler for URL" << url;
 }
 

--- a/vicinae/src/services/shortcut/shortcut.cpp
+++ b/vicinae/src/services/shortcut/shortcut.cpp
@@ -101,7 +101,6 @@ void Shortcut::parseLink(const QString &link) {
     case PH_KEY:
       if (ch == '=') {
         arg.first = link.sliced(startPos, i - startPos);
-        qDebug() << "key" << arg.first;
         state = PH_VALUE_START;
       }
       break;
@@ -120,7 +119,6 @@ void Shortcut::parseLink(const QString &link) {
       }
       if (!ch.isLetterOrNumber()) {
         arg.second += link.sliced(startPos, i - startPos);
-        qDebug() << "value" << arg.second;
         parsed.args.insert(arg);
         --i;
         state = PH_KEY_START;


### PR DESCRIPTION
Not as big as it may sound, but we can now hot reload the extension manager as we make modifications to it or the api package directly. Edits to proto files will still require recompilation though.
This also fixes many cmake issues with the API/Extension manager builds.