### PR TITLE
fix(nix): parse manifest.yaml for nix build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        vicinaePkg = pkgs.callPackage ./vicinae.nix { hash = self.rev ? self.dirtyRev; };
+        vicinaePkg = pkgs.callPackage ./vicinae.nix { };
       in
       {
         packages.default = vicinaePkg;


### PR DESCRIPTION
This pull request adapts the Nix derivation to read version information from the manifest.yaml in the directory.
This resolves #212 .

<img width="1304" height="864" alt="SCR-20250907-qcfh" src="https://github.com/user-attachments/assets/30659b2c-5f4a-49bd-8d9c-c145acc773e9" />

Turns out Nix does not have a native Yaml parsing function? So I implemented a whacky parser with `builtins.match` and a [regex](https://regex101.com/r/vgsgYY/1)