### PR TITLE
feat(theme): override subtitle colors on hover/selection

### DIFF
--- a/extra/theme-template.toml
+++ b/extra/theme-template.toml
@@ -63,6 +63,10 @@ foreground = "#e8e6e1"
 hover = { background = "#bb2e2e2e" }
 focus = { outline = "colors.core.accent" }
 
+[colors.list.item.hover]
+foreground = "#e8e6e1"
+secondary_foreground = "#e8e6e1"
+
 [colors.list.item.selection]
 background = "#2e2e2e"
 foreground = "#e8e6e1"

--- a/src/server/src/qml/qml/ListItemDelegate.qml
+++ b/src/server/src/qml/qml/ListItemDelegate.qml
@@ -59,7 +59,7 @@ SelectableDelegate {
                 anchors.verticalCenter: parent.verticalCenter
                 width: Math.min(implicitWidth, textRow.availableForText - textRow.subtitleReserved)
                 text: root.itemTitle
-                color: root.selected ? Theme.listItemSelectionFg : Theme.foreground
+                color: root.selected ? Theme.listItemSelectionFg : root.hovered ? Theme.listItemHoverFg : Theme.foreground
                 font.pointSize: Theme.regularFontSize
                 elide: Text.ElideRight
                 maximumLineCount: 1
@@ -73,7 +73,7 @@ SelectableDelegate {
                 anchors.verticalCenter: parent.verticalCenter
                 width: Math.min(implicitWidth, Math.max(0, textRow.availableForText - titleText.width - textRow.spacing))
                 text: root.itemSubtitle
-                color: Theme.textMuted
+                color: root.selected ? Theme.listItemSecondarySelectionFg : root.hovered ? Theme.listItemSecondaryHoverFg : Theme.textMuted
                 font.pointSize: Theme.smallerFontSize
                 elide: Text.ElideRight
                 maximumLineCount: 1

--- a/src/server/src/qml/theme-bridge.hpp
+++ b/src/server/src/qml/theme-bridge.hpp
@@ -24,6 +24,9 @@ class ThemeBridge : public QObject {
   Q_PROPERTY(QColor divider READ divider NOTIFY changed)
   Q_PROPERTY(QColor secondaryBackground READ secondaryBackground NOTIFY changed)
   Q_PROPERTY(QColor listItemSelectionFg READ listItemSelectionFg NOTIFY changed)
+  Q_PROPERTY(QColor listItemHoverFg READ listItemHoverFg NOTIFY changed)
+  Q_PROPERTY(QColor listItemSecondarySelectionFg READ listItemSecondarySelectionFg NOTIFY changed)
+  Q_PROPERTY(QColor listItemSecondaryHoverFg READ listItemSecondaryHoverFg NOTIFY changed)
   Q_PROPERTY(QColor scrollBarBackground READ scrollBarBackground NOTIFY changed)
   Q_PROPERTY(QColor gridItemBackground READ gridItemBackground NOTIFY changed)
   Q_PROPERTY(QColor gridItemSelectionOutline READ gridItemSelectionOutline NOTIFY changed)
@@ -61,6 +64,11 @@ public:
   QColor listItemSelectionBg() const { return resolve(SemanticColor::ListItemSelectionBackground); }
   QColor listItemSelectionFg() const { return resolve(SemanticColor::ListItemSelectionForeground); }
   QColor listItemHoverBg() const { return resolve(SemanticColor::ListItemHoverBackground); }
+  QColor listItemHoverFg() const { return resolve(SemanticColor::ListItemHoverForegroud); }
+  QColor listItemSecondarySelectionFg() const {
+    return resolve(SemanticColor::ListItemSecondarySelectionForeground);
+  }
+  QColor listItemSecondaryHoverFg() const { return resolve(SemanticColor::ListItemSecondaryHoverForeground); }
   QColor accent() const { return resolve(SemanticColor::Accent); }
   QColor statusBarBackground() const { return resolve(SemanticColor::StatusBarBackground); }
   QColor mainWindowBorder() const { return resolve(SemanticColor::MainWindowBorder); }

--- a/src/server/src/theme/colors.hpp
+++ b/src/server/src/theme/colors.hpp
@@ -30,6 +30,7 @@ enum SemanticColor : std::uint8_t {
   ListItemHoverBackground,
   ListItemHoverForegroud,
   ListItemSecondaryHoverBackground,
+  ListItemSecondaryHoverForeground,
   ListItemSecondarySelectionBackground,
   ListItemSecondarySelectionForeground,
 

--- a/src/server/src/theme/theme-file.cpp
+++ b/src/server/src/theme/theme-file.cpp
@@ -131,6 +131,8 @@ QColor ThemeFile::deriveSemantic(SemanticColor color) const {
     return resolve(SemanticColor::ListItemSelectionForeground);
   case SemanticColor::ListItemSecondarySelectionBackground:
     return resolve(SemanticColor::ListItemSelectionBackground);
+  case SemanticColor::ListItemSecondaryHoverForeground:
+    return resolve(SemanticColor::ListItemSecondarySelectionForeground);
   case SemanticColor::ListItemSecondaryHoverBackground:
     return isDark() ? resolve(SemanticColor::ListItemSecondarySelectionBackground).darker(110)
                     : resolve(SemanticColor::ListItemSecondarySelectionBackground).lighter(110);

--- a/src/server/src/theme/theme-parser.cpp
+++ b/src/server/src/theme/theme-parser.cpp
@@ -54,6 +54,7 @@ static const std::vector<std::pair<std::string, SemanticColor>> recognizedKeys =
 
     {"list.item.hover.background", SemanticColor::ListItemHoverBackground},
     {"list.item.hover.foreground", SemanticColor::ListItemHoverForegroud},
+    {"list.item.hover.secondary_foreground", SemanticColor::ListItemSecondaryHoverForeground},
     {"list.item.selection.background", SemanticColor::ListItemSelectionBackground},
     {"list.item.selection.foreground", SemanticColor::ListItemSelectionForeground},
     {"list.item.selection.secondary_background", SemanticColor::ListItemSecondarySelectionBackground},


### PR DESCRIPTION
Adds support for:
- `colors.list.item.hover.secondary_foreground`
- `colors.list.item.selection.secondary_foreground`

fixes #1229