### PR TITLE
ui: add home/end key handlers to jump to list start/end

### DIFF
--- a/vicinae/include/extension/extension-grid-component.hpp
+++ b/vicinae/include/extension/extension-grid-component.hpp
@@ -145,6 +145,8 @@ public:
   bool selectDown() { return m_list->selectDown(); }
   bool selectLeft() { return m_list->selectLeft(); }
   bool selectRight() { return m_list->selectRight(); }
+  bool selectHome() { return m_list->selectHome(); }
+  bool selectEnd() { return m_list->selectEnd(); }
   void activateCurrentSelection() const { m_list->activateCurrentSelection(); }
 
   GridItemViewModel const *selected() const {

--- a/vicinae/include/extension/extension-list-component.hpp
+++ b/vicinae/include/extension/extension-list-component.hpp
@@ -130,6 +130,8 @@ public:
 
   bool selectUp() { return m_list->selectUp(); }
   bool selectDown() { return m_list->selectDown(); }
+  bool selectHome() { return m_list->selectHome(); }
+  bool selectEnd() { return m_list->selectEnd(); }
   void activateCurrentSelection() const { m_list->activateCurrentSelection(); }
 
   ListItemViewModel const *selected() const {

--- a/vicinae/src/action-panel/action-panel.hpp
+++ b/vicinae/src/action-panel/action-panel.hpp
@@ -166,6 +166,10 @@ protected:
           return m_list->selectUp();
         case Qt::Key_Down:
           return m_list->selectDown();
+        case Qt::Key_Home:
+          return m_list->selectHome();
+        case Qt::Key_End:
+          return m_list->selectEnd();
         case Qt::Key_Return:
         case Qt::Key_Enter:
           m_list->activateCurrentSelection();

--- a/vicinae/src/extension/extension-grid-component.cpp
+++ b/vicinae/src/extension/extension-grid-component.cpp
@@ -31,6 +31,10 @@ bool ExtensionGridComponent::inputFilter(QKeyEvent *event) {
       return m_list->selectUp();
     case Qt::Key_Down:
       return m_list->selectDown();
+    case Qt::Key_Home:
+      return m_list->selectHome();
+    case Qt::Key_End:
+      return m_list->selectEnd();
     case Qt::Key_Return:
       m_list->activateCurrentSelection();
       return true;

--- a/vicinae/src/extension/extension-list-component.cpp
+++ b/vicinae/src/extension/extension-list-component.cpp
@@ -90,6 +90,10 @@ bool ExtensionListComponent::inputFilter(QKeyEvent *event) {
       return m_list->selectUp();
     case Qt::Key_Down:
       return m_list->selectDown();
+    case Qt::Key_Home:
+      return m_list->selectHome();
+    case Qt::Key_End:
+      return m_list->selectEnd();
     }
   }
 

--- a/vicinae/src/extensions/clipboard/history/clipboard-history-view.cpp
+++ b/vicinae/src/extensions/clipboard/history/clipboard-history-view.cpp
@@ -663,6 +663,10 @@ bool ClipboardHistoryView::inputFilter(QKeyEvent *event) {
       return m_list->selectUp();
     case Qt::Key_Down:
       return m_list->selectDown();
+    case Qt::Key_Home:
+      return m_list->selectHome();
+    case Qt::Key_End:
+      return m_list->selectEnd();
     case Qt::Key_Return:
       m_list->activateCurrentSelection();
       return true;

--- a/vicinae/src/ui/action-pannel/action-pannel-list-view.cpp
+++ b/vicinae/src/ui/action-pannel/action-pannel-list-view.cpp
@@ -35,6 +35,10 @@ bool ActionPannelListView::eventFilter(QObject *sender, QEvent *event) {
         return _list->selectUp();
       case Qt::Key_Down:
         return _list->selectDown();
+      case Qt::Key_Home:
+        return _list->selectHome();
+      case Qt::Key_End:
+        return _list->selectEnd();
       case Qt::Key_Return:
         _list->activateCurrentSelection();
         return true;

--- a/vicinae/src/ui/omni-list/omni-list.cpp
+++ b/vicinae/src/ui/omni-list/omni-list.cpp
@@ -634,6 +634,34 @@ bool OmniList::selectRight() {
   return false;
 }
 
+bool OmniList::selectHome() {
+  if (m_items.empty()) return false;
+
+  // Find the first selectable item
+  for (int i = 0; i < m_items.size(); ++i) {
+    if (m_items[i].item->selectable()) {
+      setSelectedIndex(i, ScrollBehaviour::ScrollAbsolute);
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool OmniList::selectEnd() {
+  if (m_items.empty()) return false;
+
+  // Find the last selectable item
+  for (int i = m_items.size() - 1; i >= 0; --i) {
+    if (m_items[i].item->selectable()) {
+      setSelectedIndex(i, ScrollBehaviour::ScrollAbsolute);
+      return true;
+    }
+  }
+
+  return false;
+}
+
 void OmniList::setSelectedIndex(int index, ScrollBehaviour scrollBehaviour) {
   int oldIndex = m_selected;
 
@@ -761,6 +789,10 @@ bool OmniList::event(QEvent *event) {
       return selectLeft();
     case Qt::Key_Right:
       return selectRight();
+    case Qt::Key_Home:
+      return selectHome();
+    case Qt::Key_End:
+      return selectEnd();
     case Qt::Key_Return:
       activateCurrentSelection();
       return true;

--- a/vicinae/src/ui/omni-list/omni-list.hpp
+++ b/vicinae/src/ui/omni-list/omni-list.hpp
@@ -414,6 +414,8 @@ public:
   bool selectDown();
   bool selectLeft();
   bool selectRight();
+  bool selectHome();
+  bool selectEnd();
   const AbstractVirtualItem *firstSelectableItem() const;
   void activateCurrentSelection() const;
 

--- a/vicinae/src/ui/omni-tree/omni-tree.cpp
+++ b/vicinae/src/ui/omni-tree/omni-tree.cpp
@@ -12,6 +12,8 @@ OmniTree::OmniTree(QWidget *parent) : QWidget(parent) {
 
 bool OmniTree::selectUp() const { return m_list->selectUp(); }
 bool OmniTree::selectDown() { return m_list->selectDown(); }
+bool OmniTree::selectHome() const { return m_list->selectHome(); }
+bool OmniTree::selectEnd() { return m_list->selectEnd(); }
 void OmniTree::activateCurrentSelection() { m_list->activateCurrentSelection(); }
 bool OmniTree::selectFirst() const { return m_list->selectFirst(); }
 

--- a/vicinae/src/ui/omni-tree/omni-tree.hpp
+++ b/vicinae/src/ui/omni-tree/omni-tree.hpp
@@ -382,6 +382,8 @@ public:
 
   bool selectUp() const;
   bool selectDown();
+  bool selectHome() const;
+  bool selectEnd();
   void activateCurrentSelection();
   bool selectFirst() const;
   bool select(const QString &id);

--- a/vicinae/src/ui/views/grid-view.cpp
+++ b/vicinae/src/ui/views/grid-view.cpp
@@ -30,6 +30,10 @@ bool GridView::inputFilter(QKeyEvent *event) {
       return m_grid->selectLeft();
     case Qt::Key_Right:
       return m_grid->selectRight();
+    case Qt::Key_Home:
+      return m_grid->selectHome();
+    case Qt::Key_End:
+      return m_grid->selectEnd();
     case Qt::Key_Return:
     case Qt::Key_Enter:
       m_grid->activateCurrentSelection();

--- a/vicinae/src/ui/views/list-view.cpp
+++ b/vicinae/src/ui/views/list-view.cpp
@@ -35,6 +35,12 @@ bool ListView::inputFilter(QKeyEvent *event) {
     case Qt::Key_Down:
       return m_list->selectDown();
       break;
+    case Qt::Key_Home:
+      return m_list->selectHome();
+      break;
+    case Qt::Key_End:
+      return m_list->selectEnd();
+      break;
     case Qt::Key_Return:
     case Qt::Key_Enter:
       m_list->activateCurrentSelection();


### PR DESCRIPTION
Half of #297. I did try page up / down, but it involves checking viewport/scroll and wasn't working as expected (like when rows are partially visible).

So this is only for Home and End keys.