### PR TITLE
ts: export AI from vicinae to raycast-api-compat

### DIFF
--- a/typescript/api/src/api/index.ts
+++ b/typescript/api/src/api/index.ts
@@ -1,3 +1,4 @@
+export * from "./ai.js";
 export * from "./components/index.js";
 export * from "./hooks/index.js";
 export * from "./context/index.js";
@@ -16,5 +17,5 @@ export * from "./local-storage.js";
 export * from "./oauth.js";
 export * from "./alert.js";
 export * from "./preference.js";
-export * from './file-search.js';
-export * from './window-management.js';
+export * from "./file-search.js";
+export * from "./window-management.js";

--- a/typescript/raycast-api-compat/src/index.ts
+++ b/typescript/raycast-api-compat/src/index.ts
@@ -25,7 +25,7 @@ export {
 	openCommandPreferences, openExtensionPreferences,
 	LaunchType,
 
-
+	AI,
 	OAuth,
 
 	List, Grid, Form, Detail,


### PR DESCRIPTION
Closes #483.

Exposes `AI` so extensions don't break.

```
TypeError: Cannot read properties of undefined (reading 'Model')
    at useAISearch (/home/rithvik/.local/share/vicinae/extensions/lucide-icons/index.js:7587:26)
    at IconGrid (/home/rithvik/.local/share/vicinae/extensions/lucide-icons/index.js:7744:56)
    at react-stack-bottom-frame (/run/user/1000/vicinae/extension-manager.js:21194:20)
    at renderWithHooks (/run/user/1000/vicinae/extension-manager.js:12324:24)
    at updateFunctionComponent (/run/user/1000/vicinae/extension-manager.js:14647:22)
    at beginWork (/run/user/1000/vicinae/extension-manager.js:15614:20)
    at runWithFiberInDEV (/run/user/1000/vicinae/extension-manager.js:11248:15)
    at performUnitOfWork (/run/user/1000/vicinae/extension-manager.js:19003:82)
    at workLoopSync (/run/user/1000/vicinae/extension-manager.js:18857:43)
    at renderRootSync (/run/user/1000/vicinae/extension-manager.js:18840:13)
```

```ts
import { AI, environment, showToast, Toast } from "@raycast/api";
import { useAI } from "@raycast/utils";

const { data, isLoading, revalidate } = useAI(prompt, {
    model: AI.Model["OpenAI_GPT4o-mini"],
    execute: environment.canAccess(AI) && searchText.length > 0 && (filteredIconsLength === 0 || manualAISearch),
    onError: (error) => {
      console.error("AI search error:", error);
    },
  });
```
