### PR TITLE
fix: list section header visibility fix when navigating 

### DIFF
--- a/src/server/src/qml/action-panel-model.cpp
+++ b/src/server/src/qml/action-panel-model.cpp
@@ -203,7 +203,16 @@ int ActionPanelModel::nextSectionIndex(int from, int direction) const {
   if (from >= 0 && from < count) { currentSection = m_flat[from].sectionIdx; }
 
   if (direction > 0) {
-    // Jump directly to first item of next section.
+    // Find the last item of the current section.
+    int currentEnd = from;
+    for (int idx = from + 1; idx < count; ++idx) {
+      if (m_flat[idx].kind == FlatItem::ActionItem && m_flat[idx].sectionIdx == currentSection)
+        currentEnd = idx;
+      else if (m_flat[idx].kind == FlatItem::ActionItem)
+        break;
+    }
+    if (currentEnd > from) { return currentEnd; }
+    // Otherwise jump to first item of next section.
     for (int idx = from + 1; idx < count; ++idx) {
       if (m_flat[idx].kind == FlatItem::ActionItem && m_flat[idx].sectionIdx != currentSection) {
         return idx;
@@ -251,13 +260,6 @@ int ActionPanelModel::nextSectionIndex(int from, int direction) const {
     }
   }
   return from;
-}
-
-int ActionPanelModel::scrollTargetIndex(int index, int direction) const {
-  if (direction < 0 && index > 0 && std::cmp_less(index, m_flat.size())) {
-    if (m_flat[index - 1].kind == FlatItem::SectionHeader) return index - 1;
-  }
-  return index;
 }
 
 void ActionPanelModel::rebuildFlatList() {

--- a/src/server/src/qml/action-panel-model.cpp
+++ b/src/server/src/qml/action-panel-model.cpp
@@ -203,16 +203,7 @@ int ActionPanelModel::nextSectionIndex(int from, int direction) const {
   if (from >= 0 && from < count) { currentSection = m_flat[from].sectionIdx; }
 
   if (direction > 0) {
-    // Find the last item of the current section.
-    int currentEnd = from;
-    for (int idx = from + 1; idx < count; ++idx) {
-      if (m_flat[idx].kind == FlatItem::ActionItem && m_flat[idx].sectionIdx == currentSection)
-        currentEnd = idx;
-      else if (m_flat[idx].kind == FlatItem::ActionItem)
-        break;
-    }
-    if (currentEnd > from) { return currentEnd; }
-    // Otherwise jump to first item of next section.
+    // Jump directly to first item of next section.
     for (int idx = from + 1; idx < count; ++idx) {
       if (m_flat[idx].kind == FlatItem::ActionItem && m_flat[idx].sectionIdx != currentSection) {
         return idx;
@@ -260,6 +251,13 @@ int ActionPanelModel::nextSectionIndex(int from, int direction) const {
     }
   }
   return from;
+}
+
+int ActionPanelModel::scrollTargetIndex(int index, int direction) const {
+  if (direction < 0 && index > 0 && std::cmp_less(index, m_flat.size())) {
+    if (m_flat[index - 1].kind == FlatItem::SectionHeader) return index - 1;
+  }
+  return index;
 }
 
 void ActionPanelModel::rebuildFlatList() {

--- a/src/server/src/qml/action-panel-model.hpp
+++ b/src/server/src/qml/action-panel-model.hpp
@@ -37,7 +37,6 @@ public:
   Q_INVOKABLE void setFilter(const QString &text);
   Q_INVOKABLE int nextSelectableIndex(int from, int direction) const;
   Q_INVOKABLE int nextSectionIndex(int from, int direction) const;
-  Q_INVOKABLE int scrollTargetIndex(int index, int direction) const;
 
   bool activateByShortcut(int key, int modifiers);
 

--- a/src/server/src/qml/action-panel-model.hpp
+++ b/src/server/src/qml/action-panel-model.hpp
@@ -37,6 +37,7 @@ public:
   Q_INVOKABLE void setFilter(const QString &text);
   Q_INVOKABLE int nextSelectableIndex(int from, int direction) const;
   Q_INVOKABLE int nextSectionIndex(int from, int direction) const;
+  Q_INVOKABLE int scrollTargetIndex(int index, int direction) const;
 
   bool activateByShortcut(int key, int modifiers);
 

--- a/src/server/src/qml/command-list-model.cpp
+++ b/src/server/src/qml/command-list-model.cpp
@@ -130,16 +130,7 @@ int CommandListModel::nextSectionIndex(int from, int direction) const {
   };
 
   if (direction > 0) {
-    // Find the last item of the current section.
-    int currentEnd = from;
-    for (int idx = from + 1; idx < count; ++idx) {
-      if (m_flat[idx].kind == FlatItem::DataItem && m_flat[idx].sectionIdx == currentSection)
-        currentEnd = idx;
-      else if (m_flat[idx].sectionIdx != currentSection)
-        break;
-    }
-    if (currentEnd > from) { return currentEnd; }
-    // Otherwise jump to first item of next section.
+    // Jump directly to first item of next section.
     for (int idx = from + 1; idx < count; ++idx) {
       if (m_flat[idx].kind == FlatItem::DataItem && m_flat[idx].sectionIdx != currentSection) {
         return idx;

--- a/src/server/src/qml/command-list-model.cpp
+++ b/src/server/src/qml/command-list-model.cpp
@@ -125,16 +125,15 @@ int CommandListModel::nextSectionIndex(int from, int direction) const {
 
   // Helper: return the first DataItem at or after `idx`.
   auto firstDataItemFrom = [&](int idx) -> int {
-    while (idx < count && m_flat[idx].kind != FlatItem::DataItem) ++idx;
+    while (idx < count && m_flat[idx].kind != FlatItem::DataItem)
+      ++idx;
     return (idx < count) ? idx : from;
   };
 
   if (direction > 0) {
     // Jump directly to first item of next section.
     for (int idx = from + 1; idx < count; ++idx) {
-      if (m_flat[idx].kind == FlatItem::DataItem && m_flat[idx].sectionIdx != currentSection) {
-        return idx;
-      }
+      if (m_flat[idx].kind == FlatItem::DataItem && m_flat[idx].sectionIdx != currentSection) { return idx; }
       if (m_flat[idx].kind == FlatItem::SectionHeader && m_flat[idx].sectionIdx != currentSection) {
         return firstDataItemFrom(idx + 1);
       }

--- a/src/server/src/qml/command-list-model.cpp
+++ b/src/server/src/qml/command-list-model.cpp
@@ -130,7 +130,16 @@ int CommandListModel::nextSectionIndex(int from, int direction) const {
   };
 
   if (direction > 0) {
-    // Jump directly to first item of next section.
+    // Find the last item of the current section.
+    int currentEnd = from;
+    for (int idx = from + 1; idx < count; ++idx) {
+      if (m_flat[idx].kind == FlatItem::DataItem && m_flat[idx].sectionIdx == currentSection)
+        currentEnd = idx;
+      else if (m_flat[idx].sectionIdx != currentSection)
+        break;
+    }
+    if (currentEnd > from) { return currentEnd; }
+    // Otherwise jump to first item of next section.
     for (int idx = from + 1; idx < count; ++idx) {
       if (m_flat[idx].kind == FlatItem::DataItem && m_flat[idx].sectionIdx != currentSection) {
         return idx;

--- a/src/server/src/qml/qml/ActionListPanel.qml
+++ b/src/server/src/qml/qml/ActionListPanel.qml
@@ -10,26 +10,63 @@ Item {
 
     signal navigateBack()
 
+    function sectionScrollTarget(index, direction) {
+        if (!root.model || typeof root.model.scrollTargetIndex !== "function")
+            return index
+        return root.model.scrollTargetIndex(index, direction)
+    }
+
+    function revealCurrentSectionHeaderIfHidden() {
+        if (listView.currentIndex < 0) return false
+
+        var scrollTarget = sectionScrollTarget(listView.currentIndex, -1)
+        if (scrollTarget === listView.currentIndex) return false
+
+        var previousContentY = listView.contentY
+        listView.positionViewAtIndex(scrollTarget, ListView.Contain)
+        return Math.abs(listView.contentY - previousContentY) > 0.5
+    }
+
     function moveUp() {
+        if (revealCurrentSectionHeaderIfHidden()) return
+
         var next = root.model.nextSelectableIndex(listView.currentIndex, -1)
-        if (next !== listView.currentIndex) listView.currentIndex = next
+        if (next !== listView.currentIndex) {
+            listView.currentIndex = next
+            var scrollTarget = sectionScrollTarget(next, -1)
+            listView.positionViewAtIndex(scrollTarget, ListView.Contain)
+        }
     }
 
     function moveDown() {
         var next = root.model.nextSelectableIndex(listView.currentIndex, 1)
-        if (next !== listView.currentIndex) listView.currentIndex = next
+        if (next !== listView.currentIndex) {
+            listView.currentIndex = next
+            var scrollTarget = sectionScrollTarget(next, -1)
+            listView.positionViewAtIndex(scrollTarget, ListView.Contain)
+        }
     }
 
     function moveSectionUp() {
         if (typeof root.model.nextSectionIndex !== "function") { moveUp(); return }
+        if (revealCurrentSectionHeaderIfHidden()) return
+
         var next = root.model.nextSectionIndex(listView.currentIndex, -1)
-        if (next !== listView.currentIndex) listView.currentIndex = next
+        if (next !== listView.currentIndex) {
+            listView.currentIndex = next
+            var scrollTarget = sectionScrollTarget(next, -1)
+            listView.positionViewAtIndex(scrollTarget, ListView.Contain)
+        }
     }
 
     function moveSectionDown() {
         if (typeof root.model.nextSectionIndex !== "function") { moveDown(); return }
         var next = root.model.nextSectionIndex(listView.currentIndex, 1)
-        if (next !== listView.currentIndex) listView.currentIndex = next
+        if (next !== listView.currentIndex) {
+            listView.currentIndex = next
+            var scrollTarget = sectionScrollTarget(next, -1)
+            listView.positionViewAtIndex(scrollTarget, ListView.Contain)
+        }
     }
 
     function activateCurrent() {

--- a/src/server/src/qml/qml/ActionListPanel.qml
+++ b/src/server/src/qml/qml/ActionListPanel.qml
@@ -69,6 +69,18 @@ Item {
         }
     }
 
+    function moveSectionUp() {
+        if (typeof root.model.nextSectionIndex !== "function") { moveUp(); return }
+        var next = root.model.nextSectionIndex(listView.currentIndex, -1)
+        if (next !== listView.currentIndex) listView.currentIndex = next
+    }
+
+    function moveSectionDown() {
+        if (typeof root.model.nextSectionIndex !== "function") { moveDown(); return }
+        var next = root.model.nextSectionIndex(listView.currentIndex, 1)
+        if (next !== listView.currentIndex) listView.currentIndex = next
+    }
+
     function activateCurrent() {
         if (listView.currentIndex >= 0)
             root.model.activate(listView.currentIndex)

--- a/src/server/src/qml/qml/ActionListPanel.qml
+++ b/src/server/src/qml/qml/ActionListPanel.qml
@@ -69,18 +69,6 @@ Item {
         }
     }
 
-    function moveSectionUp() {
-        if (typeof root.model.nextSectionIndex !== "function") { moveUp(); return }
-        var next = root.model.nextSectionIndex(listView.currentIndex, -1)
-        if (next !== listView.currentIndex) listView.currentIndex = next
-    }
-
-    function moveSectionDown() {
-        if (typeof root.model.nextSectionIndex !== "function") { moveDown(); return }
-        var next = root.model.nextSectionIndex(listView.currentIndex, 1)
-        if (next !== listView.currentIndex) listView.currentIndex = next
-    }
-
     function activateCurrent() {
         if (listView.currentIndex >= 0)
             root.model.activate(listView.currentIndex)

--- a/src/server/src/qml/qml/ActionListPanel.qml
+++ b/src/server/src/qml/qml/ActionListPanel.qml
@@ -19,10 +19,10 @@ Item {
     function revealCurrentSectionHeaderIfHidden() {
         if (listView.currentIndex < 0) return false
 
-        var scrollTarget = sectionScrollTarget(listView.currentIndex, -1)
+        const scrollTarget = sectionScrollTarget(listView.currentIndex, -1)
         if (scrollTarget === listView.currentIndex) return false
 
-        var previousContentY = listView.contentY
+        const previousContentY = listView.contentY
         listView.positionViewAtIndex(scrollTarget, ListView.Contain)
         return Math.abs(listView.contentY - previousContentY) > 0.5
     }
@@ -30,19 +30,19 @@ Item {
     function moveUp() {
         if (revealCurrentSectionHeaderIfHidden()) return
 
-        var next = root.model.nextSelectableIndex(listView.currentIndex, -1)
+        const next = root.model.nextSelectableIndex(listView.currentIndex, -1)
         if (next !== listView.currentIndex) {
             listView.currentIndex = next
-            var scrollTarget = sectionScrollTarget(next, -1)
+            const scrollTarget = sectionScrollTarget(next, -1)
             listView.positionViewAtIndex(scrollTarget, ListView.Contain)
         }
     }
 
     function moveDown() {
-        var next = root.model.nextSelectableIndex(listView.currentIndex, 1)
+        const next = root.model.nextSelectableIndex(listView.currentIndex, 1)
         if (next !== listView.currentIndex) {
             listView.currentIndex = next
-            var scrollTarget = sectionScrollTarget(next, -1)
+            const scrollTarget = sectionScrollTarget(next, -1)
             listView.positionViewAtIndex(scrollTarget, ListView.Contain)
         }
     }
@@ -51,20 +51,20 @@ Item {
         if (typeof root.model.nextSectionIndex !== "function") { moveUp(); return }
         if (revealCurrentSectionHeaderIfHidden()) return
 
-        var next = root.model.nextSectionIndex(listView.currentIndex, -1)
+        const next = root.model.nextSectionIndex(listView.currentIndex, -1)
         if (next !== listView.currentIndex) {
             listView.currentIndex = next
-            var scrollTarget = sectionScrollTarget(next, -1)
+            const scrollTarget = sectionScrollTarget(next, -1)
             listView.positionViewAtIndex(scrollTarget, ListView.Contain)
         }
     }
 
     function moveSectionDown() {
         if (typeof root.model.nextSectionIndex !== "function") { moveDown(); return }
-        var next = root.model.nextSectionIndex(listView.currentIndex, 1)
+        const next = root.model.nextSectionIndex(listView.currentIndex, 1)
         if (next !== listView.currentIndex) {
             listView.currentIndex = next
-            var scrollTarget = sectionScrollTarget(next, -1)
+            const scrollTarget = sectionScrollTarget(next, -1)
             listView.positionViewAtIndex(scrollTarget, ListView.Contain)
         }
     }

--- a/src/server/src/qml/qml/GenericListView.qml
+++ b/src/server/src/qml/qml/GenericListView.qml
@@ -57,19 +57,19 @@ Item {
     function revealCurrentSectionHeaderIfHidden() {
         if (listView.currentIndex < 0) return false
 
-        var scrollTarget = sectionScrollTarget(listView.currentIndex, -1)
+        const scrollTarget = sectionScrollTarget(listView.currentIndex, -1)
         if (scrollTarget === listView.currentIndex) return false
 
-        var previousContentY = listView.contentY
+        const previousContentY = listView.contentY
         listView.positionViewAtIndex(scrollTarget, ListView.Contain)
         return Math.abs(listView.contentY - previousContentY) > 0.5
     }
 
     function moveDown() {
-        var next = root.listModel.nextSelectableIndex(listView.currentIndex, 1)
+        const next = root.listModel.nextSelectableIndex(listView.currentIndex, 1)
         if (next !== listView.currentIndex) {
             listView.currentIndex = next
-            var scrollTarget = sectionScrollTarget(next, -1)
+            const scrollTarget = sectionScrollTarget(next, -1)
             listView.positionViewAtIndex(scrollTarget, ListView.Contain)
         }
     }
@@ -77,20 +77,20 @@ Item {
     function moveUp() {
         if (revealCurrentSectionHeaderIfHidden()) return
 
-        var next = root.listModel.nextSelectableIndex(listView.currentIndex, -1)
+        const next = root.listModel.nextSelectableIndex(listView.currentIndex, -1)
         if (next !== listView.currentIndex) {
             listView.currentIndex = next
-            var scrollTarget = sectionScrollTarget(next, -1)
+            const scrollTarget = sectionScrollTarget(next, -1)
             listView.positionViewAtIndex(scrollTarget, ListView.Contain)
         }
     }
 
     function moveSectionDown() {
         if (typeof root.listModel.nextSectionIndex !== "function") { moveDown(); return }
-        var next = root.listModel.nextSectionIndex(listView.currentIndex, 1)
+        const next = root.listModel.nextSectionIndex(listView.currentIndex, 1)
         if (next !== listView.currentIndex) {
             listView.currentIndex = next
-            var scrollTarget = sectionScrollTarget(next, -1)
+            const scrollTarget = sectionScrollTarget(next, -1)
             listView.positionViewAtIndex(scrollTarget, ListView.Contain)
         }
     }
@@ -99,10 +99,10 @@ Item {
         if (typeof root.listModel.nextSectionIndex !== "function") { moveUp(); return }
         if (revealCurrentSectionHeaderIfHidden()) return
 
-        var next = root.listModel.nextSectionIndex(listView.currentIndex, -1)
+        const next = root.listModel.nextSectionIndex(listView.currentIndex, -1)
         if (next !== listView.currentIndex) {
             listView.currentIndex = next
-            var scrollTarget = sectionScrollTarget(next, -1)
+            const scrollTarget = sectionScrollTarget(next, -1)
             listView.positionViewAtIndex(scrollTarget, ListView.Contain)
         }
     }

--- a/src/server/src/qml/qml/GenericListView.qml
+++ b/src/server/src/qml/qml/GenericListView.qml
@@ -48,19 +48,39 @@ Item {
     signal itemActivated(int index)
     signal itemSelected(int index)
 
+    function sectionScrollTarget(index, direction) {
+        if (!root.listModel || typeof root.listModel.scrollTargetIndex !== "function")
+            return index
+        return root.listModel.scrollTargetIndex(index, direction)
+    }
+
+    function revealCurrentSectionHeaderIfHidden() {
+        if (listView.currentIndex < 0) return false
+
+        var scrollTarget = sectionScrollTarget(listView.currentIndex, -1)
+        if (scrollTarget === listView.currentIndex) return false
+
+        var previousContentY = listView.contentY
+        listView.positionViewAtIndex(scrollTarget, ListView.Contain)
+        return Math.abs(listView.contentY - previousContentY) > 0.5
+    }
+
     function moveDown() {
         var next = root.listModel.nextSelectableIndex(listView.currentIndex, 1)
         if (next !== listView.currentIndex) {
             listView.currentIndex = next
-            listView.positionViewAtIndex(next, ListView.Contain)
+            var scrollTarget = sectionScrollTarget(next, -1)
+            listView.positionViewAtIndex(scrollTarget, ListView.Contain)
         }
     }
 
     function moveUp() {
+        if (revealCurrentSectionHeaderIfHidden()) return
+
         var next = root.listModel.nextSelectableIndex(listView.currentIndex, -1)
         if (next !== listView.currentIndex) {
             listView.currentIndex = next
-            var scrollTarget = root.listModel.scrollTargetIndex(next, -1)
+            var scrollTarget = sectionScrollTarget(next, -1)
             listView.positionViewAtIndex(scrollTarget, ListView.Contain)
         }
     }
@@ -70,16 +90,19 @@ Item {
         var next = root.listModel.nextSectionIndex(listView.currentIndex, 1)
         if (next !== listView.currentIndex) {
             listView.currentIndex = next
-            listView.positionViewAtIndex(next, ListView.Contain)
+            var scrollTarget = sectionScrollTarget(next, -1)
+            listView.positionViewAtIndex(scrollTarget, ListView.Contain)
         }
     }
 
     function moveSectionUp() {
         if (typeof root.listModel.nextSectionIndex !== "function") { moveUp(); return }
+        if (revealCurrentSectionHeaderIfHidden()) return
+
         var next = root.listModel.nextSectionIndex(listView.currentIndex, -1)
         if (next !== listView.currentIndex) {
             listView.currentIndex = next
-            var scrollTarget = root.listModel.scrollTargetIndex(next, -1)
+            var scrollTarget = sectionScrollTarget(next, -1)
             listView.positionViewAtIndex(scrollTarget, ListView.Contain)
         }
     }

--- a/src/server/src/qml/root-search-model.cpp
+++ b/src/server/src/qml/root-search-model.cpp
@@ -519,17 +519,7 @@ int RootSearchModel::nextSectionIndex(int from, int direction) const {
   auto isSelectable = [&](int idx) { return m_flat[idx].kind != FlatItem::SectionHeader; };
 
   if (direction > 0) {
-    // Find the last item of the current section.
-    int currentEnd = from;
-    for (int idx = from + 1; idx < count; ++idx) {
-      if (isSelectable(idx) && m_flat[idx].section == currentSection)
-        currentEnd = idx;
-      else if (m_flat[idx].section != currentSection)
-        break;
-    }
-    // If not already at the last item, jump there first.
-    if (currentEnd > from) { return currentEnd; }
-    // Otherwise jump to first item of next section.
+    // Jump directly to first item of next section.
     for (int idx = from + 1; idx < count; ++idx) {
       if (isSelectable(idx) && m_flat[idx].section != currentSection) return idx;
     }

--- a/src/server/src/qml/root-search-model.cpp
+++ b/src/server/src/qml/root-search-model.cpp
@@ -519,7 +519,17 @@ int RootSearchModel::nextSectionIndex(int from, int direction) const {
   auto isSelectable = [&](int idx) { return m_flat[idx].kind != FlatItem::SectionHeader; };
 
   if (direction > 0) {
-    // Jump directly to first item of next section.
+    // Find the last item of the current section.
+    int currentEnd = from;
+    for (int idx = from + 1; idx < count; ++idx) {
+      if (isSelectable(idx) && m_flat[idx].section == currentSection)
+        currentEnd = idx;
+      else if (m_flat[idx].section != currentSection)
+        break;
+    }
+    // If not already at the last item, jump there first.
+    if (currentEnd > from) { return currentEnd; }
+    // Otherwise jump to first item of next section.
     for (int idx = from + 1; idx < count; ++idx) {
       if (isSelectable(idx) && m_flat[idx].section != currentSection) return idx;
     }


### PR DESCRIPTION
- Fixed section header visibility during keyboard navigation:
      - headers now show correctly when moving to section boundaries (including wrap from last item to first)
      - removed unnecessary viewport snapping when header is already visible
      - also applies to section jumps via Ctrl + Up/Down