### PR TITLE
form: add Form.DateTime

### DIFF
--- a/extra/extension-boilerplate/src/form.tsx
+++ b/extra/extension-boilerplate/src/form.tsx
@@ -40,6 +40,14 @@ export default function FormElements() {
 			<Form.DatePicker
 				id="dateOfBirth"
 				title="DatePicker"
+				type={Form.DatePicker.Type.Date}
+				defaultValue={new Date()}
+			/>
+
+			<Form.DatePicker
+				id="datetime"
+				title="DatePicker with time"
+				type={Form.DatePicker.Type.DateTime}
 				defaultValue={new Date()}
 			/>
 

--- a/typescript/api/src/api/components/form.tsx
+++ b/typescript/api/src/api/components/form.tsx
@@ -138,15 +138,50 @@ const PasswordField: React.FC<PasswordFieldProps> = ({ ref, ...props }) => {
 	return <password-field {...props} />;
 };
 
+export enum DatePickerType {
+	DateTime = "dateTime",
+	Date = "date",
+}
+
 interface DatePickerProps
 	extends FormItemProps<Date | null>,
-		WithFormRef<Form.DatePicker> {}
+		WithFormRef<Form.DatePicker> {
+	min?: Date;
+	max?: Date;
+	type?: DatePickerType;
+}
 
-const DatePicker: React.FC<DatePickerProps> = ({ ref, ...props }) => {
+const DatePickerRoot: React.FC<DatePickerProps> = ({
+	ref,
+	onChange,
+	...props
+}) => {
 	useImperativeFormHandle(ref);
 
-	return <date-picker-field {...props} />;
+	const _onChange = onChange
+		? (newValue: string | null) => {
+				const dateObj = newValue ? new Date(newValue) : null;
+				onChange(dateObj);
+			}
+		: undefined;
+
+	return (
+		<date-picker-field {...wrapFormItemProps(props)} onChange={_onChange} />
+	);
 };
+
+const DatePicker = Object.assign(DatePickerRoot, {
+	Type: DatePickerType,
+	isFullDay: (value: Date | null | undefined) => {
+		if (!value) return false;
+		return (
+			value.getHours() === 0 &&
+			value.getMinutes() === 0 &&
+			value.getSeconds() === 0 &&
+			value.getMilliseconds() === 0
+		);
+	},
+});
 
 interface CheckboxProps
 	extends FormItemProps<boolean>,

--- a/typescript/api/types/jsx.d.ts
+++ b/typescript/api/types/jsx.d.ts
@@ -7,7 +7,7 @@ import { Keyboard } from "../api/keyboard";
 import { Grid } from "../api/components/grid";
 
 import "react";
-import type { Application, Quicklink } from "../src";
+import type { Application, DatePickerType, Quicklink } from "../src";
 
 type BaseFormField = {
 	onBlur?: Function;
@@ -161,7 +161,11 @@ declare module "react" {
 			"dropdown-field": BaseFormField & {
 				children?: ReactNode;
 			};
-			"date-picker-field": {};
+			"date-picker-field": BaseFormField & {
+				min?: Date;
+				max?: Date;
+				type?: DatePickerType;
+			};
 			"checkbox-field": BaseFormField & {};
 			"password-field": {};
 			"textarea-field": {};

--- a/vicinae/CMakeLists.txt
+++ b/vicinae/CMakeLists.txt
@@ -232,6 +232,7 @@ set(SRCS
 	include/extension/form/extension-password-field.hpp
 	include/extension/form/extension-checkbox-field.hpp
 	include/extension/form/extension-dropdown.hpp
+	include/extension/form/extension-date-picker.hpp
 
 	include/extend/extension-detail-view.hpp
 

--- a/vicinae/include/extend/form-model.hpp
+++ b/vicinae/include/extend/form-model.hpp
@@ -79,7 +79,14 @@ struct FormModel {
   public:
     TextAreaField(const FieldBase &base) : IField(base) {}
   };
-  struct DatePickerFieldModel : public FieldBase {};
+  struct DatePickerField : public IField {
+    std::optional<QString> min; // ISO string
+    std::optional<QString> max; // ISO string
+    std::optional<QString> type; // "date" | "dateTime"
+
+  public:
+    DatePickerField(const FieldBase &base) : IField(base) {}
+  };
   struct InvalidField : public FieldBase {};
 
   struct Separator {};

--- a/vicinae/include/extension/extension-form-component.hpp
+++ b/vicinae/include/extension/extension-form-component.hpp
@@ -12,6 +12,7 @@
 #include "extension/form/extension-form-input.hpp"
 #include "extension/form/extension-dropdown.hpp"
 #include "extension/form/extension-password-field.hpp"
+#include "extension/form/extension-date-picker.hpp"
 #include "ui/vertical-scroll-area/vertical-scroll-area.hpp"
 #include "extend/form-model.hpp"
 #include "extension/extension-view.hpp"
@@ -37,6 +38,7 @@ class ExtensionFormField : public FormField {
     if (auto f = dynamic_cast<const FormModel::TextAreaField *>(field)) { return new ExtensionTextArea; }
     if (auto f = dynamic_cast<const FormModel::DropdownField *>(field)) { return new ExtensionDropdown; }
     if (auto f = dynamic_cast<const FormModel::PasswordField *>(field)) { return new ExtensionPasswordField; }
+    if (auto f = dynamic_cast<const FormModel::DatePickerField *>(field)) { return new ExtensionDatePicker; }
 
     return nullptr;
   }

--- a/vicinae/include/extension/form/extension-date-picker.hpp
+++ b/vicinae/include/extension/form/extension-date-picker.hpp
@@ -1,0 +1,86 @@
+#pragma once
+#include "extend/form-model.hpp"
+#include "extension/form/extension-form-input.hpp"
+#include <qdatetime.h>
+#include <qdatetimeedit.h>
+
+class ExtensionDatePicker : public ExtensionFormInput {
+  Q_OBJECT
+
+  QDateTimeEdit *m_input = new QDateTimeEdit(this);
+  std::shared_ptr<FormModel::DatePickerField> m_model;
+
+  static QDateTime parseIso(const QString &s) {
+    auto dt = QDateTime::fromString(s, Qt::ISODateWithMs);
+    if (!dt.isValid()) dt = QDateTime::fromString(s, Qt::ISODate);
+    return dt;
+  }
+
+  void handleChanged(const QDateTime &dt) {
+    if (m_model && m_model->onChange) {
+      m_extensionNotifier->notify(*m_model->onChange, dt.toString(Qt::ISODateWithMs));
+    }
+  }
+
+public:
+  void clear() override {
+    // Reset to current date/time; if the field stores value, higher-level reset will override
+    m_input->setDateTime(QDateTime::currentDateTime());
+  }
+
+  QJsonValue asJsonValue() const override { return m_input->dateTime().toString(Qt::ISODateWithMs); }
+
+  void setValueAsJson(const QJsonValue &value) override {
+    if (value.isString()) {
+      auto dt = parseIso(value.toString());
+      if (dt.isValid()) m_input->setDateTime(dt);
+    }
+  }
+
+  void render(const std::shared_ptr<FormModel::IField> &field) override {
+    m_model = std::static_pointer_cast<FormModel::DatePickerField>(field);
+
+    const auto type = m_model->type.value_or("dateTime");
+
+    if (type == "date") {
+      m_input->setDisplayFormat("yyyy-MM-dd");
+      // normalize to midnight when rendering an existing value
+      if (auto v = m_model->value; v && v->isString()) {
+        auto dt = parseIso(v->toString());
+        if (dt.isValid()) {
+          m_input->setDate(dt.date());
+          m_input->setTime(QTime(0, 0));
+        }
+      }
+    } else {
+      m_input->setDisplayFormat("yyyy-MM-dd HH:mm");
+      if (auto v = m_model->value; v && v->isString()) {
+        auto dt = parseIso(v->toString());
+        if (dt.isValid()) m_input->setDateTime(dt);
+      }
+    }
+
+    // Min/Max
+    if (auto min = m_model->min) {
+      auto dt = parseIso(*min);
+      if (dt.isValid()) m_input->setMinimumDateTime(dt);
+    }
+    if (auto max = m_model->max) {
+      auto dt = parseIso(*max);
+      if (dt.isValid()) m_input->setMaximumDateTime(dt);
+    }
+
+    // Default value if present and not already set
+    if (auto value = m_model->value; value && value->isString()) {
+      auto dt = parseIso(value->toString());
+      if (dt.isValid()) m_input->setDateTime(dt);
+    }
+  }
+
+  ExtensionDatePicker() {
+    m_input->setCalendarPopup(true);
+    m_input->setButtonSymbols(QAbstractSpinBox::NoButtons);
+    setWrapped(m_input);
+    connect(m_input, &QDateTimeEdit::dateTimeChanged, this, &ExtensionDatePicker::handleChanged);
+  }
+};

--- a/vicinae/src/extend/form-model.cpp
+++ b/vicinae/src/extend/form-model.cpp
@@ -74,6 +74,11 @@ FormModel FormModel::fromJson(const QJsonObject &json) {
         if (props.contains("label")) checkbox->m_label = props.value("label").toString();
         model.items.emplace_back(checkbox);
       } else if (*it == "date-picker-field") {
+        auto dp = std::make_shared<DatePickerField>(base);
+        if (props.contains("min")) dp->min = props.value("min").toString();
+        if (props.contains("max")) dp->max = props.value("max").toString();
+        if (props.contains("type")) dp->type = props.value("type").toString();
+        model.items.emplace_back(dp);
       } else if (*it == "text-area-field") {
         auto ta = std::make_shared<TextAreaField>(base);
         if (props.contains("placeholder")) ta->placeholder = props.value("placeholder").toString();


### PR DESCRIPTION
Adds date and datetime picker. Fields added to boilerplate form demo.

The input field looks different for some reason:
<img width="776" height="497" alt="image" src="https://github.com/user-attachments/assets/81bb3461-5874-4163-ac15-a75b0c61b56d" />

There is a calendar date picker, but I couldn't find any Qt gui for time. So even datetime shows only a calendar (and time has to be changed in text).

<img width="778" height="534" alt="image" src="https://github.com/user-attachments/assets/44efd0df-176a-4627-8c64-2863c88fb2f6" />

It doesn't look great, but makes a few extensions not crash:

extension: `raycast-timezone-converter`
<img width="776" height="489" alt="image" src="https://github.com/user-attachments/assets/c8256555-f6fb-420d-b848-76d4f331d946" />

fyi: there is a bug where on the page above, submitting when the dropdown is selected crashes vicinae. But submitting with datetime focus works normally. Will take a look at it later.