### PR TITLE
fix: hide search accessory container instead of actual accessory

### DIFF
--- a/vicinae/include/extension/extension-list-component.hpp
+++ b/vicinae/include/extension/extension-list-component.hpp
@@ -157,6 +157,7 @@ public:
   void onItemActivated(const ListItemViewModel &item);
   void handleDebouncedSearchNotification();
   void textChanged(const QString &text) override;
+  void initialize() override;
 
   ExtensionListComponent();
   ~ExtensionListComponent();

--- a/vicinae/src/extension/extension-list-component.cpp
+++ b/vicinae/src/extension/extension-list-component.cpp
@@ -86,7 +86,7 @@ void ExtensionListComponent::render(const RenderModel &baseModel) {
     renderDropdown(dropdown);
   }
 
-  m_selector->setVisible(newModel.searchBarAccessory.has_value() && isVisible());
+  setSearchAccessoryVisiblity(newModel.searchBarAccessory.has_value() && isVisible());
 
   if (!newModel.navigationTitle.isEmpty()) { setNavigationTitle(newModel.navigationTitle); }
   if (!newModel.searchPlaceholderText.isEmpty()) { setSearchPlaceholderText(newModel.searchPlaceholderText); }
@@ -263,10 +263,11 @@ void ExtensionListComponent::textChanged(const QString &text) {
   //_debounce->start();
 }
 
+void ExtensionListComponent::initialize() { setSearchAccessoryVisiblity(false); }
+
 ExtensionListComponent::ExtensionListComponent() : _debounce(new QTimer(this)), _shouldResetSelection(true) {
   m_selector->setMinimumWidth(300);
   m_selector->setEnableDefaultFilter(false);
-  m_selector->hide();
   setDefaultActionShortcuts({primaryShortcut, secondaryShortcut});
   m_split->setMainWidget(m_list);
   m_split->setDetailWidget(m_detail);

--- a/vicinae/src/navigation-controller.cpp
+++ b/vicinae/src/navigation-controller.cpp
@@ -180,6 +180,7 @@ void NavigationController::popCurrentView() {
   emit headerVisiblityChanged(next->needsTopBar);
   emit searchVisibilityChanged(next->supportsSearch);
   emit statusBarVisiblityChanged(next->needsStatusBar);
+  emit searchAccessoryVisiblityChanged(next->accessoryVisibility);
   emit loadingChanged(next->isLoading);
 
   if (auto cmpl = next->completer) {
@@ -214,6 +215,13 @@ void NavigationController::clearSearchAccessory(const BaseView *caller) {
   if (auto state = findViewState(VALUE_OR(caller, topView()))) {
     state->searchAccessory.reset();
     if (state->sender == topView()) { emit searchAccessoryCleared(); }
+  }
+}
+
+void NavigationController::setSearchAccessoryVisibility(bool value, const BaseView *caller) {
+  if (auto state = findViewState(VALUE_OR(caller, topView()))) {
+    state->accessoryVisibility = value;
+    if (state->sender == topView()) { emit searchAccessoryVisiblityChanged(value); }
   }
 }
 

--- a/vicinae/src/navigation-controller.hpp
+++ b/vicinae/src/navigation-controller.hpp
@@ -195,6 +195,7 @@ public:
     QString placeholderText;
     QString searchText;
     QObjectUniquePtr<QWidget> searchAccessory;
+    bool accessoryVisibility = true;
     std::optional<CompleterState> completer;
     std::unique_ptr<ActionPanelState> actionPanelState;
     bool loading;
@@ -274,6 +275,13 @@ public:
   void setSearchVisibility(bool value, const BaseView *caller = nullptr);
   void setStatusBarVisibility(bool value, const BaseView *caller = nullptr);
 
+  /**
+   * Unlike clear accessory, this only alters the visiblity: doesn't delete anything.
+   * We need to rework the search accessory system anyways, as the ownership rules
+   * are beyond confusing.
+   */
+  void setSearchAccessoryVisibility(bool value, const BaseView *caller = nullptr);
+
   void showHud(const QString &title, const std::optional<ImageURL> &icon = std::nullopt);
 
   void launch(const std::shared_ptr<AbstractCmd> &cmd);
@@ -323,6 +331,7 @@ signals:
 
   void searchAccessoryChanged(QWidget *widget) const;
   void searchAccessoryCleared() const;
+  void searchAccessoryVisiblityChanged(bool visible) const;
 
   void completionCreated(const CompleterState &completer) const;
   void completionDestroyed() const;

--- a/vicinae/src/ui/top-bar/top-bar.cpp
+++ b/vicinae/src/ui/top-bar/top-bar.cpp
@@ -136,6 +136,8 @@ GlobalHeader::GlobalHeader(NavigationController &controller) : m_navigation(cont
     }
   });
   connect(&m_navigation, &NavigationController::searchAccessoryChanged, this, &GlobalHeader::setAccessory);
+  connect(&m_navigation, &NavigationController::searchAccessoryVisiblityChanged, m_accessoryContainer,
+          &QStackedWidget::setVisible);
   connect(&m_navigation, &NavigationController::searchAccessoryCleared, this, &GlobalHeader::clearAccessory);
   connect(&m_navigation, &NavigationController::searchTextChanged, m_input, [this](const QString &text) {
     if (m_input->text() == text) return; // prevents losing cursor position during editing

--- a/vicinae/src/ui/views/base-view.cpp
+++ b/vicinae/src/ui/views/base-view.cpp
@@ -88,6 +88,11 @@ void BaseView::setSearchPlaceholderText(const QString &value) const {
 
 void BaseView::clearSearchAccessory() { m_ctx->navigation->clearSearchAccessory(m_navProxy); }
 
+void BaseView::setSearchAccessoryVisiblity(bool value) {
+  if (!m_ctx) return;
+  m_ctx->navigation->setSearchAccessoryVisibility(value, m_navProxy);
+}
+
 void BaseView::setTopBarVisiblity(bool visible) {
   if (!m_ctx) return;
   m_ctx->navigation->setHeaderVisiblity(visible, m_navProxy);

--- a/vicinae/src/ui/views/base-view.hpp
+++ b/vicinae/src/ui/views/base-view.hpp
@@ -51,6 +51,7 @@ public:
 
   QString navigationTitle() const;
   void setSearchAccessory(QWidget *accessory);
+  void setSearchAccessoryVisiblity(bool value);
 
   /**
    * Called when the view becomes visible. This is called the first time the view is shown


### PR DESCRIPTION
the accessory still took space on the right of the search bar although the accessory itself wasn't being shown