### PR TITLE
fix: the issue-template referred to deprecated command to report bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ assignees: ''
 > [!WARNING]  
 > If you are able to run Vicinae on your system, you should use the "Report bug" command to create a new issue as it will auto fill version and system information for you (since v0.6.1).
 > You can automatically run it using:
-> ```vicinae vicinae://extensions/vicinae/vicinae/report-bug```
+> ```vicinae vicinae://launch/core/report-bug```
 
 ## **System information**
 


### PR DESCRIPTION
The old shortcut usually was just not doing anything silently. One has to check the vicinae server logs to see that the `extensions` ways of calling things is deprecated, while still not having a clue of how to update the link without further guidace).

The updated link correctly opens the issue template from the command line.