### PR TITLE
refactor: Handle events in terms of `FileEvent` structs

### DIFF
--- a/vicinae/src/services/files-service/file-indexer/db-writer.cpp
+++ b/vicinae/src/services/files-service/file-indexer/db-writer.cpp
@@ -65,3 +65,7 @@ void DbWriter::indexFiles(std::vector<std::filesystem::path> paths) {
 void DbWriter::deleteIndexedFiles(std::vector<std::filesystem::path> paths) {
   submit([paths = std::move(paths)](FileIndexerDatabase &db) { db.deleteIndexedFiles(paths); });
 }
+
+void DbWriter::indexEvents(std::vector<FileEvent> events) {
+  submit([events = std::move(events)](FileIndexerDatabase &db) { db.indexEvents(events); });
+}

--- a/vicinae/src/services/files-service/file-indexer/db-writer.hpp
+++ b/vicinae/src/services/files-service/file-indexer/db-writer.hpp
@@ -39,4 +39,6 @@ public:
   // Receive by value because `paths` could mutate while the work is waiting in queue
   void indexFiles(std::vector<std::filesystem::path> paths);
   void deleteIndexedFiles(std::vector<std::filesystem::path> paths);
+
+  void indexEvents(std::vector<FileEvent> events);
 };

--- a/vicinae/src/services/files-service/file-indexer/file-indexer-db.hpp
+++ b/vicinae/src/services/files-service/file-indexer/file-indexer-db.hpp
@@ -49,6 +49,8 @@ public:
   std::vector<std::filesystem::path> search(std::string_view searchQuery,
                                             const AbstractFileIndexer::QueryParams &params);
 
+  void indexEvents(const std::vector<FileEvent> &events);
+
   void runMigrations();
 
   QSqlDatabase *database();

--- a/vicinae/src/services/files-service/file-indexer/indexer-scanner.hpp
+++ b/vicinae/src/services/files-service/file-indexer/indexer-scanner.hpp
@@ -9,7 +9,7 @@ private:
   static constexpr size_t MAX_PENDING_BATCH_COUNT = 10;
   static constexpr size_t BACKPRESSURE_WAIT_MS = 100;
 
-  std::deque<std::vector<std::filesystem::path>> m_writeBatches;
+  std::deque<std::vector<FileEvent>> m_writeBatches;
   std::mutex m_batchMutex;
   std::condition_variable m_batchCv;
 
@@ -19,7 +19,7 @@ private:
   std::thread m_scanThread;
 
   void scan(const std::filesystem::path &path);
-  void enqueueBatch(const std::vector<std::filesystem::path> &paths);
+  void enqueueBatch(const std::vector<FileEvent> &paths);
 
 public:
   IndexerScanner(std::shared_ptr<DbWriter> writer, const Scan &scan, FinishCallback callback);

--- a/vicinae/src/services/files-service/file-indexer/scan.hpp
+++ b/vicinae/src/services/files-service/file-indexer/scan.hpp
@@ -24,3 +24,11 @@ struct Scan {
     return path < other.path;
   }
 };
+
+enum class FileEventType { Modify, Delete };
+
+struct FileEvent {
+  FileEventType type;
+  std::filesystem::path path;
+  std::filesystem::file_time_type eventTime;
+};

--- a/vicinae/src/services/files-service/file-indexer/writer-worker.cpp
+++ b/vicinae/src/services/files-service/file-indexer/writer-worker.cpp
@@ -9,7 +9,7 @@ void WriterWorker::stop() {
 
 void WriterWorker::run() {
   while (m_alive) {
-    std::deque<std::vector<std::filesystem::path>> batch;
+    std::deque<std::vector<FileEvent>> batch;
 
     {
       std::unique_lock<std::mutex> lock(batchMutex);
@@ -27,12 +27,11 @@ void WriterWorker::run() {
   }
 }
 
-void WriterWorker::batchWrite(std::vector<fs::path> paths) {
+void WriterWorker::batchWrite(std::vector<FileEvent> paths) {
   // Writing is happening in the writerThread
-  m_writer->indexFiles(std::move(paths));
+  m_writer->indexEvents(std::move(paths));
 }
 
 WriterWorker::WriterWorker(std::shared_ptr<DbWriter> writer, std::mutex &batchMutex,
-                           std::deque<std::vector<std::filesystem::path>> &batchQueue,
-                           std::condition_variable &batchCv)
+                           std::deque<std::vector<FileEvent>> &batchQueue, std::condition_variable &batchCv)
     : m_writer(writer), batchMutex(batchMutex), batchQueue(batchQueue), m_batchCv(batchCv) {}

--- a/vicinae/src/services/files-service/file-indexer/writer-worker.hpp
+++ b/vicinae/src/services/files-service/file-indexer/writer-worker.hpp
@@ -7,12 +7,12 @@ class WriterWorker : public NonCopyable {
   std::shared_ptr<DbWriter> m_writer;
 
   std::mutex &batchMutex;
-  std::deque<std::vector<std::filesystem::path>> &batchQueue;
+  std::deque<std::vector<FileEvent>> &batchQueue;
   std::condition_variable &m_batchCv;
   std::atomic<bool> m_alive = true;
   std::atomic<bool> m_isWorking = false;
 
-  void batchWrite(std::vector<std::filesystem::path> paths);
+  void batchWrite(std::vector<FileEvent> paths);
 
 public:
   void run();
@@ -20,5 +20,5 @@ public:
   bool isWorking() const { return m_isWorking; }
 
   WriterWorker(std::shared_ptr<DbWriter> writer, std::mutex &batchMutex,
-               std::deque<std::vector<std::filesystem::path>> &batchQueue, std::condition_variable &batchCv);
+               std::deque<std::vector<FileEvent>> &batchQueue, std::condition_variable &batchCv);
 };


### PR DESCRIPTION
A FileEvent struct contains:
- path
- type {Modify, Delete}
- eventTime

eventTime is now written at scan time, not DB write time.