### PR TITLE
fix: update tsconfig.json boilerplate to be typescript v6 compatible

### DIFF
--- a/extra/extension-boilerplate/tsconfig.json
+++ b/extra/extension-boilerplate/tsconfig.json
@@ -12,6 +12,7 @@
 		"skipLibCheck": true,
 		"forceConsistentCasingInFileNames": true,
 		"resolveJsonModule": true,
-		"jsx": "react-jsx"
+		"jsx": "react-jsx",
+		"types": ["node"]
 	}
 }

--- a/src/lib/emoji/scripts/emoji/tsconfig.json
+++ b/src/lib/emoji/scripts/emoji/tsconfig.json
@@ -104,6 +104,7 @@
 
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true,                                /* Skip type checking all .d.ts files. */
+    "types": ["node"]
   }
 }

--- a/src/typescript/api/tsconfig.json
+++ b/src/typescript/api/tsconfig.json
@@ -10,6 +10,7 @@
 		"forceConsistentCasingInFileNames": true,
 		"strict": true,
 		"noImplicitAny": false,
-		"skipLibCheck": true
+		"skipLibCheck": true,
+		"types": ["node"]
 	}
 }

--- a/src/typescript/extension-manager/tsconfig.json
+++ b/src/typescript/extension-manager/tsconfig.json
@@ -104,6 +104,7 @@
 
 		/* Completeness */
 		// "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-		"skipLibCheck": true /* Skip type checking all .d.ts files. */
+		"skipLibCheck": true, /* Skip type checking all .d.ts files. */
+		"types": ["node"]
 	}
 }

--- a/src/typescript/raycast-api-compat/tsconfig.json
+++ b/src/typescript/raycast-api-compat/tsconfig.json
@@ -15,6 +15,9 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitAny": false,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": [
+      "node"
+    ]
   }
 }


### PR DESCRIPTION
The latest release of VS Code updates the built-in TypeScript compiler to v6. This introduces a breaking change: Node.js types are no longer automatically included. As a result, projects now need to explicitly specify `"types": ["node"]` in their `tsconfig.json`.

More details: https://gist.github.com/privatenumber/3d2e80da28f84ee30b77d53e1693378f

This PR adds the required `types` field to all `tsconfig.json` files in the project, including those in the extension boilerplate.

The change is backward compatible, so projects still using TypeScript v5 should not experience any issues.