### PR TITLE
markdown: render html block with libxml

### DIFF
--- a/vicinae/CMakeLists.txt
+++ b/vicinae/CMakeLists.txt
@@ -5,8 +5,9 @@ set(TARGET vicinae)
 
 find_package(Qt6 REQUIRED COMPONENTS Core Widgets Sql Network Svg DBus Concurrent)
 find_package(OpenSSL REQUIRED)
+find_package(LibXml2 REQUIRED)
 
-list(APPEND LIBS  Qt6::Widgets Qt6::Sql Qt6::Network Qt6::Svg Qt6::DBus Qt6::Concurrent ${CMARK_LIBRARY} ${CMARK_EXT_LIBRARY} protobuf::libprotobuf minizip OpenSSL::Crypto wayland-client xdgpp qt6keychain)
+list(APPEND LIBS  Qt6::Widgets Qt6::Sql Qt6::Network Qt6::Svg Qt6::DBus Qt6::Concurrent ${CMARK_LIBRARY} ${CMARK_EXT_LIBRARY} protobuf::libprotobuf minizip OpenSSL::Crypto wayland-client xdgpp qt6keychain LibXml2::LibXml2)
 
 set(WLR_CLIP_BIN ${CMAKE_BINARY_DIR}/wlr-clip/wlr-clip${CMAKE_EXECUTABLE_SUFFIX})
 set(ASSET_PATH ${CMAKE_CURRENT_SOURCE_DIR}/assets)

--- a/vicinae/src/ui/markdown/markdown-renderer.hpp
+++ b/vicinae/src/ui/markdown/markdown-renderer.hpp
@@ -6,6 +6,7 @@
 #include <qplaintextedit.h>
 #include <qstring.h>
 #include <cmark-gfm.h>
+#include <libxml/tree.h>
 #include <qstringview.h>
 #include <qtextbrowser.h>
 #include <qtextcursor.h>
@@ -63,7 +64,10 @@ class MarkdownRenderer : public QWidget {
   void insertHeading(cmark_node *node);
   void insertTopLevelNode(cmark_node *node);
 
-  void parseAndInsertHtmlImages(const QString &html);
+  void insertHtmlBlock(const QString &html);
+  void processHtmlNodes(xmlNode *node);
+  void insertHtmlImage(xmlNode *node);
+  cmark_node *parseMarkdown(const QString &markdown);
 
   void insertIfNotFirstBlock();
 


### PR DESCRIPTION
This replaces the regex based `<img>` parser with libxml. And also renders markdown for text nodes inside the html block. Supersedes #769.

example: `how-long-to-beat`
<img width="780" height="494" alt="image" src="https://github.com/user-attachments/assets/62ebed61-2ec0-4bab-b53f-441396b0a599" />

extension: `store.vicinae.systemd`
<img width="776" height="491" alt="image" src="https://github.com/user-attachments/assets/2d2f0c6c-1bb5-4071-99af-0950e0c947b1" />

boilerplate: blue square (img with src that includes a `<`, invalid xml, valid html) still renders fine
<img width="773" height="491" alt="image" src="https://github.com/user-attachments/assets/6f51e4cd-e341-4103-9d5b-a9f885e4e39d" />
