### PR TITLE
Fix a SEGV When No Items Match Typed Text

### DIFF
--- a/vicinae/src/ui/omni-list/omni-list.cpp
+++ b/vicinae/src/ui/omni-list/omni-list.cpp
@@ -824,6 +824,11 @@ OmniList::AbstractVirtualItem *OmniList::itemAt(const QString &id) {
 }
 
 bool OmniList::selectFirst() {
+  if (m_items.empty()) {
+    setSelectedIndex(-1);
+    return false;
+  }
+
   for (int i = 0; i < m_items.size(); ++i) {
     auto item = m_items[i].item;
 


### PR DESCRIPTION
First let me say that I haven't programmed in C++ since I did embedded stuff like 10 years ago, so this may be way off base. So feel free to tell me to just pound sand and close this PR! I just stumbled around with GDB until I found the spot then had a LLM fix the function based on the backtrace. So I have no context and the only positive point is that it isn't crashing for me anymore :laughing: .

Using latest master I am getting a segfault when I type enough text that it doesn't match anything and should just go to the fallback options. From what I can tell it is because of a list that is assumed to have items in it but doesn't for some reason.