### PR TITLE
fix: scroll viewport to focused window on Hyprland scrolling layout

### DIFF
--- a/src/server/src/actions/wm/window-actions.hpp
+++ b/src/server/src/actions/wm/window-actions.hpp
@@ -8,15 +8,17 @@ class FocusWindowAction : public AbstractAction {
   std::shared_ptr<AbstractWindowManager::AbstractWindow> m_window;
 
   void execute(ApplicationContext *ctx) override {
-    auto wm = ctx->services->windowManager();
-    wm->provider()->focusWindowSync(*m_window.get());
+    auto window = m_window;
+    ctx->navigation->deferUntilWindowHidden([ctx, window]() {
+      auto wm = ctx->services->windowManager();
+      wm->provider()->focusWindowSync(*window.get());
+    });
+    ctx->navigation->closeWindow({.clearRootSearch = true});
   }
 
 public:
   FocusWindowAction(const std::shared_ptr<AbstractWindowManager::AbstractWindow> &window)
-      : AbstractAction("Focus window", ImageURL::builtin("app-window")), m_window(window) {
-    setAutoClose();
-  }
+      : AbstractAction("Focus window", ImageURL::builtin("app-window")), m_window(window) {}
 };
 
 class CloseWindowAction : public AbstractAction {

--- a/src/server/src/navigation-controller.cpp
+++ b/src/server/src/navigation-controller.cpp
@@ -34,6 +34,16 @@ bool NavigationController::hasCompleter() const {
   return false;
 }
 
+void NavigationController::deferUntilWindowHidden(std::function<void()> fn) {
+  m_deferredWindowHiddenAction = std::move(fn);
+}
+
+std::function<void()> NavigationController::takeDeferredWindowHiddenAction() {
+  auto fn = std::move(m_deferredWindowHiddenAction);
+  m_deferredWindowHiddenAction = nullptr;
+  return fn;
+}
+
 void NavigationController::setInstantDismiss(bool value) { m_instantDismiss = value; }
 
 void NavigationController::goBack(const GoBackOptions &opts) {

--- a/src/server/src/navigation-controller.hpp
+++ b/src/server/src/navigation-controller.hpp
@@ -8,6 +8,7 @@
 #include "ui/action-pannel/action.hpp"
 #include "ui/dialog/dialog.hpp"
 #include "ui/image/url.hpp"
+#include <functional>
 #include <QString>
 #include <chrono>
 #include <cstdint>
@@ -263,6 +264,8 @@ public:
   Q_INVOKABLE void toggleWindow();
   bool isWindowOpened() const;
   void requestWindowSize(QSize size);
+  void deferUntilWindowHidden(std::function<void()> fn);
+  std::function<void()> takeDeferredWindowHiddenAction();
 
   bool windowActivated();
   void setWindowActivated(bool value = true);
@@ -398,6 +401,7 @@ private:
   bool m_popToRootOnClose = false;
   bool m_instantDismiss = false;
   bool m_closeOnFocusLoss = false;
+  std::function<void()> m_deferredWindowHiddenAction;
   std::vector<std::unique_ptr<ViewState>> m_views;
   std::optional<PendingPopToRoot> m_pendingPopToRoot;
 };

--- a/src/server/src/qml/launcher-window.cpp
+++ b/src/server/src/qml/launcher-window.cpp
@@ -30,6 +30,7 @@
 #include <QQuickWindow>
 #include <QWindow>
 #include <QKeyEvent>
+#include <QTimer>
 #include <qcoreevent.h>
 #ifdef WAYLAND_LAYER_SHELL
 #include <LayerShellQt/Window>
@@ -309,6 +310,10 @@ void LauncherWindow::handleVisibilityChanged(bool visible) {
     m_window->requestActivate();
   } else {
     m_window->hide();
+
+    if (auto deferred = m_ctx.navigation->takeDeferredWindowHiddenAction()) {
+      QTimer::singleShot(0, this, [deferred = std::move(deferred)]() mutable { deferred(); });
+    }
   }
 }
 

