### PR TITLE
feat: switch to on-demand keyboard interactivity mode

### DIFF
--- a/vicinae/src/ipc-command-handler.cpp
+++ b/vicinae/src/ipc-command-handler.cpp
@@ -130,14 +130,17 @@ void IpcCommandHandler::handleUrl(const QUrl &url) {
     for (ExtensionRootProvider *ext : root->extensions()) {
       for (const auto &cmd : ext->repository()->commands()) {
         if (cmd->author() == author && cmd->commandId() == cmdName && cmd->repositoryName() == extName) {
+          m_ctx.navigation->popToRoot({.clearSearch = false});
           m_ctx.navigation->launch(cmd);
 
           if (auto text = query.queryItemValue("fallbackText"); !text.isEmpty()) {
             m_ctx.navigation->setSearchText(text);
           }
 
-          m_ctx.navigation->setInstantDismiss();
-          m_ctx.navigation->showWindow();
+          if (!m_ctx.navigation->isWindowOpened()) {
+            m_ctx.navigation->setInstantDismiss();
+            m_ctx.navigation->showWindow();
+          }
 
           break;
         }

--- a/vicinae/src/navigation-controller.cpp
+++ b/vicinae/src/navigation-controller.cpp
@@ -276,11 +276,28 @@ void NavigationController::closeWindow(const CloseWindowOptions &settings) {
   if (isRootSearch() && settings.clearRootSearch) clearSearchText();
 }
 
+bool NavigationController::windowActivated() { return m_windowActivated; }
+
+void NavigationController::setWindowActivated(bool value) {
+  if (m_windowActivated == value) return;
+
+  m_windowActivated = value;
+  emit windowActivationChanged(value);
+}
+
 void NavigationController::toggleWindow() {
-  if (m_windowOpened)
+  if (m_windowOpened) {
+    if (m_windowActivated) {
+      closeWindow();
+      return;
+    }
+
+    // if window was not activated, we reactivate it by closing then showing (most reliable way to ensure
+    // reactivation)
     closeWindow();
-  else
-    showWindow();
+  }
+
+  showWindow();
 }
 
 bool NavigationController::isWindowOpened() const { return m_windowOpened; }

--- a/vicinae/src/navigation-controller.hpp
+++ b/vicinae/src/navigation-controller.hpp
@@ -209,14 +209,13 @@ public:
     ~ViewState();
   };
 
-  bool m_isPanelOpened = false;
-  bool m_popToRootOnClose = false;
-  bool m_instantDismiss = false;
-
   void closeWindow(const CloseWindowOptions &settings = {});
   void showWindow();
   void toggleWindow();
   bool isWindowOpened() const;
+
+  bool windowActivated();
+  void setWindowActivated(bool value = true);
 
   void setPopToRootOnClose(bool value);
 
@@ -339,6 +338,7 @@ signals:
   void headerVisiblityChanged(bool value);
   void searchVisibilityChanged(bool value);
   void statusBarVisiblityChanged(bool value);
+  void windowActivationChanged(bool value) const;
 
 private:
   ApplicationContext &m_ctx;
@@ -350,5 +350,9 @@ private:
   bool isRootSearch() const;
 
   bool m_windowOpened = false;
+  bool m_windowActivated = false;
+  bool m_isPanelOpened = false;
+  bool m_popToRootOnClose = false;
+  bool m_instantDismiss = false;
   std::vector<std::unique_ptr<ViewState>> m_views;
 };

--- a/vicinae/src/ui/launcher-window/launcher-window.cpp
+++ b/vicinae/src/ui/launcher-window/launcher-window.cpp
@@ -6,6 +6,7 @@
 #include "services/config/config-service.hpp"
 #include "ui/top-bar/top-bar.hpp"
 #include "utils/environment.hpp"
+#include <qcoreevent.h>
 #ifdef WAYLAND_LAYER_SHELL
 #include <LayerShellQt/window.h>
 #endif
@@ -158,6 +159,12 @@ void LauncherWindow::hideEvent(QHideEvent *event) {
   QWidget::hideEvent(event);
 }
 
+void LauncherWindow::changeEvent(QEvent *event) {
+  if (event->type() == QEvent::ActivationChange) { m_ctx.navigation->setWindowActivated(isActiveWindow()); }
+
+  QWidget::changeEvent(event);
+}
+
 void LauncherWindow::setupUI() {
   setWindowFlags(Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint);
   setAttribute(Qt::WA_TranslucentBackground, true);
@@ -175,7 +182,7 @@ void LauncherWindow::setupUI() {
       lshell->setLayer(Shell::Window::LayerOverlay);
       lshell->setScope("vicinae");
       lshell->setScreenConfiguration(Shell::Window::ScreenFromCompositor);
-      lshell->setKeyboardInteractivity(Shell::Window::KeyboardInteractivityExclusive);
+      lshell->setKeyboardInteractivity(Shell::Window::KeyboardInteractivityOnDemand);
       lshell->setExclusiveZone(-1);
       lshell->setAnchors(Shell::Window::AnchorNone);
     } else {

--- a/vicinae/src/ui/launcher-window/launcher-window.hpp
+++ b/vicinae/src/ui/launcher-window/launcher-window.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <qcoreevent.h>
 #include <qdebug.h>
 #include <qevent.h>
 #include <qlogging.h>
@@ -44,6 +45,7 @@ protected:
   void handleActionVisibilityChanged(bool visible);
   void hideEvent(QHideEvent *event) override;
   void showEvent(QShowEvent *event) override;
+  void changeEvent(QEvent *event) override;
 
 private:
   ActionVeilWidget *m_actionVeil;


### PR DESCRIPTION
For layer-shell users.  This allows focusing other windows, focus is no longer exclusively held by the vicinae.
Note that this also modifies the behavior of the toggle action: we reactivate (refocus) the window if it is shown but deactivated, instead of closing it.  We still close the window if toggling while activated.