### PR TITLE
fix: close launcher before executing action to avoid race condition

### DIFF
--- a/src/server/src/navigation-controller.cpp
+++ b/src/server/src/navigation-controller.cpp
@@ -447,10 +447,10 @@ void NavigationController::executeAction(AbstractAction *action) {
     }
   }
 
+  if (action->autoClose()) { closeWindow({.clearRootSearch = true}); }
+
   action->execute(&m_ctx);
   closeActionPanel();
-
-  if (action->autoClose()) { closeWindow({.clearRootSearch = true}); }
 }
 
 AbstractAction *NavigationController::findBoundAction(const QKeyEvent *event) const {


### PR DESCRIPTION
Resolves #1047 

I was running into the same issue using `river-classic`. In my case, I was able to successfully swap focus via `vicinae app launch <id>`, but when I did it via the launcher window, the launcher window would close and focus would return to the same window it was on before opening launcher.

As @aurelleb suspected, this seems to have been caused by some sort of race condition in the WM related to closing the launcher window immediately after executing the switch window action. Moving this line such that the launcher window is closed *before* executing the action fixes the issue for me. 