### PR TITLE
add `command.updateCommandMetadata`

### DIFF
--- a/proto/command.proto
+++ b/proto/command.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+import "common.proto";
+
+package proto.ext.command;
+
+message UpdateCommandMetadataRequest {
+  // Null/empty clears the override.
+  optional string subtitle = 1;
+};
+
+message Request {
+  oneof payload {
+    UpdateCommandMetadataRequest update_command_metadata = 1;
+  };
+};
+
+message Response {
+  oneof payload {
+    proto.ext.common.AckResponse update_command_metadata = 1;
+  };
+};
+
+

--- a/proto/extension.proto
+++ b/proto/extension.proto
@@ -8,6 +8,7 @@ import "common.proto";
 import "oauth.proto";
 import "file-search.proto";
 import "wm.proto";
+import "command.proto";
 
 package proto.ext.extension;
 
@@ -25,6 +26,7 @@ message RequestData {
     oauth.Request oauth = 5;
     file_search.Request file_search = 6;
     wm.Request wm = 7;
+    command.Request command = 8;
   };
 };
 
@@ -45,6 +47,7 @@ message ResponseData {
     oauth.Response oauth = 5;
     file_search.Response file_search = 6;
     wm.Response wm = 7;
+    command.Response command = 8;
   };
 };
 

