### PR TITLE
fix(extension): send initial list item changed event

### DIFF
--- a/vicinae/include/extension/extension-list-component.hpp
+++ b/vicinae/include/extension/extension-list-component.hpp
@@ -49,4 +49,5 @@ private:
   QTimer *m_dropdownDebounce = new QTimer(this);
   bool m_dropdownShouldResetSelection = false;
   int m_renderCount = 0;
+  std::optional<QString> m_onSelectionChanged;
 };

--- a/vicinae/src/extension/extension-list-component.cpp
+++ b/vicinae/src/extension/extension-list-component.cpp
@@ -126,6 +126,8 @@ void ExtensionListComponent::render(const RenderModel &baseModel) {
   ++m_renderCount;
   auto newModel = std::get<ListModel>(baseModel);
 
+  m_onSelectionChanged = newModel.onSelectionChanged;
+
   if (auto accessory = newModel.searchBarAccessory) {
     auto dropdown = std::get<DropdownModel>(*accessory);
 
@@ -239,7 +241,7 @@ void ExtensionListComponent::onSelectionChanged(const ListItemViewModel *next) {
     return;
   }
 
-  if (auto handler = _model.onSelectionChanged) { notify(*handler, {next->id}); }
+  if (auto handler = m_onSelectionChanged) { notify(*handler, {next->id}); }
 
   m_split->setDetailVisibility(_model.isShowingDetail);
 


### PR DESCRIPTION
the list model was changed (and the signal fired) before we got a chance to set the new model state.