### PR TITLE
fix: Explicitly specify D-Bus signal signature for Gnome clipboard events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 extension-manager/runtime/node_modules
 /cmake-build-debug
 /.idea
+/.vscode
 /vgcore*
 .env
 .direnv

--- a/vicinae/src/services/clipboard/gnome/gnome-clipboard-server.cpp
+++ b/vicinae/src/services/clipboard/gnome/gnome-clipboard-server.cpp
@@ -107,7 +107,8 @@ bool GnomeClipboardServer::setupDBusConnection() {
 
   // Connect to ClipboardChanged signal
   // Signal signature: (ayss) = array of bytes, string, string
-  bool connected = m_bus.connect(DBUS_SERVICE, DBUS_PATH, DBUS_INTERFACE, "ClipboardChanged", this,
+  // Explicitly specify the D-Bus signature to ensure proper type matching in Qt6
+  bool connected = m_bus.connect(DBUS_SERVICE, DBUS_PATH, DBUS_INTERFACE, "ClipboardChanged", "ayss", this,
                                  SLOT(handleClipboardChanged(QByteArray, QString, QString)));
 
   if (!connected) {
@@ -140,8 +141,8 @@ void GnomeClipboardServer::cleanupDBusConnection() {
     // Stop listening to clipboard changes
     m_interface->call("StopListening");
 
-    // Disconnect from D-Bus signal
-    m_bus.disconnect(DBUS_SERVICE, DBUS_PATH, DBUS_INTERFACE, "ClipboardChanged", this,
+    // Disconnect from D-Bus signal (must use same signature as connect)
+    m_bus.disconnect(DBUS_SERVICE, DBUS_PATH, DBUS_INTERFACE, "ClipboardChanged", "ayss", this,
                      SLOT(handleClipboardChanged(QByteArray, QString, QString)));
 
     delete m_interface;


### PR DESCRIPTION
This pull request makes a small but important fix to the D-Bus signal connection logic in the GNOME clipboard server. The change ensures that the D-Bus signal signature is explicitly specified when connecting and disconnecting the `ClipboardChanged` signal, which is necessary for proper type matching in Qt6. This is required for clipboard history to work in GNOME 49