### PR TITLE
chore: add clangd to ignore -mno-direct-extern-access

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  Remove: [-mno-direct-extern-access]


### PR DESCRIPTION
This is only to remove the warning clangd puts at the top of every file in this project.