### PR TITLE
perf(clipboard): Optimize history view initial load with sort-before-join query

### DIFF
--- a/vicinae/src/extensions/clipboard/history/clipboard-history-controller.hpp
+++ b/vicinae/src/extensions/clipboard/history/clipboard-history-controller.hpp
@@ -11,8 +11,11 @@ class ClipboardHistoryController : public QObject {
   Q_OBJECT
 
   using QueryWatcher = QFutureWatcher<PaginatedResponse<ClipboardHistoryEntry>>;
+  using CountWatcher = QFutureWatcher<int>;
 
 public:
+  static constexpr int DEFAULT_PAGE_SIZE = 1000;
+
   ClipboardHistoryController(ClipboardService *clipboard, ClipboardHistoryModel *model,
                              QObject *parent = nullptr);
 
@@ -23,9 +26,11 @@ public:
 signals:
   void dataLoadingChanged(bool value);
   void dataRetrieved(const PaginatedResponse<ClipboardHistoryEntry> &res);
+  void countRetrieved(int count);
 
 private slots:
   void handleResults();
+  void handleCountResults();
   void handleClipboardChanged();
 
 private:
@@ -33,6 +38,7 @@ private:
   ClipboardService *m_clipboard = nullptr;
 
   QueryWatcher m_watcher;
+  CountWatcher m_countWatcher;
   QString m_query;
   std::optional<ClipboardOfferKind> m_kind;
 };

--- a/vicinae/src/extensions/clipboard/history/clipboard-history-view.cpp
+++ b/vicinae/src/extensions/clipboard/history/clipboard-history-view.cpp
@@ -380,16 +380,15 @@ void ClipboardHistoryView::initialize() {
   setModel(m_model);
   m_defaultAction = parseDefaultAction(preferences.value("defaultAction").toString());
   setSearchPlaceholderText("Browse clipboard history...");
+  m_statusToolbar->setLeftText("Loading...");
   textChanged("");
   m_filterInput->setValue(getSavedDropdownFilter().value_or("all"));
   handleFilterChange(*m_filterInput->value());
 
   connect(m_model, &ClipboardHistoryModel::dataChanged, this, [this]() { refreshCurrent(); });
   connect(m_controller, &ClipboardHistoryController::dataLoadingChanged, this, &BaseView::setLoading);
-  connect(m_controller, &ClipboardHistoryController::dataRetrieved, this,
-          [this](const PaginatedResponse<ClipboardHistoryEntry> &page) {
-            m_statusToolbar->setLeftText(QString("%1 Items").arg(page.totalCount));
-          });
+  connect(m_controller, &ClipboardHistoryController::countRetrieved, this,
+          [this](int count) { m_statusToolbar->setLeftText(QString("%1 Items").arg(count)); });
 }
 
 std::unique_ptr<ActionPanelState> ClipboardHistoryView::createActionPanel(const ItemType &info) const {

--- a/vicinae/src/services/clipboard/clipboard-db.hpp
+++ b/vicinae/src/services/clipboard/clipboard-db.hpp
@@ -90,6 +90,8 @@ public:
   PaginatedResponse<ClipboardHistoryEntry> query(int limit = 100, int offset = 0,
                                                  const ClipboardListSettings &opts = {}) const;
 
+  int count(const ClipboardListSettings &opts = {}) const;
+
   bool removeAll();
 
   bool setKeywords(const QString &id, const QString &keywords);

--- a/vicinae/src/services/clipboard/clipboard-service.cpp
+++ b/vicinae/src/services/clipboard/clipboard-service.cpp
@@ -182,6 +182,10 @@ ClipboardService::listAll(int limit, int offset, const ClipboardListSettings &op
       [opts, limit, offset]() { return ClipboardDatabase().query(limit, offset, opts); });
 }
 
+QFuture<int> ClipboardService::countAll(const ClipboardListSettings &opts) const {
+  return QtConcurrent::run([opts]() { return ClipboardDatabase().count(opts); });
+}
+
 ClipboardOfferKind ClipboardService::getKind(const ClipboardDataOffer &offer) {
   if (offer.mimeType == "text/uri-list") {
     QString text = offer.data;

--- a/vicinae/src/services/clipboard/clipboard-service.hpp
+++ b/vicinae/src/services/clipboard/clipboard-service.hpp
@@ -107,6 +107,7 @@ public:
   bool setPinned(const QString id, bool pinned);
   QFuture<PaginatedResponse<ClipboardHistoryEntry>> listAll(int limit = 100, int offset = 0,
                                                             const ClipboardListSettings &opts = {}) const;
+  QFuture<int> countAll(const ClipboardListSettings &opts = {}) const;
   bool copyText(const QString &text, const Clipboard::CopyOptions &options = {.concealed = true});
   bool copyHtml(const Clipboard::Html &data, const Clipboard::CopyOptions &options = {.concealed = false});
   bool copyFile(const std::filesystem::path &path,


### PR DESCRIPTION
## Summary

- Restructure clipboard history query to use sort-before-join strategy, allowing the index to be used for sorting before the expensive JOIN operation
- Add separate async count query to avoid blocking data display

## Performance

Tested with 17,000 clipboard entries:
- Initial load: **1.9s → 0.69s** (~3x faster)
- Count loads asynchronously (non-blocking)

## Technical Details

The bottleneck was that `ORDER BY pinned_at DESC, updated_at DESC` couldn't use the index after JOIN and GROUP BY had already materialized the full result set. The fix sorts the selection table first (using the index), then joins only the limited rows.