### PR TITLE
feat(dmenu): add --preview flag for tab-separated label/preview pairs

### DIFF
--- a/lib/vicinae-ipc/include/vicinae-ipc/ipc.hpp
+++ b/lib/vicinae-ipc/include/vicinae-ipc/ipc.hpp
@@ -87,6 +87,7 @@ struct DMenu {
     std::optional<int> width;
     std::optional<int> height;
     bool noFooter = false;
+    bool preview = false;
   };
 
   struct Response {

--- a/vicinae/src/cli/cli.cpp
+++ b/vicinae/src/cli/cli.cpp
@@ -264,6 +264,8 @@ class DMenuCommand : public AbstractCommandLineCommand {
                   "Do not show quick look if available for a given entry");
     app->add_flag("--no-metadata", m_req.noMetadata, "Do not show metadata section in quick look");
     app->add_flag("--no-footer", m_req.noFooter, "Hide the status bar footer");
+    app->add_flag("--preview", m_req.preview,
+                  "Enable tab-separated preview mode (format: label<TAB>preview_path)");
   }
 
   void run(CLI::App *app) override {

--- a/vicinae/src/ui/dmenu-view/dmenu-view.hpp
+++ b/vicinae/src/ui/dmenu-view/dmenu-view.hpp
@@ -34,8 +34,8 @@ private:
   void selectEntry(const QString &text);
   void initialize() override;
 
-  std::vector<std::string_view> m_entries;
-  std::vector<Scored<std::string_view>> m_filteredEntries;
+  std::vector<DMenuEntry> m_entries;
+  std::vector<Scored<DMenuEntry>> m_filteredEntries;
   std::string_view m_sectionNameTemplate;
   std::string m_sectionName;
   bool m_selected = false;


### PR DESCRIPTION
## Summary

- Adds `--preview` flag to dmenu CLI for tab-separated input format (`label<TAB>preview_path`)
- When enabled, displays clean labels while showing preview images from specified paths
- Suppresses icon prefixes in preview mode to avoid redundancy with the preview panel

## Usage

```bash
# Tab-separated: label<TAB>absolute_preview_path
printf "Gruvbox\t/path/to/gruvbox.png\nDracula\t/path/to/dracula.png" | vicinae dmenu --preview
```

## Use Case

Theme pickers and similar UIs where you want human-readable names with associated image previews, rather than raw file paths.

## Example

<img width="810" height="523" alt="image" src="https://github.com/user-attachments/assets/4f4ccf4e-6724-4587-abdc-bc722a7b53b4" />
