### PR TITLE
fix: prevent infinite loop on file-indexer.db when watched (1)

### DIFF
--- a/vicinae/src/services/files-service/file-indexer/file-indexer.cpp
+++ b/vicinae/src/services/files-service/file-indexer/file-indexer.cpp
@@ -65,7 +65,8 @@ void FileIndexer::start() {
   }
 
   for (const auto &entrypoint : m_watcherPaths) {
-    m_dispatcher.enqueue({.type = ScanType::Watcher, .path = entrypoint});
+    m_dispatcher.enqueue(
+        {.type = ScanType::Watcher, .path = entrypoint, .excludedFilenames = m_excludedFilenames});
   }
 }
 
@@ -93,6 +94,9 @@ void FileIndexer::preferenceValuesChanged(const QJsonObject &preferences) {
   m_watcherPaths = ranges_to<std::vector>(
       preferences.value("watcherPaths").toString().split(';', Qt::SkipEmptyParts) |
       std::views::transform([](const QStringView &v) { return fs::path(v.toString().toStdString()); }));
+
+  std::string databaseFilename = FileIndexerDatabase::getDatabasePath().filename().string();
+  m_excludedFilenames = {databaseFilename, databaseFilename + "-wal"};
 }
 
 QFuture<std::vector<IndexerFileResult>> FileIndexer::queryAsync(std::string_view view,

--- a/vicinae/src/services/files-service/file-indexer/file-indexer.hpp
+++ b/vicinae/src/services/files-service/file-indexer/file-indexer.hpp
@@ -26,6 +26,7 @@ public:
   std::shared_ptr<DbWriter> m_writer;
   std::vector<std::filesystem::path> m_entrypoints;
   std::vector<std::filesystem::path> m_watcherPaths;
+  std::vector<std::string> m_excludedFilenames;
   FileIndexerDatabase m_db;
 
   ScanDispatcher m_dispatcher;

--- a/vicinae/src/services/files-service/file-indexer/scan.hpp
+++ b/vicinae/src/services/files-service/file-indexer/scan.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <filesystem>
 #include <optional>
+#include <vector>
 
 // Add new types here for new scanner types (e.g. watchers)
 enum ScanType { Full, Incremental, Watcher };
@@ -18,6 +19,7 @@ struct Scan {
   ScanType type;
   std::filesystem::path path;
   std::optional<size_t> maxDepth;
+  std::vector<std::string> excludedFilenames;
 
   bool operator<(const Scan &other) const {
     // TODO: Find a proper way to suppport std::set

--- a/vicinae/src/services/files-service/file-indexer/watcher-scanner.cpp
+++ b/vicinae/src/services/files-service/file-indexer/watcher-scanner.cpp
@@ -50,6 +50,12 @@ void WatcherScanner::handleEvent(const wtr::event &ev) {
     return;
   }
 
+  for (const auto &excludedPath : scan.excludedFilenames) {
+    auto eventPathStr = ev.path_name.string();
+    auto excludedPathStr = excludedPath;
+    if (eventPathStr.ends_with(excludedPathStr)) { return; }
+  }
+
   // WHY
   auto toFileTimeType = [](long long t) {
     using namespace std::chrono;


### PR DESCRIPTION
When the database file is watched, inotify goes on an infinite loop of getting a database file change event, saving it to the database, which triggers a file change event, etc.

This prevents the database file from being processed.
Feel free to improve the logic, as to me it does not look ideal to have the filename hardcoded but I could not find another way to do it with my (still) limited knowledge of the codebase!