### PR TITLE
feat: Made debug mode visible on launcher corner

### DIFF
--- a/src/server/src/qml/config-bridge.hpp
+++ b/src/server/src/qml/config-bridge.hpp
@@ -13,6 +13,7 @@ class ConfigBridge : public QObject {
   Q_PROPERTY(int windowHeight READ windowHeight NOTIFY changed)
   Q_PROPERTY(bool emacsMode READ emacsMode NOTIFY changed)
   Q_PROPERTY(bool considerPreedit READ considerPreedit NOTIFY changed)
+  Q_PROPERTY(bool debugBuild READ debugBuild CONSTANT)
 
 signals:
   void changed();
@@ -39,6 +40,7 @@ public:
   int windowHeight() const { return cfg().launcherWindow.size.height; }
   bool emacsMode() const { return cfg().keybinding == "emacs"; }
   bool considerPreedit() const { return cfg().considerPreedit; }
+  bool debugBuild() const { return DEBUG; }
 
 private:
   static const config::ConfigValue &cfg() { return ServiceRegistry::instance()->config()->value(); }

--- a/src/server/src/qml/qml/LauncherWindow.qml
+++ b/src/server/src/qml/qml/LauncherWindow.qml
@@ -143,6 +143,27 @@ Window {
         id: alertDialog
     }
 
+    Rectangle {
+        visible: Config.debugBuild
+        z: 200
+        width: 80
+        height: 20
+        anchors.top: parent.top
+        anchors.right: parent.right
+        anchors.topMargin: Config.borderWidth + 4
+        anchors.rightMargin: Config.borderWidth + 4
+        radius: 4
+        color: "#E0CC00"
+
+        Text {
+            anchors.centerIn: parent
+            text: "DEV"
+            font.pixelSize: 11
+            font.bold: true
+            color: "#000000"
+        }
+    }
+
     Connections {
         target: launcher.alertModel
         function onVisibleChanged() {


### PR DESCRIPTION
Added badge on corner to not look into settings to check is prod or debug version is running.
Code generated by `claude-opus-4-6`

<img width="792" height="150" alt="image" src="https://github.com/user-attachments/assets/dacc20e7-15ff-450a-b871-e71d60836027" />
