### PR TITLE
nix: fix mkVicinaeExtension not being for each system

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
           [[ "$OLD_EXT_MAN_DEPS_HASH" == "$NEW_EXT_MAN_DEPS_HASH" ]] || { echo -e "\e[31mHash mismatch for extension-manager npm deps, please replace the value in vicinae.nix with '$NEW_EXT_MAN_DEPS_HASH'.\e[0m" >&2; exit 1;}
         '';
       });
-      mkVicinaeExtension = import ./nix/mkVicinaeExtension.nix;
+      mkVicinaeExtension = forEachPkgs (_: import ./nix/mkVicinaeExtension.nix);
       devShells = forEachPkgs (pkgs: {
         default = pkgs.mkShell {
           # automatically pulls nativeBuildInputs + buildInputs


### PR DESCRIPTION
this is to prevent api breakage, which was accidentally introduced with #754