### PR TITLE
fix(nix): mk*Extension: don't shadow derviation args

### DIFF
--- a/nix/mkVicinaeExtension.nix
+++ b/nix/mkVicinaeExtension.nix
@@ -12,13 +12,13 @@ lib.extendMkDerivation {
       version ? lib.warn "mkVicinaeExtension: not including version is deprecated" "0",
       src,
       ...
-    }:
+    }@attrs:
     {
       inherit version;
-      npmDeps = importNpmLock { npmRoot = src; };
-      npmConfigHook = importNpmLock.npmConfigHook;
+      npmDeps = attrs.npmDeps or (importNpmLock { npmRoot = src; });
+      npmConfigHook = attrs.npmConfigHook or importNpmLock.npmConfigHook;
       # NOTE: using buildPhase because $out doesn't work with npmBuildFlags
-      buildPhase = "npm run build -- --out=$out";
-      dontNpmInstall = true;
+      buildPhase = attrs.buildPhase or "npm run build -- --out=$out";
+      dontNpmInstall = attrs.dontNpmInstall or true;
     };
 }


### PR DESCRIPTION
previously the below would be incorrectly shadowed, with this patch it behaves correctly:
```nix
mkVicinaeExtension {
  ...
  buildPhase = "npm run build --my-flags";
}
```
it also allows for not supplying `hash` and `rev` to raycast builder if src is given.