### PR TITLE
fix: use common data dirs as default script dirs

### DIFF
--- a/lib/xdgpp/xdgpp/env/env.cpp
+++ b/lib/xdgpp/xdgpp/env/env.cpp
@@ -68,6 +68,21 @@ std::vector<fs::path> xdgpp::dataDirs() {
   return parseDirs<fs::path>(xdd);
 }
 
+std::vector<fs::path> xdgpp::commonDataDirs() {
+  std::vector<fs::path> paths;
+  auto dirs = xdgpp::dataDirs();
+  auto home = dataHome();
+
+  paths.reserve(dirs.size() + 1);
+  paths.emplace_back(home);
+
+  for (const auto &dir : dirs) {
+    if (dir != home) { paths.emplace_back(dir); }
+  }
+
+  return paths;
+}
+
 std::vector<fs::path> xdgpp::appDirs() {
   std::vector<fs::path> paths;
   auto dirs = xdgpp::dataDirs();

--- a/lib/xdgpp/xdgpp/env/env.hpp
+++ b/lib/xdgpp/xdgpp/env/env.hpp
@@ -25,6 +25,11 @@ std::filesystem::path cacheHome();
 std::vector<std::filesystem::path> dataDirs();
 
 /**
+ * Like `dataDirs` but makes sure common directories are included if they are not in the XDG_DATA_DIRS.
+ */
+std::vector<std::filesystem::path> commonDataDirs();
+
+/**
  * Directories where applications (desktop entries) are looked for.
  * This is essentially dataDirs() but with /applications appended to each path.
  */

--- a/vicinae/src/services/script-command/script-command-service.cpp
+++ b/vicinae/src/services/script-command/script-command-service.cpp
@@ -32,7 +32,7 @@ void ScriptCommandService::setCustomScriptPaths(const std::vector<std::filesyste
 }
 
 const std::vector<std::filesystem::path> &ScriptCommandService::defaultScriptDirectories() const {
-  static const auto dirs = xdgpp::dataDirs() |
+  static const auto dirs = xdgpp::commonDataDirs() |
                            std::views::transform([](auto &&p) { return p / "vicinae" / "scripts"; }) |
                            std::ranges::to<std::vector>();
   return dirs;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved resource and script discovery mechanism that now automatically searches both user home directories and system-wide standard data directories in a unified manner. This enhancement ensures that application scripts and data files can be reliably discovered from standard system locations, providing better compatibility with system-wide installations and shared resource directories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->