### PR TITLE
fix: make sure copied selection is always bumped to the top of the list

### DIFF
--- a/vicinae/include/clipboard-actions.hpp
+++ b/vicinae/include/clipboard-actions.hpp
@@ -31,7 +31,9 @@ public:
 };
 
 class PasteToFocusedWindowAction : public AbstractAction {
-  Clipboard::Content m_content;
+
+public:
+  void setConcealed(bool value = true) { m_concealed = value; }
 
   QString title() const override {
     auto wm = ServiceRegistry::instance()->windowManager();
@@ -51,17 +53,21 @@ class PasteToFocusedWindowAction : public AbstractAction {
     return name;
   }
 
+  PasteToFocusedWindowAction(const Clipboard::Content &content = Clipboard::NoData{})
+      : AbstractAction("Copy to focused window", ImageURL::builtin("copy-clipboard")), m_content(content) {}
+
 protected:
   void execute(ApplicationContext *ctx) override {
     auto clipman = ctx->services->clipman();
-
     ctx->navigation->closeWindow();
-    QTimer::singleShot(100, [content = m_content, clipman]() { clipman->pasteContent(content, {}); });
+    QTimer::singleShot(100, [content = m_content, concealed = m_concealed, clipman]() {
+      clipman->pasteContent(content, {.concealed = concealed});
+    });
   }
 
   void loadClipboardData(const Clipboard::Content &content) { m_content = content; }
 
-public:
-  PasteToFocusedWindowAction(const Clipboard::Content &content = Clipboard::NoData{})
-      : AbstractAction("Copy to focused window", ImageURL::builtin("copy-clipboard")), m_content(content) {}
+private:
+  Clipboard::Content m_content;
+  bool m_concealed = false;
 };

--- a/vicinae/src/services/clipboard/clipboard-db.cpp
+++ b/vicinae/src/services/clipboard/clipboard-db.cpp
@@ -271,11 +271,11 @@ bool ClipboardDatabase::transaction(const TxHandle &handle) {
   return m_db.rollback();
 }
 
-bool ClipboardDatabase::tryBubbleUpSelection(const QString &selectionHash) {
+bool ClipboardDatabase::tryBubbleUpSelection(const QString &idLike) {
   QSqlQuery query(m_db);
 
-  query.prepare("UPDATE selection SET updated_at = unixepoch() WHERE hash_md5 = :hash");
-  query.addBindValue(selectionHash);
+  query.prepare("UPDATE selection SET updated_at = unixepoch() WHERE hash_md5 = :id OR id = :id");
+  query.bindValue(":id", idLike);
 
   if (!query.exec()) { qCritical() << "Failed to execute clipboard update"; }
 

--- a/vicinae/src/services/clipboard/clipboard-db.hpp
+++ b/vicinae/src/services/clipboard/clipboard-db.hpp
@@ -97,8 +97,9 @@ public:
    * Tries to take an existing selection and update its created_at date
    * to make it appear as new without duplicating it. Return whether a record
    * was updated or not.
+   * The id can either be the selection id or the selection hash.
    */
-  bool tryBubbleUpSelection(const QString &selectionHash);
+  bool tryBubbleUpSelection(const QString &idLike);
   bool insertSelection(const InsertSelectionPayload &payload);
   bool insertOffer(const InsertClipboardOfferPayload &payload);
   bool indexSelectionContent(const QString &selectionId, const QString &content);

--- a/vicinae/src/services/clipboard/clipboard-service.cpp
+++ b/vicinae/src/services/clipboard/clipboard-service.cpp
@@ -370,14 +370,12 @@ void ClipboardService::saveSelection(ClipboardSelection selection) {
     return;
   }
 
-  auto selectionHash = QString::fromUtf8(computeSelectionHash(selection).toHex());
   QString preferredMimeType = getSelectionPreferredMimeType(selection);
-
   ClipboardHistoryEntry insertedEntry;
   ClipboardDatabase cdb;
-
   auto preferredOfferIt =
       std::ranges::find_if(selection.offers, [&](auto &&o) { return o.mimeType == preferredMimeType; });
+  auto selectionHash = QCryptographicHash::hash(preferredOfferIt->data, QCryptographicHash::Md5).toHex();
 
   cdb.transaction([&](ClipboardDatabase &db) {
     if (db.tryBubbleUpSelection(selectionHash)) {

--- a/vicinae/src/services/clipboard/clipboard-service.hpp
+++ b/vicinae/src/services/clipboard/clipboard-service.hpp
@@ -92,6 +92,13 @@ private:
    */
   QByteArray computeSelectionHash(const ClipboardSelection &selection) const;
   bool isClearSelection(const ClipboardSelection &selection) const;
+  static bool isConcealedSelection(const ClipboardSelection &selection);
+
+  /**
+   * Sanitize the passed selection by removing duplicate offers.
+   * The selection is sanitized in place, no copy is made.
+   */
+  static ClipboardSelection &sanitizeSelection(ClipboardSelection &selection);
 
   QByteArray decryptOffer(const QByteArray &data, ClipboardEncryptionType enc) const;
 

--- a/vicinae/src/services/clipboard/clipboard-service.hpp
+++ b/vicinae/src/services/clipboard/clipboard-service.hpp
@@ -34,11 +34,15 @@ struct Html {
   std::optional<QString> text;
 };
 
+struct SelectionRecordHandle {
+  QString id;
+};
+
 struct CopyOptions {
   bool concealed = false;
 };
 
-using Content = std::variant<NoData, File, Text, Html, ClipboardSelection>;
+using Content = std::variant<NoData, File, Text, Html, SelectionRecordHandle, ClipboardSelection>;
 
 static Content fromJson(const QJsonObject &obj) {
   if (obj.contains("path")) { return File{.path = obj.value("path").toString().toStdString()}; }
@@ -120,6 +124,7 @@ public:
   void saveSelection(ClipboardSelection selection);
   ClipboardSelection retrieveSelection(int offset = 0);
   std::optional<ClipboardSelection> retrieveSelectionById(const QString &id);
+  bool copySelectionRecord(const QString &id, const Clipboard::CopyOptions &options);
   bool copySelection(const ClipboardSelection &selection, const Clipboard::CopyOptions &options);
   bool copyQMimeData(QMimeData *data, const Clipboard::CopyOptions &options = {});
 
@@ -138,5 +143,10 @@ signals:
   void itemInserted(const ClipboardHistoryEntry &entry) const;
   void selectionPinStatusChanged(const QString &id, bool pinned) const;
   void selectionRemoved(const QString &id) const;
+  /**
+   * When a selection is copied, its update time is modified which makes it appear on top
+   * of the list.
+   */
+  void selectionUpdated() const;
   void monitoringChanged(bool value) const;
 };


### PR DESCRIPTION
Fixes #321 
This also strengthens duplicate detection to avoid the creation of noisy entries.