### PR TITLE
fix(ui): prevent hud focus stealing using wlr layer shell

### DIFF
--- a/vicinae/src/extension/manager/extension-manager.cpp
+++ b/vicinae/src/extension/manager/extension-manager.cpp
@@ -3,6 +3,7 @@
 #include <qfuturewatcher.h>
 #include <qlogging.h>
 #include <qstringview.h>
+#include <qtenvironmentvariables.h>
 #include <string>
 #include <unordered_map>
 #include "pid-file/pid-file.hpp"
@@ -158,9 +159,7 @@ bool ExtensionManager::start() {
 
   if (process.state() == QProcess::Running) { process.close(); }
 
-  auto sysEnv = QProcessEnvironment::systemEnvironment();
-
-  if (auto path = sysEnv.value("EXT_MANAGER_PATH"); !path.isEmpty()) {
+  if (auto path = qEnvironmentVariable("EXT_MANAGER_PATH"); !path.isEmpty()) {
     managerPath = path.toStdString();
     qInfo() << "EXT_MANAGER_PATH is set, and will override bundled version" << path;
   } else {

--- a/vicinae/src/font-service.cpp
+++ b/vicinae/src/font-service.cpp
@@ -3,6 +3,7 @@
 #include <qlogging.h>
 #include <qnamespace.h>
 #include <qprocess.h>
+#include <qtenvironmentvariables.h>
 
 static const std::vector<QString> UNIX_EMOJI_FONT_CANDIDATES = {
     "Twemoji",
@@ -19,9 +20,7 @@ QFont FontService::findEmojiFont() {
   return QFont("Apple Color Emoji");
 #endif
 
-  auto environ = QProcessEnvironment::systemEnvironment();
-
-  if (auto emojiFont = environ.value("EMOJI_FONT"); !emojiFont.isEmpty()) {
+  if (auto emojiFont = qEnvironmentVariable("EMOJI_FONT"); !emojiFont.isEmpty()) {
     if (!QFontDatabase::hasFamily(emojiFont)) {
       qWarning() << "EMOJI_FONT environment variable was set to" << emojiFont
                  << "but there is no such family installed.";

--- a/vicinae/src/navigation-controller.cpp
+++ b/vicinae/src/navigation-controller.cpp
@@ -1,7 +1,8 @@
 #include "navigation-controller.hpp"
-#include "ui/keyboard.hpp"
 #include "ui/views/base-view.hpp"
+#include "utils/environment.hpp"
 #include <qlogging.h>
+#include <qtenvironmentvariables.h>
 #include <qwidget.h>
 #include <QProcessEnvironment>
 
@@ -41,15 +42,14 @@ void NavigationController::setLoading(bool value, const BaseView *caller) {
 }
 
 void NavigationController::showHud(const QString &title, const std::optional<ImageURL> &icon) {
-  bool hudDisabled = QProcessEnvironment::systemEnvironment().value("VICINAE_DISABLE_HUD", "0") == "1";
-
   closeWindow();
 
-  if (hudDisabled) {
+  if (Environment::isHudDisabled()) {
     qDebug() << "HUD disabled via VICINAE_DISABLE_HUD environment variable, skipping:" << title;
-  } else {
-    emit showHudRequested(title, icon);
+    return;
   }
+
+  emit showHudRequested(title, icon);
 }
 
 void NavigationController::setDialog(DialogContentWidget *widget) { emit confirmAlertRequested(widget); }

--- a/vicinae/src/ui/hud/hud.cpp
+++ b/vicinae/src/ui/hud/hud.cpp
@@ -1,5 +1,10 @@
 #include "hud.hpp"
+#include "utils/environment.hpp"
 #include "utils/layout.hpp"
+#include <qnamespace.h>
+#include <qtenvironmentvariables.h>
+#include "LayerShellQt/Window"
+#include "vicinae.hpp"
 
 void HudWidget::paintEvent(QPaintEvent *event) {
   OmniPainter painter(this);
@@ -15,8 +20,29 @@ void HudWidget::paintEvent(QPaintEvent *event) {
 }
 
 void HudWidget::setupUI() {
-  setWindowFlags(Qt::FramelessWindowHint | Qt::Window);
+  setWindowFlags(Qt::FramelessWindowHint);
   setAttribute(Qt::WA_TranslucentBackground, true);
+
+#ifdef WAYLAND_LAYER_SHELL
+  if (Environment::isLayerShellEnabled()) {
+    namespace Shell = LayerShellQt;
+
+    createWinId();
+    if (auto lshell = Shell::Window::get(windowHandle())) {
+      lshell->setLayer(Shell::Window::LayerOverlay);
+      lshell->setScope(Omnicast::APP_ID);
+      lshell->setScreenConfiguration(Shell::Window::ScreenFromCompositor);
+      lshell->setKeyboardInteractivity(Shell::Window::KeyboardInteractivityNone);
+      lshell->setExclusiveZone(-1);
+      lshell->setAnchors(Shell::Window::AnchorNone);
+    } else {
+      qWarning() << "Unable apply layer shell rules to hud window: LayerShellQt::Window::get() returned null";
+    }
+  } else {
+    qInfo() << "USE_LAYER_SHELL=0 is set, not using layer shell";
+  }
+#endif
+
   auto content = HStack().add(UI::Icon().size({16, 16}).ref(m_icon)).add(UI::Text("").ref(m_text)).spacing(5);
 
   VStack().add(content.buildWidget(), 0, Qt::AlignCenter).margins(15, 10, 15, 10).imbue(this);

--- a/vicinae/src/ui/hud/hud.hpp
+++ b/vicinae/src/ui/hud/hud.hpp
@@ -5,6 +5,7 @@
 #include <qwidget.h>
 #include "ui/image/image.hpp"
 
+/*
 class FadeWidget : public QWidget {
 private:
   QGraphicsOpacityEffect *opacityEffect;
@@ -48,10 +49,11 @@ public:
     fadeAnimation->start();
   }
 };
+*/
 
 class TypographyWidget;
 
-class HudWidget : public FadeWidget {
+class HudWidget : public QWidget {
   TypographyWidget *m_text = nullptr;
   ImageWidget *m_icon = nullptr;
   bool m_shouldDrawBorders = true;

--- a/vicinae/src/ui/launcher-window/launcher-window.cpp
+++ b/vicinae/src/ui/launcher-window/launcher-window.cpp
@@ -4,6 +4,8 @@
 #include "ui/keyboard.hpp"
 #include "ui/status-bar/status-bar.hpp"
 #include "ui/top-bar/top-bar.hpp"
+#include "utils/environment.hpp"
+#include <qtenvironmentvariables.h>
 #ifdef WAYLAND_LAYER_SHELL
 #include <LayerShellQt/window.h>
 #endif
@@ -67,7 +69,7 @@ LauncherWindow::LauncherWindow(ApplicationContext &ctx) : m_ctx(ctx) {
     m_ctx.navigation->closeActionPanel();
   });
 
-  connect(m_hudDismissTimer, &QTimer::timeout, this, [this]() { m_hud->fadeOut(); });
+  connect(m_hudDismissTimer, &QTimer::timeout, this, [this]() { m_hud->hide(); });
 
   connect(m_ctx.navigation.get(), &NavigationController::actionPanelVisibilityChanged, this,
           [this](bool value) {
@@ -134,7 +136,7 @@ void LauncherWindow::handleShowHUD(const QString &text, const std::optional<Imag
   m_hud->clear();
   m_hud->setText(text);
   if (icon) m_hud->setIcon(*icon);
-  m_hud->showDirect();
+  m_hud->show();
   m_hudDismissTimer->start();
 }
 
@@ -152,9 +154,7 @@ void LauncherWindow::setupUI() {
   m_hud->setMaximumWidth(300);
 
 #ifdef WAYLAND_LAYER_SHELL
-  bool useLayerShell = QProcessEnvironment().systemEnvironment().value("USE_LAYER_SHELL", "1") == "1";
-
-  if (useLayerShell) {
+  if (Environment::isLayerShellEnabled()) {
     namespace Shell = LayerShellQt;
 
     createWinId();

--- a/vicinae/src/utils/environment.hpp
+++ b/vicinae/src/utils/environment.hpp
@@ -31,6 +31,10 @@ inline bool isWlrootsCompositor() {
          desktop.contains("river", Qt::CaseInsensitive);
 }
 
+inline bool isHudDisabled() { return qEnvironmentVariable("VICINAE_DISABLE_HUD", "0") == "1"; }
+
+inline bool isLayerShellEnabled() { return qEnvironmentVariable("USE_LAYER_SHELL", "1") == "1"; }
+
 /**
  * Gets human-readable environment description
  */

--- a/vicinae/src/vicinae.cpp
+++ b/vicinae/src/vicinae.cpp
@@ -1,6 +1,7 @@
 #include "vicinae.hpp"
 #include "utils/utils.hpp"
 #include <qprocess.h>
+#include <qtenvironmentvariables.h>
 #include <ranges>
 
 namespace fs = std::filesystem;
@@ -23,17 +24,18 @@ fs::path Omnicast::commandSocketPath() { return runtimeDir() / "vicinae.sock"; }
 fs::path Omnicast::pidFile() { return runtimeDir() / "vicinae.pid"; }
 
 std::vector<fs::path> Omnicast::xdgConfigDirs() {
-  auto env = QProcessEnvironment::systemEnvironment();
   std::set<fs::path> seen;
   std::vector<fs::path> paths;
   fs::path configHome = homeDir() / ".config";
 
-  if (auto value = env.value("XDG_CONFIG_HOME"); !value.isEmpty()) { configHome = value.toStdString(); }
+  if (auto value = qEnvironmentVariable("XDG_CONFIG_HOME"); !value.isEmpty()) {
+    configHome = value.toStdString();
+  }
 
   paths.emplace_back(configHome);
   seen.insert(configHome);
 
-  for (const QString &dir : env.value("XDG_CONFIG_DIRS").split(':')) {
+  for (const QString &dir : qEnvironmentVariable("XDG_CONFIG_DIRS").split(':')) {
     fs::path path = dir.toStdString();
 
     if (std::ranges::contains(seen, path)) { continue; }
@@ -66,11 +68,10 @@ std::vector<fs::path> Omnicast::systemPaths() {
 }
 
 std::vector<fs::path> Omnicast::xdgDataDirs() {
-  auto env = QProcessEnvironment::systemEnvironment();
   std::set<fs::path> seen;
   std::vector<fs::path> paths;
 
-  for (const QString &dir : env.value("XDG_DATA_DIRS").split(':')) {
+  for (const QString &dir : qEnvironmentVariable("XDG_DATA_DIRS").split(':')) {
     fs::path path = dir.toStdString();
 
     if (std::ranges::contains(seen, path)) { continue; }


### PR DESCRIPTION
this prevents the HUD from stealing focus as it's no longer a window but a layer shell surface as well.
This does not fix hud stealing on Gnome environments, where disabling the HUD is still the main recommendation.