### PR TITLE
fix(extensions): Pass command arguments to extension runtime

### DIFF
--- a/vicinae/src/extension/extension-command-runtime.cpp
+++ b/vicinae/src/extension/extension-command-runtime.cpp
@@ -221,6 +221,11 @@ void ExtensionCommandRuntime::load(const LaunchProps &props) {
     preferences->insert({key.toStdString(), transformJsonValueToProto(value)});
   }
 
+  auto arguments = load->mutable_argument_values();
+  for (const auto &[key, value] : props.arguments) {
+      arguments->insert({key.toStdString(), transformJsonValueToProto(value)});
+  }
+
   payload->set_allocated_load(load);
 
   auto loadRequest = manager->requestManager(payload);


### PR DESCRIPTION
I was building an extension and couldn't get my command arguments to show up props.arguments was always empty.

I did some digging and it looks like the C++ backend was forgetting to pack the arguments before sending them over to the Node.js manager.

🍺