### PR TITLE
fix: add float type to home-manager module environment definition

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -42,6 +42,7 @@ in
             valueType = attrsOf (oneOf [
               str
               int
+              float
               bool
             ]);
           in


### PR DESCRIPTION
otherwise we can't even set as in example:
```
QT_SCALE_FACTOR=1.5;
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Environment variables now support floating-point numbers as valid values, in addition to strings, integers, and booleans.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->