### PR TITLE
fix: set raw image data for clipboard images, resolves #826

### DIFF
--- a/vicinae/src/services/clipboard/clipboard-service.cpp
+++ b/vicinae/src/services/clipboard/clipboard-service.cpp
@@ -540,9 +540,10 @@ bool ClipboardService::copySelection(const ClipboardSelection &selection,
         qWarning() << offer.mimeType << "could not be converted to valid image format";
         mimeData->setData(offer.mimeType, offer.data);
       } else {
-        mimeData->setData(offer.mimeType, offer.data);  // Raw bytes
-        mimeData->setImageData(img);  // QImage for Qt apps
-        qDebug() << "ClipboardService: Set image data with mime type" << offer.mimeType << "size:" << offer.data.size();
+        mimeData->setData(offer.mimeType, offer.data);
+        mimeData->setImageData(img);
+        qDebug() << "ClipboardService: Set image data with mime type" << offer.mimeType
+                 << "size:" << offer.data.size();
       }
     } else {
       if (Utils::isTextMimeType(offer.mimeType)) {


### PR DESCRIPTION
- this is because Gnome D-Bus needs the raw data