### PR TITLE
feat: add Ctrl+Up/Down to jump between grid sections

### DIFF
--- a/src/server/src/qml/command-grid-model.cpp
+++ b/src/server/src/qml/command-grid-model.cpp
@@ -142,6 +142,35 @@ int CommandGridModel::sectionColumns(int sectionIdx) const {
   return m_sections[sectionIdx].columns.value_or(m_columns);
 }
 
+int CommandGridModel::nextNonEmptySection(int sectionIdx, int direction) const {
+  if (m_sections.empty()) return -1;
+
+  int idx = sectionIdx;
+  for (size_t attempts = 0; attempts < m_sections.size(); ++attempts) {
+    idx += direction;
+    if (idx < 0) {
+      idx = static_cast<int>(m_sections.size()) - 1;
+    } else if (std::cmp_greater_equal(idx, m_sections.size())) {
+      idx = 0;
+    }
+
+    if (m_sections[idx].count > 0) return idx;
+  }
+
+  return -1;
+}
+
+void CommandGridModel::selectSectionBoundary(int sectionIdx, bool endOfSection, bool revealHeader) {
+  if (sectionIdx < 0 || std::cmp_greater_equal(sectionIdx, m_sections.size()) ||
+      m_sections[sectionIdx].count <= 0) {
+    return;
+  }
+
+  m_preferSectionHeaderForSelection = revealHeader;
+  m_alignSelectionScrollToTop = revealHeader && !endOfSection;
+  select(sectionIdx, endOfSection ? m_sections[sectionIdx].count - 1 : 0);
+}
+
 void CommandGridModel::rebuildRows() { setSections(m_sections); }
 
 void CommandGridModel::select(int section, int item) {
@@ -216,6 +245,8 @@ void CommandGridModel::fromGlobal(int globalIdx, int &section, int &item) const 
 
 void CommandGridModel::navigateRight() {
   m_lastNavDirection = 1;
+  m_preferSectionHeaderForSelection = false;
+  m_alignSelectionScrollToTop = false;
   int g = toGlobal(m_selSection, m_selItem) + 1;
   int const total = totalItemCount();
   if (total == 0) return;
@@ -227,6 +258,8 @@ void CommandGridModel::navigateRight() {
 
 void CommandGridModel::navigateLeft() {
   m_lastNavDirection = -1;
+  m_preferSectionHeaderForSelection = false;
+  m_alignSelectionScrollToTop = false;
   int g = toGlobal(m_selSection, m_selItem) - 1;
   int const total = totalItemCount();
   if (total == 0) return;
@@ -238,6 +271,8 @@ void CommandGridModel::navigateLeft() {
 
 void CommandGridModel::navigateDown() {
   m_lastNavDirection = 1;
+  m_preferSectionHeaderForSelection = false;
+  m_alignSelectionScrollToTop = false;
   if (m_selSection < 0) return;
 
   int const cols = sectionColumns(m_selSection);
@@ -273,6 +308,8 @@ void CommandGridModel::navigateDown() {
 
 void CommandGridModel::navigateUp() {
   m_lastNavDirection = -1;
+  m_preferSectionHeaderForSelection = false;
+  m_alignSelectionScrollToTop = false;
   if (m_selSection < 0) return;
 
   int const cols = sectionColumns(m_selSection);
@@ -309,17 +346,41 @@ void CommandGridModel::navigateUp() {
   }
 }
 
+void CommandGridModel::navigateSectionUp() {
+  m_lastNavDirection = -1;
+  m_alignSelectionScrollToTop = false;
+  if (m_selSection < 0 || std::cmp_greater_equal(m_selSection, m_sections.size())) return;
+
+  if (m_selItem > 0) {
+    selectSectionBoundary(m_selSection, false);
+    return;
+  }
+
+  int const prevSection = nextNonEmptySection(m_selSection, -1);
+  if (prevSection >= 0) selectSectionBoundary(prevSection, false);
+}
+
+void CommandGridModel::navigateSectionDown() {
+  m_lastNavDirection = 1;
+  m_alignSelectionScrollToTop = false;
+  if (m_selSection < 0 || std::cmp_greater_equal(m_selSection, m_sections.size())) return;
+
+  int const nextSection = nextNonEmptySection(m_selSection, 1);
+  if (nextSection >= 0) selectSectionBoundary(nextSection, false);
+}
+
+bool CommandGridModel::alignSelectionScrollToTop() const { return m_alignSelectionScrollToTop; }
+
 int CommandGridModel::flatRowForSelection() const {
   if (m_selSection < 0 || m_selItem < 0) return -1;
   for (int r = 0; std::cmp_less(r, m_rows.size()); ++r) {
     const auto &row = m_rows[r];
     if (row.kind == FlatRow::ItemRow && row.sectionIdx == m_selSection && m_selItem >= row.startItem &&
         m_selItem < row.startItem + row.itemCount) {
-      // When navigating up into the first item row of a section that has
-      // a header, return the header row so positionViewAtIndex also keeps
-      // the section title visible. When navigating down, return the item
-      // row directly so the viewport doesn't jump back to the header.
-      if (m_lastNavDirection < 0 && row.startItem == 0 && r > 0 &&
+      // When section navigation lands on the first row of a section that has
+      // a header, return the header row so positionViewAtIndex keeps the
+      // section title visible.
+      if (m_preferSectionHeaderForSelection && row.startItem == 0 && r > 0 &&
           m_rows[r - 1].kind == FlatRow::SectionHeader && m_rows[r - 1].sectionIdx == m_selSection) {
         return r - 1;
       }

--- a/src/server/src/qml/command-grid-model.hpp
+++ b/src/server/src/qml/command-grid-model.hpp
@@ -52,7 +52,10 @@ public:
   Q_INVOKABLE void navigateDown();
   Q_INVOKABLE void navigateLeft();
   Q_INVOKABLE void navigateRight();
+  Q_INVOKABLE void navigateSectionUp();
+  Q_INVOKABLE void navigateSectionDown();
   Q_INVOKABLE int flatRowForSelection() const;
+  Q_INVOKABLE bool alignSelectionScrollToTop() const;
 
   int columns() const { return m_columns; }
   void setColumns(int cols);
@@ -105,6 +108,8 @@ private:
   std::vector<FlatRow> buildFlatList(const std::vector<SectionInfo> &sections);
   void rebuildRows();
   int sectionColumns(int sectionIdx) const;
+  int nextNonEmptySection(int sectionIdx, int direction) const;
+  void selectSectionBoundary(int sectionIdx, bool endOfSection, bool revealHeader = true);
   int totalItemCount() const;
   int toGlobal(int section, int item) const;
   void fromGlobal(int globalIdx, int &section, int &item) const;
@@ -120,4 +125,6 @@ private:
   bool m_awaitingData = true;
   int m_selectedIndex = -1;
   int m_lastNavDirection = 0;
+  bool m_preferSectionHeaderForSelection = false;
+  bool m_alignSelectionScrollToTop = false;
 };

--- a/src/server/src/qml/qml/GenericGridView.qml
+++ b/src/server/src/qml/qml/GenericGridView.qml
@@ -8,7 +8,8 @@ Item {
     //   isSection, sectionName, rowSectionIdx, rowStartItem, rowItemCount
     // AND expose Q_INVOKABLEs for selection/navigation:
     //   selectedSection, selectedItem, select(), activateSelected(),
-    //   navigateUp/Down/Left/Right(), flatRowForSelection()
+    //   navigateUp/Down/Left/Right(), navigateSectionUp/Down(),
+    //   flatRowForSelection()
     property var cmdModel: null
 
     // Cell delegate component — instantiated per cell.
@@ -60,7 +61,23 @@ Item {
     function moveUp() { if (cmdModel) cmdModel.navigateUp() }
     function moveDown() { if (cmdModel) cmdModel.navigateDown() }
     function moveLeft() { if (cmdModel) cmdModel.navigateLeft() }
-	function moveRight() { if (cmdModel) cmdModel.navigateRight() }
+    function moveRight() { if (cmdModel) cmdModel.navigateRight() }
+    function moveSectionUp() { if (cmdModel) cmdModel.navigateSectionUp() }
+    function moveSectionDown() { if (cmdModel) cmdModel.navigateSectionDown() }
+
+    function _isRowVisible(row) {
+        if (row < 0) return false
+
+        const item = listView.itemAtIndex(row)
+        if (!item) return false
+
+        const viewportTop = listView.contentY
+        const viewportBottom = viewportTop + listView.height
+        const itemTop = item.y
+        const itemBottom = item.y + item.height
+
+        return itemBottom > viewportTop && itemTop < viewportBottom
+    }
 
     ListView {
         id: listView
@@ -263,7 +280,15 @@ Item {
         target: root.cmdModel
         function onSelectionChanged() {
             var row = root.cmdModel ? root.cmdModel.flatRowForSelection() : -1
-            if (row >= 0) listView.positionViewAtIndex(row, ListView.Contain)
+            if (row >= 0) {
+                var mode = ListView.Contain
+                if (root.cmdModel && typeof root.cmdModel.alignSelectionScrollToTop === "function"
+                        && root.cmdModel.alignSelectionScrollToTop()
+                        && !root._isRowVisible(row)) {
+                    mode = ListView.Beginning
+                }
+                listView.positionViewAtIndex(row, mode)
+            }
         }
     }
 


### PR DESCRIPTION
Adds Ctrl+Up/Down section-jump navigation for grid views. The grid selection now jumps between section starts, keeps section headers visible when needed, and avoids unnecessary scrolling when the target section header is already on screen.