### PR TITLE
fix: return value ignored

### DIFF
--- a/vicinae/src/ui/image/local-image-loader.cpp
+++ b/vicinae/src/ui/image/local-image-loader.cpp
@@ -9,7 +9,10 @@ void LocalImageLoader::render(const RenderConfig &cfg) {
     m_loader = std::make_unique<SvgImageLoader>(QString(m_path.c_str()));
   } else {
     QFile file(m_path);
-    file.open(QIODevice::ReadOnly);
+    if (!file.open(QIODevice::ReadOnly)) {
+      qWarning() << "Failed to open image file:" << m_path;
+      return;
+    }
     m_loader = std::make_unique<IODeviceImageLoader>(file.readAll());
   }
 


### PR DESCRIPTION
This resolves the following compiler warning:
```sh
[62/215] Building CXX object vicinae/CMakeFiles/vicinae.dir/src/ui/image/local-image-loader.cpp.o
/home/antoinegs/gits/vicinae/vicinae/src/ui/image/local-image-loader.cpp: In member function ‘virtual void LocalImageLoader::render(const RenderConfig&)’:
/home/antoinegs/gits/vicinae/vicinae/src/ui/image/local-image-loader.cpp:12:14: warning: ignoring return value of ‘virtual bool QFile::open(QIODeviceBase::OpenMode)’, declared with attribute ‘nodiscard’ [-Wunused-result]
   12 |     file.open(QIODevice::ReadOnly);
      |     ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/qt6/QtCore/qdir.h:11,
                 from /home/antoinegs/gits/vicinae/vicinae/src/vicinae.hpp:3,
                 from /home/antoinegs/gits/vicinae/vicinae/src/common.hpp:6,
                 from /home/antoinegs/gits/vicinae/vicinae/src/ui/image/image.hpp:2,
                 from /home/antoinegs/gits/vicinae/vicinae/src/ui/image/local-image-loader.cpp:1:
/usr/include/qt6/QtCore/qfile.h:291:32: note: declared here
  291 |     QFILE_MAYBE_NODISCARD bool open(OpenMode flags) override;
```