### PR TITLE
nix/mkVicinaeExtnesion: pass extra args to buildNpmPackage

### DIFF
--- a/nix/mkVicinaeExtension.nix
+++ b/nix/mkVicinaeExtension.nix
@@ -16,18 +16,20 @@
 lib.warnIf (pkgs != null)
   "mkVicinaeExtension: calling with pkgs is deprecated and no longer necessary"
   (
-    buildNpmPackage {
-      inherit pname version;
-      npmDeps = importNpmLock { npmRoot = src; };
-      npmConfigHook = importNpmLock.npmConfigHook;
-      # NOTE: using buildPhase because $out doesn't work with npmBuildFlags
-      buildPhase = "npm run build -- --out=$out";
-      dontNpmInstall = true;
-    }
-    // builtins.removeAttrs args [
-      "pname"
-      "version"
-      "name"
-      "pkgs"
-    ]
+    buildNpmPackage (
+      {
+        inherit pname version;
+        npmDeps = importNpmLock { npmRoot = src; };
+        npmConfigHook = importNpmLock.npmConfigHook;
+        # NOTE: using buildPhase because $out doesn't work with npmBuildFlags
+        buildPhase = "npm run build -- --out=$out";
+        dontNpmInstall = true;
+      }
+      // builtins.removeAttrs args [
+        "pname"
+        "version"
+        "name"
+        "pkgs"
+      ]
+    )
   )


### PR DESCRIPTION
forgot that functional apply is higher priority than attrset override. current broken on master so this should be merged asap.