### PR TITLE
feat(script): add installation script with additional update functionality

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -327,7 +327,22 @@ main() {
 
 		echo ""
 		echo "🎉 Vicinae $latest_version has been successfully installed!"
-		echo "You can now run 'vicinae' from anywhere in your terminal."
+		echo ""
+
+		local local_bin_path="$HOME/.local/bin"
+		if [[ ":$PATH:" == *":$local_bin_path:"* ]]; then
+			echo "✓ ~/.local/bin is already in your PATH"
+			echo "You can now run 'vicinae' from anywhere in your terminal."
+		else
+			echo "To use Vicinae, add ~/.local/bin to your PATH:"
+			echo "  export PATH=\"\$HOME/.local/bin:\$PATH\""
+			echo ""
+			echo "You can add this to your shell profile (~/.bashrc, ~/.zshrc, etc.) for permanent access."
+			echo "Then restart your terminal or run the export command above."
+		fi
+
+		echo ""
+		echo "Check the quickstart section for your Desktop Environment at https://docs.vicinae.com"
 	else
 		echo "✓ Vicinae is already up to date ($installed_version)"
 	fi


### PR DESCRIPTION
- add a new `install.sh` for easy installation of vicinae using one command. 
- It uses the appimage bundle, extracts it at `~/.local/vicinae` and  symlink the main vicinae binary to `~/.local/bin`
- you can add the new installation command to the readme. I didn't do it because it might mislead people before this pr is merged.
- I also opened pr [#22](https://github.com/vicinaehq/docs/pull/22) on the docs site to expose this script at https://vicinae.com/install.sh

you can test it using

```
curl -fsSl https://raw.githubusercontent.com/dagimg-dot/vicinae/refs/heads/feat/install-script/scripts/install.sh | bash
```