### PR TITLE
nix: allow using the module in non-flake contexts

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -59,20 +59,6 @@
         vicinae = self.packages.${final.system}.default;
         mkVicinaeExtension = import ./nix/mkVicinaeExtension.nix;
       };
-      homeManagerModules.default =
-        {
-          config,
-          pkgs,
-          lib,
-          ...
-        }:
-        import ./nix/module.nix {
-          inherit
-            config
-            pkgs
-            lib
-            self
-            ;
-        };
+      homeManagerModules.default = import ./nix/module.nix;
     };
 }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -2,12 +2,11 @@
   config,
   pkgs,
   lib,
-  self,
   ...
 }:
 let
   cfg = config.services.vicinae;
-  vicinaePkg = self.outputs.packages.${pkgs.system}.default;
+  vicinaePkg = pkgs.callPackage ./vicinae.nix { };
 in
 {
 


### PR DESCRIPTION
The usage of `self` to refer to the flake in the home-manager module is an extension that is not part of the main home-manager module system. While it is passed in as part of the flake in flake.nix and typically works fine, it means that non-flake users cannot use the module by doing a standard `fetchTarball` of the vicinae source code, and then referring to the `/nix/module.nix` path. By running `callPackage` inline, we can avoid the need to refer to `self` and allow non-flake users to include the module directly.

For example, as a user of `npins`, I can now use this as
```nix
let
  pins = import ./npins;
in
{
  imports = [ "${pins.vicinae}/nix/module.nix" ];
  services.vicinae.enable = true;
}
```
whereas before the `self` parameter needed by `module.nix` would have been missing.