### PR TITLE
fix: nix devshell to use correct qt environment

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,32 +40,38 @@
         '';
         mkVicinaeExtension = pkgs.callPackage ./nix/mkVicinaeExtension.nix { };
         mkRayCastExtension = pkgs.callPackage ./nix/mkRayCastExtension.nix { };
-      });
-      devShells = forEachPkgs (pkgs: {
-        default = pkgs.mkShell {
-          stdenv = pkgs.gcc15Stdenv;
-
-          # automatically pulls nativeBuildInputs + buildInputs
-          inputsFrom = [ (pkgs.callPackage ./nix/vicinae.nix { gcc15Stdenv = pkgs.gcc15Stdenv; }) ];
-          buildInputs = with pkgs; [
-            ccache
-            catch2_3
+      }); devShells = forEachPkgs (
+        pkgs:
+        let
+          qtEnv = pkgs.qt6.env "qt-custom-${pkgs.qt6.qtbase.version}" [
+            pkgs.qt6.qtdeclarative
+            pkgs.qt6.qtwayland
+            pkgs.qt6.qtsvg
           ];
+        in
+        {
+          default = pkgs.mkShell {
+            stdenv = pkgs.gcc15Stdenv;
 
-          packages = with pkgs; [
-            clang-tools
-            nixd
-            nixfmt-rfc-style
-          ];
+            # automatically pulls nativeBuildInputs + buildInputs
+            inputsFrom = [ (pkgs.callPackage ./nix/vicinae.nix { gcc15Stdenv = pkgs.gcc15Stdenv; }) ];
 
-          shellHook = ''
-            export CC=${pkgs.gcc15}/bin/gcc
-            export CXX=${pkgs.gcc15}/bin/g++
-            export CMAKE_C_COMPILER=$CC
-            export CMAKE_CXX_COMPILER=$CXX
-          '';
-        };
-      });
+            packages = with pkgs; [
+              ccache
+              catch2_3
+              qtEnv
+              clang-tools
+            ];
+
+            shellHook = ''
+              export CC=${pkgs.gcc15}/bin/gcc
+              export CXX=${pkgs.gcc15}/bin/g++
+              export CMAKE_C_COMPILER=$CC
+              export CMAKE_CXX_COMPILER=$CXX
+            '';
+          };
+        }
+      );
       overlays.default = final: prev: {
         vicinae = final.callPackage ./nix/vicinae.nix { };
         mkVicinaeExtension = prev.callPackage ./nix/mkVicinaeExtension.nix { };


### PR DESCRIPTION
This moves QT dependencies into a QTEnv.
In the history of nixpkgs this was done internally by qt6.full but that package was removed.
sadly this gives makes us repeat the qt packages from the package definition but oh well :shrug: 

with this devshell i can build and execute vicinae without problems

i also removed nixd and nixfmt because these packages should not be installed by the flake. the user may decide to use another lsp