### PR TITLE
Fix building on nix for good

### DIFF
--- a/.github/workflows/nix-support.yml
+++ b/.github/workflows/nix-support.yml
@@ -1,0 +1,20 @@
+name: Nix hash check
+
+on:
+  push:
+  workflow_dispatch:
+
+
+jobs:
+  update-tags:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: cachix/install-nix-action@v31
+      - name: Check nix hashes
+        run: |
+          nix run .#nix-update-script --extra-experimental-features nix-command flakes --accept-flake-config

--- a/vicinae.nix
+++ b/vicinae.nix
@@ -157,4 +157,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     mainProgram = "vicinae";
   };
+  passthru = {
+    inherit apiDeps extensionManagerDeps;
+  };
 }


### PR DESCRIPTION
When I wanted to build vicinae from the provided nix flake earlier today, the build failed because of a hash mismatch. This happened because something about the npm deps got changed without modifying the hard-coded hashes in the nix build file (this is expected nix behavior). In a nix-centric project this issue would not occur, because they build via nix and catch these issues when they happen. Since the nix build was donated to this repo and you (lead dev who made the breaking change) are not using it, it gets out of sync. 

To solve this issue, this PR adds an update script, which updates the hashes nix uses and can be run via the provided GH action, if you (understandably so) do not want to use nix. This is my first time messing around with GH actions, thus my GH action might not be optimal.

I would have liked to fetch the npm deps as a flake input, but that does not seem to be possible, hence the dubious workarounds employed by me.
