### PR TITLE
add Action.CreateQuicklink

### DIFF
--- a/typescript/api/src/api/components/actions.tsx
+++ b/typescript/api/src/api/components/actions.tsx
@@ -55,6 +55,18 @@ export type ActionSubmitFormProps = Omit<BaseActionProps, "title"> & {
 	title?: string;
 };
 
+export type Quicklink = {
+	name?: string;
+	link: string;
+	application?: string | Application;
+	icon?: Icon;
+};
+
+export type ActionCreateQuicklinkProps = Omit<BaseActionProps, "title"> & {
+	title?: string;
+	quicklink: Quicklink;
+};
+
 const ActionRoot: React.FC<ActionProps> = (props) => {
 	return <action {...props} />;
 };
@@ -154,6 +166,30 @@ const SubmitForm: React.FC<ActionSubmitFormProps> = ({
 	return <action {...nativeProps} />;
 };
 
+const CreateQuicklink: React.FC<ActionCreateQuicklinkProps> = ({
+	title = "Create Quicklink",
+	quicklink,
+	...props
+}) => {
+	const nativeProps: React.JSX.IntrinsicElements["action"] = {
+		...props,
+		title,
+		type: "create-quicklink",
+		quicklink: {
+			link: quicklink.link,
+			name: quicklink.name,
+			application:
+				typeof quicklink.application === "string"
+					? quicklink.application
+					: quicklink.application?.name,
+			icon: quicklink.icon,
+		},
+		onAction: () => {},
+	};
+
+	return <action {...nativeProps} />;
+};
+
 export const Action = Object.assign(ActionRoot, {
 	CopyToClipboard,
 	Push,
@@ -161,6 +197,7 @@ export const Action = Object.assign(ActionRoot, {
 	Paste,
 	SubmitForm,
 	OpenInBrowser,
+	CreateQuicklink,
 	Style: {
 		Regular: "regular",
 		Destructive: "destructive",

--- a/typescript/api/types/jsx.d.ts
+++ b/typescript/api/types/jsx.d.ts
@@ -7,7 +7,7 @@ import { Keyboard } from "../api/keyboard";
 import { Grid } from "../api/components/grid";
 
 import "react";
-import { List } from "../src";
+import type { Application, Quicklink } from "../src";
 
 type BaseFormField = {
 	onBlur?: Function;
@@ -126,6 +126,8 @@ declare module "react" {
 				shortcut?: Keyboard.Shortcut;
 				icon?: ImageLike;
 				autoFocus?: boolean;
+				type?: string;
+				quicklink?: Quicklink;
 			};
 			"tag-list": {
 				title?: string;

--- a/vicinae/include/create-quicklink-command.hpp
+++ b/vicinae/include/create-quicklink-command.hpp
@@ -374,11 +374,46 @@ public:
     appSelector->setValue("default");
   }
 
+  void setPrefilledValues(const QString &link, const QString &name = "", const QString &application = "",
+                          const QString &icon = "") {
+    m_prefilledName = name;
+    m_prefilledLink = link;
+    m_prefilledApp = application;
+    m_prefilledIcon = icon;
+  }
+
   void initializeForm() override {
     initializeAppSelector();
     initializeIconSelector();
-    QTimer::singleShot(0, this, [this]() { form()->focusFirst(); });
+
+    auto appDb = context()->services->appDb();
+
+    if (!m_prefilledName.isEmpty()) { name->setText(m_prefilledName); }
+    if (!m_prefilledLink.isEmpty()) {
+      link->setText(m_prefilledLink);
+      handleLinkBlurred();
+    }
+    if (!m_prefilledApp.isEmpty() && appDb->findById(m_prefilledApp)) {
+      appSelector->setValue(m_prefilledApp);
+    }
+    if (!m_prefilledIcon.isEmpty()) { iconSelector->setValue(m_prefilledIcon); }
+
+    QTimer::singleShot(0, this, [this]() {
+      if (!m_prefilledName.isEmpty()) {
+        name->selectAll();
+      } else if (!m_prefilledLink.isEmpty()) {
+        link->input()->setFocus();
+      } else {
+        form()->focusFirst();
+      }
+    });
   }
+
+private:
+  QString m_prefilledLink;
+  QString m_prefilledName;
+  QString m_prefilledApp;
+  QString m_prefilledIcon;
 
   void onSubmit() override {
     auto shortcutDb = context()->services->shortcuts();

--- a/vicinae/include/extend/action-model.hpp
+++ b/vicinae/include/extend/action-model.hpp
@@ -26,6 +26,8 @@ struct ActionModel {
   std::optional<QString> onSubmit;
   std::optional<ImageLikeModel> icon;
   std::optional<Keyboard::Shortcut> shortcut;
+  QString type;
+  QJsonObject quicklink;
 };
 
 struct ActionPannelSectionModel {

--- a/vicinae/include/extension/extension-view.hpp
+++ b/vicinae/include/extension/extension-view.hpp
@@ -7,6 +7,8 @@
 #include "ui/image/url.hpp"
 #include "ui/action-pannel/action.hpp"
 #include "ui/views/simple-view.hpp"
+#include "common-actions.hpp"
+#include "create-quicklink-command.hpp"
 #include <qboxlayout.h>
 #include <qevent.h>
 #include <qjsonarray.h>
@@ -23,6 +25,32 @@ class ExtensionSimpleView : public SimpleView {
   std::vector<Keyboard::Shortcut> m_defaultActionShortcuts;
 
   AbstractAction *createActionFromModel(const ActionModel &model) {
+    if (model.type == "create-quicklink") {
+      auto quicklinkObj = model.quicklink;
+      QString name = quicklinkObj.value("name").toString();
+      QString link = quicklinkObj.value("link").toString();
+      QString application = quicklinkObj.value("application").toString();
+      QString icon;
+
+      if (quicklinkObj.contains("icon")) {
+        auto iconValue = quicklinkObj.value("icon");
+
+        if (iconValue.isString()) { icon = iconValue.toString(); }
+      }
+
+      auto view = new ShortcutFormView();
+      view->setPrefilledValues(link, name, application, icon);
+      ImageURL actionIcon;
+
+      if (model.icon) {
+        actionIcon = ImageURL(*model.icon);
+      } else {
+        actionIcon = ImageURL::builtin("link");
+      }
+
+      return new PushViewAction(model.title, view, actionIcon);
+    }
+
     return new StaticAction(model.title, model.icon, [this, model]() {
       qDebug() << "notify action" << model.onAction;
       notify(model.onAction, {});

--- a/vicinae/src/extend/action-model.cpp
+++ b/vicinae/src/extend/action-model.cpp
@@ -54,11 +54,13 @@ ActionModel ActionPannelParser::parseAction(const QJsonObject &instance) {
 
   if (props.contains("onSubmit")) { action.onSubmit = props.value("onSubmit").toString(); }
 
-  auto type = props.value("type").toString("callback");
+  action.type = props.value("type").toString("callback");
 
   if (props.contains("shortcut")) { action.shortcut = parseKeyboardShortcut(props.value("shortcut")); }
 
   if (props.contains("icon")) { action.icon = ImageModelParser().parse(props.value("icon")); }
+
+  if (props.contains("quicklink")) { action.quicklink = props.value("quicklink").toObject(); }
 
   return action;
 }

--- a/vicinae/src/extension/extension-navigation-controller.hpp
+++ b/vicinae/src/extension/extension-navigation-controller.hpp
@@ -33,7 +33,14 @@ public:
 
   std::vector<ExtensionViewWrapper *> views() const { return m_views; }
 
-  void handleViewPoped() {
+  void handleViewPoped(const BaseView *view) {
+    // Only handle pops for ExtensionViewWrapper views that are in our stack
+    auto wrapper = dynamic_cast<const ExtensionViewWrapper *>(view);
+    if (!wrapper) return;
+
+    auto it = std::find(m_views.begin(), m_views.end(), const_cast<ExtensionViewWrapper *>(wrapper));
+    if (it == m_views.end()) return;
+
     if (m_views.size() > 1) { m_controller->notify("pop-view", {}); }
 
     m_views.pop_back();


### PR DESCRIPTION
extension: `random`
<img width="785" height="490" alt="image" src="https://github.com/user-attachments/assets/2e80d4d0-e7b1-4079-adfb-22a04c88c7f7" />
<img width="781" height="492" alt="image" src="https://github.com/user-attachments/assets/ece63e29-797d-4a8f-b250-fb15c07f28c4" />

extension: `notion`
<img width="780" height="488" alt="image" src="https://github.com/user-attachments/assets/7cec75d5-8b51-44a1-85ff-beee2736e79f" />

extension: `devdocs`
- author and extension name are undefined, but this PR is only for creating quicklinks
- extension source detection (required for shortcuts to deeplinks) + environment.* values coming in the next PR
<img width="779" height="489" alt="image" src="https://github.com/user-attachments/assets/27ee5e86-5055-4d45-8528-9b59775ac3aa" />
