### PR TITLE
feat: add default vicinae icon theme (papirus) for better otb exp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ extension-manager/runtime/node_modules
 vicinae/assets/extension-runtime.js
 
 *.tar.gz
+!extra/icons/vicinae-icon-theme.tar.gz
 /dist
 
 __cmake*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,8 +166,36 @@ endif()
 set(INSTALL_SHARE ${CMAKE_INSTALL_PREFIX}/share)
 set(VICINAE_INSTALL_SHARE ${INSTALL_SHARE}/vicinae)
 
-make_directory(${CMAKE_INSTALL_PREFIX}/share/applications)
 make_directory(${VICINAE_INSTALL_SHARE})
 
-install(FILES ./extra/vicinae.desktop DESTINATION ${INSTALL_SHARE}/applications)
 install(DIRECTORY ./extra/themes DESTINATION ${VICINAE_INSTALL_SHARE})
+
+if (UNIX AND NOT APPLE)
+	# install desktop file
+	set(APP_DIR ${INSTALL_SHARE}/applications)
+	make_directory(${APP_DIR})
+	install(FILES ./extra/vicinae.desktop DESTINATION ${APP_DIR})
+
+	# install default icon set
+	set(ICON_DIR ${INSTALL_SHARE}/icons)
+	set(ICON_THEME_ARCHIVE ${CMAKE_SOURCE_DIR}/extra/icons/vicinae-icon-theme.tar.gz)
+	set(ICON_THEME_STAMP "${CMAKE_BINARY_DIR}/icon-theme.stamp")
+	set(ICON_BINARY_DIR "${CMAKE_BINARY_DIR}/icons")
+
+	add_custom_command(
+		OUTPUT "${ICON_THEME_STAMP}"
+		COMMAND ${CMAKE_COMMAND} -E tar xzf "${ICON_THEME_ARCHIVE}"
+		COMMAND ${CMAKE_COMMAND} -E touch "${ICON_THEME_STAMP}"
+		WORKING_DIRECTORY "${ICON_BINARY_DIR}"
+		DEPENDS "${ICON_THEME_ARCHIVE}"
+		COMMENT "Extracting icon theme..."
+	)
+	add_custom_target(extract_icons DEPENDS "${ICON_THEME_STAMP}")
+	add_dependencies(vicinae extract_icons)
+	make_directory(${ICON_BINARY_DIR})
+	make_directory(${ICON_DIR})
+	install(DIRECTORY ${ICON_BINARY_DIR}/vicinae DESTINATION ${ICON_DIR} COMPONENT icons)
+endif()
+
+
+

--- a/vicinae/src/main.cpp
+++ b/vicinae/src/main.cpp
@@ -224,7 +224,7 @@ root->updateIndex();
 
     FaviconService::instance()->setService(next.faviconService);
 
-    if (auto icon = next.theme.iconTheme) { QIcon::setThemeName(icon.value()); }
+    QIcon::setThemeName(next.theme.iconTheme.value_or(Omnicast::DEFAULT_ICON_THEME_NAME));
 
     if (next.font.normal && *next.font.normal != prev.font.normal.value_or("")) {
       QApplication::setFont(*next.font.normal);

--- a/vicinae/src/vicinae.hpp
+++ b/vicinae/src/vicinae.hpp
@@ -20,6 +20,7 @@ static const QString APP_ID = "vicinae";
 static const QString APP_SCHEME = APP_ID;
 static const std::array<QString, 2> APP_SCHEMES = {APP_SCHEME, "raycast"};
 static const QString DEFAULT_FAVICON_SERVICE = "twenty";
+static const QString DEFAULT_ICON_THEME_NAME = "vicinae";
 
 /**
  * We use the http:// scheme instead of discord:// as we don't make assumptions


### PR DESCRIPTION
We now ship an icon theme that is installed as part of the vicinae installation process.
It is there to provide a better out of the box experience to most users and avoid situations in which we have to default on `hicolor` because figuring out what icon theme to pick is not an easy task.