### PR TITLE
fix: Don't rely on protobuf generated headers for including <ranges>

### DIFF
--- a/vicinae/src/ext-clip/app.cpp
+++ b/vicinae/src/ext-clip/app.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <iomanip>
 #include <string>
+#include <ranges>
 #include <unistd.h>
 #include "proto/wlr-clipboard.pb.h"
 #include "wayland/mime.hpp"

--- a/vicinae/src/extension/requests/app-request-router.cpp
+++ b/vicinae/src/extension/requests/app-request-router.cpp
@@ -1,3 +1,4 @@
+#include <ranges>
 #include "app-request-router.hpp"
 #include "proto/application.pb.h"
 #include "services/app-service/abstract-app-db.hpp"

--- a/vicinae/src/script/script-command-file.cpp
+++ b/vicinae/src/script/script-command-file.cpp
@@ -1,3 +1,4 @@
+#include <ranges>
 #include "script/script-command-file.hpp"
 #include "emoji/emoji.hpp"
 #include "services/script-command/script-command-service.hpp"

--- a/vicinae/src/services/script-command/script-command-service.cpp
+++ b/vicinae/src/services/script-command/script-command-service.cpp
@@ -2,6 +2,7 @@
 #include "script/script-scanner.hpp"
 #include "xdgpp/env/env.hpp"
 #include <algorithm>
+#include <ranges>
 #include <QtConcurrentRun>
 
 ScriptCommandService::ScriptCommandService() {


### PR DESCRIPTION
Fixes build failure on Fedora 42 and 43.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added internal compiler support for C++ standard library features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->