### PR TITLE
fix(calc): recognise leading currency symbols in calculations

### DIFF
--- a/vicinae/src/extensions/root/root-search-controller.cpp
+++ b/vicinae/src/extensions/root/root-search-controller.cpp
@@ -104,7 +104,9 @@ void RootSearchController::startCalculator() {
   }
 
   bool containsNonAlnum = std::ranges::any_of(m_query, [](QChar ch) { return !ch.isLetterOrNumber(); });
-  const auto isAllowedLeadingChar = [](QChar c) { return c == '(' || c == ')' || c.isLetterOrNumber(); };
+  const auto isAllowedLeadingChar = [&](QChar c) {
+    return c == '(' || c == ')' || c.isLetterOrNumber() || c.category() == QChar::Symbol_Currency;
+  };
   bool isComputable = expression.size() > 1 && isAllowedLeadingChar(expression.at(0)) && containsNonAlnum;
 
   if (!isComputable || !m_calculator->backend()) { return; }


### PR DESCRIPTION
Previously, expressions starting with a currency symbol were not classified as calculations.