### PR TITLE
fix(ui): use maximum width for empty view to ensure centering on small windows

### DIFF
--- a/vicinae/src/ui/empty-view/empty-view.cpp
+++ b/vicinae/src/ui/empty-view/empty-view.cpp
@@ -20,7 +20,7 @@ void EmptyViewWidget::setupUi() {
 
   m_title->setAlignment(Qt::AlignCenter);
   m_description->setAlignment(Qt::AlignCenter);
-  content->setFixedWidth(400);
+  content->setMaximumWidth(400);
 
   HStack().add(VStack().add(content).center()).center().imbue(this);
 }


### PR DESCRIPTION
## Summary
Fixes a visual alignment issue where the "No results" empty state appeared off-center on windows narrower than 400px.

## Problem
The `EmptyViewWidget` was using `setFixedWidth(400)`. When the launcher window was smaller than 400px (e.g., in `dmenu` mode with a narrow width), the 400px container was wider than the viewport. The layout logic centered this 400px block, causing the visible content (icon and text) to be shifted relative to the actual window center.

## Solution
Changed `setFixedWidth(400)` to `setMaximumWidth(400)`.
- On windows > 400px: Behavior remains the same (content is 400px wide and centered).
- On windows < 400px: The container shrinks to fit the window, and the content centers correctly within the visible area.

## Before
<img width="308" height="356" alt="image" src="https://github.com/user-attachments/assets/e7754b3a-5691-4cc4-900f-ca64aa9c53e1" />


## After
<img width="300" height="353" alt="image" src="https://github.com/user-attachments/assets/4b36c877-2b2c-45d2-9c76-f800f0ebed1c" />
