### PR TITLE
fix(.desktop): disable StartupNotify

### DIFF
--- a/extra/vicinae.desktop
+++ b/extra/vicinae.desktop
@@ -10,6 +10,7 @@ Categories=Utility;Accessibility;
 NoDisplay=false
 Actions=open;close;toggle
 StartupWMClass=vicinae
+StartupNotify=false
 
 [Desktop Action open]
 Name=Open Vicinae Window


### PR DESCRIPTION
Disables StartupNotify to prevent a lingering icon in the taskbar of KDE Plasma when toggling Vicinae.

# Before

https://github.com/user-attachments/assets/d583b45a-b3c0-4c5c-a510-e72089d1b798

# After

https://github.com/user-attachments/assets/3d8d72e2-20ec-4304-b0f9-1f55d00c496e

