### PR TITLE
Fix instructions to toggle Vicinae window after starting the server

### DIFF
--- a/vicinae/src/cli/server.cpp
+++ b/vicinae/src/cli/server.cpp
@@ -229,7 +229,7 @@ void CliServerCommand::run(CLI::App *app) {
 
   ctx.navigation->launch(std::make_shared<RootCommand>());
 
-  qInfo() << "Vicinae server successfully started. Call vicinae without an argument to toggle the window";
+  qInfo() << "Vicinae server successfully started. Call \"vicinae toggle\" to toggle the window";
 
   qApp->exec();
 }


### PR DESCRIPTION
Hi. I'm not sure it was a regression from the latest changes. If it was, please feel free to close this PR.

After updating, I realized the `vicinae` command was not toggling the window anymore but the server still presented the following message:

<img width="1211" height="810" alt="image" src="https://github.com/user-attachments/assets/a009cd7f-b767-4201-87ae-a1f461acdf80" />

This PR fixes the message by mentioning the `vicinae toggle` command to toggle the window instead of the `vicinae` command without arguments.

For reference, this is the behavior of the `vicinae` command:

<img width="1211" height="811" alt="image" src="https://github.com/user-attachments/assets/c70f3afc-ce4f-40ff-8043-01a42ae6c092" />

(it only displays information about the CLI).

Sorry for creating a PR directly, let me know if I should have created an issue first (I didn't find any existing issue about this problem). Thanks for the great work, it's being a pleasure daily driving Vicinae here :raised_hands: 