### PR TITLE
build(nix): add catch2_3 for debug build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,8 +45,9 @@
         default = pkgs.mkShell {
           # automatically pulls nativeBuildInputs + buildInputs
           inputsFrom = [ (pkgs.callPackage ./nix/vicinae.nix { gcc15Stdenv = pkgs.gcc15Stdenv; }) ];
-          buildInputs = [
-            pkgs.ccache
+          buildInputs = with pkgs; [
+            ccache
+            catch2_3
           ];
 
           packages = with pkgs; [


### PR DESCRIPTION
This package is needed for compiling the debug build.