### PR TITLE
Fix operator precedence in mkRayCastExtension.nix

### DIFF
--- a/nix/mkRayCastExtension.nix
+++ b/nix/mkRayCastExtension.nix
@@ -22,7 +22,7 @@ lib.extendMkDerivation {
           fetchFromGitHub {
             owner = "raycast";
             repo = "extensions";
-            rev = attrs.rev or throw "mkRayCastExtension: `rev` is required when src isn't suplied";
+            rev = attrs.rev or (throw "mkRayCastExtension: `rev` is required when src isn't suplied");
             hash =
               if hash != null then
                 hash


### PR DESCRIPTION
The last update caused an error when I was trying to build raycast extensions in my nix config. 

Example config triggering the error: 
https://github.com/augustocdias/dotfiles/blob/nix/home/vicinae/extensions.nix#L34-L41

I'm getting the following error when rebuilding: 

```
error: attempt to call something which is not a function but a string "e2b0d762797ae321e81bdbf1ab68c2b6a1a9f0ec" at /nix/store/r9g7dx..../nix/mkRayCastExtension.nix: 25:19:
       repo = "extensions";
       rev = attrs.rev or throw "mkRayCastExtension: `rev` is required when src isn't suplied";
             ^
```