--- a/typescript/api/src/api/bus.ts
+++ b/typescript/api/src/api/bus.ts
@@ -81,6 +81,8 @@ type EndpointMapping = {
 
   "ui.popToRoot": "ui.popToRoot",
 
+  "command.updateCommandMetadata": "command.updateCommandMetadata";
+
   "storage.get": "storage.get";
   "storage.set": "storage.set";
   "storage.remove": "storage.remove";

--- a/typescript/api/src/api/command.ts
+++ b/typescript/api/src/api/command.ts
@@ -1,0 +1,18 @@
+import { bus } from './bus';
+
+/**
+ * Update the values of properties declared in the manifest of the current command.
+ * Currently only `subtitle` is supported. Pass `null` to clear the custom subtitle.
+ *
+ * Raycast API: https://developers.raycast.com/api-reference/command#updatecommandmetadata
+ */
+export async function updateCommandMetadata(metadata: {
+  subtitle?: string | null;
+}): Promise<void> {
+  const payload: { subtitle?: string | undefined } = {};
+  if (Object.prototype.hasOwnProperty.call(metadata, 'subtitle')) {
+    payload.subtitle = metadata.subtitle ?? undefined;
+  }
+
+  await bus.turboRequest('command.updateCommandMetadata', payload);
+}

--- a/typescript/api/src/api/index.ts
+++ b/typescript/api/src/api/index.ts
@@ -19,3 +19,4 @@ export * from "./alert.js";
 export * from "./preference.js";
 export * from "./file-search.js";
 export * from "./window-management.js";
+export * from "./command.js";

--- a/typescript/raycast-api-compat/src/index.ts
+++ b/typescript/raycast-api-compat/src/index.ts
@@ -21,6 +21,7 @@ export {
 	confirmAlert, Alert,
 	open, showInFileBrowser,
 	closeMainWindow, showHUD, clearSearchBar, getSelectedText, popToRoot, PopToRootType,
+	updateCommandMetadata,
 
 	openCommandPreferences, openExtensionPreferences,
 	LaunchType,

--- a/vicinae/CMakeLists.txt
+++ b/vicinae/CMakeLists.txt
@@ -522,6 +522,7 @@ set(SRCS
 	src/extension/requests/file-search-request-router.cpp
 	src/extension/requests/app-request-router.cpp
 	src/extension/requests/clipboard-request-router.cpp
+	src/extension/requests/command-request-router.cpp
 	src/extension/requests/wm-router.cpp
 	src/extension/extension-command-runtime.cpp
 

--- a/vicinae/include/extension/extension-command.hpp
+++ b/vicinae/include/extension/extension-command.hpp
@@ -18,6 +18,7 @@
 #include <qthread.h>
 #include <qtmetamacros.h>
 #include <qwidget.h>
+#include <optional>
 
 class ExtensionCommand : public AbstractCmd {
   QString _extensionId;
@@ -28,6 +29,7 @@ class ExtensionCommand : public AbstractCmd {
   std::filesystem::path m_path;
   ExtensionManifest::Command m_command;
   QString m_author;
+  std::optional<QString> m_subtitleOverride;
 
 public:
   ExtensionCommand(const ExtensionManifest::Command &command) : m_command(command) {}
@@ -69,6 +71,9 @@ public:
   QString repositoryName() const override;
 
   bool isDefaultDisabled() const override;
+
+  std::optional<QString> overriddenSubtitle() const { return m_subtitleOverride; }
+  void setSubtitleOverride(const std::optional<QString> &subtitle) { m_subtitleOverride = subtitle; }
 
   void setPath(const std::filesystem::path &path);
   void setExtensionTitle(const QString &title);

--- a/vicinae/src/extension/extension-command-runtime.cpp
+++ b/vicinae/src/extension/extension-command-runtime.cpp
@@ -8,6 +8,7 @@
 #include "extension/requests/ui-request-router.hpp"
 #include "extension/requests/file-search-request-router.hpp"
 #include "extension/requests/wm-router.hpp"
+#include "extension/requests/command-request-router.hpp"
 #include "proto/manager.pb.h"
 #include "proto/oauth.pb.h"
 #include "common.hpp"
@@ -75,6 +76,8 @@ ExtensionCommandRuntime::dispatchRequest(ExtensionRequest *request) {
     return m_fileSearchRouter->route(data.file_search());
   case Request::kWm:
     return m_wmRouter->route(data.wm());
+  case Request::kCommand:
+    return m_commandRouter->route(data.command());
   case Request::kOauth:
     handleOAuth(request, data.oauth());
     return nullptr;
@@ -161,6 +164,8 @@ void ExtensionCommandRuntime::initialize() {
   m_isDevMode = manager->hasDevelopmentSession(m_command->extensionId());
   m_navigation->setDevMode(m_isDevMode);
   m_uiRouter = std::make_unique<UIRequestRouter>(m_navigation.get(), *context()->services->toastService());
+  m_commandRouter =
+      std::make_unique<CommandRequestRouter>(m_navigation.get(), context()->services->rootItemManager());
   m_fileSearchRouter = std::make_unique<FileSearchRequestRouter>(*context()->services->fileService());
   m_storageRouter =
       std::make_unique<StorageRequestRouter>(context()->services->localStorage(), m_command->extensionId());

--- a/vicinae/src/extension/extension-command-runtime.hpp
+++ b/vicinae/src/extension/extension-command-runtime.hpp
@@ -15,6 +15,7 @@ class ExtensionRequest;
 class ExtensionEvent;
 class FileSearchRequestRouter;
 class WindowManagementRouter;
+class CommandRequestRouter;
 
 class ExtensionCommandRuntime : public CommandContext {
   bool m_isDevMode = false;
@@ -28,6 +29,7 @@ class ExtensionCommandRuntime : public CommandContext {
   std::unique_ptr<ClipboardRequestRouter> m_clipboardRouter;
   std::unique_ptr<FileSearchRequestRouter> m_fileSearchRouter;
   std::unique_ptr<WindowManagementRouter> m_wmRouter;
+  std::unique_ptr<CommandRequestRouter> m_commandRouter;
 
   QString m_sessionId;
 

--- a/vicinae/src/extension/extension-navigation-controller.hpp
+++ b/vicinae/src/extension/extension-navigation-controller.hpp
@@ -48,6 +48,10 @@ public:
 
   void setDevMode(bool mode) { m_devMode = mode; }
 
+  void setSubtitleOverride(const std::optional<QString> &subtitle) {
+    m_command->setSubtitleOverride(subtitle);
+  }
+
   ExtensionNavigationController(const std::shared_ptr<ExtensionCommand> &command,
                                 NavigationController *navigation, ExtensionManager *manager)
       : m_command(command), m_navigation(navigation),

--- a/vicinae/src/extension/requests/command-request-router.cpp
+++ b/vicinae/src/extension/requests/command-request-router.cpp
@@ -1,0 +1,41 @@
+#include "command-request-router.hpp"
+#include "proto/command.pb.h"
+#include "proto/extension.pb.h"
+
+using Request = proto::ext::command::Request;
+
+proto::ext::extension::Response *CommandRequestRouter::wrap(proto::ext::command::Response *cmdRes) {
+  auto res = new proto::ext::extension::Response;
+  auto data = new proto::ext::extension::ResponseData;
+  data->set_allocated_command(cmdRes);
+  res->set_allocated_data(data);
+  return res;
+}
+
+proto::ext::extension::Response *CommandRequestRouter::route(const Request &req) {
+  switch (req.payload_case()) {
+  case Request::kUpdateCommandMetadata: {
+    auto res = new proto::ext::command::Response;
+    auto ack = new proto::ext::common::AckResponse;
+
+    const auto &meta = req.update_command_metadata();
+
+    // Set or clear subtitle override
+    if (meta.has_subtitle() && !QString::fromStdString(meta.subtitle()).isEmpty()) {
+      m_navigation->setSubtitleOverride(QString::fromStdString(meta.subtitle()));
+    } else {
+      m_navigation->setSubtitleOverride(std::nullopt);
+    }
+
+    // Refresh view to display the new subtitle
+    if (m_rootManager) emit m_rootManager->itemsChanged();
+
+    res->set_allocated_update_command_metadata(ack);
+    return wrap(res);
+  }
+  default:
+    break;
+  }
+
+  return nullptr;
+}

--- a/vicinae/src/extension/requests/command-request-router.hpp
+++ b/vicinae/src/extension/requests/command-request-router.hpp
@@ -1,0 +1,19 @@
+#pragma once
+#include "proto/command.pb.h"
+#include "proto/extension.pb.h"
+#include "extension/extension-navigation-controller.hpp"
+#include "services/root-item-manager/root-item-manager.hpp"
+
+class CommandRequestRouter {
+
+  ExtensionNavigationController *m_navigation = nullptr;
+  RootItemManager *m_rootManager = nullptr;
+
+  proto::ext::extension::Response *wrap(proto::ext::command::Response *cmdRes);
+
+public:
+  CommandRequestRouter(ExtensionNavigationController *navigation, RootItemManager *rootManager)
+      : m_navigation(navigation), m_rootManager(rootManager) {}
+
+  proto::ext::extension::Response *route(const proto::ext::command::Request &req);
+};

--- a/vicinae/src/root-search/extensions/extension-root-provider.cpp
+++ b/vicinae/src/root-search/extensions/extension-root-provider.cpp
@@ -9,7 +9,17 @@
 #include "services/root-item-manager/root-item-manager.hpp"
 
 QString CommandRootItem::displayName() const { return m_command->name(); }
-QString CommandRootItem::subtitle() const { return m_command->repositoryDisplayName(); }
+
+QString CommandRootItem::subtitle() const {
+  // Display overriden subtitle if set
+  if (auto ext = std::dynamic_pointer_cast<ExtensionCommand>(m_command)) {
+    if (ext->overriddenSubtitle() && !ext->overriddenSubtitle()->isEmpty()) {
+      return *ext->overriddenSubtitle();
+    }
+  }
+  return m_command->repositoryDisplayName();
+}
+
 ImageURL CommandRootItem::iconUrl() const { return m_command->iconUrl(); }
 ArgumentList CommandRootItem::arguments() const { return m_command->arguments(); }
 QString CommandRootItem::providerId() const { return "command"; }


### PR DESCRIPTION
https://developers.raycast.com/api-reference/command#updatecommandmetadata

Extensions that used this api used to crash:
```
TypeError: (0 , b.updateCommandMetadata) is not a function
    at S (/home/rithvik/.local/share/vicinae/extensions/a27daf43-1a9d-4720-9a21-f2d47bc399c4/status.js:3:591)
    at loadNoView (/run/user/1000/vicinae/extension-manager.js:33563:9)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async main (/run/user/1000/vicinae/extension-manager.js:33576:5)
```

They now work and update the command subtitle. I think raycast persists this subtitle across reboots, but for now, this only stores in mem. Restarting vicinae will clear them.

extension: `tailscale`

<img width="784" height="496" alt="image" src="https://github.com/user-attachments/assets/124e95fb-00ee-46dc-bc78-286eeb973ce9" />

extension: `year-in-progress`

<img width="785" height="493" alt="image" src="https://github.com/user-attachments/assets/a04d237b-1160-473d-a4eb-c84d5970d0ed" />
