### PR TITLE
nix/mkVicinaeExtension: pass extra args to buildNpmPackage

### DIFF
--- a/nix/mkVicinaeExtension.nix
+++ b/nix/mkVicinaeExtension.nix
@@ -11,14 +11,23 @@
   # TODO: throw after 26.05, remove after 26.11 NixOS release
   name ? lib.throwIf (pname == null) "mkVicinaeExtension: must be called with pname" null,
   pkgs ? null,
-}:
+  ...
+}@args:
 lib.warnIf (pkgs != null)
   "mkVicinaeExtension: calling with pkgs is deprecated and no longer necessary"
-  (buildNpmPackage {
-    inherit pname version src;
-    npmDeps = importNpmLock { npmRoot = src; };
-    npmConfigHook = importNpmLock.npmConfigHook;
-    # NOTE: using buildPhase because $out doesn't work with npmBuildFlags
-    buildPhase = "npm run build -- --out=$out";
-    dontNpmInstall = true;
-  })
+  (
+    buildNpmPackage {
+      inherit pname version;
+      npmDeps = importNpmLock { npmRoot = src; };
+      npmConfigHook = importNpmLock.npmConfigHook;
+      # NOTE: using buildPhase because $out doesn't work with npmBuildFlags
+      buildPhase = "npm run build -- --out=$out";
+      dontNpmInstall = true;
+    }
+    // builtins.removeAttrs args [
+      "pname"
+      "version"
+      "name"
+      "pkgs"
+    ]
+  )


### PR DESCRIPTION
needed to fix https://github.com/vicinaehq/extensions/pull/56#issuecomment-3565012958, also just generally good practice