### PR TITLE
cli: add extension types generation

### DIFF
--- a/extra/extension-boilerplate/.gitignore
+++ b/extra/extension-boilerplate/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+vicinae-env.d.ts

--- a/typescript/api/src/commands/build/index.ts
+++ b/typescript/api/src/commands/build/index.ts
@@ -5,6 +5,7 @@ import { cpSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { Logger } from "../../utils/logger.js";
 import { extensionDataDir } from "../../utils/utils.js";
+import { updateExtensionTypes } from "../../utils/extension-types.js";
 import ManifestSchema from "../../schemas/manifest.js";
 
 export default class Build extends Command {
@@ -71,14 +72,14 @@ export default class Build extends Command {
 				const tsSource = `${base}.ts`;
 				let source = tsxSource;
 
-				if (cmd.mode == "view" && !existsSync(tsxSource)) {
+				if (cmd.mode === "view" && !existsSync(tsxSource)) {
 					throw new Error(
 						`Unable to find view command ${cmd.name} at ${tsxSource}`,
 					);
 				}
 
 				// we allow .ts or .tsx for no-view
-				if (cmd.mode == "no-view") {
+				if (cmd.mode === "no-view") {
 					if (!existsSync(tsxSource)) {
 						source = tsSource;
 						if (!existsSync(tsSource)) {
@@ -115,6 +116,9 @@ export default class Build extends Command {
 		};
 
 		process.chdir(src);
+
+		logger.logInfo("Generating extension types...");
+		updateExtensionTypes(manifest, src);
 
 		logger.logInfo("Checking types...");
 		const typeCheck = spawnSync("npx", ["tsc", "--noEmit"]);

--- a/typescript/api/src/schemas/manifest.ts
+++ b/typescript/api/src/schemas/manifest.ts
@@ -1,5 +1,243 @@
 import { z } from "zod";
 
+// Preference schema for extension and command preferences
+const preferenceBase = {
+	name: z.string().min(1).describe("A unique id for the preference."),
+	title: z
+		.string()
+		.describe(
+			"The display name of the preference shown in Raycast preferences. For 'checkbox', 'textfield' and 'password', it is shown as a section title above the respective input element. If you want to group multiple checkboxes into a single section, set the 'title' of the first checkbox and leave the 'title' of the other checkboxes empty.",
+		),
+	description: z
+		.string()
+		.describe(
+			"It helps users understand what the preference does. It will be displayed as a tooltip when hovering over it.",
+		),
+	required: z
+		.boolean()
+		.describe(
+			"Indicates whether the value is required and must be entered by the user before the extension is usable.",
+		),
+};
+
+const preferenceSchema = z.discriminatedUnion("type", [
+	// textfield preference
+	z
+		.object({
+			...preferenceBase,
+			type: z.literal("textfield"),
+			placeholder: z
+				.string()
+				.describe(
+					"Text displayed in the preference's field when no value has been input.",
+				)
+				.optional(),
+			default: z
+				.union([
+					z.string(),
+					z.object({
+						macOS: z.string().optional(),
+						Windows: z.string().optional(),
+					}),
+				])
+				.describe(
+					"The optional default value for the field. For textfields, this is a string value. Additionally, you can specify a different value per platform by passing an object: { 'macOS': ..., 'Windows': ... }.",
+				)
+				.optional(),
+		})
+		.strict(),
+	// password preference
+	z
+		.object({
+			...preferenceBase,
+			type: z.literal("password"),
+			placeholder: z
+				.string()
+				.describe(
+					"Text displayed in the preference's field when no value has been input.",
+				)
+				.optional(),
+			default: z
+				.union([
+					z.string(),
+					z.object({
+						macOS: z.string().optional(),
+						Windows: z.string().optional(),
+					}),
+				])
+				.describe(
+					"The optional default value for the field. For passwords, this is a string value. Additionally, you can specify a different value per platform by passing an object: { 'macOS': ..., 'Windows': ... }.",
+				)
+				.optional(),
+		})
+		.strict(),
+	// checkbox preference
+	z
+		.object({
+			...preferenceBase,
+			type: z.literal("checkbox"),
+			label: z
+				.string()
+				.min(1)
+				.describe("The label of the checkbox. Shown next to the checkbox."),
+			default: z
+				.union([
+					z.boolean(),
+					z.object({
+						macOS: z.boolean().optional(),
+						Windows: z.boolean().optional(),
+					}),
+				])
+				.describe(
+					"The optional default value for the field. For checkboxes, this is a boolean value. Additionally, you can specify a different value per platform by passing an object: { 'macOS': ..., 'Windows': ... }.",
+				)
+				.optional(),
+		})
+		.strict(),
+	// dropdown preference
+	z
+		.object({
+			...preferenceBase,
+			type: z.literal("dropdown"),
+			data: z
+				.array(
+					z.object({
+						title: z.string(),
+						value: z.string(),
+					}),
+				)
+				.min(1)
+				.describe(
+					"An array of objects with 'title' and 'value' properties, e.g.: [{'title': 'Item 1', 'value': '1'}]",
+				),
+			default: z
+				.union([
+					z.string(),
+					z.object({
+						macOS: z.string().optional(),
+						Windows: z.string().optional(),
+					}),
+				])
+				.describe(
+					"The optional default value for the field. For dropdowns, this is the value of an object in the data array. Additionally, you can specify a different value per platform by passing an object: { 'macOS': ..., 'Windows': ... }.",
+				)
+				.optional(),
+		})
+		.strict(),
+	// appPicker preference
+	z
+		.object({
+			...preferenceBase,
+			type: z.literal("appPicker"),
+			default: z
+				.union([
+					z.string(),
+					z.object({
+						macOS: z.string().optional(),
+						Windows: z.string().optional(),
+					}),
+				])
+				.describe(
+					"The optional default value for the field. For appPickers, this is an application name, bundle ID or path. Additionally, you can specify a different value per platform by passing an object: { 'macOS': ..., 'Windows': ... }.",
+				)
+				.optional(),
+		})
+		.strict(),
+	// file preference
+	z
+		.object({
+			...preferenceBase,
+			type: z.literal("file"),
+			default: z
+				.union([
+					z.string(),
+					z.object({
+						macOS: z.string().optional(),
+						Windows: z.string().optional(),
+					}),
+				])
+				.describe(
+					"The optional default value for the field. For file preferences, this is a file path. Additionally, you can specify a different value per platform by passing an object: { 'macOS': ..., 'Windows': ... }.",
+				)
+				.optional(),
+		})
+		.strict(),
+	// directory preference
+	z
+		.object({
+			...preferenceBase,
+			type: z.literal("directory"),
+			default: z
+				.union([
+					z.string(),
+					z.object({
+						macOS: z.string().optional(),
+						Windows: z.string().optional(),
+					}),
+				])
+				.describe(
+					"The optional default value for the field. For directory preferences, this is a directory path. Additionally, you can specify a different value per platform by passing an object: { 'macOS': ..., 'Windows': ... }.",
+				)
+				.optional(),
+		})
+		.strict(),
+]);
+
+// Argument schema for command arguments
+const argumentBase = {
+	name: z
+		.string()
+		.min(1)
+		.describe(
+			"A unique id for the argument. This value will be used to as the key in the object passed as top-level prop.",
+		),
+	placeholder: z
+		.string()
+		.min(1)
+		.describe("Placeholder for the argument's input field."),
+	required: z
+		.boolean()
+		.describe(
+			"Indicates whether the value is required and must be entered by the user before the command is opened. Default value for this is 'false'.",
+		)
+		.optional(),
+};
+
+const argumentSchema = z.discriminatedUnion("type", [
+	// text argument
+	z
+		.object({
+			...argumentBase,
+			type: z.literal("text"),
+		})
+		.strict(),
+	// password argument
+	z
+		.object({
+			...argumentBase,
+			type: z.literal("password"),
+		})
+		.strict(),
+	// dropdown argument
+	z
+		.object({
+			...argumentBase,
+			type: z.literal("dropdown"),
+			data: z
+				.array(
+					z.object({
+						title: z.string(),
+						value: z.string(),
+					}),
+				)
+				.min(1)
+				.describe(
+					"An array of objects with 'title' and 'value' properties, e.g.: [{'title': 'Item 1', 'value': '1'}]",
+				),
+		})
+		.strict(),
+]);
+
 export default z.object({
 	icon: z
 		.string()
@@ -143,13 +381,13 @@ export default z.object({
 						)
 						.optional(),
 					preferences: z
-						.any()
+						.array(preferenceSchema)
 						.describe(
 							'Commands can optionally contribute preferences that are shown in Vicinae Preferences > Extensions when selecting the command. You can use preferences for configuration values and passwords or personal access tokens. Commands automatically "inherit" extension preferences and can also override entries with the same `name`.',
 						)
 						.optional(),
 					arguments: z
-						.any()
+						.array(argumentSchema)
 						.describe(
 							"An optional array of arguments that are requested from user when the command is called",
 						)
@@ -209,7 +447,7 @@ export default z.object({
 						)
 						.optional(),
 					preferences: z
-						.any()
+						.array(preferenceSchema)
 						.describe(
 							'Tools can optionally contribute preferences that are shown in Vicinae Preferences > Extensions when selecting the AI Extension item. You can use preferences for configuration values and passwords or personal access tokens. Tools automatically "inherit" extension preferences and can also override entries with the same `name`.',
 						)
@@ -262,7 +500,7 @@ export default z.object({
 			"It helps users understand what the extension does. It will be displayed in the Store and in Preferences.",
 		),
 	preferences: z
-		.any()
+		.array(preferenceSchema)
 		.describe(
 			"Extensions can contribute preferences that are shown in Vicinae Preferences > Extensions. You can use preferences for configuration values and passwords or personal access tokens.",
 		)

--- a/typescript/api/src/utils/extension-types.ts
+++ b/typescript/api/src/utils/extension-types.ts
@@ -1,0 +1,200 @@
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { z } from "zod";
+import type ManifestSchema from "../schemas/manifest.js";
+
+type Manifest = z.infer<typeof ManifestSchema>;
+type Preference = NonNullable<Manifest["preferences"]>[number];
+type Argument = NonNullable<Manifest["commands"][number]["arguments"]>[number];
+
+/**
+ * Generates and updates the extension types file in the specified directory
+ */
+export function updateExtensionTypes(
+	manifest: Manifest,
+	outDir: string,
+): { envPath: string } {
+	const content = createExtensionTypes(manifest);
+	const envPath = join(outDir, "vicinae-env.d.ts");
+	writeFileSync(envPath, content);
+	return { envPath };
+}
+
+/**
+ * Generates TypeScript type definitions from a manifest (package.json)
+ */
+export function createExtensionTypes(manifest: Manifest): string {
+	const extPrefs = generateExtensionPreferences(manifest);
+	const cmdPrefs = generateCommandPreferences(manifest);
+	const argTypes = generateCommandArguments(manifest);
+
+	return `
+/// <reference types="@vicinae/api">
+
+/*
+ * This file is auto-generated from the extension's manifest.
+ * Do not modify manually. Instead, update the \`package.json\` file.
+ */
+
+type ExtensionPreferences = {
+  ${extPrefs}
+}
+
+declare type Preferences = ExtensionPreferences
+
+declare namespace Preferences {
+  ${cmdPrefs}
+}
+
+declare namespace Arguments {
+  ${argTypes}
+}
+	`.trim();
+}
+
+/**
+ * Generates TypeScript type definitions for extension preferences
+ */
+function generateExtensionPreferences(manifest: Manifest): string {
+	if (!manifest.preferences) {
+		return "";
+	}
+
+	const extPrefs: string[] = [];
+	for (const pref of manifest.preferences) {
+		let prefText = generateDocComment(pref.title, pref.description);
+		if (prefText) {
+			prefText += "\n\t";
+		}
+		prefText += `"${pref.name}"${pref.required ? "?" : ""}: ${getPreferenceType(pref)};`;
+		extPrefs.push(prefText);
+	}
+
+	return extPrefs.join("\n").trim();
+}
+
+/**
+ * Generates a JSDoc comment string for a preference or argument
+ */
+function generateDocComment(title?: string, description?: string): string {
+	if (!title && !description) {
+		return "";
+	}
+
+	const content = [title, description].filter(Boolean).join(" - ");
+	return `\n\t/** ${content.trim()} */`;
+}
+
+/**
+ * Generates a TypeScript type string for a preference value
+ */
+function getPreferenceType(pref: Preference): string {
+	if (pref.type === "checkbox") {
+		return "boolean";
+	}
+
+	if (
+		pref.type === "dropdown" &&
+		Array.isArray(pref.data) &&
+		pref.data.length > 0
+	) {
+		// Build a union type from the 'value' fields for dropdowns
+		const unionValues = pref.data
+			.map((option) =>
+				typeof option.value === "string" ? `"${option.value}"` : undefined,
+			)
+			.filter((v): v is string => !!v)
+			.join(" | ");
+		return unionValues || "string";
+	}
+
+	return "string";
+}
+
+/**
+ * Generates TypeScript type definitions for command preferences
+ */
+function generateCommandPreferences(manifest: Manifest): string {
+	const cmdPrefs: string[] = [];
+
+	for (const cmd of manifest.commands) {
+		const prefix =
+			generateDocComment(`Command: ${cmd.title}`) +
+			`\n\texport type ${toPascalCase(cmd.name)} = ExtensionPreferences & {`;
+
+		const prefs: string[] = [];
+		for (const pref of cmd.preferences ?? []) {
+			let prefText = "";
+			const docComment = generateDocComment(pref.title, pref.description);
+			if (docComment) {
+				prefText = `\n\t\t${docComment.trim()}\n\t\t`;
+			}
+			prefText += `"${pref.name}"${pref.required ? "?" : ""}: ${getPreferenceType(pref)};`;
+			prefs.push(prefText);
+		}
+
+		cmdPrefs.push(`${prefix}\n\t\t${prefs.join("\n").trim()}\n\t}`);
+	}
+
+	return cmdPrefs.join("\n").trim();
+}
+
+/**
+ * Generates TypeScript type definitions for command arguments
+ */
+function generateCommandArguments(manifest: Manifest): string {
+	const cmdArgs: string[] = [];
+
+	for (const cmd of manifest.commands) {
+		const prefix =
+			generateDocComment(`Command: ${cmd.title}`) +
+			`\n\texport type ${toPascalCase(cmd.name)} = {`;
+
+		const args: string[] = [];
+		for (const arg of cmd.arguments ?? []) {
+			const docComment = generateDocComment(arg.placeholder);
+			let argText = `\n\t\t${docComment.trim()}\n\t\t`;
+			argText += `"${arg.name}"${arg.required ? "?" : ""}: ${getArgumentType(arg)}`;
+			args.push(argText);
+		}
+
+		cmdArgs.push(`${prefix}\n\t\t${args.join("\n").trim()}\n\t}`);
+	}
+
+	return cmdArgs.join("\n").trim();
+}
+
+/**
+ * Generates a TypeScript type string for an argument value
+ */
+function getArgumentType(arg: Argument): string {
+	if (
+		arg.type === "dropdown" &&
+		Array.isArray(arg.data) &&
+		arg.data.length > 0
+	) {
+		// Build a union type from the 'value' fields
+		const unionValues = arg.data
+			.map((option) =>
+				typeof option.value === "string" ? `"${option.value}"` : undefined,
+			)
+			.filter((v): v is string => !!v)
+			.join(" | ");
+		if (unionValues) {
+			return unionValues;
+		}
+	}
+	return "string";
+}
+
+/**
+ * Converts a string to PascalCase
+ */
+function toPascalCase(str: string): string {
+	return str
+		.replace(/([a-z])([A-Z])/g, "$1 $2") // Splits camelCase words into separate words
+		.replace(/[-_]+|[^\p{L}\p{N}]/gu, " ") // Replaces dashes, underscores, and special characters with spaces
+		.toLowerCase() // Converts the entire string to lowercase
+		.replace(/(?:^|\s)(\p{L})/gu, (_, letter) => letter.toUpperCase()) // Capitalizes the first letter of each word
+		.replace(/\s+/g, ""); // Removes all spaces
+}

--- a/vicinae/src/services/extension-boilerplate-generator/extension-boilerplate-generator.cpp
+++ b/vicinae/src/services/extension-boilerplate-generator/extension-boilerplate-generator.cpp
@@ -125,7 +125,7 @@ ExtensionBoilerplateGenerator::generate(const fs::path &targetDir, const Extensi
 
   if (!gitignore.open(QIODevice::WriteOnly)) { return tl::unexpected(QString("Failed to write gitignore")); }
 
-  gitignore.write("node_modules\n");
+  gitignore.write("node_modules\nvicinae-env.d.ts\n");
   userCopy(":boilerplate/tsconfig.json", QString::fromStdString(extDir / "tsconfig.json"));
   userCopy(":boilerplate/extension_icon", QString::fromStdString(assetsDir / "extension_icon.png"));
   userCopy(":boilerplate/README.md", QString::fromStdString(extDir / "README.md"));


### PR DESCRIPTION
The `build` and `develop` commands of the cli now generate type defs for extensions based on preferences and arguments defined in package.json.

- required will had a `?`
- checkbox types -> boolean
- dropdown types -> string union

Not strictly required for typegen, but added proper types to manifest schema for prefs and args. They are discriminated union based the the `type` field.

<img width="656" height="898" alt="image" src="https://github.com/user-attachments/assets/04ce848c-1997-4b6f-8b4f-cb629bf87ed1" />
