### PR TITLE
fix(extension): support List.Item title and subtitle props alternate usage with tooltip.

### DIFF
--- a/vicinae/include/extend/list-model.hpp
+++ b/vicinae/include/extend/list-model.hpp
@@ -54,6 +54,7 @@ class ListModelParser {
   ListItemViewModel parseListItem(const QJsonObject &instance, size_t index);
   ListSectionModel parseSection(const QJsonObject &instance);
   ImageLikeModel parseListItemIcon(const QJsonValue &value) const;
+  QString parseListItemTitle(const QJsonValue &value) const;
 
 public:
   ListModelParser();

--- a/vicinae/src/extend/list-model.cpp
+++ b/vicinae/src/extend/list-model.cpp
@@ -19,14 +19,24 @@ ImageLikeModel ListModelParser::parseListItemIcon(const QJsonValue &value) const
   return ImageModelParser().parse(value);
 }
 
+QString ListModelParser::parseListItemTitle(const QJsonValue &value) const {
+  if (value.isObject()) {
+    // we ignore the tooltip for now
+    auto obj = value.toObject();
+    if (obj.contains("value")) { return obj.value("value").toString(); }
+  }
+
+  return value.toString();
+}
+
 ListItemViewModel ListModelParser::parseListItem(const QJsonObject &instance, size_t index) {
   ListItemViewModel model;
   auto props = instance.value("props").toObject();
   auto children = instance.value("children").toArray();
 
   model.id = props["id"].toString(QString::number(index));
-  model.title = props["title"].toString();
-  model.subtitle = props["subtitle"].toString();
+  model.title = parseListItemTitle(props["title"]);
+  model.subtitle = parseListItemTitle(props["subtitle"]);
 
   if (props.contains("icon")) { model.icon = parseListItemIcon(props.value("icon")); }
 


### PR DESCRIPTION
Currently the raycast api supports tooltip usage using `{ tooltip?: string; value: string }` on some List.Item properties such as title, subtitle and icon.

Icon is already handled as part of https://github.com/vicinaehq/vicinae/commit/b466d44b3efeea6031ff0f9b023ce42097dd86fd

However title and subtitle are missing. If we use the tooltip form - no text is displayed as the `.toString()` returns empty string from an object.

We make it use the `value` property correctly.

Ref: https://developers.raycast.com/api-reference/user-interface/list#list.item

