### PR TITLE
fix: use layer top instead of overlay

### DIFF
--- a/vicinae/src/services/file-chooser/native/native-file-chooser.cpp
+++ b/vicinae/src/services/file-chooser/native/native-file-chooser.cpp
@@ -26,7 +26,7 @@ NativeFileChooser::NativeFileChooser(QObject *parent) : AbstractFileChooser(pare
 
     m_dialog.createWinId();
     if (auto lshell = Shell::Window::get(m_dialog.windowHandle())) {
-      lshell->setLayer(Shell::Window::LayerOverlay);
+      lshell->setLayer(Shell::Window::LayerTop);
       lshell->setScope(Omnicast::APP_ID);
       lshell->setScreenConfiguration(Shell::Window::ScreenFromCompositor);
       lshell->setKeyboardInteractivity(Shell::Window::KeyboardInteractivityExclusive);

--- a/vicinae/src/ui/hud/hud.cpp
+++ b/vicinae/src/ui/hud/hud.cpp
@@ -28,7 +28,7 @@ void HudWidget::setupUI() {
 
     createWinId();
     if (auto lshell = Shell::Window::get(windowHandle())) {
-      lshell->setLayer(Shell::Window::LayerOverlay);
+      lshell->setLayer(Shell::Window::LayerTop);
       lshell->setScope(Omnicast::APP_ID);
       lshell->setScreenConfiguration(Shell::Window::ScreenFromCompositor);
       lshell->setKeyboardInteractivity(Shell::Window::KeyboardInteractivityNone);

--- a/vicinae/src/ui/launcher-window/launcher-window.cpp
+++ b/vicinae/src/ui/launcher-window/launcher-window.cpp
@@ -201,7 +201,7 @@ void LauncherWindow::setupUI() {
 
     createWinId();
     if (auto lshell = Shell::Window::get(windowHandle())) {
-      lshell->setLayer(Shell::Window::LayerOverlay);
+      lshell->setLayer(Shell::Window::LayerTop);
       lshell->setScope("vicinae");
       lshell->setScreenConfiguration(Shell::Window::ScreenFromCompositor);
       // we will switch to on demand in future version of layer-shell-qt when proper activation


### PR DESCRIPTION
To avoid obstructing input method candidate box.

Without this patch, fcitx5 always appears behind the popup (only when it's in wayland mode, it works if it is loaded as QT_IM_MODULE):

<img width="2880" height="1800" alt="2025-12-08T21:13:18,865865434+08:00" src="https://github.com/user-attachments/assets/efcd1371-955f-4c17-ae2d-c2398e9e9213" />

With this patch:

<img width="2880" height="1800" alt="2025-12-08T21:19:31,934612063+08:00" src="https://github.com/user-attachments/assets/22dc9dd5-25f5-4a3b-b7d8-439a34caec99" />
