### PR TITLE
fix: use fixed size for list item

### DIFF
--- a/vicinae/src/ui/omni-list/omni-list.hpp
+++ b/vicinae/src/ui/omni-list/omni-list.hpp
@@ -482,6 +482,8 @@ public:
   };
   virtual ItemData data() const = 0;
 
+  int calculateHeight(int width) const override { return 41; }
+
   bool hasUniformHeight() const override { return true; }
   bool hasPartialUpdates() const override { return true; }
 


### PR DESCRIPTION
by using a fixed size items without an icons will get the same size as items without one