### PR TITLE
flake.nix: cause overlay to obey apply order

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -61,7 +61,7 @@
         };
       });
       overlays.default = final: prev: {
-        vicinae = prev.callPackage ./nix/vicinae.nix { gcc15Stdenv = prev.gcc15Stdenv; };
+        vicinae = final.callPackage ./nix/vicinae.nix { };
         mkVicinaeExtension = prev.callPackage ./nix/mkVicinaeExtension.nix { };
       };
       homeManagerModules.default = import ./nix/module.nix self;


### PR DESCRIPTION
Closes #910

Setting `prev.gcc15Stdenv` is useless in this context. We aren't trying to avoid overlays side-effects on `final.gcc15Stdenv`.