### PR TITLE
[fix] Force cancel to focus onAboutToShow

### DIFF
--- a/src/server/src/qml/qml/AlertDialog.qml
+++ b/src/server/src/qml/qml/AlertDialog.qml
@@ -13,8 +13,10 @@ Popup {
 
     property bool _confirmed: false
 
-    onAboutToShow: _confirmed = false
-    onOpened: Qt.callLater(cancelBtn.forceActiveFocus)
+	onAboutToShow: {
+		_confirmed = false;
+		Qt.callLater(cancelBtn.forceActiveFocus);
+	}
     onClosed: {
         if (!_confirmed)
             launcher.alertModel.cancel();


### PR DESCRIPTION
Move the forceActiveFocus call to onAboutToShow instead of onOpened to prevent focus to change after the alert has been opened.

Fixes #1257

Note: I tried running make format but it formatted around 30 files unrelated to the PR. Is this known? Am I doing something wrong?