### PR TITLE
Fix Extension Development Auto-Refresh UI

### DIFF
--- a/vicinae/include/omni-command-db.hpp
+++ b/vicinae/include/omni-command-db.hpp
@@ -102,6 +102,7 @@ public:
       if (repositories[i]->id() == repository->id()) {
         repositories[i] = repository;
         index = i;
+        emit registryAdded(repository);
         break;
       }
     }

--- a/vicinae/src/root-extension-manager.hpp
+++ b/vicinae/src/root-extension-manager.hpp
@@ -15,6 +15,8 @@ class RootExtensionManager : public QObject {
 public:
   void start() {
     connect(&m_commandDb, &OmniCommandDatabase::registryAdded, this, [this](const auto &registry) {
+      // Remove existing provider first to avoid duplicates when refreshing extensions
+      m_manager.removeProvider(QString("extension.%1").arg(registry->id()));
       m_manager.addProvider(std::make_unique<ExtensionRootProvider>(registry));
     });
     connect(&m_commandDb, &OmniCommandDatabase::repositoryRemoved, this,


### PR DESCRIPTION
### Problem
Extension development auto-refresh was working (rebuilding extensions), but the Vicinae launcher UI never showed the new change but after the first fix, this got solved. And after that it started showing visual corruption with overlapping text and distorted command lists when extensions were refreshed during development.

### Root Cause
Two issues:

1.`registerRepository()` didn't emit `registryAdded` signal when replacing existing repositories, so the UI never knew to refresh
2.  `RootExtensionManager` added new providers without removing old ones, causing duplicate entries and UI corruption

### Solution
**Two minimal fixes:**

1. emit `registryAdded(repository)` when replacing existing repositories

2. remove existing provider before adding new one:

Extension development workflow now works without restarting the vicinae server whenever the extension code changes or the manifest file is updated.