### PR TITLE
fix(calculator): output exact decimals and support manual format conversions

### DIFF
--- a/src/server/src/services/calculator-service/qalculate/qalculate-backend.cpp
+++ b/src/server/src/services/calculator-service/qalculate/qalculate-backend.cpp
@@ -109,7 +109,7 @@ void QalculateBackend::initializeCalculator() {
   m_printOpts.interval_display = INTERVAL_DISPLAY_SIGNIFICANT_DIGITS;
   m_printOpts.use_unicode_signs = true;
   m_printOpts.base_display = BASE_DISPLAY_ALTERNATIVE;
-  m_printOpts.number_fraction_format = FRACTION_DECIMAL_EXACT;
+  m_printOpts.number_fraction_format = FRACTION_DECIMAL;
 
   m_calc.reset();
   m_calc.loadGlobalDefinitions();


### PR DESCRIPTION
Fixes #1118

**What changed:**
1. Set the default print option to `FRACTION_DECIMAL`. This provides the expected decimal outputs for standard math and conversions (e.g., `1257/17` or `cm to in`), resolving the bug.
2. Updated the `compute` loop to only fail if `msg->type() == MESSAGE_ERROR`. This allows `libqalculate` to process internal formatting pseudo-units (like `to fraction`) without informational messages silently failing and hiding the calculator.