### PR TITLE
Call initial onChange on List.Dropdown

### DIFF
--- a/vicinae/src/extension/extension-list-component.cpp
+++ b/vicinae/src/extension/extension-list-component.cpp
@@ -62,6 +62,9 @@ void ExtensionListComponent::renderDropdown(const DropdownModel &dropdown) {
 
   m_selector->setEnableDefaultFilter(dropdown.filtering.enabled);
 
+  // Track if we are setting an initial value so we can fire onChange once on first load
+  const bool hadPreviousSelection = m_selector->value() != nullptr;
+
   if (auto controlledValue = dropdown.value) {
     m_selector->setValue(*controlledValue);
   } else if (!m_selector->value()) {
@@ -73,6 +76,13 @@ void ExtensionListComponent::renderDropdown(const DropdownModel &dropdown) {
   }
 
   m_selector->setIsLoading(dropdown.isLoading);
+
+  // If there was no previous selection and we just set one, invoke onChange once
+  if (!hadPreviousSelection) {
+    if (auto selected = m_selector->value()) {
+      if (auto onChange = dropdown.onChange) { notify(*onChange, {selected->generateId()}); }
+    }
+  }
 }
 
 bool ExtensionListComponent::inputFilter(QKeyEvent *event) {


### PR DESCRIPTION
Raycast seems to call a dropdown's onChange on first render.

this is required for at least 2 extensions that rely on this behavior:

### `hacker-news`

Wasn't loading front page until the search bar accessory dropdown changed.

<img width="782" height="493" alt="image" src="https://github.com/user-attachments/assets/eec9c142-db68-4f09-ad96-feb00a1445b9" />

### `search-mdn`

Wouldn't set locale to `en-US` and since the initial useState value is `en-us` (mostly a mistake), the content wouldn't be fetched and nothing would show.

https://github.com/raycast/extensions/blob/88f9134b01e9c537302d6bf35b837cdf39d9423e/extensions/search-mdn/src/index.tsx#L49

<img width="781" height="178" alt="image" src="https://github.com/user-attachments/assets/e91ea7d6-73e4-47f3-852d-bd607589ae2a" />

.

<img width="784" height="492" alt="image" src="https://github.com/user-attachments/assets/0d0171d3-d321-4fb2-9d9f-654dd15bec76" />
