### PR TITLE
nix: added GCC 15 to Nix devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,8 @@
       });
       devShells = forEachPkgs (pkgs: {
         default = pkgs.mkShell {
+          stdenv = pkgs.gcc15Stdenv;
+
           # automatically pulls nativeBuildInputs + buildInputs
           inputsFrom = [ (pkgs.callPackage ./nix/vicinae.nix { gcc15Stdenv = pkgs.gcc15Stdenv; }) ];
           buildInputs = with pkgs; [
@@ -55,6 +57,13 @@
             nixd
             nixfmt-rfc-style
           ];
+
+          shellHook = ''
+            export CC=${pkgs.gcc15}/bin/gcc
+            export CXX=${pkgs.gcc15}/bin/g++
+            export CMAKE_C_COMPILER=$CC
+            export CMAKE_CXX_COMPILER=$CXX
+          '';
         };
       });
       overlays.default = final: prev: {


### PR DESCRIPTION
this fixes compilation issues on NixOS during local development. previously, cmake pulled out whatever compiler version was set as default on dev machine. now, flake guarantees that it's always GCC 15.