### PR TITLE
build: add VICINAE_PROVENANCE flag to identify the way vicinae was built

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5  \
             -DBUILD_TESTS=ON  \
+            -DVICINAE_PROVENANCE=binary_release \
             -DLTO=ON \
             -DUSE_SYSTEM_PROTOBUF=OFF \
             -DUSE_SYSTEM_ABSEIL=OFF \
@@ -122,6 +123,7 @@ jobs:
           cmake -G Ninja ..                           \
             -DCMAKE_BUILD_TYPE=${BUILD_TYPE}          \
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5        \
+            -DVICINAE_PROVENANCE=appimage             \
             -DLTO=ON                                  \
             -DUSE_SYSTEM_PROTOBUF=OFF                 \
             -DUSE_SYSTEM_CMARK_GFM=OFF                \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,12 @@ if (NOT DEFINED VICINAE_GIT_COMMIT_HASH)
 	get_git_commit(VICINAE_GIT_COMMIT_HASH)
 endif()
 
+if (DEFINED VICINAE_PROVENANCE)
+	message(STATUS "Provenance was explicitly set to ${VICINAE_PROVENANCE}")
+else()
+	set(VICINAE_PROVENANCE "local")
+endif()
+
 message(STATUS "Vicinae version: ${VICINAE_GIT_TAG}")
 message(STATUS "Vicinae commit hash: ${VICINAE_GIT_COMMIT_HASH}")
 
@@ -92,6 +98,7 @@ get_cxx_compiler_name(CXX_COMPILER_NAME)
 
 add_compile_definitions(VICINAE_GIT_TAG="${VICINAE_GIT_TAG}")
 add_compile_definitions(VICINAE_GIT_COMMIT_HASH="${VICINAE_GIT_COMMIT_HASH}")
+add_compile_definitions(VICINAE_PROVENANCE="${VICINAE_PROVENANCE}")
 
 set(CMARK_LIBRARY "cmark-gfm")
 

--- a/nix/vicinae.nix
+++ b/nix/vicinae.nix
@@ -65,6 +65,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DVICINAE_GIT_TAG=${manifest.tag}"
     "-DVICINAE_GIT_COMMIT_HASH=${manifest.short_rev}"
+    "-DVICINAE_PROVENANCE=nix"
     "-DINSTALL_NODE_MODULES=OFF"
     "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}"
     "-DCMAKE_INSTALL_DATAROOTDIR=share"

--- a/vicinae/src/cli/cli.cpp
+++ b/vicinae/src/cli/cli.cpp
@@ -73,7 +73,8 @@ class VersionCommand : public AbstractCommandLineCommand {
 
   void run(CLI::App *app) override {
     std::cout << "Version " << VICINAE_GIT_TAG << " (commit " << VICINAE_GIT_COMMIT_HASH << ")\n"
-              << "Build: " << BUILD_INFO << "\n";
+              << "Build: " << BUILD_INFO << "\n"
+              << "Provenance: " << VICINAE_PROVENANCE << "\n";
   }
 };
 

--- a/vicinae/src/extensions/vicinae/report-bug-command.hpp
+++ b/vicinae/src/extensions/vicinae/report-bug-command.hpp
@@ -8,8 +8,9 @@ static const QString ISSUE_TEMPLATE = R"(**System information**
 
 - Version: %1 (%2)
 - Build info: %3
-- OS: %4
-- QT Platform: %5
+- Provenance: %4
+- OS: %5
+- QT Platform: %6
 
 **Describe the bug**
 
@@ -59,6 +60,7 @@ class ReportVicinaeBugCommand : public BuiltinUrlCommand {
     QString content = ISSUE_TEMPLATE.arg(VICINAE_GIT_TAG)
                           .arg(VICINAE_GIT_COMMIT_HASH)
                           .arg(BUILD_INFO)
+                          .arg(VICINAE_PROVENANCE)
                           .arg(osString)
                           .arg(QApplication::platformName());
     QUrl url(Omnicast::GH_REPO_CREATE_ISSUE);


### PR DESCRIPTION
@jaredallard @cilginc @ArjixWasTaken you may be interested into that for your from source builds.