### PR TITLE
perf(gnome): Add event debouncing and eliminate unnecessary window list refreshes

### DIFF
--- a/vicinae/src/services/window-manager/gnome/gnome-window-manager.hpp
+++ b/vicinae/src/services/window-manager/gnome/gnome-window-manager.hpp
@@ -1,12 +1,13 @@
 #pragma once
-#include "services/window-manager/abstract-window-manager.hpp"
-#include "services/app-service/abstract-app-db.hpp"
-#include "lib/keyboard/keyboard.hpp"
-#include "gnome-window.hpp"
 #include "gnome-listener.hpp"
+#include "gnome-window.hpp"
+#include "lib/keyboard/keyboard.hpp"
+#include "services/app-service/abstract-app-db.hpp"
+#include "services/window-manager/abstract-window-manager.hpp"
 #include <QDBusInterface>
-#include <QJsonObject>
 #include <QJsonArray>
+#include <QJsonObject>
+#include <QTimer>
 #include <memory>
 
 /**
@@ -14,6 +15,11 @@
  * Communicates with the Vicinae GNOME extension via D-Bus to manage windows.
  */
 class GnomeWindowManager : public AbstractWindowManager {
+  Q_OBJECT
+
+signals:
+  void windowFocused(const QString &windowId);
+
 private:
   static constexpr const char *DBUS_SERVICE = "org.gnome.Shell";
   static constexpr const char *DBUS_PATH = "/org/gnome/Shell/Extensions/Windows";
@@ -21,6 +27,8 @@ private:
 
   mutable std::unique_ptr<QDBusInterface> m_dbusInterface;
   std::unique_ptr<Gnome::EventListener> m_eventListener;
+  QTimer m_debounceTimer;
+  bool m_pendingWindowsChanged = false;
 
   /**
    * Get or create the D-Bus interface

--- a/vicinae/src/services/window-manager/gnome/gnome-window.hpp
+++ b/vicinae/src/services/window-manager/gnome/gnome-window.hpp
@@ -44,6 +44,7 @@ public:
   QString wmClassInstance() const { return m_wmClassInstance; }
   bool focused() const { return m_focused; }
   bool inCurrentWorkspace() const { return m_inCurrentWorkspace; }
+  void setFocused(bool focused) { m_focused = focused; }
 
   /**
    * Update window with detailed information from Details() response


### PR DESCRIPTION
## Summary

Significantly improves GNOME window manager performance by adding event debouncing and filtering out events that don't require full window list refreshes.

## Problem

The previous implementation had several performance issues:

1. **No event debouncing** - Every D-Bus event immediately triggered `windowsChanged()`, causing multiple rapid-fire refreshes during a single toggle operation

2. **All events triggered full refreshes** - Non-list-changing events (`focuswindow`, `movewindow`, `statewindow`, `workspacechanged`, `monitorlayoutchanged`) all triggered expensive full window list rebuilds with D-Bus calls and object recreation

3. **Vicinae's own window triggered refreshes** - When the launcher closed/hid, it would trigger a `closewindow` event that caused an unnecessary refresh even though vicinae doesn't track its own window

4. **Excessive object creation** - A single toggle (open + close) created ~75 GnomeWindow objects (5 events × 15 windows) with 5 D-Bus calls

## Solution

- **Debouncing**: Added 50ms debounce timer to batch rapid events into a single refresh
- **Event filtering**: Only `openwindow` and `closewindow` events trigger list refreshes (matching Hyprland's efficient pattern)
- **Smart closewindow handling**: Skip refresh if the closed window isn't in our cache (filters out vicinae's own window)
- **Efficient focus updates**: Handle `focuswindow` by updating focus state in-place on cached objects without D-Bus calls or object recreation

## Performance Impact

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Events triggering refresh | 5+ per toggle | 1 per toggle | ~80% reduction |
| D-Bus calls per toggle | 5+ | 1 | ~80% reduction |
| Object creations per toggle | ~75 | ~15 | ~80% reduction |
| Focus change cost | Full refresh | O(n) in-memory update | No D-Bus calls |

## Changes

- `gnome-window-manager.hpp`: Add debounce timer, pending flag, and `windowFocused` signal
- `gnome-window-manager.cpp`: Implement debouncing, event filtering, and efficient focus handling
- `gnome-window.hpp`: Add `setFocused()` method for in-place focus state updates