### PR TITLE
refactor: get rid of sqlite unixepoch() default values

### DIFF
--- a/vicinae/database/clipboard/migrations/001_init.sql
+++ b/vicinae/database/clipboard/migrations/001_init.sql
@@ -7,8 +7,8 @@ CREATE TABLE IF NOT EXISTS selection (
 	preferred_mime_type TEXT NOT NULL,
 	source TEXT,
 	offer_count INTEGER,
-	created_at INTEGER DEFAULT (unixepoch()),
-	updated_at INTEGER DEFAULT (unixepoch()), -- updated when the same selection is reselected
+	created_at INTEGER NOT NULL,
+	updated_at INTEGER NOT NULL, -- updated when the same selection is reselected
 	pinned_at INTEGER,
 	kind INTEGER,
 	keywords TEXT DEFAULT '' -- additional user defined text to index

--- a/vicinae/database/vicinae/migrations/001_init.sql
+++ b/vicinae/database/vicinae/migrations/001_init.sql
@@ -5,8 +5,8 @@ CREATE TABLE IF NOT EXISTS shortcut (
 		url TEXT NOT NULL,
 		app TEXT NOT NULL,
 		open_count INTEGER DEFAULT 0,
-		created_at INTEGER DEFAULT (unixepoch()),
-		updated_at INTEGER DEFAULT (unixepoch()),
+		created_at INTEGER NOT NULL,
+		updated_at INTEGER NOT NULL,
 		last_used_at INTEGER
 );
 
@@ -65,7 +65,7 @@ CREATE TABLE IF NOT EXISTS calculator_history (
 	type_hint INTEGER NOT NULL, -- unit conversion / regular arithmetic
 	question TEXT NOT NULL,
 	answer TEXT NOT NULL,
-	created_at INTEGER DEFAULT (unixepoch()),
+	created_at INTEGER NOT NULL,
 	pinned_at INTEGER
 );
 

--- a/vicinae/src/favicon/favicon-service.cpp
+++ b/vicinae/src/favicon/favicon-service.cpp
@@ -34,10 +34,11 @@ void FaviconService::handleFetchedFavicon(const QString &domain, const QPixmap &
   QSqlQuery query(_db);
 
   query.prepare(R"(
-		INSERT INTO favicon (id, size)
-		VALUES (:id, :size)
+		INSERT INTO favicon (id, created_at, size)
+		VALUES (:id, :epoch, :size)
 	)");
   query.bindValue(":id", domain);
+  query.bindValue(":epoch", QDateTime::currentSecsSinceEpoch());
   query.bindValue(":size", favicon.width());
 
   if (!query.exec()) {
@@ -52,8 +53,9 @@ QPixmap FaviconService::retrieveFromCache(const QString &domain) {
   QPixmap pm;
   QSqlQuery query(_db);
 
-  query.prepare("UPDATE favicon SET last_used_at = unixepoch() WHERE id = :domain;");
+  query.prepare("UPDATE favicon SET last_used_at = :epoch WHERE id = :domain;");
   query.bindValue(":domain", domain);
+  query.bindValue(":epoch", QDateTime::currentSecsSinceEpoch());
 
   if (!query.exec()) { qDebug() << "Favicon DB: failed to update last_used_at" << query.lastError(); }
 
@@ -140,8 +142,8 @@ FaviconService::FaviconService(const std::filesystem::path &path, QObject *paren
 		CREATE TABLE IF NOT EXISTS favicon (
 			id TEXT PRIMARY KEY,
 			size INTEGER,
-			created_at INTEGER DEFAULT (unixepoch()),
-			last_used_at INTEGER DEFAULT (unixepoch()),
+			created_at INTEGER NOT NULL,
+			last_used_at INTEGER,
 			updated_at INTEGER
 		);
 	)");

--- a/vicinae/src/services/calculator-service/calculator-service.cpp
+++ b/vicinae/src/services/calculator-service/calculator-service.cpp
@@ -198,13 +198,14 @@ bool CalculatorService::addRecord(const AbstractCalculatorBackend::CalculatorRes
   QSqlQuery query = m_db.createQuery();
 
   query.prepare(R"(
-		INSERT INTO calculator_history (id, type_hint, question, answer)
-		VALUES (:id, :type_hint, :question, :answer)
+		INSERT INTO calculator_history (id, type_hint, question, answer, created_at)
+		VALUES (:id, :type_hint, :question, :answer, :epoch)
 	)");
   query.bindValue(":id", Crypto::UUID::v4());
   query.bindValue(":type_hint", result.type);
   query.bindValue(":question", result.question);
   query.bindValue(":answer", result.answer);
+  query.bindValue(":epoch", QDateTime::currentSecsSinceEpoch());
 
   if (!query.exec()) {
     qCritical() << "Failed to add calculator record" << query.lastError();
@@ -233,8 +234,9 @@ bool CalculatorService::addRecord(const AbstractCalculatorBackend::CalculatorRes
 bool CalculatorService::pinRecord(const QString &id) {
   QSqlQuery query = m_db.createQuery();
 
-  query.prepare("UPDATE calculator_history SET pinned_at = unixepoch() WHERE id = :id");
-  query.addBindValue(id);
+  query.prepare("UPDATE calculator_history SET pinned_at = :epoch WHERE id = :id");
+  query.bindValue(":id", id);
+  query.bindValue(":epoch", QDateTime::currentSecsSinceEpoch());
 
   if (!query.exec()) {
     qCritical() << "Failed to pin record with id" << id << query.lastError();


### PR DESCRIPTION
For some reason the usage of sqlite's `unixepoch` function seems to not work properly in some environments. So far issues with timestamps have only been observed on Fedora systems: #571

We now explicitly pass the timestamp as a query parameter, and we generate it from code directly instead of letting sqlite handle it.