### PR TITLE
fix: Do not render copied md/html

### DIFF
--- a/src/server/src/qml/qml/ClipboardHistoryView.qml
+++ b/src/server/src/qml/qml/ClipboardHistoryView.qml
@@ -143,6 +143,7 @@ Item {
 
                                 Text {
                                     text: delegateLoader.title
+                                    textFormat: Text.PlainText
                                     color: itemDelegate.selected ? Theme.listItemSelectionFg : Theme.foreground
                                     font.pointSize: Theme.regularFontSize
                                     elide: Text.ElideRight

--- a/src/server/src/qml/qml/TextViewer.qml
+++ b/src/server/src/qml/qml/TextViewer.qml
@@ -13,6 +13,7 @@ ScrollView {
     Text {
         width: root.availableWidth
         text: root.text
+        textFormat: Text.PlainText
         color: Theme.foreground
         font.pointSize: Theme.smallerFontSize
         font.family: root.monospace ? "monospace" : undefined


### PR DESCRIPTION
Closes https://github.com/vicinaehq/vicinae/issues/1244

Before:
<img width="765" height="265" alt="image" src="https://github.com/user-attachments/assets/6e8c90c8-3a02-40c0-9e60-33d31708a7ff" />



After:
<img width="765" height="265" alt="image" src="https://github.com/user-attachments/assets/ccdd3b2f-8ccd-4d20-9e41-98ddac517510" />
