### PR TITLE
Fix deeplink documentation spacing in CLI option

### DIFF
--- a/src/cli/src/cli.cpp
+++ b/src/cli/src/cli.cpp
@@ -299,8 +299,7 @@ public:
 
   void setup(CLI::App *app) override {
     app->alias("link");
-    app->add_option("link", link, "The deeplink to open (see https://docs.vicinae.com/deeplinks )")
-        ->required();
+    app->add_option("link", link, "The deeplink to open. See https://docs.vicinae.com/deeplinks")->required();
   }
 
   bool run(CLI::App *app) override {


### PR DESCRIPTION
The current link in many terminals will open `https://docs.vicinae.com/deeplinks)` which of course returns a 404