### PR TITLE
feat: improvements to incremental search (2)

### DIFF
--- a/vicinae/src/services/files-service/file-indexer/file-indexer-db.cpp
+++ b/vicinae/src/services/files-service/file-indexer/file-indexer-db.cpp
@@ -149,12 +149,47 @@ FileIndexerDatabase::ScanRecord FileIndexerDatabase::mapScan(const QSqlQuery &qu
   return record;
 }
 
-std::optional<FileIndexerDatabase::ScanRecord> FileIndexerDatabase::getLastScan() const {
+std::optional<FileIndexerDatabase::ScanRecord>
+FileIndexerDatabase::getLastSuccessfulScan(const std::filesystem::path &path) const {
   QSqlQuery query(m_db);
+  query.prepare("SELECT id, status, created_at, entrypoint, type "
+                "FROM scan_history "
+                "WHERE type in (:type1, :type2) "
+                "AND status = :status "
+                "AND entrypoint = :entrypoint "
+                "ORDER BY created_at "
+                "DESC LIMIT 1");
 
-  if (!query.exec("SELECT id, status, created_at, entrypoint, type FROM scan_history ORDER BY created_at "
-                  "DESC LIMIT 1")) {
-    qCritical() << "Failed to list scan records" << query.lastError();
+  query.bindValue(":type1", static_cast<quint8>(ScanType::Full));
+  query.bindValue(":type2", static_cast<quint8>(ScanType::Incremental));
+  query.bindValue(":status", static_cast<quint8>(ScanStatus::Succeeded));
+  query.bindValue(":entrypoint", path.c_str());
+
+  if (!query.exec()) {
+    qCritical() << "Failed to get last successful scan record" << query.lastError();
+    return {};
+  }
+
+  if (!query.next()) return std::nullopt;
+
+  return mapScan(query);
+}
+
+std::optional<FileIndexerDatabase::ScanRecord>
+FileIndexerDatabase::getLastScan(const std::filesystem::path &path, ScanType scanType) const {
+  QSqlQuery query(m_db);
+  query.prepare("SELECT id, status, created_at, entrypoint, type "
+                "FROM scan_history "
+                "WHERE type = :type "
+                "AND entrypoint = :entrypoint "
+                "ORDER BY created_at "
+                "DESC LIMIT 1");
+
+  query.bindValue(":type", static_cast<quint8>(scanType));
+  query.bindValue(":entrypoint", path.c_str());
+
+  if (!query.exec()) {
+    qCritical() << "Failed to get last scan record" << query.lastError();
     return {};
   }
 
@@ -182,11 +217,14 @@ std::vector<FileIndexerDatabase::ScanRecord> FileIndexerDatabase::listScans() {
   return records;
 }
 
-std::vector<FileIndexerDatabase::ScanRecord> FileIndexerDatabase::listStartedScans() {
+std::vector<FileIndexerDatabase::ScanRecord> FileIndexerDatabase::listScans(ScanType scanType,
+                                                                            ScanStatus scanStatus) {
   QSqlQuery query(m_db);
 
-  query.prepare("SELECT id, status, created_at, entrypoint, type FROM scan_history WHERE status = :status");
+  query.prepare("SELECT id, status, created_at, entrypoint, type "
+                "FROM scan_history WHERE status = :status and type = :type");
   query.bindValue(":status", static_cast<quint8>(ScanStatus::Started));
+  query.bindValue(":type", static_cast<quint8>(scanType));
 
   if (!query.exec()) {
     qCritical() << "Failed to list started scan records" << query.lastError();

--- a/vicinae/src/services/files-service/file-indexer/file-indexer-db.hpp
+++ b/vicinae/src/services/files-service/file-indexer/file-indexer-db.hpp
@@ -31,10 +31,12 @@ public:
   static QString createRandomConnectionId();
   static std::filesystem::path getDatabasePath();
 
-  std::vector<ScanRecord> listScans();
-  std::optional<ScanRecord> getLastScan() const;
+  std::optional<ScanRecord> getLastScan(const std::filesystem::path &path, ScanType scanType) const;
+  std::optional<FileIndexerDatabase::ScanRecord>
+  getLastSuccessfulScan(const std::filesystem::path &path) const;
 
-  std::vector<ScanRecord> listStartedScans();
+  std::vector<ScanRecord> listScans();
+  std::vector<ScanRecord> listScans(ScanType scanType, ScanStatus scanStatus);
 
   bool updateScanStatus(int scanId, ScanStatus status);
   tl::expected<ScanRecord, QString> createScan(const std::filesystem::path &path, ScanType type);

--- a/vicinae/src/services/files-service/file-indexer/file-indexer.hpp
+++ b/vicinae/src/services/files-service/file-indexer/file-indexer.hpp
@@ -37,7 +37,10 @@ public:
   QString preparePrefixSearchQuery(std::string_view query) const;
 
 public:
-  void startFullscan();
+  void startFullScan();
+  void startSingleScan(std::filesystem::path entrypoint, ScanType type,
+                       std::vector<std::string> excludedFilenames = {});
+  void markScanAsInterrupted(std::optional<FileIndexerDatabase::ScanRecord> scan);
   void rebuildIndex() override;
   void preferenceValuesChanged(const QJsonObject &preferences) override;
   QFuture<std::vector<IndexerFileResult>> queryAsync(std::string_view view,

--- a/vicinae/src/services/files-service/file-indexer/filesystem-walker.cpp
+++ b/vicinae/src/services/files-service/file-indexer/filesystem-walker.cpp
@@ -152,9 +152,8 @@ void FileSystemWalker::walk(const fs::path &root, const WalkCallback &callback) 
 
       if (m_recursive && isDir) {
         size_t depth = std::distance(path.begin(), path.end()) - rootDepth;
-        bool isDepthLimited = m_maxDepth && depth > *m_maxDepth;
-
-        if (!isDepthLimited) dirStack.push(entry);
+        bool shouldDescend = !m_maxDepth || depth <= *m_maxDepth;
+        if (shouldDescend) dirStack.push(entry);
       }
 
       callback(entry);

--- a/vicinae/src/services/files-service/file-indexer/filesystem-walker.hpp
+++ b/vicinae/src/services/files-service/file-indexer/filesystem-walker.hpp
@@ -19,6 +19,7 @@ public:
 class FileSystemWalker {
 public:
   using WalkCallback = std::function<void(const std::filesystem::directory_entry &path)>;
+  using DirectoryFilter = std::function<bool(const std::filesystem::directory_entry &dir)>;
 
   /**
    * Register specific filenames for them to be considered as ignore files.

--- a/vicinae/src/services/files-service/file-indexer/incremental-scanner.hpp
+++ b/vicinae/src/services/files-service/file-indexer/incremental-scanner.hpp
@@ -10,6 +10,8 @@ class IncrementalScanner : public AbstractScanner, public NonCopyable {
   std::vector<std::filesystem::path> getScannableDirectories(const std::filesystem::path &path,
                                                              std::optional<size_t> maxDepth) const;
   void processDirectory(const std::filesystem::path &path);
+  bool shouldProcessEntry(const std::filesystem::directory_entry &entry,
+                          const QDateTime &cutOffDateTime) const;
 
   void scan(const Scan &scan);
 


### PR DESCRIPTION
Instead of limiting ourselves to a depth of 5, we can traverse the whole tree and use the mtime to decide which ones to process.

Due to the changes done for this, it incidentally fixes the issue resolved by https://github.com/vicinaehq/vicinae/pull/586 so I have closed that one:
>If an increment scan were to fail once, incremental scans would be disabled indefinitely because they are not cleaned up, and thus stay in the startedScans list.
>This ensures that increment scans are scheduled at launch if a full scan is not requested.
