### PR TITLE
fix: add null pointer checks in VirtualKeyboard constructor [AI]

### DIFF
--- a/vicinae/src/lib/wayland/virtual-keyboard.cpp
+++ b/vicinae/src/lib/wayland/virtual-keyboard.cpp
@@ -18,10 +18,20 @@ namespace Wayland {
 static constexpr const auto delayMs = chrono::duration_cast<chrono::microseconds>(2ms).count();
 
 VirtualKeyboard::VirtualKeyboard() {
-  m_display = qApp->nativeInterface<QNativeInterface::QWaylandApplication>()->display();
-  wl_seat *seat = qApp->nativeInterface<QNativeInterface::QWaylandApplication>()->seat();
-  wl_keyboard *kb = qApp->nativeInterface<QNativeInterface::QWaylandApplication>()->keyboard();
+  auto *waylandApp = qApp->nativeInterface<QNativeInterface::QWaylandApplication>();
+  if (!waylandApp) { return; }
+
+  m_display = waylandApp->display();
+  if (!m_display) { return; }
+
+  wl_seat *seat = waylandApp->seat();
+  if (!seat) { return; }
+
+  wl_keyboard *kb = waylandApp->keyboard();
+  if (!kb) { return; }
+
   wl_registry *registry = wl_display_get_registry(m_display);
+  if (!registry) { return; }
 
   wl_registry_add_listener(registry, &_listener, this);
   wl_display_dispatch(m_display);


### PR DESCRIPTION
## Summary

Fixes a **segmentation fault** that occurs when `VirtualKeyboard` is instantiated on non-Wayland platforms (e.g., X11, Awesome WM).

## Problem

The `VirtualKeyboard::VirtualKeyboard()` constructor was calling:
```cpp
qApp->nativeInterface<QNativeInterface::QWaylandApplication>()->display()
```

without checking if `nativeInterface()` returned `nullptr`. On non-Wayland platforms, this immediately crashes with a null pointer dereference.

This regression was introduced in PR #531, where `HyprlandWindowManager` started unconditionally creating a `VirtualKeyboard` member that would fail on non-Wayland platforms.

## Root Cause Flow

1. `WindowManager::createCandidates()` creates all window manager instances, including `HyprlandWindowManager`
2. `HyprlandWindowManager` constructor creates a `VirtualKeyboard` member
3. On X11 (non-Wayland): `qApp->nativeInterface<QNativeInterface::QWaylandApplication>()` returns `nullptr`
4. Dereferencing a null pointer → **SIGSEGV**

## Solution

Added null pointer checks before accessing Wayland interfaces. When any required Wayland component is unavailable, the constructor gracefully returns early, and `isAvailable()` correctly reports `false`.

Checks added for:
- `waylandApp` pointer
- `m_display`
- `seat`
- `keyboard`
- `registry`

## Testing

Tested on X11 with Awesome WM:
- ✅ Program starts without crashing
- ✅ Wayland-dependent window managers fail gracefully
- ✅ X11 and other platforms work correctly

Closes: Coredump on non-Wayland platforms
Related: #531