### PR TITLE
feat: Adding scroll cycle feature to vlist

### DIFF
--- a/vicinae/src/ui/vlist/vlist.cpp
+++ b/vicinae/src/ui/vlist/vlist.cpp
@@ -62,32 +62,42 @@ void VListWidget::selectNext() {
   selectFirst();
 }
 
-int VListWidget::firstSelectableIndex() const {
-  if (!m_model) return -1;
+std::optional<VListModel::Index> VListWidget::firstSelectableIndex() const {
+  if (!m_model) return std::nullopt;
   for (int i = 0; i != m_count; ++i) {
     if (m_model->isSelectable(i)) {
       return i;
     }
   }
-  return -1;
+  return std::nullopt;
 }
 
-int VListWidget::lastSelectableIndex() const {
-  if (!m_model) return -1;
+std::optional<VListModel::Index> VListWidget::lastSelectableIndex() const {
+  if (!m_model) return std::nullopt;
   for (int i = m_count - 1; i >= 0; --i) {
     if (m_model->isSelectable(i)) {
       return i;
     }
   }
-  return -1;
+  return std::nullopt;
 }
 
 void VListWidget::selectFirst() {
-  setSelected(firstSelectableIndex());
+  if (auto idx = firstSelectableIndex()) {
+    setSelected(*idx);
+    return;
+  }
+  m_selected.reset();
+  emit itemSelected({});
 }
 
 void VListWidget::selectLast() {
-  setSelected(lastSelectableIndex());
+  if (auto idx = lastSelectableIndex()) {
+    setSelected(*idx);
+    return;
+  }
+  m_selected.reset();
+  emit itemSelected({});
 }
 
 std::span<const VListWidget::ViewportItem> VListWidget::visibleItems() const { return m_visibleItems; }
@@ -244,10 +254,10 @@ void VListWidget::setMargins(const QMargins &margins) {
 void VListWidget::setMargins(int n) { setMargins(QMargins{n, n, n, n}); }
 
 void VListWidget::setSelected(VListModel::Index idx) {
-  if (!m_model || idx < 0 || idx >= m_count) {
+  if (!m_model) {
     if (m_selected) {
       m_selected.reset();
-      emit itemSelected(-1);
+      emit itemSelected(std::nullopt);
     }
     return;
   }

--- a/vicinae/src/ui/vlist/vlist.hpp
+++ b/vicinae/src/ui/vlist/vlist.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <optional>
 #include <qevent.h>
 #include <qobject.h>
 #include <qscrollbar.h>
@@ -254,8 +255,8 @@ protected:
   void handleScrollChanged(int value) { updateViewport(); }
   void resizeEvent(QResizeEvent *event) override;
 
-  int firstSelectableIndex() const;
-  int lastSelectableIndex() const;
+  std::optional<VListModel::Index> firstSelectableIndex() const;
+  std::optional<VListModel::Index> lastSelectableIndex() const;
 
 private:
   struct WidgetData {


### PR DESCRIPTION
This solves issue #842 (partially, for now)
- When the up key is pressed on the top element, it goes to the last element, and vice versa; it also works with the grid view.
- Made some code refactoring


https://github.com/user-attachments/assets/dcbc59b1-2416-4283-adc0-99aef1ecda4e