--- a/src/server/src/services/window-manager/hyprland/hyprland.cpp
+++ b/src/server/src/services/window-manager/hyprland/hyprland.cpp
@@ -51,7 +51,8 @@ AbstractWindowManager::WindowPtr HyprlandWindowManager::getFocusedWindowSync() c
 }
 
 void HyprlandWindowManager::focusWindowSync(const AbstractWindow &window) const {
-  Hyprctl::oneshot(std::format("dispatch focuswindow address:{}", window.id().toStdString()));
+  Hyprctl::oneshot(std::format("[[BATCH]]dispatch focuswindow address:{};dispatch layoutmsg fit active",
+                               window.id().toStdString()));
 }
 
 bool HyprlandWindowManager::closeWindow(const AbstractWindow &window) const {

--- a/src/server/src/services/window-manager/hyprland/hyprland.cpp
+++ b/src/server/src/services/window-manager/hyprland/hyprland.cpp
@@ -1,4 +1,5 @@
 #include <format>
+#include <QThread>
 #include "hyprland.hpp"
 #include "services/window-manager/abstract-window-manager.hpp"
 #include "services/window-manager/hyprland/hypr-workspace.hpp"
@@ -6,6 +7,32 @@
 #include "vicinae.hpp"
 
 using Hyprctl = Hyprland::Controller;
+
+namespace {
+bool isScrollingLayout() {
+  auto response = Hyprctl::oneshot("-j/getoption general:layout");
+  auto json = QJsonDocument::fromJson(response);
+
+  if (!json.isObject()) return false;
+
+  return json.object().value("str").toString() == "scrolling";
+}
+
+bool waitUntilFocused(QStringView address, int timeoutMs = 200) {
+  constexpr int pollIntervalMs = 10;
+
+  for (int elapsed = 0; elapsed <= timeoutMs; elapsed += pollIntervalMs) {
+    auto response = Hyprctl::oneshot("-j/activewindow");
+    auto json = QJsonDocument::fromJson(response);
+
+    if (json.isObject() && json.object().value("address").toString() == address) return true;
+
+    QThread::msleep(pollIntervalMs);
+  }
+
+  return false;
+}
+} // namespace
 
 HyprlandWindowManager::HyprlandWindowManager() {
   connect(&m_ev, &Hyprland::EventListener::openwindow, this, [this]() { emit windowsChanged(); });
@@ -51,8 +78,17 @@ AbstractWindowManager::WindowPtr HyprlandWindowManager::getFocusedWindowSync() c
 }
 
 void HyprlandWindowManager::focusWindowSync(const AbstractWindow &window) const {
-  Hyprctl::oneshot(std::format("[[BATCH]]dispatch focuswindow address:{};dispatch layoutmsg fit active",
-                               window.id().toStdString()));
+  const auto activeWorkspace = getActiveWorkspace();
+  const auto targetWorkspace = window.workspace();
+  const bool sameWorkspace = activeWorkspace && targetWorkspace && activeWorkspace->id() == *targetWorkspace;
+
+  Hyprctl::oneshot(std::format("dispatch focuswindow address:{}", window.id().toStdString()));
+
+  if (!sameWorkspace || !isScrollingLayout()) return;
+
+  if (!waitUntilFocused(window.id())) return;
+
+  Hyprctl::oneshot("dispatch layoutmsg center");
 }
 
 bool HyprlandWindowManager::closeWindow(const AbstractWindow &window) const {


### PR DESCRIPTION
**fixes** https://github.com/vicinaehq/vicinae/issues/1329

On Hyprland's scrolling layout, the window switcher focuses the target window but doesn't scroll the viewport to reveal its column. This is because focuswindow only updates compositor-level focus without notifying the layout to adjust the viewport.

Fix: Batch dispatch layoutmsg fit active alongside focuswindow. This tells the scrolling layout to scroll the viewport to the focused column. It's a no-op on other layouts (dwindle, master)
