### PR TITLE
feat: do not require system keychain by default

### DIFF
--- a/vicinae/CMakeLists.txt
+++ b/vicinae/CMakeLists.txt
@@ -6,9 +6,7 @@ set(TARGET vicinae)
 find_package(Qt6 REQUIRED COMPONENTS Core Widgets Sql Network Svg DBus)
 find_package(OpenSSL REQUIRED)
 
-
-
-list(APPEND LIBS  Qt6::Widgets Qt6::Sql Qt6::Network Qt6::Svg Qt6::DBus qt6keychain ${CMARK_LIBRARY} protobuf::libprotobuf minizip OpenSSL::Crypto wayland-client xdgpp)
+list(APPEND LIBS  Qt6::Widgets Qt6::Sql Qt6::Network Qt6::Svg Qt6::DBus ${CMARK_LIBRARY} protobuf::libprotobuf minizip OpenSSL::Crypto wayland-client xdgpp qt6keychain)
 
 set(WLR_CLIP_BIN ${CMAKE_BINARY_DIR}/wlr-clip/wlr-clip${CMAKE_EXECUTABLE_SUFFIX})
 set(ASSET_PATH ${CMAKE_CURRENT_SOURCE_DIR}/assets)
@@ -154,6 +152,7 @@ set(SRCS
 	src/services/clipboard/clipboard-server-factory.hpp
 	src/services/clipboard/clipboard-server-factory.cpp
 	src/services/clipboard/clipboard-service.hpp
+	src/services/clipboard/clipboard-encrypter.cpp
 	src/services/clipboard/clipboard-service.cpp
 	src/services/clipboard/gnome/gnome-clipboard-server.hpp
 	src/services/clipboard/gnome/gnome-clipboard-server.cpp

--- a/vicinae/include/clipboard-actions.hpp
+++ b/vicinae/include/clipboard-actions.hpp
@@ -60,6 +60,7 @@ protected:
   void execute(ApplicationContext *ctx) override {
     auto clipman = ctx->services->clipman();
     ctx->navigation->closeWindow();
+
     QTimer::singleShot(100, [content = m_content, concealed = m_concealed, clipman]() {
       clipman->pasteContent(content, {.concealed = concealed});
     });

--- a/vicinae/src/extensions/clipboard/clipboard-extension.hpp
+++ b/vicinae/src/extensions/clipboard/clipboard-extension.hpp
@@ -17,6 +17,7 @@ public:
   QString description() const override { return "System clipboard integration"; }
 
   std::vector<Preference> preferences() const override {
+    auto encryption = Preference::makeCheckbox("encryption");
     auto monitoring = Preference::makeCheckbox("monitoring");
     auto eraseOnStartup = Preference::makeCheckbox("eraseOnStartup");
 
@@ -24,12 +25,18 @@ public:
     eraseOnStartup.setDescription("Erase clipboard history every time the vicinae server is started");
     eraseOnStartup.setDefaultValue(false);
 
+    encryption.setTitle("Disk encryption");
+    encryption.setDescription("Whether to encrypt the clipboard data on disk. The "
+                              "encryption key is stored and retrieved from the system keychain. Enabling "
+                              "this might trigger your keychain's unlock dialog.");
+    encryption.setDefaultValue(false);
+
     monitoring.setTitle("Clipboard monitoring");
     monitoring.setDescription("Whether clipboard activity is recorded in the history. Every clipboard action "
                               "performed while this is turned off will not be recorded.");
     monitoring.setDefaultValue(true);
 
-    return {monitoring, eraseOnStartup};
+    return {monitoring, encryption, eraseOnStartup};
   }
 
   virtual void initialized(const QJsonObject &preferences) const override {
@@ -44,6 +51,7 @@ public:
 
     clipman->setRecordAllOffers(value.value("store-all-offerings").toBool());
     clipman->setMonitoring(value.value("monitoring").toBool());
+    clipman->setEncryption(value.value("encryption").toBool());
   }
 
   ClipboardExtension() { registerCommand<ClipboardHistoryCommand>(); }

--- a/vicinae/src/extensions/clipboard/history/clipboard-history-view.hpp
+++ b/vicinae/src/extensions/clipboard/history/clipboard-history-view.hpp
@@ -113,7 +113,7 @@ private:
 
   void generateList(const PaginatedResponse<ClipboardHistoryEntry> &result);
   void selectionChanged(const OmniList::AbstractVirtualItem *next,
-                        const OmniList::AbstractVirtualItem *previous) const;
+                        const OmniList::AbstractVirtualItem *previous);
 
   void clipboardSelectionInserted(const ClipboardHistoryEntry &entry);
   void handlePinChanged(int entryId, bool value);

--- a/vicinae/src/services/clipboard/clipboard-db.cpp
+++ b/vicinae/src/services/clipboard/clipboard-db.cpp
@@ -52,7 +52,7 @@ PaginatedResponse<ClipboardHistoryEntry> ClipboardDatabase::listAll(int limit, i
 
   QString queryString = R"(
 	  	SELECT
-			selection.id, o.mime_type, o.text_preview, pinned_at, o.content_hash_md5, updated_at, o.size, selection.kind, o.url_host
+			selection.id, o.mime_type, o.text_preview, pinned_at, o.content_hash_md5, updated_at, o.size, selection.kind, o.url_host, o.encryption_type
 		FROM
 			selection
 		JOIN
@@ -96,16 +96,15 @@ PaginatedResponse<ClipboardHistoryEntry> ClipboardDatabase::listAll(int limit, i
 
   while (query.next()) {
     auto sum = query.value(4).toString();
-    ClipboardHistoryEntry dto{
-        .id = query.value(0).toString(),
-        .mimeType = query.value(1).toString(),
-        .textPreview = query.value(2).toString(),
-        .pinnedAt = query.value(3).toULongLong(),
-        .md5sum = sum,
-        .updatedAt = query.value(5).toULongLong(),
-        .size = query.value(6).toULongLong(),
-        .kind = static_cast<ClipboardOfferKind>(query.value(7).toUInt()),
-    };
+    ClipboardHistoryEntry dto{.id = query.value(0).toString(),
+                              .mimeType = query.value(1).toString(),
+                              .textPreview = query.value(2).toString(),
+                              .pinnedAt = query.value(3).toULongLong(),
+                              .md5sum = sum,
+                              .updatedAt = query.value(5).toULongLong(),
+                              .size = query.value(6).toULongLong(),
+                              .kind = static_cast<ClipboardOfferKind>(query.value(7).toUInt()),
+                              .encryption = static_cast<ClipboardEncryptionType>(query.value(9).toUInt())};
 
     if (auto val = query.value(8); !val.isNull()) { dto.urlHost = val.toString(); }
 

--- a/vicinae/src/services/clipboard/clipboard-db.hpp
+++ b/vicinae/src/services/clipboard/clipboard-db.hpp
@@ -52,6 +52,7 @@ struct ClipboardHistoryEntry {
   uint64_t size;
   ClipboardOfferKind kind;
   std::optional<QString> urlHost;
+  ClipboardEncryptionType encryption;
 };
 
 struct ClipboardListSettings {

--- a/vicinae/src/services/clipboard/clipboard-encrypter.cpp
+++ b/vicinae/src/services/clipboard/clipboard-encrypter.cpp
@@ -1,0 +1,50 @@
+#include "services/clipboard/clipboard-encrypter.hpp"
+#include <qstringview.h>
+#include <qt6keychain/keychain.h>
+#include "vicinae.hpp"
+#include "crypto.hpp"
+
+static const QString KEYCHAIN_ENCRYPTION_KEY_NAME = "clipboard-data-key";
+
+void ClipboardEncrypter::loadKey() {
+  using namespace QKeychain;
+
+  auto readJob = new ReadPasswordJob(Omnicast::APP_ID);
+
+  readJob->setKey(KEYCHAIN_ENCRYPTION_KEY_NAME);
+  readJob->start();
+
+  connect(readJob, &ReadPasswordJob::finished, this, [this, readJob](Job *job) {
+    if (readJob->error() == QKeychain::NoError) {
+      m_key = readJob->binaryData();
+      return;
+    }
+
+    auto writeJob = new QKeychain::WritePasswordJob(Omnicast::APP_ID);
+    auto keyData = Crypto::AES256GCM::generateKey();
+
+    writeJob->setKey(KEYCHAIN_ENCRYPTION_KEY_NAME);
+    writeJob->setBinaryData(keyData);
+    writeJob->start();
+
+    connect(writeJob, &WritePasswordJob::finished, this, [this, keyData, writeJob]() {
+      if (writeJob->error() == QKeychain::NoError) {
+        m_key = keyData;
+        return;
+      }
+
+      qCritical() << "Failed to write encryption key to keychain" << writeJob->errorString();
+      m_keychainError = writeJob->errorString();
+    });
+  });
+}
+
+ClipboardEncrypter::EncryptResult ClipboardEncrypter::encrypt(const QByteArray &plain) const {
+  if (!m_keychainError.isEmpty()) return tl::unexpected(m_keychainError);
+  return Crypto::AES256GCM::encrypt(plain, m_key);
+}
+
+ClipboardEncrypter::DecryptResult ClipboardEncrypter::decrypt(const QByteArray &encrypted) const {
+  if (!m_keychainError.isEmpty()) return tl::unexpected(m_keychainError);
+  return Crypto::AES256GCM::decrypt(encrypted, m_key);
+}

--- a/vicinae/src/services/clipboard/clipboard-encrypter.hpp
+++ b/vicinae/src/services/clipboard/clipboard-encrypter.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include "expected.hpp"
+#include <qobject.h>
+#include <qstringview.h>
+
+class ClipboardEncrypter : public QObject {
+public:
+  using EncryptResult = tl::expected<QByteArray, QString>;
+  using DecryptResult = tl::expected<QByteArray, QString>;
+
+  void loadKey();
+  EncryptResult encrypt(const QByteArray &plain) const;
+  DecryptResult decrypt(const QByteArray &encrypted) const;
+
+private:
+  QByteArray m_key;
+  QString m_keychainError;
+};


### PR DESCRIPTION
The clipboard history is no longer encrypted by default as the dependency on the system keychain can be quite annoying to deal with. It is still possible to opt into encryption by enabling it in the clipboard extension preferences.
