### PR TITLE
fix: deprecation message shows wrong docs link

### DIFF
--- a/src/server/src/ipc-command-handler.cpp
+++ b/src/server/src/ipc-command-handler.cpp
@@ -219,7 +219,7 @@ std::expected<void, std::string> IpcCommandHandler::handleUrl(const QUrl &url) {
 
     qWarning().nospace() << "vicinae://extensions is deprecated and will be removed in a future release. "
                             "Please use vicinae://launch instead. See "
-                         << Omnicast::DOC_URL + "/deeplink" << " for more information.";
+                         << Omnicast::DOC_URL + "/deeplinks" << " for more information.";
 
     if (components.size() == 2) {
       QString author = components[0];


### PR DESCRIPTION
This message is shown when using deprecated ways of accessing deeplinks.
The existing link is 404 in the docs.
The correct link should go e.g. https://docs.vicinae.com/deeplinks 
This is super minor...