### PR TITLE
fix(extension): fix List.Dropdown entries not displaying if not within section

### DIFF
--- a/vicinae/src/extension/extension-list-component.cpp
+++ b/vicinae/src/extension/extension-list-component.cpp
@@ -38,7 +38,7 @@ void ExtensionListComponent::renderDropdown(const DropdownModel &dropdown) {
         freeSectionItems.emplace_back(std::make_shared<DropdownSelectorItem>(*listItem));
       } else if (auto section = std::get_if<DropdownModel::Section>(&item)) {
         if (!freeSectionItems.empty()) {
-          // m_selector->addSection("", freeSectionItems);
+          m_selector->addSection("", freeSectionItems);
           freeSectionItems.clear();
         }
 


### PR DESCRIPTION
Currently items within a `List.Dropdown` are not displayed if the following are true:

1. They are not within a section.
2. A `List.Dropdown.Section` sibling exists after it.

This is because the current code logic simply clears it without creating a section.
This seems to have been handled at some point correctly - so the fix is just re-adding a comment back.

Seems to have been a missing leftover from this lol commit https://github.com/vicinaehq/vicinae/commit/729539b3d6bd9245d9f5fdc663ff291ba2c5ba7f

## Tested with following dropdown:

```jsx
<List.Dropdown
  tooltip="Select Drink Type"
  storeValue={true}
  onChange={(newValue) => {
	  console.log(newValue)
  }}
  >
	  <List.Dropdown.Item key="water" title={"water"} value={"water"} />
	  <List.Dropdown.Section title="Alcoholic Beverages">
		  <List.Dropdown.Item key={"wine"} title={"wine"} value={"wine"} />
		  <List.Dropdown.Item key={"beer"} title={"beer"} value={"beer"} />
	  </List.Dropdown.Section>
	  <List.Dropdown.Item key="juice" title={"juice"} value={"juice"} />
	  <List.Dropdown.Section title="Soft Drinks">
		  <List.Dropdown.Item key={"coke"} title={"coke"} value={"coke"} />
		  <List.Dropdown.Item key={"coke_zero"} title={"coke_zero"} value={"coke_zero"} />
	  </List.Dropdown.Section>
	  <List.Dropdown.Item key="sparkling_water" title={"sparkling_water"} value={"sparkling_water"} />
  </List.Dropdown>
```

Can see that now all items are displayed and appear in the dropdown.