### PR TITLE
markdown: render images with fixed aspect ratio

### DIFF
--- a/extra/extension-boilerplate/src/simple-detail.tsx
+++ b/extra/extension-boilerplate/src/simple-detail.tsx
@@ -8,7 +8,7 @@ Now you can start making changes to this command source file and see it update l
 
 If you are online, you should be able to see the Vicinae logo below:
 
-![](https://github.com/vicinaehq/vicinae/raw/main/.github/assets/vicinae-banner.png?raycast-width=500&raycast-height=140)
+![](https://github.com/vicinaehq/vicinae/raw/main/.github/assets/vicinae-banner.png?raycast-height=100)
 
 ---
 


### PR DESCRIPTION
When only one of height or width is provided, the other value defaulted to full width/height, making images stretch/squeeze.

This is now handled properly.

boilerplate now has vicinae logo with height only, and it scales:
<img width="787" height="314" alt="image" src="https://github.com/user-attachments/assets/47d66671-aa62-48e5-aaf8-5c854db9c671" />

extension: `pokedex`
<img width="777" height="487" alt="image" src="https://github.com/user-attachments/assets/8e046656-a9c4-41b3-b478-c91d820f07bf" />

extension: `qrcode-generator`
<img width="785" height="498" alt="image" src="https://github.com/user-attachments/assets/f2b5c422-f001-483f-a0e7-e2359d0c5939" />
