### PR TITLE
fix: Allow Enter (Numpad's Return) to execute Return actions

### DIFF
--- a/vicinae/include/ui/action-pannel/action.hpp
+++ b/vicinae/include/ui/action-pannel/action.hpp
@@ -5,6 +5,7 @@
 #include <qcontainerfwd.h>
 #include <qevent.h>
 #include <qlogging.h>
+#include <qnamespace.h>
 #include <qtmetamacros.h>
 
 class AppWindow;
@@ -46,16 +47,7 @@ public:
   bool isBoundTo(const QKeyEvent *event) {
     if (event->key() == Qt::Key_Enter) {
       qDebug() << "remapping numpad enter to return";
-
-      /*
-       * The action is being compared with the modifier in Shortcut::operator==.
-       * Users may want to be able to use the numpad's Enter key like the (non-numpad) return key. (Issue 734)
-       * For that to work, we need to remove the KeypadModifier flag from the modifiers list.
-       */
-      Qt::KeyboardModifiers modifiers = event->modifiers();
-      modifiers ^= Qt::KeypadModifier;
-
-      return isBoundTo(Keyboard::Shortcut(Qt::Key_Return, modifiers));
+      return isBoundTo(Keyboard::Shortcut(Qt::Key_Return, event->modifiers() ^= Qt::KeypadModifier));
     }
 
     return isBoundTo(Keyboard::Shortcut(event));


### PR DESCRIPTION
Nyallo!

This pull request intends to close #734 

> Quick reminder: Return -> Enter/Return on the "main" keyboard, Enter -> Enter/Return on the numpad

**Why**
Users may expect the Enter key to produce the same actions as the Return key, as seen in the mentioned issue, and my personal experience using the program (my muscle memory is using the Enter key, and nothing happens)

**How**
The keyboard shortcuts for actions are being compared by [`Shortcut::operator==`](https://github.com/vicinaehq/vicinae/blob/d7e98b4447d5c7df88e3e67c5ddfbae56730d341/vicinae/src/lib/keyboard/keyboard.cpp#L287).

Users may want to be able to use the Enter key like the return key, and because:
- The generic `enter` Shortcut is configured with `Qt::Key_Return` [(link)](https://github.com/vicinaehq/vicinae/blob/d7e98b4447d5c7df88e3e67c5ddfbae56730d341/vicinae/src/lib/keyboard/keyboard.hpp#L15) and
- `isBoundTo` remap the Qt::Key_Enter to Qt::KeyReturn with the original modifiers [(link)](https://github.com/vicinaehq/vicinae/blob/d7e98b4447d5c7df88e3e67c5ddfbae56730d341/vicinae/include/ui/action-pannel/action.hpp#L49), and
- `Qt::Key_Enter` comes with `Qt::KeypadModifier`, and `Qt::Key_Return` doesn't, the numpad's Enter couldn't be used.

This commit/pull request fixes this by flipping the `Qt::KeypadModifier` flag in the shortcut modifiers, allowing the action to be run with the enter key.