### PR TITLE
feat: Add text selection and context menu to markdown view

### DIFF
--- a/src/server/src/qml/markdown/text-selection-controller.cpp
+++ b/src/server/src/qml/markdown/text-selection-controller.cpp
@@ -141,6 +141,8 @@ QString TextSelectionController::linkAt(QQuickItem *textEdit, qreal containerX, 
 }
 
 void TextSelectionController::handlePress(qreal x, qreal y) {
+  if (m_flickable) m_flickable->forceActiveFocus(Qt::MouseFocusReason);
+
   // Triple-click: press shortly after double-click at same spot → select all
   if (m_doubleClickTimer.isValid() && m_doubleClickTimer.elapsed() < 400 &&
       std::hypot(x - m_doubleClickPos.x(), y - m_doubleClickPos.y()) < DRAG_THRESHOLD) {

--- a/src/server/src/qml/qml/markdown/MarkdownView.qml
+++ b/src/server/src/qml/qml/markdown/MarkdownView.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import QtQuick.Effects
 import Vicinae
 
 Item {
@@ -213,6 +214,79 @@ Item {
     Shortcut {
         sequence: StandardKey.SelectAll
         onActivated: root._controller.selectAll()
+    }
+
+    Popup {
+        id: selectionMenu
+        width: 160
+        topPadding: 6
+        bottomPadding: 6
+        leftPadding: Config.borderWidth
+        rightPadding: Config.borderWidth
+
+        // Make it disappear nicely when clicking elsewhere
+        focus: true
+        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+
+        background: Rectangle {
+            radius: Config.borderRounding
+            color: Qt.rgba(Theme.statusBarBackground.r, Theme.statusBarBackground.g, Theme.statusBarBackground.b, 1)
+            border.color: Theme.mainWindowBorder
+            border.width: Config.borderWidth
+
+            layer.enabled: true
+            layer.effect: MultiEffect {
+                autoPaddingEnabled: true
+                shadowEnabled: true
+                shadowBlur: 0.4
+                shadowColor: Qt.rgba(0, 0, 0, 0.25)
+                shadowVerticalOffset: 4
+            }
+        }
+
+        contentItem: ColumnLayout {
+            spacing: 0
+
+            ActionItemDelegate {
+                Layout.fillWidth: true
+                title: "Copy"
+                iconSource: ""
+                shortcutTokens: []
+                isSubmenu: false
+                isDanger: false
+                opacity: root._controller.hasSelection ? 1.0 : 0.5
+                enabled: root._controller.hasSelection
+
+                onClicked: {
+                    root._controller.copy();
+                    selectionMenu.close();
+                }
+            }
+
+            ActionItemDelegate {
+                Layout.fillWidth: true
+                title: "Select All"
+                iconSource: ""
+                shortcutTokens: []
+                isSubmenu: false
+                isDanger: false
+
+                onClicked: {
+                    root._controller.selectAll();
+                    selectionMenu.close();
+                }
+            }
+        }
+    }
+
+    TapHandler {
+        acceptedButtons: Qt.RightButton
+        onTapped: eventPoint => {
+            root.forceActiveFocus();
+            selectionMenu.x = eventPoint.position.x;
+            selectionMenu.y = eventPoint.position.y;
+            selectionMenu.open();
+        }
     }
 
     Connections {


### PR DESCRIPTION
When using an extension I noticed it was impossible to copy text since both Ctrl+C and right click paths are not disabled for MarkdownView, unless there is a copy button on a code block, yet it was possible to select text, which is fairly confusing from a UX standpoint. This PR enables keyboard shortcuts and adds a right-click context menu for the view.

Context menu uses the ActionItemDelegate component for visual consistency. Screenshots below with two different themes, it should work nicely and look great with all themes.

Extension used for demo: [ChatGPT (Raycast)](https://www.raycast.com/abielzulio/chatgpt)

<img width="493" height="268" alt="Screenshot_20260326_233529" src="https://github.com/user-attachments/assets/7c9e54d8-b7a4-49e3-9633-0a4fdf6d7c88" />

<img width="492" height="281" alt="Screenshot_20260326_233548" src="https://github.com/user-attachments/assets/11680b0c-9dc0-4679-b572-f08c4ea0845f" />
