### PR TITLE
Flush temp file before attempting to unzip extension

### DIFF
--- a/vicinae/src/lib/zip/unzip.cpp
+++ b/vicinae/src/lib/zip/unzip.cpp
@@ -86,6 +86,7 @@ Unzipper::Unzipper(std::string_view path) {
   }
 
   m_tmpFile->write(path.data(), path.size());
+  m_tmpFile->flush();
   m_handle.file = unzOpen(m_tmpFile->filesystemFileName().c_str());
   unzGetGlobalInfo(m_handle.file, &m_handle.info);
 }


### PR DESCRIPTION
Some extensions fail to install from both stores, failing on the unzip op. This fixes it.

test extensions:
- `rodalies` (from vicinae store)
- `temporary-email` (from raycast store)
