### PR TITLE
fix(docs): Update incorrect settings example

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -136,7 +136,7 @@ in
           font = {
             normal = {
               size = 12;
-              normal = "Maple Nerd Font";
+              family = "Maple Nerd Font";
             };
           };
           theme = {


### PR DESCRIPTION
Nix/Home-Manager has a seemingly copy-pasted value for this, which doesn't actually compile. Update reflects what `vicinae config default` reports