### PR TITLE
fix: Add padding to menu list

### DIFF
--- a/src/server/src/qml/qml/SettingsSidebar.qml
+++ b/src/server/src/qml/qml/SettingsSidebar.qml
@@ -124,6 +124,7 @@ Item {
             Layout.fillWidth: true
             Layout.fillHeight: true
             clip: true
+            bottomMargin: 8
             boundsBehavior: Flickable.StopAtBounds
             model: root._allItems
 


### PR DESCRIPTION
Before:
<img width="358" height="181" alt="image" src="https://github.com/user-attachments/assets/8916255e-4cc9-43a0-a0c0-bf39ceedc088" />

After:
<img width="358" height="181" alt="image" src="https://github.com/user-attachments/assets/0e745037-40fe-4268-89e9-f1a14d5c41e8" />
