### PR TITLE
feat: make font rendering type configurable

### DIFF
--- a/extra/config.jsonc
+++ b/extra/config.jsonc
@@ -59,6 +59,11 @@
 	"keybinding": "default",
 
 	"font": {
+		// Text rendering backend used by Qt Quick text.
+		// "native": uses platform/fontconfig rendering (can have better dark-mode weight/clarity)
+		// "qt": uses Qt distance-field rendering (typically better performance for heavy scaling/animation)
+		"rendering": "qt",
+
 		// The font family to use for the general vicinae UI.
 		// "auto" (recommended): uses the bundled Inter font
 		// "system": uses the system/platform default font

--- a/src/server/src/cli/server.cpp
+++ b/src/server/src/cli/server.cpp
@@ -46,6 +46,7 @@
 #include "vicinae.hpp"
 #include <filesystem>
 #include <QGuiApplication>
+#include <QQuickWindow>
 #include <csignal>
 #include <QString>
 #include <qlockfile.h>
@@ -56,6 +57,14 @@
 #include "server.hpp"
 
 namespace fs = std::filesystem;
+
+static void applyTextRenderingMode(const config::FontConfig &fontConfig) {
+  if (fontConfig.rendering == "qt") {
+    QQuickWindow::setTextRenderType(QQuickWindow::QtTextRendering);
+  } else {
+    QQuickWindow::setTextRenderType(QQuickWindow::NativeTextRendering);
+  }
+}
 
 void CliServerCommand::setup(CLI::App *app) {
   app->add_flag("--open", m_open, "Open the main window once the server is started");
@@ -99,6 +108,7 @@ void CliServerCommand::run(CLI::App *) {
   int argc = 1;
   static char *argv[] = {strdup("command"), nullptr};
   QGuiApplication const qapp(argc, argv);
+  QQuickWindow::setTextRenderType(QQuickWindow::NativeTextRendering);
 
   if (const auto launcher = Environment::detectAppLauncher()) {
     qInfo() << "Detected launch prefix:" << *launcher;
@@ -256,6 +266,8 @@ void CliServerCommand::run(CLI::App *) {
     bool const themeChangeRequired = nextTheme.name != prevTheme.name;
 
     IconThemeDatabase const iconThemeDb;
+
+    applyTextRenderingMode(next.font);
 
     theme.setFontBasePointSize(next.font.normal.size);
 

--- a/src/server/src/config/config.hpp
+++ b/src/server/src/config/config.hpp
@@ -129,6 +129,8 @@ template <> struct Partial<WindowConfig> {
 };
 
 struct FontConfig {
+  std::string rendering = "qt";
+
   struct {
     std::string family = "auto";
     float size = 10.5;
@@ -136,6 +138,8 @@ struct FontConfig {
 };
 
 template <> struct Partial<FontConfig> {
+  std::optional<std::string> rendering;
+
   struct {
     std::optional<std::string> family;
     std::optional<float> size;

--- a/src/server/src/config/template.hpp
+++ b/src/server/src/config/template.hpp
@@ -33,6 +33,11 @@ const std::string_view TEMPLATE = R"({
 	"keybinding": "default",
 
 	"font": {
+		// Text rendering backend for Qt Quick text.
+		// 'native' follows system/fontconfig rendering (can be better on dark themes).
+		// 'qt' uses Qt distance field rendering (usually faster for scaling/animations).
+		"rendering": "qt",
+
 		"normal": {
 			// The font family to use for the general vicinae UI.
 			"family": "auto",

--- a/src/server/src/qml/general-settings-model.cpp
+++ b/src/server/src/qml/general-settings-model.cpp
@@ -70,6 +70,11 @@ void GeneralSettingsModel::setWindowOpacity(const QString &v) {
     cfgManager().mergeWithUser({.launcherWindow = config::Partial<config::WindowConfig>{.opacity = val}});
 }
 
+bool GeneralSettingsModel::nativeTextRendering() const { return cfg().font.rendering != "qt"; }
+void GeneralSettingsModel::setNativeTextRendering(bool v) {
+  cfgManager().mergeWithUser({.font = config::Partial<config::FontConfig>{.rendering = v ? "native" : "qt"}});
+}
+
 QString GeneralSettingsModel::fontSize() const { return QString::number(cfg().font.normal.size); }
 void GeneralSettingsModel::setFontSize(const QString &v) {
   bool ok = false;

--- a/src/server/src/qml/general-settings-model.hpp
+++ b/src/server/src/qml/general-settings-model.hpp
@@ -19,6 +19,8 @@ class GeneralSettingsModel : public QObject {
   Q_PROPERTY(bool clientSideDecorations READ clientSideDecorations WRITE setClientSideDecorations NOTIFY
                  configChanged)
   Q_PROPERTY(QString windowOpacity READ windowOpacity WRITE setWindowOpacity NOTIFY configChanged)
+  Q_PROPERTY(
+      bool nativeTextRendering READ nativeTextRendering WRITE setNativeTextRendering NOTIFY configChanged)
   Q_PROPERTY(QString fontSize READ fontSize WRITE setFontSize NOTIFY configChanged)
   Q_PROPERTY(QVariantList themeItems READ themeItems NOTIFY configChanged)
   Q_PROPERTY(QVariantList fontItems READ fontItems NOTIFY configChanged)
@@ -55,6 +57,8 @@ public:
   void setClientSideDecorations(bool v);
   QString windowOpacity() const;
   void setWindowOpacity(const QString &v);
+  bool nativeTextRendering() const;
+  void setNativeTextRendering(bool v);
   QString fontSize() const;
   void setFontSize(const QString &v);
 

--- a/src/server/src/qml/qml/AdvancedSettingsPage.qml
+++ b/src/server/src/qml/qml/AdvancedSettingsPage.qml
@@ -91,6 +91,15 @@ Flickable {
         }
 
         SettingsRow {
+            label: "Native font rendering"
+            description: "Use platform/fontconfig text rendering for system-consistent text. Disable for Qt distance-field rendering (usually faster). May require reopening Vicinae to fully apply."
+            SettingsToggle {
+                checked: root.model.nativeTextRendering
+                onToggled: root.model.nativeTextRendering = checked
+            }
+        }
+
+        SettingsRow {
             label: "Favicon Fetching"
             description: "The favicon provider used to load favicons where needed. Select 'None' to turn off favicon loading."
             SearchableDropdown {


### PR DESCRIPTION
Qt Quick's default distance-field text rendering can appear noticeably thinner, hairier or generally inconsistent on dark backgrounds. This is very noticeable on certain types of displays and looks fairly broken/poor quality. It mostly applies to light text on dark backgrounds, but can also be noticeable against light backgrounds. Users on Linux have system-level fontconfig settings that could provide better rendering results if used and there is an expectation that they will be used wherever possible.

I added a configurable text rendering mode that allows users to choose between two different rendering types:

* Native: Uses platform/fontconfig. Depending on the config - results in thicker, sharper text that respects system font settings
* Qt: Uses Qt's distance-field rendering for potentially better performance with scaling and animations, which I left as the default

Changes:

- Expose text rendering toggle in Advanced Settings page
- add toggle in Advanced Settings UI ("Native font rendering")
- Apply text rendering mode globally on startup and when config change

Added documentation in config templates and example config as well

---

Demo

This requires some explaining. Display types behave very differently on different setups. This demo was taken on a 34" 3440x1440 curved VA display, which does not tolerate poor font rendering at all. For you, it might not be that different, or might look worse, which is why this is an option and not a new default. Demos are difficult to translate between screens, but try to:
1. Open either the video or the GIF (GIF is easier - just open it in a new tab)
2. View in **100% 1:1 scaling** - that means disabling any "Retina" type screen scaling settings and zooming out to 100%
2. Test on different display types and devices 
3. Be considerate to people's preferences if it looks a certain way for you - as it might not look the same to them.

Personally I strongly prefer Windows' RGB subpixel antialiasing font rendering, so I prefer when my new option is enabled.

My demo isn't very good as I needed to cause a rerender (by changing the search query), but the loop will show you the difference pretty clearly.

GIF version (click to open in new tab and view at proper scaling):
![vicinae_font_rendering_fix](https://github.com/user-attachments/assets/6a62448c-9356-4a8e-a74b-6d378ad32012)

MP4 version:
https://github.com/user-attachments/assets/44d4c077-1334-4979-a737-3e2dc801f687

---

My font config:
<details><summary>Click to expand</summary>

```xml
<fontconfig>
 <match target="font">
  <edit mode="assign" name="lcdfilter">
   <const>lcddefault</const>
  </edit>
 </match>
 <match target="font">
  <edit mode="assign" name="rgba">
   <const>rgb</const>
  </edit>
 </match>
 <match target="font">
  <edit mode="assign" name="hinting">
   <bool>true</bool>
  </edit>
 </match>
 <match target="font">
  <edit mode="assign" name="hintstyle">
   <const>hintslight</const>
  </edit>
 </match>
 <dir>~/.local/share/fonts</dir>
 <match target="font">
  <edit mode="assign" name="antialias">
   <bool>true</bool>
  </edit>
 </match>
</fontconfig>
```
Plus,
`FREETYPE_PROPERTIES=cff:no-stem-darkening=0 autofitter:no-stem-darkening=0 type1:no-stem-darkening=0 t1cid:no-stem-darkening=0`

</details>