### PR TITLE
build: add static linking options for qt-keychain and layer-shell

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,10 +60,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5  \
             -DLTO=ON \
-            -DUSE_SYSTEM_PROTOBUF=OFF \
-            -DUSE_SYSTEM_ABSEIL=OFF \
-            -DUSE_SYSTEM_CMARK_GFM=OFF \
-            -DUSE_SYSTEM_MINIZIP=OFF \
+            -DPREFER_STATIC_LIBS=ON \
             -DCMAKE_PREFIX_PATH="$Qt6_DIR" \
             -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}"
 

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ vicinae/assets/extension-runtime.js
 
 __cmake*
 *.tgz
+
+/qt6

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 set(PROJECT_NAME vicinae)
+
 project(${PROJECT_NAME} VERSION 1.0.0 LANGUAGES C CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
@@ -13,10 +14,13 @@ option(NOSTRIP "Never strip debug symbols from the binary, even in release mode.
 option(WAYLAND_LAYER_SHELL "Enable support for the layer shell Wayland protocol" OFF)
 option(TYPESCRIPT_EXTENSIONS "Enable support for extensions built with React/Typescript (no browser involved)" ON)
 
+option(PREFER_STATIC_LIBS "When available, link to a library statically instead of dynamically" OFF)
 option(USE_SYSTEM_PROTOBUF "Use system protobuf instead of building it from source" ON)
 option(USE_SYSTEM_ABSEIL "Use system abseil (libabsl) instead of building it from source" ON)
 option(USE_SYSTEM_CMARK_GFM "Use system cmark-gfm (github's fork of cmark) instead of building it from source" ON)
 option(USE_SYSTEM_MINIZIP "Use system minizip instead of building it from source" ON)
+option(USE_SYSTEM_LAYER_SHELL "Use system qt layer shell instead of building it from source" ON)
+option(USE_SYSTEM_QT_KEYCHAIN "Use system qt-keychain instead of building it from source. Note: still depends on system libsecret." ON)
 option(LIBQALCULATE_BACKEND "Compile in support for the Qalculate! calculator backend" ON)
 
 if (UNIX AND NOT APPLE)
@@ -24,6 +28,18 @@ if (UNIX AND NOT APPLE)
 endif()
 
 # End of Vicinae build configuration options
+
+if (PREFER_STATIC_LIBS)
+	set(CMAKE_FIND_LIBRARY_SUFFIXES ".a" ".so" ".dylib")
+	set(BUILD_SHARED_LIBS OFF)
+	set(USE_SYSTEM_PROTOBUF OFF)
+	set(USE_SYSTEM_ABSEIL OFF)
+	set(USE_SYSTEM_CMARK_GFM OFF)
+	set(USE_SYSTEM_MINIZIP OFF)
+	set(USE_SYSTEM_LAYER_SHELL OFF)
+	set(USE_SYSTEM_QT_KEYCHAIN OFF)
+	set(LIBQALCULATE_BACKEND OFF)
+endif()
 
 include(Git)
 include(Utils)
@@ -45,6 +61,16 @@ add_compile_definitions(VICINAE_GIT_TAG="${VICINAE_GIT_TAG}")
 add_compile_definitions(VICINAE_GIT_COMMIT_HASH="${VICINAE_GIT_COMMIT_HASH}")
 
 set(CMARK_LIBRARY "cmark-gfm")
+
+if (NOT USE_SYSTEM_QT_KEYCHAIN)
+	include(QtKeychain)
+	checkout_qt_keychain()
+endif()
+
+if (NOT USE_SYSTEM_LAYER_SHELL)
+	include(QtLayerShell)
+	checkout_layer_shell_qt()
+endif()
 
 if (NOT USE_SYSTEM_MINIZIP)
 	include(Minizip)

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,11 @@ no-ts-ext:
 	cmake --build $(BUILD_DIR)
 .PHONY: no-ts-ext
 
+static:
+	cmake -G Ninja -DPREFER_STATIC_LIBS=ON -DCMAKE_BUILD_TYPE=Release -B $(BUILD_DIR)
+	cmake --build $(BUILD_DIR)
+.PHONY: static
+
 # optimize for portability (build problematic libs statically)
 # this will increase compile time as more libraries will have to be compiled from source,
 # but the resulting binary will be more portable across different distros, especially the ones

--- a/cmake/Abseil.cmake
+++ b/cmake/Abseil.cmake
@@ -10,5 +10,6 @@ function(checkout_abseil)
 	  GIT_TAG        20250814.0
 	)
 	
+	set(BUILD_SHARED_LIBS OFF)
 	FetchContent_MakeAvailable(abseil)
 endfunction()

--- a/cmake/Protobuf.cmake
+++ b/cmake/Protobuf.cmake
@@ -13,6 +13,7 @@ function(checkout_protobuf)
 	set(protobuf_BUILD_TESTS OFF)
 	set(protobuf_BUILD_PROTOBUF_BINARIES ON)
 	set(protobuf_BUILD_PROTOC_BINARIES ON)
+	set(protobuf_BUILD_SHARED_LIBS OFF)
 	FetchContent_MakeAvailable(protobuf)
 endfunction()
 

--- a/cmake/QtKeychain.cmake
+++ b/cmake/QtKeychain.cmake
@@ -1,0 +1,17 @@
+include(FetchContent)
+
+function(checkout_qt_keychain)
+	set(FETCHCONTENT_QUIET OFF)
+
+	FetchContent_Declare(
+	  qt-keychain
+	  EXCLUDE_FROM_ALL
+	  GIT_REPOSITORY https://github.com/frankosterfeld/qtkeychain
+	  GIT_TAG v0.14.0
+	)
+
+	set(BUILD_SHARED_LIBS OFF)
+	set(BUILD_WITH_QT6 ON)
+	set(BUILD_TRANSLATIONS OFF)
+	FetchContent_MakeAvailable(qt-keychain)
+endfunction()

--- a/cmake/QtLayerShell.cmake
+++ b/cmake/QtLayerShell.cmake
@@ -1,0 +1,16 @@
+include(FetchContent)
+
+function(checkout_layer_shell_qt)
+	set(FETCHCONTENT_QUIET OFF)
+	set(LAYER_SHELL_QT_DECLARATIVE OFF)
+
+	FetchContent_Declare(
+	  layer-shell-qt
+	  EXCLUDE_FROM_ALL
+	  GIT_REPOSITORY https://github.com/vicinaehq/layer-shell-qt
+	)
+
+	set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build static libraries" FORCE)
+
+	FetchContent_MakeAvailable(layer-shell-qt)
+endfunction()

--- a/vicinae/CMakeLists.txt
+++ b/vicinae/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_AUTORCC ON)
 set(LIBS)
 set(TARGET vicinae)
 
