### PR TITLE
nix: remove flake-utils, use overlay's pkgs to call vicinae

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1762111121,
@@ -36,8 +18,8 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
+    systems.url = "github:nix-systems/default";
   };
 
   nixConfig = {
@@ -15,13 +15,15 @@
     {
       self,
       nixpkgs,
-      flake-utils,
+      systems,
     }:
-    flake-utils.lib.eachDefaultSystem (
-      system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
-        vicinaePkg = pkgs.callPackage ./nix/vicinae.nix { };
+    let
+      inherit (nixpkgs) lib;
+      forEachPkgs = f: lib.genAttrs (import systems) (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      packages = forEachPkgs (pkgs: {
+        default = pkgs.callPackage ./nix/vicinae.nix { };
         nix-update-script = pkgs.writeShellScriptBin "nix-update-script" ''
           OLD_API_DEPS_HASH=$(${pkgs.lib.getExe pkgs.nix} eval --raw .#packages.x86_64-linux.default.passthru.apiDeps.hash)
           OLD_EXT_MAN_DEPS_HASH=$(${pkgs.lib.getExe pkgs.nix} eval --raw .#packages.x86_64-linux.default.passthru.extensionManagerDeps.hash)
@@ -36,13 +38,12 @@
 
           [[ "$OLD_EXT_MAN_DEPS_HASH" == "$NEW_EXT_MAN_DEPS_HASH" ]] || { echo -e "\e[31mHash mismatch for extension-manager npm deps, please replace the value in vicinae.nix with '$NEW_EXT_MAN_DEPS_HASH'.\e[0m" >&2; exit 1;}
         '';
-      in
-      {
-        packages.default = vicinaePkg;
-        packages.nix-update-script = nix-update-script;
-        mkVicinaeExtension = import ./nix/mkVicinaeExtension.nix;
-        devShells.default = pkgs.mkShell {
-          inputsFrom = [ vicinaePkg ]; # automatically pulls nativeBuildInputs + buildInputs
+      });
+      mkVicinaeExtension = import ./nix/mkVicinaeExtension.nix;
+      devShells = forEachPkgs (pkgs: {
+        default = pkgs.mkShell {
+          # automatically pulls nativeBuildInputs + buildInputs
+          inputsFrom = [ (pkgs.callPackage ./nix/vicinae.nix { }) ];
           buildInputs = [
             pkgs.ccache
           ];
@@ -52,9 +53,7 @@
             nixfmt-rfc-style
           ];
         };
-      }
-    )
-    // {
+      });
       overlays.default = final: prev: {
         vicinae = prev.callPackage ./nix/vicinae.nix { };
         mkVicinaeExtension = import ./nix/mkVicinaeExtension.nix;


### PR DESCRIPTION
Overlays should be called with `prev` so that the consumer's other overlays will apply to vicinae's dependencies. Related to https://github.com/vicinaehq/vicinae/pull/507, this will causes user's of the overlay with a different nixpkgs to have a different derivation, which will cause the vicinae in the cachix not to be used. This is desirable because as previously stated overlays should respond to the consumer's nixpkgs.

flake-utils is an unnecessary dependency which can be removed while keeping the functionality of having a system input the consumer can override. The system input can also be removed at the expense of users on platforms other than those explicitly supported losing the ability to use this flake (I've opted not to remove it). 