### PR TITLE
fix(config): skip file remove when updating config

### DIFF
--- a/vicinae/src/services/config/config-service.hpp
+++ b/vicinae/src/services/config/config-service.hpp
@@ -107,6 +107,10 @@ private:
 
   void handleDirectoryChanged(const QString &path) {
     qDebug() << "config directory changed, reloading config...";
+    reloadConfig();
+  }
+
+  void reloadConfig() {
     auto prev = m_config;
     m_config = load();
     emit configChanged(m_config, prev);
@@ -195,7 +199,8 @@ public:
       return;
     }
     file.write(doc.toJson());
-    qDebug() << "write config";
+    // do not emit update signal during save, wait a bit
+    QTimer::singleShot(0, this, &ConfigService::reloadConfig);
   }
 
   ConfigService() {


### PR DESCRIPTION
For NixOS/Home Manager users this breaks the symlink from the nix store, and results in errors the next time home manager builds.

Fixes: #652 