### PR TITLE
fix: correctly wait for the custom locker to be done executing

### DIFF
--- a/src/server/src/extensions/power-management/power-management-extension.cpp
+++ b/src/server/src/extensions/power-management/power-management-extension.cpp
@@ -78,7 +78,7 @@ class LockCommand : public BuiltinCallbackCommand {
       QProcess process;
 
       process.start(program);
-      if (!process.waitForFinished()) { toast->failure("Failed to lock using custom program " + program); }
+      if (!process.waitForFinished(-1)) { toast->failure("Failed to lock using custom program " + program); }
     } else {
       if (!pm->provider()->canLock()) {
         toast->failure("System can't lock");


### PR DESCRIPTION
When specifying a custom locker in the power management options, it would get killed 30 seconds after locking the session.
The `QProcess` used to launch the custom locker is destroyed (and kills the underlying program) after the call to `waitForFinished()`, which only waits 30s by default. Using `waitForFinished(-1)` fixes the issue.

Running a debug build of vicinae gives this warning (`loquet` being the custom locker):
```
[18:20:47.638] WARN   -  QProcess: Destroyed while process ("loquet") is still running.
```