### PR TITLE
fix(form): fixes vertical padding for forms

### DIFF
--- a/src/server/src/qml/qml/FormView.qml
+++ b/src/server/src/qml/qml/FormView.qml
@@ -8,6 +8,8 @@ Flickable {
     contentHeight: layout.implicitHeight
     clip: true
     boundsBehavior: Flickable.StopAtBounds
+    bottomMargin: root.padding
+    topMargin: root.padding
 
     default property alias contentData: layout.data
     property real padding: 16
@@ -39,10 +41,6 @@ Flickable {
         width: Math.min(root.width - root.padding * 2, root.maxContentWidth)
         x: (root.width - width) / 2
         spacing: 12
-
-        Item {
-            implicitHeight: 12
-        }
     }
 
     Connections {


### PR DESCRIPTION
This pr fixes an issue with the vertical padding in forms.
Currently there is only top padding not bottom padding.

Before:
https://github.com/user-attachments/assets/4a93a95b-eb9b-4f67-89f7-dc28c02f04ec

After:
https://github.com/user-attachments/assets/96ba9163-2e65-49fc-bfe9-0a64d637a1af



