### PR TITLE
fix: libqalculate results with repeating decimals not displaying

### DIFF
--- a/src/server/src/services/calculator-service/qalculate/qalculate-backend.cpp
+++ b/src/server/src/services/calculator-service/qalculate/qalculate-backend.cpp
@@ -105,7 +105,7 @@ void QalculateBackend::initializeCalculator() {
   m_evalOpts.parse_options.units_enabled = true;
   m_evalOpts.parse_options.unknowns_enabled = false;
 
-  m_printOpts.indicate_infinite_series = true;
+  m_printOpts.indicate_infinite_series = false;
   m_printOpts.interval_display = INTERVAL_DISPLAY_SIGNIFICANT_DIGITS;
   m_printOpts.use_unicode_signs = true;
   m_printOpts.base_display = BASE_DISPLAY_ALTERNATIVE;


### PR DESCRIPTION
This fixes #1081 
## Summary
When evaluating an expression like ```1/3``` (or any expression that would result in a repeating decimal) using the libqalculate backend in Vicinae, the calculator errors out with a message like ```Trailing characters "" (not a valid variable/function/unit) in number "0.333" were ignored.``` referencing the … character (U+2026), the only fix i found so far is just disabling the indicate_infinite_series option in the print options  so instead of ```0.33…``` we would have ```0.33333333```