### PR TITLE
fix(nix): adapt npmDeps hash for extension-manager

### DIFF
--- a/vicinae.nix
+++ b/vicinae.nix
@@ -40,7 +40,7 @@ let
   # Prepare node_modules for extension-manager folder
   extensionManagerDeps = fetchNpmDeps {
     src = src + /extension-manager;
-    hash = "sha256-7kScWi1ySUBTDsGQqgpt2wYmujP9Mlwq3x2FKOlGwgo=";
+    hash = "sha256-zoTe/n7PmC7h3bEYFX8OtLKr6T8WA7ijNhAekIhsgLc=";
   };
 
 in


### PR DESCRIPTION
This pull request updates the npm dependency hash for the extension-manager NPM package. This error was mentioned in #6 