### PR TITLE
refactor: do not use home and end keys to navigate lists

### DIFF
--- a/vicinae/src/action-panel/action-panel.hpp
+++ b/vicinae/src/action-panel/action-panel.hpp
@@ -166,10 +166,6 @@ protected:
           return m_list->selectUp();
         case Qt::Key_Down:
           return m_list->selectDown();
-        case Qt::Key_Home:
-          return m_list->selectHome();
-        case Qt::Key_End:
-          return m_list->selectEnd();
         case Qt::Key_Return:
         case Qt::Key_Enter:
           m_list->activateCurrentSelection();

--- a/vicinae/src/extension/extension-grid-component.cpp
+++ b/vicinae/src/extension/extension-grid-component.cpp
@@ -37,10 +37,6 @@ bool ExtensionGridComponent::inputFilter(QKeyEvent *event) {
         return true;
       }
       break;
-    case Qt::Key_Home:
-      return m_list->selectHome();
-    case Qt::Key_End:
-      return m_list->selectEnd();
     case Qt::Key_Return:
       m_list->activateCurrentSelection();
       return true;

--- a/vicinae/src/extension/extension-list-component.cpp
+++ b/vicinae/src/extension/extension-list-component.cpp
@@ -100,16 +100,12 @@ bool ExtensionListComponent::inputFilter(QKeyEvent *event) {
       return m_list->selectUp();
     case Qt::Key_Down:
       return m_list->selectDown();
-    case Qt::Key_Home:
-      return m_list->selectHome();
     case Qt::Key_Tab:
       if (!context()->navigation->hasCompleter()) {
         m_list->selectNext();
         return true;
       }
       break;
-    case Qt::Key_End:
-      return m_list->selectEnd();
     }
   }
 

--- a/vicinae/src/extensions/clipboard/history/clipboard-history-view.cpp
+++ b/vicinae/src/extensions/clipboard/history/clipboard-history-view.cpp
@@ -667,10 +667,6 @@ bool ClipboardHistoryView::inputFilter(QKeyEvent *event) {
     case Qt::Key_Tab:
       m_list->selectNext();
       return true;
-    case Qt::Key_Home:
-      return m_list->selectHome();
-    case Qt::Key_End:
-      return m_list->selectEnd();
     case Qt::Key_Return:
       m_list->activateCurrentSelection();
       return true;

--- a/vicinae/src/ui/action-pannel/action-pannel-list-view.cpp
+++ b/vicinae/src/ui/action-pannel/action-pannel-list-view.cpp
@@ -35,10 +35,6 @@ bool ActionPannelListView::eventFilter(QObject *sender, QEvent *event) {
         return _list->selectUp();
       case Qt::Key_Down:
         return _list->selectDown();
-      case Qt::Key_Home:
-        return _list->selectHome();
-      case Qt::Key_End:
-        return _list->selectEnd();
       case Qt::Key_Return:
         _list->activateCurrentSelection();
         return true;

--- a/vicinae/src/ui/omni-list/omni-list.cpp
+++ b/vicinae/src/ui/omni-list/omni-list.cpp
@@ -800,10 +800,6 @@ bool OmniList::event(QEvent *event) {
       return selectLeft();
     case Qt::Key_Right:
       return selectRight();
-    case Qt::Key_Home:
-      return selectHome();
-    case Qt::Key_End:
-      return selectEnd();
     case Qt::Key_Return:
       activateCurrentSelection();
       return true;

--- a/vicinae/src/ui/views/grid-view.cpp
+++ b/vicinae/src/ui/views/grid-view.cpp
@@ -36,10 +36,6 @@ bool GridView::inputFilter(QKeyEvent *event) {
         return true;
       }
       break;
-    case Qt::Key_Home:
-      return m_grid->selectHome();
-    case Qt::Key_End:
-      return m_grid->selectEnd();
     case Qt::Key_Return:
     case Qt::Key_Enter:
       m_grid->activateCurrentSelection();

--- a/vicinae/src/ui/views/list-view.cpp
+++ b/vicinae/src/ui/views/list-view.cpp
@@ -42,12 +42,6 @@ bool ListView::inputFilter(QKeyEvent *event) {
       }
       break;
     }
-    case Qt::Key_Home:
-      return m_list->selectHome();
-      break;
-    case Qt::Key_End:
-      return m_list->selectEnd();
-      break;
     case Qt::Key_Return:
     case Qt::Key_Enter:
       m_list->activateCurrentSelection();


### PR DESCRIPTION
fixes #762 
See justification for this in the linked pr.