### PR TITLE
fix: changes labels for multiline fields from vertical-center to top-left aligned

### DIFF
--- a/src/server/src/qml/qml/CreateExtensionFormView.qml
+++ b/src/server/src/qml/qml/CreateExtensionFormView.qml
@@ -45,6 +45,7 @@ Item {
             id: descriptionField
             label: "Description"
             error: root.host.descriptionError
+            topAlignLabel: true
 
             FormTextArea {
                 text: root.host.description
@@ -102,6 +103,7 @@ Item {
             id: cmdDescField
             label: "Description"
             error: root.host.commandDescriptionError
+            topAlignLabel: true
 
             FormTextArea {
                 text: root.host.commandDescription

--- a/src/server/src/qml/qml/EditKeywordsFormView.qml
+++ b/src/server/src/qml/qml/EditKeywordsFormView.qml
@@ -18,6 +18,7 @@ Item {
         FormField {
             label: "Keywords"
             info: root.host.infoText
+            topAlignLabel: true
 
             FormTextArea {
                 id: textArea

--- a/src/server/src/qml/qml/ExtensionFormView.qml
+++ b/src/server/src/qml/qml/ExtensionFormView.qml
@@ -168,6 +168,7 @@ Item {
             label: parent.label
             error: parent.error
             info: parent.info
+            topAlignLabel: true
 
             function focusField() {
                 textArea.forceActiveFocus();
@@ -279,6 +280,7 @@ Item {
             }
 
             readonly property var _fd: parent.fieldData || ({})
+            topAlignLabel: filePicker.multiple
 
             FormFilePicker {
                 id: filePicker

--- a/src/server/src/qml/qml/FormField.qml
+++ b/src/server/src/qml/qml/FormField.qml
@@ -9,6 +9,8 @@ ColumnLayout {
     property string label: ""
     property string error: ""
     property string info: ""
+    property bool topAlignLabel: false
+    property real topAlignLabelTopPadding: 8
     default property alias contentData: contentSlot.data
 
     RowLayout {
@@ -18,12 +20,13 @@ ColumnLayout {
         Text {
             Layout.preferredWidth: 2
             Layout.fillWidth: true
+            Layout.topMargin: root.topAlignLabel ? root.topAlignLabelTopPadding : 0
             text: root.label
             color: Theme.textMuted
             font.pointSize: Theme.smallerFontSize
             horizontalAlignment: Text.AlignRight
-            verticalAlignment: Text.AlignVCenter
-            Layout.alignment: Qt.AlignVCenter
+            verticalAlignment: root.topAlignLabel ? Text.AlignTop : Text.AlignVCenter
+            Layout.alignment: root.topAlignLabel ? Qt.AlignTop : Qt.AlignVCenter
         }
 
         Item {

--- a/src/server/src/qml/qml/MissingPreferenceView.qml
+++ b/src/server/src/qml/qml/MissingPreferenceView.qml
@@ -164,6 +164,7 @@ Item {
             id: field
             label: parent.label
             info: parent.description
+            topAlignLabel: missingFilePicker.multiple
 
             FormFilePicker {
                 id: missingFilePicker

--- a/src/server/src/qml/qml/PreferenceFormView.qml
+++ b/src/server/src/qml/qml/PreferenceFormView.qml
@@ -132,6 +132,7 @@ Item {
             id: field
             label: parent.label
             info: parent.description
+            topAlignLabel: prefFilePicker.multiple
 
             FormFilePicker {
                 id: prefFilePicker

--- a/src/server/src/qml/qml/SnippetFormView.qml
+++ b/src/server/src/qml/qml/SnippetFormView.qml
@@ -29,6 +29,7 @@ Item {
             label: "Content"
             error: root.host.contentError
             info: "You can use {dynamic placeholders} to make the content dynamic. No autocomplete is available for now."
+            topAlignLabel: true
 
             FormTextArea {
                 text: root.host.content


### PR DESCRIPTION
This pr changes the position of form labels for multi line inputs.

The way it is now with the label vertically centered make the reading flow of the form a little of. Your eyes have dart around to gather all the context of the field. 

This changes them top top-left aligned instead

<img width="853" height="600" alt="image" src="https://github.com/user-attachments/assets/c94ac9c5-3c11-41d4-8527-5725bec825c9" />
<img width="854" height="600" alt="image" src="https://github.com/user-attachments/assets/d8817735-80c5-4c8f-a6a3-096daaa39c4f" />
