### PR TITLE
feat: add missing throttle property to List component

### DIFF
--- a/typescript/api/docs/@vicinae/namespaces/List/type-aliases/Props.md
+++ b/typescript/api/docs/@vicinae/namespaces/List/type-aliases/Props.md
@@ -103,3 +103,9 @@ use filtering
 ### searchText?
 
 > `optional` **searchText**: `string`
+
+***
+
+### throttle?
+
+> `optional` **throttle**: `boolean`

--- a/typescript/api/src/api/components/list.tsx
+++ b/typescript/api/src/api/components/list.tsx
@@ -31,6 +31,7 @@ export declare namespace List {
 		searchBarPlaceholder?: string;
 		navigationTitle?: string;
 		searchBarAccessory?: ReactNode;
+		throttle?: boolean;
 		onSearchTextChange?: (text: string) => void;
 		onSelectionChange?: (id: string) => void;
 	};


### PR DESCRIPTION
The `throttle` property appears to be missing from the main `List` TS props - added in this PR, in order to match the definition of `ListProps_2` from `@raycast/api`.
It is already implemented and working on the CPP side - tsc errors out only because of type-checking.

I'm fairly confident this change would be needed, but not 100% confident, hope this is relevant - sorry if not!

Also, the docs appear to be out of date, I only committed the changes from `docgen-md` for the List component and ignored the rest.

lmk if there is something else I should do or anything I should know about!