### PR TITLE
fix: file index rebuild not deleting records (3)

### DIFF
--- a/vicinae/src/services/files-service/file-indexer/db-writer.cpp
+++ b/vicinae/src/services/files-service/file-indexer/db-writer.cpp
@@ -66,6 +66,13 @@ void DbWriter::deleteIndexedFiles(std::vector<std::filesystem::path> paths) {
   submit([paths = std::move(paths)](FileIndexerDatabase &db) { db.deleteIndexedFiles(paths); });
 }
 
+void DbWriter::deleteAllIndexedFiles(std::function<void()> onComplete) {
+  submit([onComplete = std::move(onComplete)](FileIndexerDatabase &db) {
+    db.deleteAllIndexedFiles();
+    if (onComplete) { onComplete(); }
+  });
+}
+
 void DbWriter::indexEvents(std::vector<FileEvent> events) {
   submit([events = std::move(events)](FileIndexerDatabase &db) { db.indexEvents(events); });
 }

--- a/vicinae/src/services/files-service/file-indexer/db-writer.hpp
+++ b/vicinae/src/services/files-service/file-indexer/db-writer.hpp
@@ -39,6 +39,7 @@ public:
   // Receive by value because `paths` could mutate while the work is waiting in queue
   void indexFiles(std::vector<std::filesystem::path> paths);
   void deleteIndexedFiles(std::vector<std::filesystem::path> paths);
+  void deleteAllIndexedFiles(std::function<void()> onComplete = nullptr);
 
   void indexEvents(std::vector<FileEvent> events);
 };

--- a/vicinae/src/services/files-service/file-indexer/file-indexer-db.cpp
+++ b/vicinae/src/services/files-service/file-indexer/file-indexer-db.cpp
@@ -304,6 +304,14 @@ void FileIndexerDatabase::deleteIndexedFiles(const std::vector<fs::path> &paths)
   if (!m_db.commit()) { qCritical() << "Failed to commit"; }
 }
 
+void FileIndexerDatabase::deleteAllIndexedFiles() {
+  QSqlQuery query(m_db);
+
+  if (!query.exec("DELETE FROM indexed_file")) {
+    qCritical() << "Failed to delete all indexed files" << query.lastError();
+  }
+}
+
 void FileIndexerDatabase::indexEvents(const std::vector<FileEvent> &events) {
   if (!m_db.transaction()) {
     qWarning() << "Failed to start batch transaction" << m_db.lastError();

--- a/vicinae/src/services/files-service/file-indexer/file-indexer-db.hpp
+++ b/vicinae/src/services/files-service/file-indexer/file-indexer-db.hpp
@@ -46,6 +46,7 @@ public:
   std::optional<QDateTime> retrieveIndexedLastModified(const std::filesystem::path &path) const;
   std::vector<std::filesystem::path> listIndexedDirectoryFiles(const std::filesystem::path &path) const;
 
+  void deleteAllIndexedFiles();
   void deleteIndexedFiles(const std::vector<std::filesystem::path> &paths);
   void indexFiles(const std::vector<std::filesystem::path> &paths);
   std::vector<std::filesystem::path> search(std::string_view searchQuery,


### PR DESCRIPTION
I noticed that after rebuilding my indexes I still had all my previous folders/indexes. 
This commit adds a full deletion of the `indexed_file` table upon starting a rebuild.