### PR TITLE
feat: add instantDismiss flag to close the window on deeplink nav

### DIFF
--- a/vicinae/src/ipc-command-handler.cpp
+++ b/vicinae/src/ipc-command-handler.cpp
@@ -139,6 +139,7 @@ void IpcCommandHandler::handleUrl(const QUrl &url) {
             m_ctx.navigation->setSearchText(text);
           }
 
+          m_ctx.navigation->setInstantDismiss();
           m_ctx.navigation->showWindow();
 
           break;

--- a/vicinae/src/navigation-controller.hpp
+++ b/vicinae/src/navigation-controller.hpp
@@ -31,7 +31,7 @@ enum class PopToRootType { Default, Immediate, Suspended };
 
 struct CloseWindowOptions {
   PopToRootType popToRootType = PopToRootType::Default;
-  bool clearRootSearch = true; // has no effect if we do not pop to root
+  bool clearRootSearch = false; // has no effect if we do not pop to root
 };
 
 struct PopToRootOptions {
@@ -158,6 +158,10 @@ struct CompleterState {
   CompleterState(const ArgumentList &args, const ImageURL &icon) : args(args), icon(icon) {}
 };
 
+struct GoBackOptions {
+  bool ignoreInstantDismiss = false;
+};
+
 class NavigationController : public QObject, NonCopyable {
   Q_OBJECT
 
@@ -186,6 +190,7 @@ public:
 
   bool m_isPanelOpened = false;
   bool m_popToRootOnClose = false;
+  bool m_instantDismiss = false;
 
   void closeWindow(const CloseWindowOptions &settings = {});
   void showWindow();
@@ -193,6 +198,16 @@ public:
   bool isWindowOpened() const;
 
   void setPopToRootOnClose(bool value);
+
+  /**
+   * If the instant dismiss flag is set to `true`, the next call to `goBack` or `closeWindow` will close the
+   * window and pop to root regardless of the state of the navigation stack.
+   *
+   * This is typically set when opening a command using an external mechanism such as a deeplink.
+   *
+   * This flag automatically resets to false when consumed.
+   */
+  void setInstantDismiss(bool value = true);
 
   void setSearchPlaceholderText(const QString &text, const BaseView *caller = nullptr);
   void setSearchText(const QString &text, const BaseView *caller = nullptr);
@@ -240,6 +255,15 @@ public:
   void setStatusBarVisibility(bool value, const BaseView *caller = nullptr);
 
   void showHud(const QString &title, const std::optional<ImageURL> &icon = std::nullopt);
+
+  /**
+   * Go back to previous navigation state.
+   * If the `instantDismiss` flag is set, this will close the window and pop to root
+   * no matter what and then clear the flag.
+   * The flag can be completely bypassed by passing `ignoreInstantDismiss`.
+   * See `setInstantDismiss`
+   */
+  void goBack(const GoBackOptions &opts = {});
 
   void popCurrentView();
   void pushView(BaseView *view);

--- a/vicinae/src/ui/launcher-window/launcher-window.cpp
+++ b/vicinae/src/ui/launcher-window/launcher-window.cpp
@@ -221,23 +221,9 @@ bool LauncherWindow::event(QEvent *event) {
       return true;
     }
 
-    switch (keyEvent->key()) {
-    case Qt::Key_Escape: {
-      if (m_ctx.navigation->viewStackSize() == 1) {
-        if (m_ctx.navigation->searchText().isEmpty()) {
-          m_ctx.navigation->closeWindow();
-          return true;
-        }
-
-        m_ctx.navigation->clearSearchText();
-        return true;
-      }
-
-      m_ctx.navigation->popCurrentView();
+    if (keyEvent->key() == Qt::Key_Escape && !keyEvent->modifiers().toInt()) {
+      m_ctx.navigation->goBack();
       return true;
-    }
-    default:
-      break;
     }
 
     if (AbstractAction *action = m_ctx.navigation->findBoundAction(keyEvent)) {

--- a/vicinae/src/ui/oauth-view.hpp
+++ b/vicinae/src/ui/oauth-view.hpp
@@ -7,13 +7,14 @@
 #include "proto/oauth.pb.h"
 #include "services/oauth/oauth-service.hpp"
 #include "theme.hpp"
-#include "ui/dialog/dialog.hpp"
+#include "navigation-controller.hpp"
 #include "ui/icon-button/icon-button.hpp"
-#include "ui/button/button.hpp"
 #include "ui/overlay/overlay.hpp"
 #include "ui/toast/toast.hpp"
-#include "ui/typography/typography.hpp"
 #include "utils/layout.hpp"
+#include "service-registry.hpp"
+#include "services/toast/toast-service.hpp"
+#include "services/app-service/app-service.hpp"
 #include <qcoreevent.h>
 #include <qevent.h>
 #include <qfuture.h>

--- a/vicinae/src/ui/top-bar/top-bar.cpp
+++ b/vicinae/src/ui/top-bar/top-bar.cpp
@@ -120,7 +120,7 @@ bool GlobalHeader::eventFilter(QObject *watched, QEvent *event) {
 void GlobalHeader::handleSearchPop() {
   if (!m_input->isVisible()) return;
 
-  if (m_navigation.viewStackSize() > 1) { m_navigation.popCurrentView(); }
+  m_navigation.popCurrentView();
 }
 
 GlobalHeader::GlobalHeader(NavigationController &controller) : m_navigation(controller) {


### PR DESCRIPTION
Thanks to this, opening a deeplink and then pressing escape will close the window and pop to root instead of going back to the root search.