### PR TITLE
fix: make std::filesystem calls not crash on permission errors

### DIFF
--- a/vicinae/src/lib/icon-theme-db/icon-theme-db.cpp
+++ b/vicinae/src/lib/icon-theme-db/icon-theme-db.cpp
@@ -47,11 +47,11 @@ IconThemeDatabase::IconThemeList IconThemeDatabase::scan() {
     std::error_code ec;
 
     for (const auto &entry : fs::directory_iterator(path, ec)) {
-      if (!entry.is_directory()) continue;
+      if (!entry.is_directory(ec)) continue;
 
       fs::path manifest = entry.path() / "index.theme";
 
-      if (!fs::is_regular_file(manifest)) continue;
+      if (!fs::is_regular_file(manifest, ec)) continue;
 
       // I guess the correct way would be to parse this with xdg desktop file
       // format instead of plain ini stuff, but for this use case this is fine.

--- a/vicinae/src/services/extension-registry/extension-registry.cpp
+++ b/vicinae/src/services/extension-registry/extension-registry.cpp
@@ -72,8 +72,9 @@ bool ExtensionRegistry::installFromZip(const QString &id, std::string_view data)
 
 bool ExtensionRegistry::uninstall(const QString &id) {
   fs::path bundle = extensionDir() / id.toStdString();
+  std::error_code ec;
 
-  if (!fs::is_directory(bundle)) return false;
+  if (!fs::is_directory(bundle, ec)) return false;
 
   fs::remove_all(bundle);
   m_storage.clearNamespace(id);
@@ -161,7 +162,7 @@ std::vector<ExtensionManifest> ExtensionRegistry::scanAll() {
   std::vector<ExtensionManifest> manifests;
 
   for (const auto &entry : fs::directory_iterator(extensionDir(), ec)) {
-    if (!entry.is_directory()) continue;
+    if (!entry.is_directory(ec)) continue;
 
     auto manifest = scanBundle(entry.path());
 

--- a/vicinae/src/services/files-service/file-indexer/abstract-scanner.cpp
+++ b/vicinae/src/services/files-service/file-indexer/abstract-scanner.cpp
@@ -1,6 +1,7 @@
 #include "abstract-scanner.hpp"
 #include <expected>
 #include <mutex>
+#include <QDebug>
 
 std::expected<Scan, bool> AbstractScanner::awaitScan() {
   std::unique_lock lock(m_scanLock);
@@ -24,6 +25,7 @@ void AbstractScanner::finishScan(const Scan &scan) {
 void AbstractScanner::enqueue(const Scan &scan) {
   std::scoped_lock guard(m_scanLock);
   m_queuedScans.push_back(scan);
+  qDebug() << "enqueued new scan" << scan.path.c_str();
 
   m_scanCv.notify_one();
 }

--- a/vicinae/src/services/files-service/file-indexer/filesystem-walker.cpp
+++ b/vicinae/src/services/files-service/file-indexer/filesystem-walker.cpp
@@ -75,12 +75,13 @@ void FileSystemWalker::setIgnoreHiddenPaths(bool value) { m_ignoreHiddenFiles = 
 
 bool FileSystemWalker::isIgnored(const std::filesystem::path &path) const {
   fs::path p = path.parent_path();
+  std::error_code ec;
 
   while (p != p.root_directory()) {
     for (const auto &name : m_ignoreFiles) {
       fs::path ignorePath = p / name;
 
-      if (!fs::is_regular_file(ignorePath)) continue;
+      if (!fs::is_regular_file(ignorePath, ec)) continue;
       if (GitIgnoreReader(ignorePath).matches(path)) { return true; }
     }
 
@@ -116,7 +117,7 @@ void FileSystemWalker::walk(const fs::path &root, const WalkCallback &callback) 
       if (std::ranges::contains(EXCLUDED_FILENAMES, path.filename())) { continue; }
       if (isIgnored(path)) { continue; }
 
-      if (m_recursive && entry.is_directory()) {
+      if (m_recursive && entry.is_directory(ec)) {
         size_t depth = std::distance(path.begin(), path.end()) - rootDepth;
 
         if (!(m_maxDepth && depth > *m_maxDepth)) { dirStack.push(entry); }

--- a/vicinae/src/theme.cpp
+++ b/vicinae/src/theme.cpp
@@ -500,7 +500,7 @@ void ThemeService::scanThemeDirectory(const std::filesystem::path &path) {
     auto it = std::filesystem::directory_iterator(dir, ec);
 
     for (const auto &entry : it) {
-      if (entry.is_directory()) {
+      if (entry.is_directory(ec)) {
         dirs.push(entry.path());
         continue;
       }

--- a/vicinae/src/ui/image/image.cpp
+++ b/vicinae/src/ui/image/image.cpp
@@ -105,8 +105,9 @@ void ImageWidget::setUrlImpl(const ImageURL &url) {
     }
 
     std::filesystem::path suffixedPath = path.parent_path() / suffixed;
+    std::error_code ec;
 
-    if (std::filesystem::is_regular_file(suffixedPath)) { path = suffixedPath; }
+    if (std::filesystem::is_regular_file(suffixedPath, ec)) { path = suffixedPath; }
 
     m_loader.reset(new LocalImageLoader(path));
   }

--- a/vicinae/src/utils/utils.cpp
+++ b/vicinae/src/utils/utils.cpp
@@ -82,7 +82,7 @@ std::vector<fs::path> homeRootDirectories() {
   std::error_code ec;
 
   for (const auto &entry : fs::directory_iterator(homeDir(), ec)) {
-    if (entry.is_directory() && !isHiddenPath(entry.path())) paths.emplace_back(entry.path());
+    if (entry.is_directory(ec) && !isHiddenPath(entry.path())) paths.emplace_back(entry.path());
   }
 
   return paths;


### PR DESCRIPTION
Should fix #239 
Funnily enough, I wasn't able to reproduce this, but I totally see how it can happen.
We also try/catch scans now, so that if such an event still occurs we at the very least do not crash the server.