### PR TITLE
fix: fallback version to init template if invalid

### DIFF
--- a/vicinae/src/services/extension-boilerplate-generator/extension-boilerplate-generator.cpp
+++ b/vicinae/src/services/extension-boilerplate-generator/extension-boilerplate-generator.cpp
@@ -1,5 +1,6 @@
 #include "services/extension-boilerplate-generator/extension-boilerplate-generator.hpp"
 #include "common.hpp"
+#include "utils/environment.hpp"
 #include "utils/utils.hpp"
 #include <filesystem>
 #include <qfile.h>
@@ -95,9 +96,14 @@ ExtensionBoilerplateGenerator::generate(const fs::path &targetDir, const Extensi
     cmdStrings << cmdString;
   }
 
-  QString version(VICINAE_GIT_TAG);
+  QString version = Environment::version();
+  bool isValidVersion = version.startsWith('v') && version.sliced(1).split('.').size() == 3;
 
-  if (!version.isEmpty()) version[0] = '^';
+  if (isValidVersion) {
+    version[0] = '^';
+  } else {
+    version = "^0.8.0"; // TODO: all builds should have a valid version, but this is provided as a quick fix
+  }
 
   // we don't use QJson because key order would not be preserved
   manifest.replace(PLACEHOLDER("NAME"), extName)

--- a/vicinae/src/utils/environment.hpp
+++ b/vicinae/src/utils/environment.hpp
@@ -36,6 +36,11 @@ inline bool isHudDisabled() { return qEnvironmentVariable("VICINAE_DISABLE_HUD",
 inline bool isLayerShellEnabled() { return qEnvironmentVariable("USE_LAYER_SHELL", "1") == "1"; }
 
 /**
+ * Version of the Vicinae app.
+ */
+inline QString version() { return VICINAE_GIT_TAG; }
+
+/**
  * Gets human-readable environment description
  */
 inline QString getEnvironmentDescription() {


### PR DESCRIPTION
Attempts to mitigate #212 so that `npm install` can proceed. This is no long term fix.