### PR TITLE
Fix: Ensure clipboard text compatibility with X11 terminals

### DIFF
--- a/vicinae/src/services/clipboard/clipboard-service.cpp
+++ b/vicinae/src/services/clipboard/clipboard-service.cpp
@@ -543,7 +543,11 @@ bool ClipboardService::copySelection(const ClipboardSelection &selection,
         mimeData->setImageData(img);
       }
     } else {
-      mimeData->setData(offer.mimeType, offer.data);
+      if (Utils::isTextMimeType(offer.mimeType)) {
+        mimeData->setText(QString::fromUtf8(offer.data));
+      } else {
+        mimeData->setData(offer.mimeType, offer.data);
+      }
     }
   }
 


### PR DESCRIPTION
### Description
This PR addresses an issue where copied text from Vicinae could not be pasted into certain X11 terminal emulators (like `st`, `xterm`, or `alacritty` in specific configurations).

### The Problem
In minimalist X11 environments (e.g., Void Linux with `dwm`), there is often no global clipboard manager to normalize MIME types. When Vicinae sets clipboard data using generic `setData("text/plain", ...)` calls, the Qt X11 platform plugin might not always expose the standard `UTF8_STRING` atom. As a result, terminals that strictly adhere to X11 selection standards see the clipboard as empty or incompatible.

### The Solution
The fix involves using `QMimeData::setText()` specifically for text-based MIME types. When `setText()` is called, the Qt backend automatically handles the negotiation and population of standard X11 atoms (`UTF8_STRING`, `STRING`, `TEXT`), ensuring broad compatibility across all X11 clients.

### Verification
- **Environment:** Void Linux, X11, dwm.
- **Before:** Text copied from Vicinae was invisible to `st` and required a proxy like `copyq` to work.
- **After:** Text is successfully pasted into `st` and other terminals natively.
- **Regression Check:** No impact on Wayland sessions, as `setText` remains a standard and safe Qt method for text handling.

Closes #516