### PR TITLE
Fix launcher dameond fail on systemd

### DIFF
--- a/extra/vicinae.service
+++ b/extra/vicinae.service
@@ -7,7 +7,7 @@ PartOf=graphical-session.target
 
 [Service]
 Type=simple
-ExecStart=vicinae server
+ExecStart=%h/.local/bin/vicinae server
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 RestartSec=5


### PR DESCRIPTION
Hi vicinae,

I noticed after installation this, it does not start. My system is Debian 13.1 with Gnome. Here's the error
```
journalctl --user -u vicinae
Oct 30 17:19:16 syscl-debian systemd[1403]: Started vicinae.service - Vicinae Launcher Daemon.
Oct 30 17:19:16 syscl-debian (vicinae)[3210149]: vicinae.service: Unable to locate executable 'vicinae': No such file or directory
Oct 30 17:19:16 syscl-debian (vicinae)[3210149]: vicinae.service: Failed at step EXEC spawning vicinae: No such file or directory
Oct 30 17:19:16 syscl-debian systemd[1403]: vicinae.service: Main process exited, code=exited, status=203/EXEC
Oct 30 17:19:16 syscl-debian systemd[1403]: vicinae.service: Failed with result 'exit-code'.
```
The problem is very clear, that it expected the vinciane while it does not exist. So to fix this problem, I think it is better to generalized the path parameter, so that it will never failed to start. 

Tested working on my system:
```
> systemctl --user daemon-reload
> systemctl --user status vicinae
● vicinae.service - Vicinae Launcher Daemon
     Loaded: loaded (/home/syscl/.config/systemd/user/vicinae.service; enabled; preset: enabled)
     Active: active (running) since Fri 2025-10-31 17:29:53 PDT; 15s ago
 Invocation: 9ba398ba6aff47a5bfa19ee7f7904e40
       Docs: https://docs.vicinae.com
   Main PID: 3705451 (vicinae)
      Tasks: 12 (limit: 38358)
     Memory: 98.8M (peak: 101.7M)
        CPU: 2.633s
     CGroup: /user.slice/user-1000.slice/user@1000.service/app.slice/vicinae.service
             ├─3705451 /home/syscl/.local/bin/vicinae server
             └─3705555 /home/syscl/.local/bin/vicinae-node /run/user/1000/vicinae/extension-manager.js

Oct 31 17:29:53 syscl-debian vicinae[3705451]: [17:29:53.946] INFO   -  Started extension manager /run/user/1000/vicinae/extension-manager.js >
Oct 31 17:29:53 syscl-debian vicinae[3705451]: [17:29:53.949] INFO   -  Starting clipboard server "x11" 
Oct 31 17:29:53 syscl-debian vicinae[3705451]: [17:29:53.950] INFO   -  Clipboard server "x11" started successfully. 
Oct 31 17:29:53 syscl-debian vicinae[3705451]: [17:29:53.950] INFO   -  Started "Qalculate!" calculator backend 
Oct 31 17:29:53 syscl-debian vicinae[3705451]: [17:29:53.964] WARN   -  Ignoring icon theme directory with no index.theme at /home/syscl/.loca>
Oct 31 17:29:53 syscl-debian vicinae[3705451]: [17:29:53.968] WARN   -  Ignoring icon theme directory with no index.theme at /usr/share/icons/>
Oct 31 17:29:53 syscl-debian vicinae[3705451]: [17:29:53.969] WARN   -  Ignoring icon theme directory with no index.theme at /usr/share/icons/>
Oct 31 17:29:53 syscl-debian vicinae[3705451]: [17:29:53.969] WARN   -  Ignoring icon theme directory with no index.theme at /usr/share/icons/>
Oct 31 17:29:54 syscl-debian vicinae[3705451]: [17:29:54.284] INFO   -  Done walking file tree at /home/syscl. Processed 5382 directories and >
Oct 31 17:29:54 syscl-debian vicinae[3705451]: [17:29:54.584] INFO   -  Vicinae server successfully started. Call "vicinae toggle" to toggle t>
```