### PR TITLE
fix: fix sleep to use a quint64 instead of a boolean

### DIFF
--- a/vicinae/src/services/power-manager/systemd/systemd-power-manager.cpp
+++ b/vicinae/src/services/power-manager/systemd/systemd-power-manager.cpp
@@ -9,7 +9,7 @@ static const constexpr uint64_t SD_LOGIND_SOFT_REBOOT = 1 << 2;
 
 bool SystemdPowerManager::powerOff() { return m_iface->call("PowerOff", false).errorMessage().isEmpty(); }
 bool SystemdPowerManager::reboot() { return m_iface->call("Reboot", false).errorMessage().isEmpty(); }
-bool SystemdPowerManager::sleep() const { return m_iface->call("Sleep", false).errorMessage().isEmpty(); }
+bool SystemdPowerManager::sleep() const { return m_iface->call("Sleep", static_cast<quint64>(0)).errorMessage().isEmpty(); }
 bool SystemdPowerManager::suspend() { return m_iface->call("Suspend", false).errorMessage().isEmpty(); }
 bool SystemdPowerManager::hibernate() { return m_iface->call("Hibernate", false).errorMessage().isEmpty(); }
 bool SystemdPowerManager::lock() {


### PR DESCRIPTION
# Fix: Correct parameter type for systemd-logind Sleep() D-Bus call

## Problem

The "Sleep" command in Vicinae fails silently due to a D-Bus parameter type mismatch. The Sleep() method was being called with a boolean (`false`) instead of the required uint64 flags parameter.

## Root Cause

The systemd-logind D-Bus interface defines:
- `Sleep(in t flags)` - expects uint64 (type signature `t`)
- `Suspend(in b interactive)` - expects boolean (type signature `b`)

The current implementation incorrectly calls both methods with `false`, which works for Suspend but fails for Sleep with:

```
Error org.freedesktop.DBus.Error.InvalidArgs: Invalid arguments 'b' to call org.freedesktop.login1.Manager.Sleep(), expecting  't'.
```

## Solution

Changed the Sleep() call to use `static_cast<quint64>(0)` to match the D-Bus method signature, consistent with the existing `softReboot()` implementation in the same file (line 28).

## Testing

Verified on systemd 258 with:
```bash
# This fails:
dbus-send --system --print-reply --dest=org.freedesktop.login1 \
  /org/freedesktop/login1 org.freedesktop.login1.Manager.Sleep boolean:false

# This works:
dbus-send --system --print-reply --dest=org.freedesktop.login1 \
  /org/freedesktop/login1 org.freedesktop.login1.Manager.Sleep uint64:0
```

References

- https://www.freedesktop.org/software/systemd/man/latest/org.freedesktop.login1.html
- https://lwn.net/Articles/978151/
- https://doc.qt.io/qt-6/qdbusabstractinterface.html