-find_package(Qt6 REQUIRED COMPONENTS Widgets Sql Network Svg DBus Keychain)
+find_package(Qt6 REQUIRED COMPONENTS Core Widgets Sql Network Svg DBus WaylandClient)
 find_package(OpenSSL REQUIRED)
 
 if (TYPESCRIPT_EXTENSIONS)
@@ -14,18 +14,39 @@ if (TYPESCRIPT_EXTENSIONS)
 	add_compile_definitions(HAS_TYPESCRIPT_EXTENSIONS=)
 endif()
 
-list(APPEND LIBS Qt6::Widgets Qt6::Sql Qt6::Network Qt6::Svg Qt6::DBus qt6keychain ${CMARK_LIBRARY} protobuf::libprotobuf minizip OpenSSL::Crypto)
+list(APPEND LIBS  Qt6::Widgets Qt6::Sql Qt6::Network Qt6::Svg Qt6::DBus qt6keychain ${CMARK_LIBRARY} protobuf::libprotobuf minizip OpenSSL::Crypto Qt6::WaylandClientPrivate)
 
 set(WLR_CLIP_BIN ${CMAKE_BINARY_DIR}/wlr-clip/wlr-clip${CMAKE_EXECUTABLE_SUFFIX})
 set(ASSET_PATH ${CMAKE_CURRENT_SOURCE_DIR}/assets)
 configure_file(resources.qrc.in resources.qrc)
 
+#if(Qt6_FOUND)
+#	find_package(Qt6 REQUIRED COMPONENTS QWaylandIntegrationPlugin)
+#    # Import static plugins
+#qt_import_plugins(${TARGET}
+#        INCLUDE Qt6::QWaylandIntegrationPlugin
+#    )
+#    
+#    # Also import other essential plugins you might need
+#    qt_import_plugins(${TARGET}
+#        INCLUDE_BY_TYPE platforms Qt6::QWaylandIntegrationPlugin
+#		#INCLUDE_BY_TYPE imageformats Qt6::QSvgPlugin Qt6::QJpegPlugin Qt6::QPngPlugin
+#    )
+#endif()
+
+
+
+
 if (WAYLAND_LAYER_SHELL)
 	message(STATUS "Compiling with wayland layer shell support (for wlroots-like compositors)")
 	find_package(Qt6 REQUIRED COMPONENTS WaylandClient)
-	find_package(LayerShellQt REQUIRED)
+	if (USE_SYSTEM_LAYER_SHELL)
+		find_package(LayerShellQt REQUIRED)
+		list(APPEND LIBS LayerShellQt::Interface)
+	else()
+		list(APPEND LIBS LayerShellQtInterface)
+	endif()
 	add_compile_definitions(-DWAYLAND_LAYER_SHELL)
-	list(APPEND LIBS LayerShellQt::Interface)
 endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -585,6 +606,12 @@ endif()
 	
 
 qt_add_executable(${TARGET} ${SRCS})
+
+if(Qt6_FOUND)
+	qt_import_plugins(${TARGET}
+        INCLUDE Qt6::QWaylandIntegrationPlugin
+    )
+endif()
 
 target_include_directories(${TARGET} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_link_libraries(${TARGET} PRIVATE ${LIBS})


### PR DESCRIPTION
New binary releases will have those two statically linked.