### PR TITLE
style: move the page icon, name, and toggle to the topbar

### DIFF
--- a/src/server/src/qml/qml/ExtensionSettingsPage.qml
+++ b/src/server/src/qml/qml/ExtensionSettingsPage.qml
@@ -6,7 +6,8 @@ Item {
     id: root
     readonly property var extModel: settings.extensionModel
     readonly property string providerId: settings.currentPage
-
+    readonly property real contentWidth: Math.min(width, 680)
+    readonly property real sideMargin: (width - contentWidth) / 2
     Component.onCompleted: {
         root.extModel.commandModel.setFilter("");
         root.extModel.selectProviderById(root.providerId);
@@ -38,18 +39,6 @@ Item {
 
     property string expandedCommandId: ""
 
-    SettingsToggle {
-        id: enableToggle
-        visible: root.extModel.selectedIsProvider
-        checked: root.extModel.selectedEnabled
-        anchors.top: parent.top
-        anchors.right: parent.right
-        anchors.topMargin: 12
-        anchors.rightMargin: 20
-        z: 1
-        onToggled: root.extModel.setEnabled(root.extModel.selectedRow, checked)
-    }
-
     Flickable {
         id: cmdFlickable
         anchors.fill: parent
@@ -75,67 +64,47 @@ Item {
             width: cmdFlickable.width
             spacing: 0
 
-            readonly property real contentWidth: Math.min(width, 680)
-            readonly property real sideMargin: (width - contentWidth) / 2
-
-            Item {
-                implicitHeight: 24
-            }
-
             ColumnLayout {
-                Layout.alignment: Qt.AlignHCenter
+                visible: root.extModel.selectedDescription !== ""
                 Layout.fillWidth: true
-                Layout.leftMargin: contentColumn.sideMargin + 20
-                Layout.rightMargin: contentColumn.sideMargin + 20
-                spacing: 8
-
-                ViciImage {
-                    source: root.extModel.selectedIconSource
-                    Layout.preferredWidth: 48
-                    Layout.preferredHeight: 48
-                    Layout.alignment: Qt.AlignHCenter
-                }
+                Layout.leftMargin: root.sideMargin + 20
+                Layout.rightMargin: root.sideMargin + 20
+                Layout.topMargin: 16
+                spacing: 0
 
                 Text {
-                    text: root.extModel.selectedTitle
+                    text: "Description"
                     color: Theme.foreground
-                    font.pointSize: Theme.regularFontSize + 2
+                    font.pointSize: Theme.regularFontSize
                     font.bold: true
-                    horizontalAlignment: Text.AlignHCenter
-                    Layout.fillWidth: true
+                    Layout.bottomMargin: 8
                 }
 
                 Text {
-                    visible: root.extModel.selectedDescription !== ""
                     text: root.extModel.selectedDescription
                     color: Theme.textMuted
                     font.pointSize: Theme.regularFontSize
-                    horizontalAlignment: Text.AlignHCenter
                     wrapMode: Text.Wrap
                     Layout.fillWidth: true
                 }
-            }
 
-            Item {
-                visible: root.extModel.hasPreferences || root.extModel.commandModel.totalCount > 0
-                implicitHeight: 16
-            }
+                Item {
+                    implicitHeight: 16
+                }
 
-            Rectangle {
-                visible: root.extModel.hasPreferences || root.extModel.commandModel.totalCount > 0
-                Layout.fillWidth: true
-                Layout.leftMargin: contentColumn.sideMargin + 20
-                Layout.rightMargin: contentColumn.sideMargin + 20
-                height: 1
-                color: Theme.divider
+                Rectangle {
+                    Layout.fillWidth: true
+                    height: 1
+                    color: Theme.divider
+                }
             }
 
             // Provider preferences
             ColumnLayout {
                 visible: root.extModel.hasPreferences
                 Layout.fillWidth: true
-                Layout.leftMargin: contentColumn.sideMargin + 20
-                Layout.rightMargin: contentColumn.sideMargin + 20
+                Layout.leftMargin: root.sideMargin + 20
+                Layout.rightMargin: root.sideMargin + 20
                 Layout.topMargin: 16
                 spacing: 0
 
@@ -167,8 +136,8 @@ Item {
             RowLayout {
                 visible: root.extModel.commandModel.totalCount > 0
                 Layout.fillWidth: true
-                Layout.leftMargin: contentColumn.sideMargin + 20
-                Layout.rightMargin: contentColumn.sideMargin + 20
+                Layout.leftMargin: root.sideMargin + 20
+                Layout.rightMargin: root.sideMargin + 20
                 Layout.topMargin: 16
                 Layout.bottomMargin: 8
                 spacing: 8
@@ -282,8 +251,8 @@ Item {
                             anchors.left: parent.left
                             anchors.right: parent.right
                             anchors.verticalCenter: parent.verticalCenter
-                            anchors.leftMargin: contentColumn.sideMargin + 20
-                            anchors.rightMargin: contentColumn.sideMargin + 20
+                            anchors.leftMargin: root.sideMargin + 20
+                            anchors.rightMargin: root.sideMargin + 20
                             spacing: 10
 
                             ViciImage {
@@ -380,8 +349,8 @@ Item {
                                 anchors.top: parent.top
                                 anchors.left: parent.left
                                 anchors.right: parent.right
-                                anchors.leftMargin: contentColumn.sideMargin + 20
-                                anchors.rightMargin: contentColumn.sideMargin + 20
+                                anchors.leftMargin: root.sideMargin + 20
+                                anchors.rightMargin: root.sideMargin + 20
                                 height: 1
                                 color: Theme.divider
                             }
@@ -391,8 +360,8 @@ Item {
                                 anchors.left: parent.left
                                 anchors.right: parent.right
                                 anchors.top: parent.top
-                                anchors.leftMargin: contentColumn.sideMargin + 52
-                                anchors.rightMargin: contentColumn.sideMargin + 20
+                                anchors.leftMargin: root.sideMargin + 52
+                                anchors.rightMargin: root.sideMargin + 20
                                 anchors.topMargin: 12
                                 spacing: 8
 
@@ -423,8 +392,9 @@ Item {
             }
 
             Item {
-                implicitHeight: 24
+                implicitHeight: 4
             }
         }
     }
 }
+

--- a/src/server/src/qml/qml/SettingsSidebar.qml
+++ b/src/server/src/qml/qml/SettingsSidebar.qml
@@ -50,73 +50,84 @@ Item {
         anchors.fill: parent
         spacing: 0
 
-        Rectangle {
+        Item {
             Layout.fillWidth: true
-            Layout.leftMargin: 8
-            Layout.rightMargin: 8
-            Layout.topMargin: 12
-            Layout.bottomMargin: 8
-            height: 28
-            radius: 4
-            color: "transparent"
-            border.color: extSearchField.activeFocus ? Theme.inputBorderFocus : Theme.inputBorder
-            border.width: 1
+            Layout.preferredHeight: 40
 
-            RowLayout {
-                anchors.fill: parent
-                anchors.leftMargin: 6
-                anchors.rightMargin: 6
-                spacing: 4
+            Rectangle {
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.leftMargin: 8
+                anchors.rightMargin: 8
+                anchors.verticalCenter: parent.verticalCenter
+                height: 28
+                radius: 4
+                color: "transparent"
+                border.color: extSearchField.activeFocus ? Theme.inputBorderFocus : Theme.inputBorder
+                border.width: 1
 
-                Image {
-                    source: "image://vicinae/builtin:magnifying-glass?fg=" + Theme.textMuted
-                    sourceSize.width: 12
-                    sourceSize.height: 12
-                    Layout.preferredWidth: 12
-                    Layout.preferredHeight: 12
-                }
+                RowLayout {
+                    anchors.fill: parent
+                    anchors.leftMargin: 6
+                    anchors.rightMargin: 6
+                    spacing: 4
 
-                TextInput {
-                    id: extSearchField
-                    Layout.fillWidth: true
-                    Layout.fillHeight: true
-                    verticalAlignment: TextInput.AlignVCenter
-                    font.pointSize: Theme.smallerFontSize
-                    color: Theme.foreground
-                    clip: true
-                    focus: true
-                    activeFocusOnTab: true
+                    Image {
+                        source: "image://vicinae/builtin:magnifying-glass?fg=" + Theme.textMuted
+                        sourceSize.width: 12
+                        sourceSize.height: 12
+                        Layout.preferredWidth: 12
+                        Layout.preferredHeight: 12
+                    }
 
-                    Connections {
-                        target: settings
-                        function onDefaultFocusRequested() {
-                            extSearchField.forceActiveFocus();
+                    TextInput {
+                        id: extSearchField
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                        verticalAlignment: TextInput.AlignVCenter
+                        font.pointSize: Theme.smallerFontSize
+                        color: Theme.foreground
+                        clip: true
+                        focus: true
+                        activeFocusOnTab: true
+
+                        Connections {
+                            target: settings
+                            function onDefaultFocusRequested() {
+                                extSearchField.forceActiveFocus();
+                            }
                         }
-                    }
 
-                    Text {
-                        anchors.fill: parent
-                        verticalAlignment: Text.AlignVCenter
-                        text: "Search..."
-                        color: Theme.textPlaceholder
-                        font: extSearchField.font
-                        visible: !extSearchField.text
-                    }
+                        Text {
+                            anchors.fill: parent
+                            verticalAlignment: Text.AlignVCenter
+                            text: "Search..."
+                            color: Theme.textPlaceholder
+                            font: extSearchField.font
+                            visible: !extSearchField.text
+                        }
 
-                    onTextChanged: root._highlightedIndex = root._navItems.length > 0 ? 0 : -1
+                        onTextChanged: root._highlightedIndex = root._navItems.length > 0 ? 0 : -1
 
-                    Keys.onUpPressed: root._navigateHighlight(-1)
-                    Keys.onDownPressed: root._navigateHighlight(1)
-                    Keys.onReturnPressed: root._activateHighlighted()
-                    Keys.onEnterPressed: root._activateHighlighted()
-                    Keys.onPressed: event => {
-                        if (event.key === Qt.Key_Escape && text) {
-                            text = "";
-                            event.accepted = true;
+                        Keys.onUpPressed: root._navigateHighlight(-1)
+                        Keys.onDownPressed: root._navigateHighlight(1)
+                        Keys.onReturnPressed: root._activateHighlighted()
+                        Keys.onEnterPressed: root._activateHighlighted()
+                        Keys.onPressed: event => {
+                            if (event.key === Qt.Key_Escape && text) {
+                                text = "";
+                                event.accepted = true;
+                            }
                         }
                     }
                 }
             }
+        }
+
+        Rectangle {
+            Layout.fillWidth: true
+            height: 1
+            color: Theme.divider
         }
 
         ListView {
@@ -125,6 +136,7 @@ Item {
             Layout.fillHeight: true
             clip: true
             bottomMargin: 8
+            topMargin: 6
             boundsBehavior: Flickable.StopAtBounds
             model: root._allItems
 

--- a/src/server/src/qml/qml/SettingsWindow.qml
+++ b/src/server/src/qml/qml/SettingsWindow.qml
@@ -3,6 +3,43 @@ import QtQuick.Layouts
 
 Window {
     id: root
+    readonly property var extModel: settings.extensionModel
+    readonly property bool isExtensionPage: settings.currentPage !== "general" && settings.currentPage !== "keybindings" && settings.currentPage !== "advanced" && settings.currentPage !== "about"
+    readonly property string topbarTitle: {
+        if (root.isExtensionPage)
+            return root.extModel.selectedTitle;
+
+        switch (settings.currentPage) {
+        case "general":
+            return "General";
+        case "keybindings":
+            return "Keybindings";
+        case "advanced":
+            return "Advanced";
+        case "about":
+            return "About";
+        default:
+            return "";
+        }
+    }
+    readonly property var topbarIconSource: {
+        if (root.isExtensionPage)
+            return root.extModel.selectedIconSource;
+
+        switch (settings.currentPage) {
+        case "general":
+            return Img.builtin("cog").withFillColor(Theme.foreground);
+        case "keybindings":
+            return Img.builtin("keyboard").withFillColor(Theme.foreground);
+        case "advanced":
+            return Img.builtin("wrench-screwdriver").withFillColor(Theme.foreground);
+        case "about":
+            return Img.builtin("vicinae").withFillColor(Theme.foreground);
+        default:
+            return "";
+        }
+    }
+
     width: 860
     height: 540
     minimumWidth: 860
@@ -44,33 +81,75 @@ Window {
                 Layout.fillHeight: true
                 spacing: 0
 
-                // Header with close button
+                // Header with page metadata and close button
                 Item {
                     Layout.fillWidth: true
                     Layout.preferredHeight: 40
 
-                    Rectangle {
-                        id: closeBtn
-                        anchors.right: parent.right
+                    RowLayout {
+                        anchors.fill: parent
+                        anchors.leftMargin: 20
                         anchors.rightMargin: 12
-                        anchors.verticalCenter: parent.verticalCenter
-                        width: 24
-                        height: 24
-                        radius: 12
-                        color: closeHover.hovered ? Qt.rgba(Theme.listItemHoverBg.r, Theme.listItemHoverBg.g, Theme.listItemHoverBg.b, Config.windowOpacity) : "transparent"
+                        spacing: 10
+
+                        ViciImage {
+                            visible: root.topbarIconSource !== ""
+                            source: root.topbarIconSource
+                            Layout.preferredWidth: 20
+                            Layout.preferredHeight: 20
+                            Layout.alignment: Qt.AlignVCenter
+                        }
 
                         Text {
-                            anchors.centerIn: parent
-                            text: "\u2715"
-                            color: closeHover.hovered ? Theme.foreground : Theme.textMuted
-                            font.pixelSize: 12
+                            visible: root.topbarTitle !== ""
+                            text: root.topbarTitle
+                            color: Theme.foreground
+                            font.pointSize: Theme.regularFontSize
+                            font.bold: true
+                            elide: Text.ElideRight
+                            Layout.fillWidth: true
+                            Layout.alignment: Qt.AlignVCenter
                         }
 
-                        HoverHandler {
-                            id: closeHover
+                        Item {
+                            Layout.fillWidth: true
                         }
-                        TapHandler {
-                            onTapped: settings.close()
+
+                        Item {
+                            visible: root.isExtensionPage && root.extModel.selectedIsProvider
+                            Layout.preferredWidth: visible ? headerToggle.implicitWidth : 0
+                            Layout.preferredHeight: visible ? headerToggle.implicitHeight : 0
+                            Layout.alignment: Qt.AlignVCenter
+
+                            SettingsToggle {
+                                id: headerToggle
+                                visible: parent.visible
+                                checked: root.extModel.selectedEnabled
+                                onToggled: root.extModel.setEnabled(root.extModel.selectedRow, checked)
+                            }
+                        }
+
+                        Rectangle {
+                            id: closeBtn
+                            Layout.alignment: Qt.AlignVCenter
+                            width: 24
+                            height: 24
+                            radius: 12
+                            color: closeHover.hovered ? Qt.rgba(Theme.listItemHoverBg.r, Theme.listItemHoverBg.g, Theme.listItemHoverBg.b, Config.windowOpacity) : "transparent"
+
+                            Text {
+                                anchors.centerIn: parent
+                                text: "\u2715"
+                                color: closeHover.hovered ? Theme.foreground : Theme.textMuted
+                                font.pixelSize: 12
+                            }
+
+                            HoverHandler {
+                                id: closeHover
+                            }
+                            TapHandler {
+                                onTapped: settings.close()
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This pr reworks the settings page topbar.

Moves the page icon, name and toggle to the topbar.
Removes the icon and name from the page content to give more space to the settings.

New:
https://github.com/user-attachments/assets/f263df3b-01d2-47ef-ae99-027c016d44e3

Old:
https://github.com/user-attachments/assets/27cb5e8c-c42b-4902-9d3b-d80e0f1d860c

The list of builtin page are hard coded a few places here, but i would say that is okay for simplicity here since they are not likely to change very often
