### PR TITLE
Reintroduce Solarized dark and light themes

### DIFF
--- a/extra/themes/solarized-dark.toml
+++ b/extra/themes/solarized-dark.toml
@@ -1,0 +1,31 @@
+[meta]
+version = 1
+name = "Solarized Dark"
+description = "Low-contrast theme designed to reduce eye strain"
+variant = "dark"
+inherits = "vicinae-dark"
+icon = "icons/solarized.png"
+
+[colors.core]
+background = "#002B36"
+foreground = "#839496"
+secondary_background = "#073642"
+border = "#586E75"
+accent = "#268BD2"
+
+[colors.accents]
+blue = "#268BD2"
+green = "#859900"
+magenta = "#D33682"
+orange = "#CB4B16"
+purple = "#6C71C4"
+red = "#DC322F"
+yellow = "#B58900"
+cyan = "#2AA198"
+
+[colors.list.item.selection]
+background = "#073642"
+secondary_background = "#586E75"
+
+[colors.list.item.hover]
+background = "#073642"

--- a/extra/themes/solarized-dark.toml
+++ b/extra/themes/solarized-dark.toml
@@ -1,3 +1,6 @@
+# Solarized Dark - Low Contrast
+# Low-contrast theme designed to reduce eye strain
+
 [meta]
 version = 1
 name = "Solarized Dark"
@@ -7,25 +10,24 @@ inherits = "vicinae-dark"
 icon = "icons/solarized.png"
 
 [colors.core]
+accent = "#268BD2"
 background = "#002B36"
+border = "#586E75"
 foreground = "#839496"
 secondary_background = "#073642"
-border = "#586E75"
-accent = "#268BD2"
 
 [colors.accents]
 blue = "#268BD2"
+cyan = "#2AA198"
 green = "#859900"
 magenta = "#D33682"
 orange = "#CB4B16"
 purple = "#6C71C4"
 red = "#DC322F"
 yellow = "#B58900"
-cyan = "#2AA198"
-
-[colors.list.item.selection]
-background = "#073642"
-secondary_background = "#586E75"
 
 [colors.list.item.hover]
-background = "#073642"
+background = { name = "colors.core.border", opacity = 0.1, lighter = 10, darker = 10  }
+
+[colors.list.item.selection]
+background = { name = "colors.core.border", opacity = 0.15, lighter = 5, darker = 15  }

--- a/extra/themes/solarized-light.toml
+++ b/extra/themes/solarized-light.toml
@@ -1,0 +1,31 @@
+[meta]
+version = 1
+name = "Solarized Light"
+description = "Light variant of the popular Solarized theme"
+variant = "light"
+inherits = "vicinae-light"
+icon = "icons/solarized.png"
+
+[colors.core]
+background = "#FDF6E3"
+foreground = "#657B83"
+secondary_background = "#EEE8D5"
+border = "#839496"
+accent = "#268BD2"
+
+[colors.accents]
+blue = "#268BD2"
+green = "#859900"
+magenta = "#D33682"
+orange = "#CB4B16"
+purple = "#6C71C4"
+red = "#DC322F"
+yellow = "#B58900"
+cyan = "#2AA198"
+
+[colors.list.item.selection]
+background = "#EEE8D5"
+secondary_background = "#F6F0DC"
+
+[colors.list.item.hover]
+background = "#F7F2E5"

--- a/extra/themes/solarized-light.toml
+++ b/extra/themes/solarized-light.toml
@@ -1,3 +1,6 @@
+# Solarized Light - Low Contrast Light
+# Light variant of the popular Solarized theme
+
 [meta]
 version = 1
 name = "Solarized Light"
@@ -7,25 +10,25 @@ inherits = "vicinae-light"
 icon = "icons/solarized.png"
 
 [colors.core]
+accent = "#268BD2"
 background = "#FDF6E3"
+border = "#839496"
 foreground = "#657B83"
 secondary_background = "#EEE8D5"
-border = "#839496"
-accent = "#268BD2"
 
 [colors.accents]
 blue = "#268BD2"
+cyan = "#2AA198"
 green = "#859900"
 magenta = "#D33682"
 orange = "#CB4B16"
 purple = "#6C71C4"
 red = "#DC322F"
 yellow = "#B58900"
-cyan = "#2AA198"
 
-[colors.list.item.selection]
-background = "#EEE8D5"
-secondary_background = "#F6F0DC"
 
 [colors.list.item.hover]
-background = "#F7F2E5"
+background = { name = "colors.core.border", opacity = 0.05, darker = 6  }
+
+[colors.list.item.selection]
+background = { name = "colors.core.border", opacity = 0.1, darker = 6  }


### PR DESCRIPTION
## Overview

Reintroduces Solarized Dark and Solarized Light as TOML themes.

These themes were previously removed in 643fbac and are now added back using the current TOML-based theme format introduced in v0.15.0.

I kept the implementation intentionally small by overriding only the core Solarized palette and a few list state colors, while inheriting the rest from the default vicinae base themes.

Tested locally by loading both themes from the theme selector and through the CLI.

### Solarized Dark

<img width="957" height="659" alt="solarized-dark" src="https://github.com/user-attachments/assets/58ec6321-7f09-45cc-927e-00a7020754f4" />

### Solarized Light

<img width="957" height="659" alt="solarized-light" src="https://github.com/user-attachments/assets/ea309669-a3a6-47b3-8086-c4fad93d33eb" />