### PR TITLE
feat: autodetect uwsm

### DIFF
--- a/vicinae/src/cli/server.cpp
+++ b/vicinae/src/cli/server.cpp
@@ -114,6 +114,10 @@ void CliServerCommand::run(CLI::App *app) {
   static char *argv[] = {strdup("command"), nullptr};
   QApplication qapp(argc, argv);
 
+  if (auto launcher = Environment::detectAppLauncher()) {
+    qInfo() << "Detected launch prefix:" << *launcher;
+  }
+
   // discard system specific qt theming
   qapp.setStyle(QStyleFactory::create("fusion"));
 

--- a/vicinae/src/root-search/apps/app-root-provider.cpp
+++ b/vicinae/src/root-search/apps/app-root-provider.cpp
@@ -10,6 +10,7 @@
 #include "settings/app-metadata-settings-detail.hpp"
 #include "services/window-manager/window-manager.hpp"
 #include "switch-windows-view.hpp"
+#include "utils/environment.hpp"
 #include <qjsonobject.h>
 #include <qwidget.h>
 
@@ -188,9 +189,10 @@ PreferenceList AppRootProvider::preferences() const {
 }
 
 void AppRootProvider::preferencesChanged(const QJsonObject &preferences) {
-  if (preferences.contains("launchPrefix")) {
-    m_appService.setLaunchPrefix(preferences.value("launchPrefix").toString());
+  auto val = preferences.value("launchPrefix").toString();
+  if (val.isEmpty()) {
+    m_appService.setLaunchPrefix(Environment::detectAppLauncher());
   } else {
-    m_appService.setLaunchPrefix(std::nullopt);
+    m_appService.setLaunchPrefix(val);
   }
 }

--- a/vicinae/src/utils/environment.hpp
+++ b/vicinae/src/utils/environment.hpp
@@ -2,7 +2,9 @@
 #include "xdgpp/env/env.hpp"
 #include <QString>
 #include <QApplication>
+#include <QProcess>
 #include <QProcessEnvironment>
+#include <QStandardPaths>
 #include <algorithm>
 #include <chrono>
 #include <cstdlib>
@@ -131,6 +133,14 @@ inline QString getEnvironmentDescription() {
   }
 
   return desc;
+}
+
+inline std::optional<QString> detectAppLauncher() {
+  QProcess proc;
+  proc.start("uwsm", {"check", "is-active"});
+  if (!proc.waitForFinished(1000) || proc.exitCode() != 0) return std::nullopt;
+  if (!QStandardPaths::findExecutable("uwsm-app").isEmpty()) return "uwsm-app --";
+  return "uwsm app --";
 }
 
 } // namespace Environment


### PR DESCRIPTION
Detects active session of uwsm. If active defaults to "uwsm-app --" launch prefix. Doesn't override user settings.