### PR TITLE
fix(ui): hide status bar divider when status bar is hidden

### DIFF
--- a/vicinae/src/ui/launcher-window/launcher-window.cpp
+++ b/vicinae/src/ui/launcher-window/launcher-window.cpp
@@ -185,6 +185,7 @@ LauncherWindow::LauncherWindow(ApplicationContext &ctx)
   connect(m_ctx.navigation.get(), &NavigationController::statusBarVisiblityChanged, this, [this](bool value) {
     if (m_currentOverlayWrapper->isVisible() || m_compacted) return;
     m_bar->setVisible(value);
+    m_barDivider->setVisible(value);
   });
   connect(&ThemeService::instance(), &ThemeService::themeChanged, this, [this]() { repaint(); });
 }


### PR DESCRIPTION
## Summary

Fixes a visual artifact where the 1px horizontal divider line above the status bar remained visible even when the status bar itself was hidden.

## The Bug
When `dmenu` is used with `--no-footer` or with a width < 500px (which triggers auto-hide), the status bar content (`m_bar`) is hidden, but the separator line (`m_barDivider`) is not, leaving a floating line at the bottom of the window.

## The Fix
Updated the `statusBarVisiblityChanged` connection in `LauncherWindow` to sync the visibility of `m_barDivider` with `m_bar`.

## Before

<img width="323" height="346" alt="image" src="https://github.com/user-attachments/assets/63abf640-f8f0-403d-b57d-591ad42128f3" />

## After

<img width="333" height="352" alt="image" src="https://github.com/user-attachments/assets/b9ca84e8-a301-4886-9ccd-e52a87ecaeb9" />
