### PR TITLE
fix: allow ESC to exit inline argument input focus

### DIFF
--- a/vicinae/src/ui/arg-completer/arg-completer.cpp
+++ b/vicinae/src/ui/arg-completer/arg-completer.cpp
@@ -54,6 +54,8 @@ void ArgCompleter::setArguments(const ArgumentList &args) {
       emit valueChanged(collect());
     });
 
+    connect(edit, &InlineQLineEdit::escapePressed, this, &ArgCompleter::escapePressed);
+
     if (arg.type == CommandArgument::Password) edit->setEchoMode(QLineEdit::EchoMode::Password);
 
     m_inputs.emplace_back(edit);

--- a/vicinae/src/ui/arg-completer/arg-completer.cpp
+++ b/vicinae/src/ui/arg-completer/arg-completer.cpp
@@ -9,6 +9,13 @@ void ArgCompleter::clear() {
 
 void ArgCompleter::setIconUrl(const ImageURL &url) { m_icon->setUrl(url); }
 
+void ArgCompleter::clearInputs() {
+  for (auto &input : m_inputs) {
+    input->clear();
+  }
+  emit valueChanged(collect());
+}
+
 void ArgCompleter::validate() {
   bool requiredFocused = false;
 

--- a/vicinae/src/ui/arg-completer/arg-completer.hpp
+++ b/vicinae/src/ui/arg-completer/arg-completer.hpp
@@ -2,7 +2,6 @@
 #include "argument.hpp"
 #include "navigation-controller.hpp"
 #include "ui/image/image.hpp"
-#include "ui/image/image.hpp"
 #include "ui/image/url.hpp"
 #include "ui/inline-input/inline_qline_edit.hpp"
 #include <qboxlayout.h>
@@ -33,5 +32,6 @@ public:
 signals:
   void activated() const;
   void destroyed() const;
+  void escapePressed() const;
   void valueChanged(const std::vector<std::pair<QString, QString>> &arguments);
 };

--- a/vicinae/src/ui/arg-completer/arg-completer.hpp
+++ b/vicinae/src/ui/arg-completer/arg-completer.hpp
@@ -23,6 +23,7 @@ public:
   ArgCompleter(QWidget *parent = nullptr);
 
   void clear();
+  void clearInputs();
   void setIconUrl(const ImageURL &url);
   void setArguments(const ArgumentList &args);
   void setValues(const ArgumentValues values);

--- a/vicinae/src/ui/inline-input/inline_qline_edit.cpp
+++ b/vicinae/src/ui/inline-input/inline_qline_edit.cpp
@@ -4,6 +4,8 @@
 #include "theme/colors.hpp"
 #include <QLineEdit>
 #include <QStyle>
+#include <qevent.h>
+#include <qnamespace.h>
 #include <qpainter.h>
 #include <qpainterpath.h>
 #include "theme/theme-file.hpp"
@@ -69,4 +71,13 @@ void InlineQLineEdit::updateStyle() {
 	)");
 
   setStyleSheet(style);
+}
+
+void InlineQLineEdit::keyPressEvent(QKeyEvent *event) {
+  if (event->key() == Qt::Key_Escape) {
+    emit escapePressed();
+    event->accept();
+    return;
+  }
+  QLineEdit::keyPressEvent(event);
 }

--- a/vicinae/src/ui/inline-input/inline_qline_edit.hpp
+++ b/vicinae/src/ui/inline-input/inline_qline_edit.hpp
@@ -11,8 +11,11 @@ public:
   void clearError();
   void handleTextChanged(const QString &s);
 
+signals:
+  void escapePressed();
+
 protected:
-  // void paintEvent(QPaintEvent *) override;
+  void keyPressEvent(QKeyEvent *event) override;
 
 private:
   void resizeFromText(const QString &s);

--- a/vicinae/src/ui/top-bar/top-bar.cpp
+++ b/vicinae/src/ui/top-bar/top-bar.cpp
@@ -78,7 +78,10 @@ void GlobalHeader::setupUI() {
   connect(m_completer, &ArgCompleter::valueChanged, this,
           [this](auto &&values) { m_navigation.setCompletionValues(values); });
 
-  connect(m_completer, &ArgCompleter::escapePressed, this, [this]() { m_input->setFocus(); });
+  connect(m_completer, &ArgCompleter::escapePressed, this, [this]() {
+    m_completer->clearInputs();
+    m_input->setFocus();
+  });
 
   connect(ServiceRegistry::instance()->config(), &config::Manager::configChanged, this,
           [this](const config::ConfigValue &next, const config::ConfigValue &prev) {

--- a/vicinae/src/ui/top-bar/top-bar.cpp
+++ b/vicinae/src/ui/top-bar/top-bar.cpp
@@ -78,6 +78,8 @@ void GlobalHeader::setupUI() {
   connect(m_completer, &ArgCompleter::valueChanged, this,
           [this](auto &&values) { m_navigation.setCompletionValues(values); });
 
+  connect(m_completer, &ArgCompleter::escapePressed, this, [this]() { m_input->setFocus(); });
+
   connect(ServiceRegistry::instance()->config(), &config::Manager::configChanged, this,
           [this](const config::ConfigValue &next, const config::ConfigValue &prev) {
             m_left->layout()->setContentsMargins(next.header.margins);


### PR DESCRIPTION
## Summary
- Enables ESC key to exit focus from inline argument inputs (used by extensions, scripts, etc.).
- Returns focus to the main search bar instead of closing the application.
- Clears input values on exit to reset the focus/execution flow.

## Details
- **Component**: `InlineQLineEdit` (used in `ArgCompleter`).
- **Fix 1 (UX)**: Intercepts `Qt::Key_Escape` in `InlineQLineEdit` and emits a signal instead of ignoring it (which previously caused the event to bubble up and close the window).
- **Fix 2 (Logic)**: Clears the input values in `ArgCompleter` when ESC is pressed. This ensures that subsequent activation of the item triggers the "focus arguments" logic again, rather than the "execute command" logic (which runs when values are present).

## Usage
1. Open a command with arguments (e.g., an extension or script).
2. Click the command to focus the inline input.
3. Type something.
4. Press ESC -> Focus should return to the main search bar (window stays open).
5. Click the command again -> Input should focus again (instead of executing immediately).