### PR TITLE
feat(api): add support for native node modules

### DIFF
--- a/typescript/api/src/commands/build/index.ts
+++ b/typescript/api/src/commands/build/index.ts
@@ -95,9 +95,12 @@ export default class Build extends Command {
 					entryPoints: [source],
 					external: ["react", "@vicinae/api", "@raycast/api"],
 					format: "cjs",
-					outfile: join(outDir, `${cmd.name}.js`),
+					outdir: outDir,
 					platform: "node",
 					minify: true,
+					loader: {
+						".node": "file",
+					},
 				});
 			});
 

--- a/typescript/api/src/commands/develop/index.ts
+++ b/typescript/api/src/commands/develop/index.ts
@@ -130,8 +130,11 @@ export default class Develop extends Command {
 					entryPoints: [source],
 					external: ["react", "@vicinae/api", "@raycast/api"],
 					format: "cjs",
-					outfile: path.join(outDir, `${cmd.name}.js`),
+					outdir: outDir,
 					platform: "node",
+					loader: {
+						".node": "file",
+					},
 				});
 			});
 
@@ -195,12 +198,12 @@ export default class Develop extends Command {
 		outStream.on("line", (data) => {
 			logger.logExtensionOut(data.toString());
 		});
-		outStream.on("error", () => { });
+		outStream.on("error", () => {});
 
 		errStream.on("line", (data) => {
 			logger.logExtensionError(data.toString());
 		});
-		errStream.on("error", () => { });
+		errStream.on("error", () => {});
 
 		await safeBuild(extensionDir);
 


### PR DESCRIPTION
This pull request adds support for native node modules. It works by telling ESBuild to load `.node` imports by copying the file to the out directory,  [doc here](https://esbuild.github.io/content-types/#external-file).

Note: ESBuild doesn't support have both `outfile` and `outdir` at the same time. `outfile` was used to specify the name of the output file. However ESBuild doesn't change the name of the file as it is an entry point and the SDK already enforces the name of the file being exactly the command name. Therefore, only defining `outdir` is fine.