### PR TITLE
chore: add compile_commands.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ extension-manager/runtime/node_modules
 /vgcore*
 .env
 .direnv
+compile_commands.json
 
 vicinae/assets/extension-runtime.js
 


### PR DESCRIPTION
The compile_commands.json file is automatically generated by build systems such as CMake using commands like:

```bash
cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ...
```

This file is primarily used for code analysis tools (e.g., clangd) and local development setups, such as Neovim with LSP plugins. It contains machine-specific compilation information and should not be tracked by git. Adding it to .gitignore helps prevent accidental commits and keeps the repository clean.