### PR TITLE
fix: emacs action toggle key

### DIFF
--- a/vicinae/src/ui/launcher-window/launcher-window.cpp
+++ b/vicinae/src/ui/launcher-window/launcher-window.cpp
@@ -221,11 +221,14 @@ bool LauncherWindow::event(QEvent *event) {
   if (event->type() == QEvent::KeyPress) {
     auto keyEvent = static_cast<QKeyEvent *>(event);
 
-    // Toggle action panel: Default Ctrl+B ; Emacs Ctrl+O
-    auto config = ServiceRegistry::instance()->config();
-    const QString keybinding = config ? config->value().keybinding : QString("default");
-    if (keybinding == "emacs") {
-      if (keyEvent->keyCombination() == QKeyCombination(Qt::ControlModifier, Qt::Key_O)) {
+	// Toggle action panel: Default Ctrl+B ; Emacs: Ctrl+., Ctrl+H
+	auto config = ServiceRegistry::instance()->config();
+	const QString keybinding = config ? config->value().keybinding : QString("default");
+
+	if (keybinding == "emacs") {
+      // Use both Ctrl+., and Ctrl+H for action panel
+      if (keyEvent->keyCombination() == QKeyCombination(Qt::ControlModifier, Qt::Key_Period) ||
+        keyEvent->keyCombination() == QKeyCombination(Qt::ControlModifier, Qt::Key_H)) {
         m_ctx.navigation->toggleActionPanel();
         return true;
       }

--- a/vicinae/src/ui/status-bar/status-bar.cpp
+++ b/vicinae/src/ui/status-bar/status-bar.cpp
@@ -63,7 +63,7 @@ void GlobalBar::actionsChanged(const ActionPanelState &panel) {
   auto config = ServiceRegistry::instance()->config();
   const QString keybinding = config ? config->value().keybinding : QString("default");
   if (keybinding == "emacs") {
-    m_actionButton->setShortcut(KeyboardShortcutModel{.key = "O", .modifiers = {"ctrl"}});
+    m_actionButton->setShortcut(KeyboardShortcutModel{.key = "H", .modifiers = {"ctrl"}});
   } else {
     m_actionButton->setShortcut(KeyboardShortcutModel{.key = "B", .modifiers = {"ctrl"}});
   }


### PR DESCRIPTION
- Ctrl+O is also bound to "Open Location" which opens desktop entry in editor which takes precendence
- Re-bound to Ctrl+H and Ctrl+. to act

- Fixed #403

Although this is simple keybinding fix, I've compiled and tested.
C-h and C-. toggle works!