### PR TITLE
Feat (Installer script): Fixed installation crash on Immutable Distros and Improved UX

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -24,7 +24,15 @@ DOCS_URL="https://docs.vicinae.com/install/script"
 
 TEMP_FILES=()
 PRESERVE_FILES=()
- 
+
+WARNINGS=()
+
+warn() {
+  echo -e "  \033[1;33m⚠ WARNING:\033[0m $1" >&2
+  WARNINGS+=("$1")
+}
+ok() { echo -e "  \033[0;32m✓\033[0m $1" >&2; }
+
 cleanup() {
 	rm -f $VICINAE_SCRIPT_PATH
 	for file in "${TEMP_FILES[@]}"; do
@@ -89,7 +97,8 @@ check_dependencies() {
 		exit 1
 	fi
 
-	echo "✓ All dependencies found"
+	ok "All dependencies found"
+	echo 
 }
 
 check_permissions() {
@@ -104,7 +113,7 @@ check_permissions() {
 		echo ""
 
 		if [[ $EUID -eq 0 ]]; then
-			echo "✓ Running as root"
+			ok "Running as root"
 		else
 			# Check for available privilege escalation tools
 			local escalation_cmd=""
@@ -144,7 +153,8 @@ check_permissions() {
 			exec $escalation_cmd "$VICINAE_SCRIPT_PATH" "${ORIGINAL_ARGS[@]}"
 		fi
 	else
-		echo "✓ Have write permissions to $PREFIX"
+		ok "Have write permissions to $PREFIX"
+		echo
 	fi
 }
 
@@ -171,9 +181,10 @@ get_latest_release_info() {
 		exit 1
 	fi
 
-	echo "✓ Latest version: $tag_name" >&2
-	echo "✓ AppImage asset: $appimage_name" >&2
+	ok "Latest version: $tag_name"
+	ok "AppImage asset: $appimage_name"
 	echo "$tag_name|$appimage_name"
+	echo
 }
 
 get_installed_version() {
@@ -221,7 +232,7 @@ download_appimage() {
 	local download_url="https://github.com/$REPO/releases/download/$version/$appimage_name"
 
 	if [[ -f "$download_path" && -x "$download_path" ]]; then
-		echo "✓ Using cached AppImage: $download_path" >&2
+		ok "Using cached AppImage: $download_path"
 		PRESERVE_FILES+=("$download_path")
 		echo "$download_path"
 		return 0
@@ -234,7 +245,7 @@ download_appimage() {
 	if curl -L --progress-bar "$download_url" -o "$download_path"; then
 		chmod +x "$download_path"
 		PRESERVE_FILES+=("$download_path") # Keep for future runs
-		echo "✓ Download completed: $download_path" >&2
+		ok "Download completed: $download_path"
 		echo "$download_path"
 	else
 		echo "Error: Failed to download AppImage" >&2
@@ -263,7 +274,7 @@ extract_appimage() {
 		if [[ -d "squashfs-root" ]]; then
 			mv squashfs-root/* squashfs-root/.[!.]* . 2>/dev/null || true
 			rmdir squashfs-root 2>/dev/null || rm -rf squashfs-root
-			echo "✓ Extraction completed" >&2
+			ok "Extraction completed"
 			echo "$extract_dir"
 			rm $extract_logs
 			rm $appimage_path
@@ -290,7 +301,8 @@ install_themes() {
 		cp -r "$themes_source"/* "$THEMES_DIR/" 2>/dev/null || true
 
 		if [[ -n "$(ls -A "$THEMES_DIR" 2>/dev/null)" ]]; then
-			echo "✓ Themes installed to $THEMES_DIR" >&2
+			ok "Themes installed to $THEMES_DIR"
+			echo
 		else
 			echo "Note: No themes found in $themes_source" >&2
 		fi
@@ -310,12 +322,13 @@ install_desktop_files() {
 		# Copy only vicinae-related desktop files
 		if ls "$applications_source"/vicinae*.desktop >/dev/null 2>&1; then
 			cp "$applications_source"/vicinae*.desktop "$APPLICATIONS_DIR/" 2>/dev/null || true
-			echo "✓ Desktop files installed to $APPLICATIONS_DIR" >&2
+			ok "Desktop files installed to $APPLICATIONS_DIR"
 
 			# Update desktop database if available
 			if command -v update-desktop-database >/dev/null 2>&1; then
 				update-desktop-database "$APPLICATIONS_DIR" 2>/dev/null || true
-				echo "✓ Desktop database updated" >&2
+				ok "Desktop database updated"
+				echo
 			fi
 		else
 			echo "Note: No vicinae desktop files found in $applications_source" >&2
@@ -326,53 +339,63 @@ install_desktop_files() {
 }
 
 install_browser_manifests() {
-	echo "Installing browser native messaging manifests..." >&2
+    echo "Installing browser native messaging manifests..." >&2
 
-	local templates_dir="$INSTALL_DIR/usr/share/vicinae/native-messaging-hosts"
-	local native_host_bin="$INSTALL_DIR/usr/libexec/vicinae/vicinae-browser-link"
-	local chrome_extension_id="com.vicinae.vicinae"
+    local templates_dir="$INSTALL_DIR/usr/share/vicinae/native-messaging-hosts"
+    local native_host_bin="$INSTALL_DIR/usr/libexec/vicinae/vicinae-browser-link"
+    local chrome_extension_id="com.vicinae.vicinae"
 
-	if [[ ! -d "$templates_dir" ]]; then
-		echo "Note: No browser manifest templates found" >&2
-		return
-	fi
+    if [[ ! -d "$templates_dir" ]]; then
+        echo "Note: No browser manifest templates found" >&2
+        return
+    fi
 
-	if [[ $EUID -ne 0 ]]; then
-		echo "Note: Skipping browser native messaging manifest installation (not root)" >&2
-		echo "  See https://docs.vicinae.com for manual setup instructions." >&2
-		return
-	fi
+    if [[ $EUID -ne 0 ]]; then
+        warn "Note: Skipping browser native messaging manifest installation (not root)"
+        echo "  See $DOCS_URL for manual setup instructions." >&2
+        return
+    fi
 
 	# Chromium
-	local chromium_dest="/etc/chromium/native-messaging-hosts"
-	local chromium_template="$templates_dir/com.vicinae.vicinae.chromium.json.in"
-	if [[ -f "$chromium_template" ]]; then
-		mkdir -p "$chromium_dest"
-		sed -e "s|@NATIVE_HOST_BIN@|$native_host_bin|g" \
-			-e "s|@CHROME_EXTENSION_ID@|$chrome_extension_id|g" \
-			"$chromium_template" > "$chromium_dest/com.vicinae.vicinae.json"
-		echo "✓ Chromium native messaging manifest installed to $chromium_dest" >&2
-	fi
+    local chromium_dest="/etc/chromium/native-messaging-hosts"
+    local chromium_template="$templates_dir/com.vicinae.vicinae.chromium.json.in"
+    if [[ -f "$chromium_template" ]]; then
+        if ! mkdir -p "$chromium_dest" 2>/tmp/vic.err; then
+            warn "Chromium: cannot create $chromium_dest"
+        elif ! sed -e "s|@NATIVE_HOST_BIN@|$native_host_bin|g" \
+                   -e "s|@CHROME_EXTENSION_ID@|$chrome_extension_id|g" \
+                   "$chromium_template" > "$chromium_dest/com.vicinae.vicinae.json" 2>/tmp/vic.err; then
+            warn "Chromium: failed to write manifest"
+        else
+            ok "Chromium native messaging manifest installed to $chromium_dest"
+        fi
+    fi
 
 	# Firefox
-	local firefox_dest="/usr/lib/mozilla/native-messaging-hosts"
-	local firefox_template="$templates_dir/com.vicinae.vicinae.firefox.json.in"
-	if [[ -f "$firefox_template" ]]; then
-		mkdir -p "$firefox_dest"
-		sed -e "s|@NATIVE_HOST_BIN@|$native_host_bin|g" \
-			"$firefox_template" > "$firefox_dest/com.vicinae.vicinae.json"
-		echo "✓ Firefox native messaging manifest installed to $firefox_dest" >&2
-	fi
+    local firefox_dest="/usr/lib/mozilla/native-messaging-hosts"
+    local firefox_template="$templates_dir/com.vicinae.vicinae.firefox.json.in"
+    if [[ -f "$firefox_template" ]]; then
+        if ! mkdir -p "$firefox_dest" 2>/tmp/vic.err; then
+            warn "Firefox: cannot create $firefox_dest"
+        elif ! sed -e "s|@NATIVE_HOST_BIN@|$native_host_bin|g" \
+                   "$firefox_template" > "$firefox_dest/com.vicinae.vicinae.json" 2>/tmp/vic.err; then
+            warn "Firefox: failed to write manifest"
+			echo
+        else
+            ok "Firefox native messaging manifest installed"
+        fi
+    fi
 }
 
 install_udev_rules() {
-	echo "Installing udev rules and modules-load config (for paste support)..." >&2
+    	echo "Installing udev rules and modules-load config (for paste support)..." >&2
 
-	if [[ $EUID -ne 0 ]]; then
-		echo "Note: Skipping udev rules installation (not root)" >&2
-		echo "  Paste support requires /dev/uinput access. See https://docs.vicinae.com for manual setup." >&2
-		return
-	fi
+    if [[ $EUID -ne 0 ]]; then
+        warn "Note: Skipping udev rules installation (not root)"
+		warn "  Paste support requires /dev/uinput access. See https://docs.vicinae.com for manual setup."
+
+        return
+    fi
 
 	local udev_source="$INSTALL_DIR/usr/lib/udev/rules.d"
 	local udev_dest="$PREFIX/lib/udev/rules.d"
@@ -380,26 +403,24 @@ install_udev_rules() {
 	local modules_dest="$PREFIX/lib/modules-load.d"
 
 	if [[ -d "$udev_source" ]]; then
-		mkdir -p "$udev_dest"
-		cp "$udev_source"/* "$udev_dest/" 2>/dev/null || true
-		echo "✓ udev rules installed to $udev_dest" >&2
-
-		if command -v udevadm >/dev/null 2>&1; then
-			udevadm control --reload-rules 2>/dev/null || true
-			udevadm trigger 2>/dev/null || true
-			echo "✓ udev rules reloaded" >&2
+        if ! mkdir -p "$udev_dest" 2>/tmp/vic.err || ! cp "$udev_source"/* "$udev_dest/" 2>/tmp/vic.err; then
+            warn "udev rules: cannot write to $udev_dest"
+        else
+            ok "udev rules installed to $udev_dest"
+            command -v udevadm >/dev/null && udevadm control --reload-rules 2>/dev/null || true
+			ok "udev rules reloaded"
 		fi
 	fi
 
 	if [[ -d "$modules_source" ]]; then
 		mkdir -p "$modules_dest"
 		cp "$modules_source"/* "$modules_dest/" 2>/dev/null || true
-		echo "✓ modules-load config installed to $modules_dest" >&2
+		ok "modules-load config installed to $modules_dest"
 
 		# Load uinput module immediately if not already loaded
 		if ! lsmod | grep -q "^uinput"; then
 			modprobe uinput 2>/dev/null || true
-			echo "✓ uinput module loaded" >&2
+			ok "uinput module loaded"
 		fi
 	fi
 }
@@ -419,12 +440,13 @@ install_systemd_service() {
 		# Replace 'vicinae' with absolute path in ExecStart
 		sed -i "s|ExecStart=vicinae|ExecStart=$BIN_DIR/$BINARY_NAME|g" "$service_dest"
 
-		echo "✓ Systemd service installed to $service_dest" >&2
+		ok "Systemd service installed to $service_dest"
 
 		# Reload systemd user daemon if available
 		if command -v systemctl >/dev/null 2>&1; then
 			systemctl --user daemon-reload 2>/dev/null || true
-			echo "✓ Systemd user daemon reloaded" >&2
+			ok "Systemd user daemon reloaded"
+			echo
 		fi
 	else
 		echo "Note: Systemd service file not found at $service_source" >&2
@@ -456,7 +478,7 @@ install_vicinae() {
 		local node_path="$INSTALL_DIR/usr/bin/node"
 		if [[ -f "$node_path" ]]; then
 			ln -sf "$node_path" "$BIN_DIR/vicinae-node"
-			echo "✓ Node.js binary symlinked to $BIN_DIR/vicinae-node" >&2
+			ok "Node.js binary symlinked to $BIN_DIR/vicinae-node"
 		fi
 
 		# After successful installation, mark the AppImage for cleanup
@@ -465,7 +487,8 @@ install_vicinae() {
 			TEMP_FILES+=("$2")
 		fi
 
-		echo "✓ Installation completed" >&2
+		ok "Installation completed"
+		echo
 
 		# Install themes, desktop files, systemd service, and system configs
 		install_themes
@@ -486,31 +509,31 @@ uninstall_vicinae() {
 
 	if [[ -d "$INSTALL_DIR" ]]; then
 		rm -rf "$INSTALL_DIR"
-		echo "✓ Removed installation directory: $INSTALL_DIR"
+		ok "Removed installation directory: $INSTALL_DIR"
 	else
 		echo "No installation directory found"
 	fi
 
 	if [[ -L "$BIN_DIR/$BINARY_NAME" ]]; then
 		rm -f "$BIN_DIR/$BINARY_NAME"
-		echo "✓ Removed binary symlink: $BIN_DIR/$BINARY_NAME"
+		ok "Removed binary symlink:	    $BIN_DIR/$BINARY_NAME"
 	else
 		echo "No binary symlink found"
 	fi
 
 	if [[ -L "$BIN_DIR/vicinae-node" ]]; then
 		rm -f "$BIN_DIR/vicinae-node"
-		echo "✓ Removed Node.js symlink: $BIN_DIR/vicinae-node"
+		ok "Removed Node.js symlink: 	    $BIN_DIR/vicinae-node"
 	fi
 
 	if [[ -d "$THEMES_DIR" ]]; then
 		rm -rf "$THEMES_DIR"
-		echo "✓ Removed themes directory: $THEMES_DIR"
+		ok "Removed themes directory: 	    $THEMES_DIR"
 	fi
 
 	if ls "$APPLICATIONS_DIR"/vicinae*.desktop >/dev/null 2>&1; then
 		rm -f "$APPLICATIONS_DIR"/vicinae*.desktop
-		echo "✓ Removed desktop files from: $APPLICATIONS_DIR"
+		ok "Removed desktop files from:     $APPLICATIONS_DIR"
 		# Update desktop database if available
 		if command -v update-desktop-database >/dev/null 2>&1; then
 			update-desktop-database "$APPLICATIONS_DIR" 2>/dev/null || true
@@ -524,7 +547,7 @@ uninstall_vicinae() {
 			systemctl --user disable "$SYSTEMD_SERVICE_NAME" 2>/dev/null || true
 		fi
 		rm -f "$SYSTEMD_USER_DIR/$SYSTEMD_SERVICE_NAME"
-		echo "✓ Removed systemd service: $SYSTEMD_USER_DIR/$SYSTEMD_SERVICE_NAME"
+		ok "Removed systemd service: 	    $SYSTEMD_USER_DIR/$SYSTEMD_SERVICE_NAME"
 		# Reload systemd user daemon
 		if command -v systemctl >/dev/null 2>&1; then
 			systemctl --user daemon-reload 2>/dev/null || true
@@ -533,28 +556,29 @@ uninstall_vicinae() {
 
 	if [[ -f "$PREFIX/lib/udev/rules.d/70-vicinae.rules" ]]; then
 		rm -f "$PREFIX/lib/udev/rules.d/70-vicinae.rules"
-		echo "✓ Removed udev rules"
+		ok "Removed udev rules"
 		if command -v udevadm >/dev/null 2>&1; then
 			udevadm control --reload-rules 2>/dev/null || true
 		fi
 	fi
 	if [[ -f "$PREFIX/lib/modules-load.d/vicinae.conf" ]]; then
 		rm -f "$PREFIX/lib/modules-load.d/vicinae.conf"
-		echo "✓ Removed modules-load config"
+		ok "Removed modules-load config"
 	fi
 
 	if [[ $EUID -eq 0 ]]; then
 		if [[ -f "/etc/chromium/native-messaging-hosts/com.vicinae.vicinae.json" ]]; then
 			rm -f "/etc/chromium/native-messaging-hosts/com.vicinae.vicinae.json"
-			echo "✓ Removed Chromium native messaging manifest"
+			ok "Removed Chromium native messaging manifest"
 		fi
 		if [[ -f "/usr/lib/mozilla/native-messaging-hosts/com.vicinae.vicinae.json" ]]; then
 			rm -f "/usr/lib/mozilla/native-messaging-hosts/com.vicinae.vicinae.json"
-			echo "✓ Removed Firefox native messaging manifest"
+			ok "Removed Firefox native messaging manifest"
 		fi
 	fi
 
-	echo "✓ Vicinae has been uninstalled"
+	echo
+	ok "Vicinae has been uninstalled"
 }
 
 show_usage() {
@@ -644,8 +668,10 @@ main() {
 	local installed_version
 	installed_version=$(get_installed_version)
 
-	echo "Installed version: $installed_version"
-	echo "Latest version: $latest_version"
+	echo
+	echo "  Installed version: $installed_version"
+	echo "  Latest version:    $latest_version"
+	echo
 
 	# Check if update is needed
 	if compare_versions "$installed_version" "$latest_version"; then
@@ -665,14 +691,21 @@ main() {
 
 		install_vicinae "$extract_dir" "$appimage_path"
 
-		echo ""
+		if (( ${#WARNINGS[@]} > 0 )); then
+			echo 
+			echo -e "\033[1;33mInstallation completed with ${#WARNINGS[@]} warning(s):\033[0m"
+			for w in "${WARNINGS[@]}"; do
+				echo "  • $w"
+			done
+		fi
+
+		echo 
 		echo "🎉 Vicinae $latest_version has been successfully installed!"
-		echo ""
+		echo 
 
 		# Check if binary directory is in PATH
 		if [[ ":$PATH:" == *":$BIN_DIR:"* ]]; then
-			echo "✓ $BIN_DIR is already in your PATH"
-			echo "You can now run 'vicinae' from anywhere in your terminal."
+			ok "$BIN_DIR is already in your PATH. You can now run 'vicinae' from anywhere in your terminal."
 		else
 			echo "To use Vicinae, add $BIN_DIR to your PATH:"
 			if [[ "$BIN_DIR" == "$HOME"* ]]; then
@@ -691,7 +724,7 @@ main() {
 		echo ""
 		echo "Check the quickstart section for your Desktop Environment at https://docs.vicinae.com"
 	else
-		echo "✓ Vicinae is already up to date ($installed_version)"
+		ok "Vicinae is already up to date"
 	fi
 }
 


### PR DESCRIPTION
- Improved success messages. They are now properly indented and colour coded while preserving the minimal aesthetic.
- Added error handling to the uvdev and browser manifest logic. (the previous script just crashes on the spot on immutable distros)
- Added warning collection to improve UX.  
  
 ‎  
## Previous Install Script : The installation fails
Fails on Immutable Distributions (exactly the ones that would prefer AppImages)  

<img width="1920" height="996" alt="Screenshot From 2026-04-21 20-40-10" src="https://github.com/user-attachments/assets/a37bf8fa-7cde-43af-8f41-f28591f4388b" />  
‎   

## This Version : The installation succeeds, with warnings
Handles the errors, logs a warning and continues.  
_Browser manifests are optional features and should not hard crash._  

<img width="1915" height="1001" alt="Screenshot From 2026-04-21 20-39-10" src="https://github.com/user-attachments/assets/732343aa-9967-48b3-806e-af293b17dc34" />  

## Uninstall & Update Views
I also cleaned up the uninstall and update displays.  

<img width="1424" height="747" alt="Screenshot From 2026-04-21 20-38-03" src="https://github.com/user-attachments/assets/65898b29-df61-4865-96f4-b8aeec408721" />  
‎   

<img width="1416" height="716" alt="Screenshot From 2026-04-21 21-00-15" src="https://github.com/user-attachments/assets/c3cbfbea-2730-4148-9866-2c212e11c9c8" />

‎   
‎   

> **AI Disclosure:** 
Artificial Intelligence was used to co-author this Pull Request