### PR TITLE
fix: nullptr dereference on hyprland paste

### DIFF
--- a/vicinae/src/lib/wayland/globals.cpp
+++ b/vicinae/src/lib/wayland/globals.cpp
@@ -1,4 +1,5 @@
 #include "globals.hpp"
+#include "virtual-keyboard-unstable-v1-client-protocol.h"
 
 namespace Wayland {
 
@@ -8,6 +9,10 @@ zwlr_data_control_manager_v1 *Globals::wlrDataControlManager() {
 
 ext_data_control_manager_v1 *Globals::dataControlDeviceManager() {
   return instance().ext_data_control_device;
+}
+
+zwp_virtual_keyboard_manager_v1 *Globals::virtualKeyboardManager() {
+  return instance().m_virtual_keyboard_manager;
 }
 
 void Globals::handleGlobal(void *data, struct wl_registry *registry, uint32_t name, const char *interface,
@@ -22,6 +27,11 @@ void Globals::handleGlobal(void *data, struct wl_registry *registry, uint32_t na
   if (strcmp(interface, ext_data_control_manager_v1_interface.name) == 0) {
     self->ext_data_control_device = static_cast<ext_data_control_manager_v1 *>(
         wl_registry_bind(registry, name, &ext_data_control_manager_v1_interface, version));
+  }
+
+  if (strcmp(interface, zwp_virtual_keyboard_manager_v1_interface.name) == 0) {
+    self->m_virtual_keyboard_manager = static_cast<zwp_virtual_keyboard_manager_v1 *>(
+        wl_registry_bind(registry, name, &zwp_virtual_keyboard_manager_v1_interface, version));
   }
 }
 

--- a/vicinae/src/lib/wayland/globals.hpp
+++ b/vicinae/src/lib/wayland/globals.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "common.hpp"
 #include "ext-data-control-v1-client-protocol.h"
+#include "virtual-keyboard-unstable-v1-client-protocol.h"
 #include "wlr-data-control-unstable-v1-client-protocol.h"
 
 namespace Wayland {
@@ -15,6 +16,8 @@ public:
    */
   static ext_data_control_manager_v1 *dataControlDeviceManager();
 
+  static zwp_virtual_keyboard_manager_v1 *virtualKeyboardManager();
+
 private:
   static Globals &instance();
 
@@ -28,5 +31,6 @@ private:
 
   zwlr_data_control_manager_v1 *m_zwlr_data_control_device = nullptr;
   ext_data_control_manager_v1 *ext_data_control_device = nullptr;
+  zwp_virtual_keyboard_manager_v1 *m_virtual_keyboard_manager = nullptr;
 };
 } // namespace Wayland

--- a/vicinae/src/lib/wayland/virtual-keyboard.hpp
+++ b/vicinae/src/lib/wayland/virtual-keyboard.hpp
@@ -40,13 +40,6 @@ public:
   bool uploadKeymap(const std::vector<xkb_keysym_t> &keysyms);
 
 private:
-  static void handleGlobal(void *data, struct wl_registry *registry, uint32_t name, const char *interface,
-                           uint32_t version);
-  static void globalRemove(void *data, struct wl_registry *registry, uint32_t name);
-
-  constexpr static const struct wl_registry_listener _listener = {.global = handleGlobal,
-                                                                  .global_remove = globalRemove};
-
   void roundtrip();
   std::string generateKeymap(const std::vector<xkb_keysym_t> &keys) const;
   uint32_t mappedKeyCode(xkb_keysym_t sym);

--- a/vicinae/src/services/window-manager/abstract-window-manager.hpp
+++ b/vicinae/src/services/window-manager/abstract-window-manager.hpp
@@ -53,6 +53,8 @@ public:
    */
   class AbstractWindow {
   public:
+    virtual ~AbstractWindow() = default;
+
     virtual QString id() const = 0;
     virtual QString title() const = 0;
     virtual QString wmClass() const = 0;
@@ -72,6 +74,8 @@ public:
 
   class AbstractWorkspace {
   public:
+    virtual ~AbstractWorkspace() = default;
+
     virtual QString id() const = 0;
     virtual QString name() const { return id(); }
     virtual QString monitor() const = 0;

--- a/vicinae/src/services/window-manager/hyprland/hyprland.cpp
+++ b/vicinae/src/services/window-manager/hyprland/hyprland.cpp
@@ -4,6 +4,7 @@
 #include "services/window-manager/hyprland/hyprctl.hpp"
 #include "lib/wayland/virtual-keyboard.hpp"
 #include "vicinae.hpp"
+#include "wayland/globals.hpp"
 #include <format>
 #include <xkbcommon/xkbcommon-keysyms.h>
 
@@ -77,7 +78,7 @@ AbstractWindowManager::WindowPtr HyprlandWindowManager::getFocusedWindowSync() c
   return std::make_shared<HyprlandWindow>(json.object());
 }
 
-bool HyprlandWindowManager::supportsPaste() const { return m_kb.isAvailable(); }
+bool HyprlandWindowManager::supportsPaste() const { return Wayland::Globals::virtualKeyboardManager(); }
 
 void HyprlandWindowManager::focusWindowSync(const AbstractWindow &window) const {
   Hyprctl::oneshot(std::format("dispatch focuswindow address:{}", window.id().toStdString()));

--- a/vicinae/src/services/window-manager/hyprland/hyprland.hpp
+++ b/vicinae/src/services/window-manager/hyprland/hyprland.hpp
@@ -1,7 +1,6 @@
 #pragma once
 #include "services/window-manager/abstract-window-manager.hpp"
 #include "services/window-manager/hyprland/hypr-listener.hpp"
-#include "wayland/virtual-keyboard.hpp"
 #include <QtConcurrent/qtconcurrentrun.h>
 #include <qapplication.h>
 #include <qfuture.h>
@@ -71,5 +70,4 @@ private:
   bool m_blur = false;
   bool m_dimAround = false;
   Hyprland::EventListener m_ev;
-  Wayland::VirtualKeyboard m_kb;
 };

--- a/vicinae/src/services/window-manager/wayland/wayland.cpp
+++ b/vicinae/src/services/window-manager/wayland/wayland.cpp
@@ -4,6 +4,7 @@
 
 #include <qscreen.h>
 #include <wayland-client-protocol.h>
+#include "wayland/globals.hpp"
 #include "wayland/virtual-keyboard.hpp"
 #include "wlr-foreign-toplevel-management-unstable-v1-client-protocol.h"
 
@@ -107,13 +108,15 @@ AbstractWindowManager::WindowPtr WaylandWindowManager::getFocusedWindowSync() co
 bool WaylandWindowManager::pasteToWindow(const AbstractWindow *window, const AbstractApplication *app) {
   using VK = Wayland::VirtualKeyboard;
 
-  if (!m_keyboard.isAvailable()) { return false; }
+  VK kb;
+
+  if (!kb.isAvailable()) { return false; }
 
   if (app && app->isTerminalEmulator()) {
-    return m_keyboard.sendKeySequence(XKB_KEY_v, VK::MOD_CTRL | VK::MOD_SHIFT);
+    return kb.sendKeySequence(XKB_KEY_v, VK::MOD_CTRL | VK::MOD_SHIFT);
   }
 
-  return m_keyboard.sendKeySequence(XKB_KEY_v, VK::MOD_CTRL);
+  return kb.sendKeySequence(XKB_KEY_v, VK::MOD_CTRL);
 }
 
 void WaylandWindowManager::focusWindowSync(const AbstractWindow &window) const {
@@ -128,7 +131,7 @@ bool WaylandWindowManager::closeWindow(const AbstractWindow &window) const {
   return true;
 }
 
-bool WaylandWindowManager::supportsPaste() const { return m_keyboard.isAvailable(); }
+bool WaylandWindowManager::supportsPaste() const { return Wayland::Globals::virtualKeyboardManager(); }
 
 // cosmic needs its own top level management protocol integration
 bool WaylandWindowManager::isActivatable() const {

--- a/vicinae/src/services/window-manager/wayland/wayland.hpp
+++ b/vicinae/src/services/window-manager/wayland/wayland.hpp
@@ -1,7 +1,5 @@
 #pragma once
 #include "services/window-manager/abstract-window-manager.hpp"
-#include "lib/wayland/virtual-keyboard.hpp"
-#include <xkbcommon/xkbcommon-keysyms.h>
 
 class WaylandWindowManager;
 
@@ -52,7 +50,6 @@ public:
   WindowList m_toplevels;
 
 private:
-  Wayland::VirtualKeyboard m_keyboard;
   struct wl_display *m_display;
   struct wl_seat *m_seat;
 };


### PR DESCRIPTION
Fixes #933

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Wayland virtual keyboard management to improve paste handling.

* **Bug Fixes**
  * Improved safety checks when pasting to prevent crashes and handle null cases.
  * Enhanced detection of terminal apps to apply correct modifier keys.
  * Verified keyboard availability before attempting paste operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->