### PR TITLE
feat: append @raycast suffix to raycast extension authors

### DIFF
--- a/vicinae/include/extension/extension-command.hpp
+++ b/vicinae/include/extension/extension-command.hpp
@@ -32,7 +32,12 @@ class ExtensionCommand : public AbstractCmd {
 public:
   ExtensionCommand(const ExtensionManifest::Command &command) : m_command(command) {}
 
-  QString author() const override { return m_author; }
+  QString author() const override {
+    // as we plan on having our own store, we want raycast extension authors
+    // to be properly segmented.
+    if (isRaycast()) return m_author + "@raycast";
+    return m_author;
+  }
 
   QString extensionId() const override;
   void setExtensionId(const QString &text);


### PR DESCRIPTION
As we want to have our own store long term, we need to properly segment authors of raycast extensions as they are tied to Raycast's userbase

BREAKING CHANGE: This will break existing deeplinks to raycast extension commands