### PR TITLE
fix: invalid format input handling in settings

### DIFF
--- a/src/server/src/qml/launcher-window.cpp
+++ b/src/server/src/qml/launcher-window.cpp
@@ -252,9 +252,16 @@ LauncherWindow::LauncherWindow(ApplicationContext &ctx, QObject *parent)
 }
 
 bool LauncherWindow::eventFilter(QObject *obj, QEvent *event) {
+  if (obj != m_window) return QObject::eventFilter(obj, event);
+
+  if (event->type() == QEvent::KeyPress) {
+    auto *ke = static_cast<QKeyEvent *>(event); // NOLINT
+    if (forwardKey(ke->key(), static_cast<int>(ke->modifiers()))) { return true; }
+  }
+
   // only works on some compositors.
   // we could probably make it work everywhere layer shell is supported by adding a layer behind ours.
-  if (obj == m_window && event->type() == QEvent::MouseMove && m_closeOnFocusLoss) {
+  if (event->type() == QEvent::MouseMove && m_closeOnFocusLoss) {
     auto *me = static_cast<QMouseEvent *>(event); // NOLINT
     QRect const contentRect(0, 0, m_window->width(), m_window->height());
     if (!contentRect.contains(me->position().toPoint())) { m_ctx.navigation->closeWindow(); }

--- a/src/server/src/qml/qml/FormCheckbox.qml
+++ b/src/server/src/qml/qml/FormCheckbox.qml
@@ -22,16 +22,7 @@ Item {
     }
 
     Keys.onSpacePressed: toggle()
-    Keys.onReturnPressed: event => {
-        if (typeof launcher !== "undefined")
-            event.accepted = launcher.forwardKey(event.key, event.modifiers);
-        if (!event.accepted)
-            toggle();
-    }
-    Keys.onPressed: event => {
-        if (typeof launcher !== "undefined")
-            event.accepted = launcher.forwardKey(event.key, event.modifiers);
-    }
+    Keys.onReturnPressed: toggle()
 
     MouseArea {
         anchors.fill: parent

--- a/src/server/src/qml/qml/FormDateInput.qml
+++ b/src/server/src/qml/qml/FormDateInput.qml
@@ -63,15 +63,6 @@ Item {
                 if (!activeFocus)
                     _validate();
             }
-
-            Keys.onReturnPressed: event => {
-                if (typeof launcher !== "undefined")
-                    event.accepted = launcher.forwardKey(event.key, event.modifiers);
-            }
-            Keys.onPressed: event => {
-                if (typeof launcher !== "undefined")
-                    event.accepted = launcher.forwardKey(event.key, event.modifiers);
-            }
         }
     }
 

--- a/src/server/src/qml/qml/FormFilePicker.qml
+++ b/src/server/src/qml/qml/FormFilePicker.qml
@@ -178,17 +178,8 @@ FocusScope {
         focus: true
         activeFocusOnTab: false
 
-        Keys.onReturnPressed: event => {
-            if (typeof launcher !== "undefined")
-                event.accepted = launcher.forwardKey(event.key, event.modifiers);
-            if (!event.accepted)
-                root._openDialog();
-        }
+        Keys.onReturnPressed: root._openDialog()
         Keys.onSpacePressed: root._openDialog()
-        Keys.onPressed: event => {
-            if (typeof launcher !== "undefined")
-                event.accepted = launcher.forwardKey(event.key, event.modifiers);
-        }
     }
 
     function _appendUnique(existing, newPaths) {

--- a/src/server/src/qml/qml/FormTextArea.qml
+++ b/src/server/src/qml/qml/FormTextArea.qml
@@ -107,16 +107,7 @@ Item {
                         event.accepted = true;
                         nextItemInFocusChain(false)?.forceActiveFocus(Qt.BacktabFocusReason);
                     }
-                    Keys.onReturnPressed: event => {
-                        if (typeof launcher !== "undefined")
-                            event.accepted = launcher.forwardKey(event.key, event.modifiers);
-                        if (!event.accepted)
-                            edit.insert(edit.cursorPosition, "\n");
-                    }
-                    Keys.onPressed: event => {
-                        if (typeof launcher !== "undefined")
-                            event.accepted = launcher.forwardKey(event.key, event.modifiers);
-                    }
+                    Keys.onReturnPressed: edit.insert(edit.cursorPosition, "\n")
                 }
             }
         }

--- a/src/server/src/qml/qml/FormTextInput.qml
+++ b/src/server/src/qml/qml/FormTextInput.qml
@@ -63,15 +63,6 @@ Item {
 
             onTextEdited: root.textEdited()
             onAccepted: root.accepted()
-
-            Keys.onReturnPressed: event => {
-                if (typeof launcher !== "undefined")
-                    event.accepted = launcher.forwardKey(event.key, event.modifiers);
-            }
-            Keys.onPressed: event => {
-                if (typeof launcher !== "undefined")
-                    event.accepted = launcher.forwardKey(event.key, event.modifiers);
-            }
         }
     }
 }

--- a/src/server/src/qml/qml/SearchableDropdown.qml
+++ b/src/server/src/qml/qml/SearchableDropdown.qml
@@ -117,20 +117,13 @@ Item {
         return from;
     }
 
-    Keys.onReturnPressed: event => {
-        if (event.modifiers !== Qt.NoModifier && typeof launcher !== "undefined") {
-            event.accepted = launcher.forwardKey(event.key, event.modifiers);
-        } else if (!dropdownPopup.visible) {
+    Keys.onReturnPressed: {
+        if (!dropdownPopup.visible)
             open();
-        }
     }
     Keys.onSpacePressed: {
         if (!dropdownPopup.visible)
             open();
-    }
-    Keys.onPressed: event => {
-        if (typeof launcher !== "undefined")
-            event.accepted = launcher.forwardKey(event.key, event.modifiers);
     }
 
     Rectangle {


### PR DESCRIPTION
we use an event filter at the launcher window level to filter input before it gets dispatched to QML