### PR TITLE
fix: Don't create vicinae.json file if not declared

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -71,8 +71,8 @@ in
     };
 
     settings = lib.mkOption {
-      type = lib.types.attrs;
-      default = { };
+      type = lib.types.nullOr lib.types.attrs;
+      default = null;
       description = "Settings written as JSON to `~/.config/vicinae/vicinae.json.";
       example = lib.literalExpression ''
         {
@@ -100,15 +100,23 @@ in
   config = lib.mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    xdg.configFile = {
-      "vicinae/vicinae.json".text = builtins.toJSON cfg.settings;
-    }
-    // lib.mapAttrs' (
-      name: theme:
-      lib.nameValuePair "vicinae/themes/${name}.json" {
-        text = builtins.toJSON theme;
-      }
-    ) cfg.themes;
+    xdg.configFile =
+      let
+        settingsFile =
+          if cfg.settings == null then
+            { }
+          else
+            {
+              "vicinae/vicinae.json".text = builtins.toJSON cfg.settings;
+            };
+      in
+      settingsFile
+      // lib.mapAttrs' (
+        name: theme:
+        lib.nameValuePair "vicinae/themes/${name}.json" {
+          text = builtins.toJSON theme;
+        }
+      ) cfg.themes;
 
     systemd.user.services.vicinae = {
       Unit = {

--- a/module.nix
+++ b/module.nix
@@ -101,7 +101,7 @@ in
     home.packages = [ cfg.package ];
 
     xdg.configFile =
-      lib.optionalAttrs (cfg.settings == null) {
+      lib.optionalAttrs (cfg.settings != null) {
         "vicinae/vicinae.json".text = builtins.toJSON cfg.settings;
       }
       // lib.mapAttrs' (

--- a/module.nix
+++ b/module.nix
@@ -101,16 +101,9 @@ in
     home.packages = [ cfg.package ];
 
     xdg.configFile =
-      let
-        settingsFile =
-          if cfg.settings == null then
-            { }
-          else
-            {
-              "vicinae/vicinae.json".text = builtins.toJSON cfg.settings;
-            };
-      in
-      settingsFile
+      lib.optionalAttrs (cfg.settings == null) {
+        "vicinae/vicinae.json".text = builtins.toJSON cfg.settings;
+      }
       // lib.mapAttrs' (
         name: theme:
         lib.nameValuePair "vicinae/themes/${name}.json" {


### PR DESCRIPTION
This morning I ran into an error when updating my nix config, this is because, with the current workings of the module you are required to set settings, This change makes it optional.