### PR TITLE
fix: do not update image source on fallback

### DIFF
--- a/vicinae/src/ui/image/image.cpp
+++ b/vicinae/src/ui/image/image.cpp
@@ -192,7 +192,7 @@ QSize ImageWidget::sizeHint() const {
 }
 
 void ImageWidget::handleLoadingError(const QString &reason) {
-  if (auto fallback = m_source.fallback()) { return setUrl(*fallback); }
+  if (auto fallback = m_source.fallback()) { return setUrlImpl(*fallback); }
   return setUrlImpl(ImageURL::builtin("question-mark-circle"));
 }
 


### PR DESCRIPTION
prevents reloading the image when it failed before