### PR TITLE
nix: simplify derivation based on nixpkgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,8 +25,8 @@
       packages = forEachPkgs (pkgs: {
         default = pkgs.callPackage ./nix/vicinae.nix { gcc15Stdenv = pkgs.gcc15Stdenv; };
         nix-update-script = pkgs.writeShellScriptBin "nix-update-script" ''
-          OLD_API_DEPS_HASH=$(${pkgs.lib.getExe pkgs.nix} eval --raw .#packages.x86_64-linux.default.passthru.apiDeps.hash)
-          OLD_EXT_MAN_DEPS_HASH=$(${pkgs.lib.getExe pkgs.nix} eval --raw .#packages.x86_64-linux.default.passthru.extensionManagerDeps.hash)
+          OLD_API_DEPS_HASH=$(${pkgs.lib.getExe pkgs.nix} eval --raw .#packages.x86_64-linux.default.apiDeps.hash)
+          OLD_EXT_MAN_DEPS_HASH=$(${pkgs.lib.getExe pkgs.nix} eval --raw .#packages.x86_64-linux.default.extensionManagerDeps.hash)
 
           cd typescript/api
           NEW_API_DEPS_HASH=$(${pkgs.lib.getExe pkgs.prefetch-npm-deps} package-lock.json)

--- a/nix/vicinae.nix
+++ b/nix/vicinae.nix
@@ -1,163 +1,106 @@
 {
-  stdenv,
-  fetchFromGitHub,
+  abseil-cpp,
   cmake,
-  pkg-config,
-  kdePackages,
-  protobuf,
-  grpc-tools,
-  nodejs,
-  minizip-ng,
   cmark-gfm,
-  libqalculate,
-  ninja,
-  lib,
   fetchNpmDeps,
-  protoc-gen-js,
-  rsync,
-  which,
-  autoPatchelfHook,
-  writeShellScriptBin,
+  kdePackages,
+  lib,
+  libqalculate,
   minizip,
+  ninja,
+  nodejs,
+  npmHooks,
+  pkg-config,
+  protobuf,
   qt6,
-  typescript,
-  wayland,
   gcc15Stdenv,
+  wayland,
+  libxml2,
 }:
 let
-  src = ../.;
-
-  manifestRaw = builtins.readFile (src + /manifest.yaml);
-
-  get =
+  manifestRaw = builtins.readFile ../manifest.yaml;
+  manifestGet =
     key:
     let
       m = builtins.match ".*${key}:[[:space:]]*\"([^\"]+)\".*" manifestRaw;
     in
     if m == null then throw "Key ${key} not found in manifest.yaml" else builtins.elemAt m 0;
-
-  manifest = {
-    tag = get "tag";
-    rev = get "rev";
-    short_rev = get "short_rev";
-  };
-
-  # Prepare node_modules for api folder
-  apiDeps = fetchNpmDeps {
-    src = src + /typescript/api;
-    hash = "sha256-4OgVCnw5th2TcXszVY5G9ENr3/Y/eR2Kd45DbUhQRNk=";
-  };
-  ts-protoc-gen-wrapper = writeShellScriptBin "protoc-gen-ts_proto" ''
-    exec node /build/source/vicinae-upstream/typescript/api/node_modules/.bin/protoc-gen-ts_proto
-  '';
-
-  # Prepare node_modules for extension-manager folder
-  extensionManagerDeps = fetchNpmDeps {
-    src = src + /typescript/extension-manager;
-    hash = "sha256-krDFHTG8irgVk4a79LMz148drLgy2oxEoHCKRpur1R4=";
-  };
 in
-gcc15Stdenv.mkDerivation rec {
-  name = "vicinae";
+gcc15Stdenv.mkDerivation (finalAttrs: {
+  pname = "vicinae";
+  version = lib.removePrefix "v" (manifestGet "tag");
 
-  inherit src;
+  src = ../.;
 
-  cmakeFlags = [
-    "-DVICINAE_GIT_TAG=${manifest.tag}"
-    "-DVICINAE_GIT_COMMIT_HASH=${manifest.short_rev}"
-    "-DVICINAE_PROVENANCE=nix"
-    "-DINSTALL_NODE_MODULES=OFF"
-    "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}"
-    "-DCMAKE_INSTALL_DATAROOTDIR=share"
-    "-DCMAKE_INSTALL_BINDIR=bin"
-    "-DCMAKE_INSTALL_LIBDIR=lib"
-  ];
+  apiDeps = fetchNpmDeps {
+    src = "${finalAttrs.src}/typescript/api";
+    hash = "sha256-UsTpMR23UQBRseRo33nbT6z/UCjZByryWfn2AQSgm6U=";
+  };
+
+  extensionManagerDeps = fetchNpmDeps {
+    src = "${finalAttrs.src}/typescript/extension-manager";
+    hash = "sha256-wl8FDFB6Vl1zD0/s2EbU6l1KX4rwUW6dOZof4ebMMO8=";
+  };
+
+  cmakeFlags = lib.mapAttrsToList lib.cmakeFeature {
+    "VICINAE_GIT_TAG" = "v${finalAttrs.version}";
+    "VICINAE_GIT_COMMIT_HASH" = manifestGet "short_rev";
+    "VICINAE_PROVENANCE" = "nix";
+    "INSTALL_NODE_MODULES" = "OFF";
+    "CMAKE_INSTALL_PREFIX" = placeholder "out";
+    "CMAKE_INSTALL_DATAROOTDIR" = "share";
+    "CMAKE_INSTALL_BINDIR" = "bin";
+    "CMAKE_INSTALL_LIBDIR" = "lib";
+  };
+
+  strictDeps = true;
 
   nativeBuildInputs = [
-    ts-protoc-gen-wrapper
-    extensionManagerDeps
-    autoPatchelfHook
     cmake
     ninja
     nodejs
     pkg-config
-    qt6.wrapQtAppsHook
-    protoc-gen-js
     protobuf
-    grpc-tools
-    which
-    rsync
-    typescript
+    qt6.wrapQtAppsHook
   ];
 
   buildInputs = [
+    abseil-cpp
+    cmark-gfm
+    kdePackages.layer-shell-qt
+    kdePackages.qtkeychain
+    libqalculate
+    minizip
+    nodejs
+    protobuf
     qt6.qtbase
     qt6.qtsvg
-    qt6.qttools
     qt6.qtwayland
-    qt6.qtdeclarative
-    qt6.qt5compat
     wayland
-    kdePackages.qtkeychain
-    kdePackages.layer-shell-qt
-    minizip
-    grpc-tools
-    protobuf
-    nodejs
-    minizip-ng
-    cmark-gfm
-    libqalculate
+    libxml2
   ];
 
-  configurePhase = ''
-    cmake -G Ninja -B build $cmakeFlags
+  postPatch = ''
+    local postPatchHooks=()
+    source ${npmHooks.npmConfigHook}/nix-support/setup-hook
+    npmRoot=typescript/api npmDeps=${finalAttrs.apiDeps} npmConfigHook
+    npmRoot=typescript/extension-manager npmDeps=${finalAttrs.extensionManagerDeps} npmConfigHook
   '';
 
-  buildPhase = ''
-    buildDir=$PWD
-    echo $buildDir
-    export npm_config_cache=${apiDeps}
-    cd $buildDir/typescript/api
-    npm i --ignore-scripts
-    patchShebangs $buildDir/typescript/api
-    npm rebuild --foreground-scripts
-    export npm_config_cache=${extensionManagerDeps}
-    cd $buildDir/typescript/extension-manager
-    npm i --ignore-scripts
-    patchShebangs $buildDir/typescript/extension-manager
-    npm rebuild --foreground-scripts
-    cd $buildDir
-    cmake --build build
-    cd $buildDir
-  '';
-
-  dontWrapQtApps = true;
-  preFixup = ''
-    wrapQtApp "$out/bin/vicinae" --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath buildInputs}
-  '';
-  postFixup = ''
-    wrapProgram $out/bin/vicinae \
-    --prefix PATH : ${
+  qtWrapperArgs = [
+    "--prefix PATH : ${
       lib.makeBinPath [
         nodejs
-        qt6.qtwayland
-        wayland
         (placeholder "out")
       ]
-    }
-  '';
+    }"
+  ];
 
-  installPhase = ''
-    cmake --install build
-  '';
-
-  meta = with lib; {
+  meta = {
     description = "A focused launcher for your desktop — native, fast, extensible";
     homepage = "https://github.com/vicinaehq/vicinae";
-    license = licenses.gpl3Plus;
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
     mainProgram = "vicinae";
   };
-  passthru = {
-    inherit apiDeps extensionManagerDeps;
-  };
-}
+})


### PR DESCRIPTION
Simplify the derivation based on the version that is upstream in Nixpkgs. See https://github.com/NixOS/nixpkgs/blob/a008f4366465ac03ac6f79af0edee60959aaa685/pkgs/by-name/vi/vicinae/package.nix for the version this is based on. This allows avoiding needless dependencies and specifying build steps where not needed, since the built-in Nixpkgs machinery for CMake and Ninja can handle it.

Also note that this does not include `glaze` (which'll be in the next version) since that change hasn't been committed yet, but I can add that once that commit is made.

This supersedes #245, which can be closed if/after this is merged.