### PR TITLE
Revert "Fix Extension Development Auto-Refresh UI"

### DIFF
--- a/vicinae/include/omni-command-db.hpp
+++ b/vicinae/include/omni-command-db.hpp
@@ -102,7 +102,6 @@ public:
       if (repositories[i]->id() == repository->id()) {
         repositories[i] = repository;
         index = i;
-        emit registryAdded(repository);
         break;
       }
     }

--- a/vicinae/src/root-extension-manager.hpp
+++ b/vicinae/src/root-extension-manager.hpp
@@ -15,8 +15,6 @@ class RootExtensionManager : public QObject {
 public:
   void start() {
     connect(&m_commandDb, &OmniCommandDatabase::registryAdded, this, [this](const auto &registry) {
-      // Remove existing provider first to avoid duplicates when refreshing extensions
-      m_manager.removeProvider(QString("extension.%1").arg(registry->id()));
       m_manager.addProvider(std::make_unique<ExtensionRootProvider>(registry));
     });
     connect(&m_commandDb, &OmniCommandDatabase::repositoryRemoved, this,


### PR DESCRIPTION
Reverts vicinaehq/vicinae#197

This calls `removeProvider` on every provider at startup, massively increasing vicinae startup time and also wiping existing aliases and preferences for all commands.

I should have been more careful reviewing this, my bad. Working on a fix for the original issue rn.