### PR TITLE
fix: db error when editing clipboard keywords

### DIFF
--- a/src/server/src/services/clipboard/clipboard-db.cpp
+++ b/src/server/src/services/clipboard/clipboard-db.cpp
@@ -168,7 +168,7 @@ std::optional<QString> ClipboardDatabase::retrieveKeywords(const QString &id) {
 }
 
 bool ClipboardDatabase::setKeywords(const QString &id, const QString &keywords) {
-  return transaction([&](auto db) {
+  return transaction([&](auto *db) {
     QSqlQuery query(m_db);
 
     query.prepare("UPDATE selection SET keywords = :keywords WHERE id = :id");
@@ -305,7 +305,7 @@ bool ClipboardDatabase::transaction(const TxHandle &handle) {
     return false;
   }
 
-  if (handle(*this)) { return m_db.commit(); }
+  if (handle(this)) { return m_db.commit(); }
 
   return m_db.rollback();
 }

--- a/src/server/src/services/clipboard/clipboard-db.hpp
+++ b/src/server/src/services/clipboard/clipboard-db.hpp
@@ -81,7 +81,7 @@ struct ClipboardSelectionRecord {
 class ClipboardDatabase {
 
 public:
-  using TxHandle = std::function<bool(ClipboardDatabase &db)>;
+  using TxHandle = std::function<bool(ClipboardDatabase *db)>;
 
   bool transaction(const TxHandle &handle);
 

--- a/src/server/src/services/clipboard/clipboard-service.cpp
+++ b/src/server/src/services/clipboard/clipboard-service.cpp
@@ -399,15 +399,15 @@ void ClipboardService::saveSelection(ClipboardSelection selection) {
     return;
   }
 
-  cdb.transaction([&](ClipboardDatabase &db) {
-    if (db.tryBubbleUpSelection(selectionHash)) {
+  cdb.transaction([&](ClipboardDatabase *db) {
+    if (db->tryBubbleUpSelection(selectionHash)) {
       qInfo() << "A similar clipboard selection is already indexed: moving it on top of the history";
       return true;
     }
 
     QString selectionId = Crypto::UUID::v4();
 
-    if (!db.insertSelection({.id = selectionId,
+    if (!db->insertSelection({.id = selectionId,
                              .offerCount = static_cast<int>(selection.offers.size()),
                              .hash = selectionHash,
                              .preferredMimeType = preferredMimeType,
@@ -424,7 +424,7 @@ void ClipboardService::saveSelection(ClipboardSelection selection) {
       QString textPreview = getOfferTextPreview(offer);
 
       if (isIndexableText && !offer.data.isEmpty()) {
-        if (!db.indexSelectionContent(selectionId, offer.data)) {
+        if (!db->indexSelectionContent(selectionId, offer.data)) {
           qWarning() << "Failed to index selection content for offer" << offer.mimeType;
           return false;
         }
@@ -451,7 +451,7 @@ void ClipboardService::saveSelection(ClipboardSelection selection) {
         if (url.scheme().startsWith("http")) { dto.urlHost = url.host(); }
       }
 
-      if (!db.insertOffer(dto)) {
+      if (!db->insertOffer(dto)) {
         qWarning() << "Failed to insert offer" << offer.mimeType;
         return false;
       }


### PR DESCRIPTION
Implicit copy of the database object started causing unexpected issues as  destructor gets prematurely called