### PR TITLE
fix: dont use nixos-unstable in cachix workflow

### DIFF
--- a/.github/workflows/cachix.yaml
+++ b/.github/workflows/cachix.yaml
@@ -12,11 +12,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v25
-      with:
-        nix_path: nixpkgs=channel:nixos-unstable
     - uses: cachix/cachix-action@v14
       with:
         name: vicinae
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - run: nix build
-    - run: nix-shell --run "echo OK"
+    - name: Build Flake
+      run: nix build
+    - name: Run Test Shell
+      run: nix develop --command echo OK 


### PR DESCRIPTION
The nixpath was only used for nix-shell which i migrated to the never cli version so it uses the flake input.
This makes us not depend on nixos-unstable anymore because we really dont need that anywhere else.