### PR TITLE
fix: missing include

### DIFF
--- a/vicinae/src/services/window-manager/abstract-window-manager.hpp
+++ b/vicinae/src/services/window-manager/abstract-window-manager.hpp
@@ -5,6 +5,7 @@
 #include <qpromise.h>
 #include <qstringview.h>
 #include "services/app-service/abstract-app-db.hpp"
+#include <QApplication>
 #include <QScreen>
 #include <qtmetamacros.h>
 #include <ranges>


### PR DESCRIPTION
This fixes
```
vicinae/vicinae/src/services/window-manager/abstract-window-manager.hpp:106:26: error: incomplete type ‘QApplication’ used in nested name specifier
  106 |     return QApplication::screens() | std::views::transform(tr) | std::ranges::to<std::vector>();
      |     
```