### PR TITLE
fix: use the correct package in home-manager module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -59,6 +59,6 @@
         vicinae = self.packages.${final.system}.default;
         mkVicinaeExtension = import ./nix/mkVicinaeExtension.nix;
       };
-      homeManagerModules.default = import ./nix/module.nix;
+      homeManagerModules.default = import ./nix/module.nix self;
     };
 }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,4 +1,4 @@
-{
+self: {
   config,
   pkgs,
   lib,
@@ -6,7 +6,9 @@
 }:
 let
   cfg = config.services.vicinae;
-  vicinaePkg = pkgs.callPackage ./vicinae.nix { };
+
+  inherit (pkgs.stdenv.hostPlatform) system;
+  vicinaePkg = self.packages.${system}.default;
 in
 {
 


### PR DESCRIPTION
Im not sure i can really test this outside of this repo because the derivations wouldnt match then (atleast i didnt find a way).

This _should_ fix having to specifiy `package = inputs.vicinae.packages.${pkgs.system}.default;` in order to get the cachix hit