### PR TITLE
fix: fixes issue where holding backspace triggers popOnBackspace

### DIFF
--- a/src/server/src/qml/qml/SearchBar.qml
+++ b/src/server/src/qml/qml/SearchBar.qml
@@ -290,7 +290,7 @@ Item {
                         event.accepted = true;
                     } else if (_handleNavigation(event)) {
                         event.accepted = true;
-                    } else if (event.key === Qt.Key_Backspace && searchInput.text === "" && !launcher.isRootSearch && launcher.showBackButton && launcher.popOnBackspace) {
+                    } else if (event.key === Qt.Key_Backspace && searchInput.text === "" && !event.isAutoRepeat && !launcher.isRootSearch && launcher.showBackButton && launcher.popOnBackspace) {
                         launcher.goBack();
                         event.accepted = true;
                     } else if (event.key === Qt.Key_Space && launcher.isRootSearch && event.modifiers === Qt.NoModifier) {


### PR DESCRIPTION
This pull request proposes a small change to the backspace handling logic in the `SearchBar.qml` component. I have found it annoying that holding the backspace to erase the search input almost always ends up with me on the roots search. 

Now, pressing and holding the backspace key will not repeatedly trigger the "go back" action only a single, non-repeated backspace press will do so.

Fixes #1117

