### PR TITLE
feat: add deeplink to open extension detail view directly

### DIFF
--- a/src/server/src/ipc-command-handler.cpp
+++ b/src/server/src/ipc-command-handler.cpp
@@ -5,7 +5,6 @@
 #include "common/entrypoint.hpp"
 #include "services/oauth/oauth-service.hpp"
 #include "theme/theme-db.hpp"
-#include "root-search/extensions/extension-root-provider.hpp"
 #include "services/root-item-manager/root-item-manager.hpp"
 #include "services/toast/toast-service.hpp"
 #include "settings-controller/settings-controller.hpp"
@@ -27,6 +26,7 @@
 #include "service-registry.hpp"
 #include "theme.hpp"
 #include "qml/provider-search-view-host.hpp"
+#include "qml/vicinae-store-detail-host.hpp"
 #include "ui/toast/toast.hpp"
 #include "vicinae.hpp"
 
@@ -219,92 +219,15 @@ std::expected<void, std::string> IpcCommandHandler::handleUrl(const QUrl &url) {
   }
 
   if (command == "extensions") {
-    auto root = m_ctx.services->rootItemManager();
-    auto components = path.sliced(1).split('/');
+    auto segments = path.sliced(1).split('/', Qt::SkipEmptyParts);
 
-    qWarning().nospace() << "vicinae://extensions is deprecated and will be removed in a future release. "
-                            "Please use vicinae://launch instead. See "
-                         << Omnicast::DOC_URL + "/deeplinks" << " for more information.";
+    if (segments.size() != 2) return std::unexpected("Usage: vicinae://extensions/<author>/<extension-name>");
 
-    if (components.size() == 2) {
-      QString author = components[0];
-      QString extName = components[1];
-      auto pred = [&](const ExtensionRootProvider *s) {
-        return s->repository()->author() == author && s->repository()->name() == extName;
-      };
-
-      auto extensions = root->extensions();
-
-      if (auto it = std::ranges::find_if(extensions, pred); it != extensions.end()) {
-        m_ctx.navigation->popToRoot({.clearSearch = false});
-        m_ctx.navigation->setInstantDismiss();
-        m_ctx.navigation->pushView(new ProviderSearchViewHost(**it));
-
-        if (auto text = query.queryItemValue("fallbackText"); !text.isEmpty()) {
-          m_ctx.navigation->setSearchText(text);
-        }
-
-        return {};
-      }
-
-      return std::unexpected("No such extension");
-    }
-
-    if (components.size() < 3) {
-      qWarning() << "Invalid use of extensions verb: expected format is "
-                    "vicinae://extensions/<author>/<ext_name>/<cmd_name>";
-      return {};
-    }
-
-    QString const &author = components[0];
-    QString const &extName = components[1];
-    QString const &cmdName = components[2];
-
-    for (ExtensionRootProvider const *ext : root->extensions()) {
-      for (const auto &cmd : ext->repository()->commands()) {
-        // Author is suffixed, check author with suffix
-        if (author.contains("@")) {
-          if (cmd->authorSuffixed() != author) continue;
-        } else {
-          // otherwise check plain author name
-          if (cmd->author() != author) continue;
-        }
-
-        if (cmd->commandId() == cmdName && cmd->repositoryName() == extName) {
-          m_ctx.navigation->popToRoot({.clearSearch = false});
-
-          // Read `arguments` query parameter
-          ArgumentValues arguments;
-          if (query.hasQueryItem("arguments")) {
-            QString const argsText = query.queryItemValue("arguments");
-            QJsonParseError parseError;
-            QJsonDocument const doc = QJsonDocument::fromJson(argsText.toUtf8(), &parseError);
-            if (parseError.error == QJsonParseError::NoError && doc.isObject()) {
-              QJsonObject obj = doc.object();
-              for (auto it = obj.begin(); it != obj.end(); ++it) {
-                arguments.emplace_back(it.key(), it.value().toString());
-              }
-            } else {
-              qWarning() << "Failed to parse arguments JSON:" << parseError.errorString();
-            }
-          }
-
-          m_ctx.navigation->setInstantDismiss();
-          m_ctx.navigation->launch(cmd, arguments);
-
-          if (auto text = query.queryItemValue("fallbackText"); !text.isEmpty()) {
-            m_ctx.navigation->setSearchText(text);
-          }
-
-          if (!m_ctx.navigation->isRootSearch() && m_ctx.navigation->activeCommand()->isView()) {
-            m_ctx.navigation->setBackButtonVisibility(false);
-            m_ctx.navigation->showWindow();
-          }
-
-          break;
-        }
-      }
-    }
+    m_ctx.navigation->popToRoot({.clearSearch = false});
+    m_ctx.navigation->setInstantDismiss();
+    m_ctx.navigation->pushView(new VicinaeStoreDetailHost(segments[0], segments[1]));
+    m_ctx.navigation->setBackButtonVisibility(false);
+    m_ctx.navigation->showWindow();
 
     return {};
   }

--- a/src/server/src/ipc-command-handler.cpp
+++ b/src/server/src/ipc-command-handler.cpp
@@ -26,6 +26,7 @@
 #include "service-registry.hpp"
 #include "theme.hpp"
 #include "qml/provider-search-view-host.hpp"
+#include "qml/raycast-store-detail-host.hpp"
 #include "qml/vicinae-store-detail-host.hpp"
 #include "ui/toast/toast.hpp"
 #include "vicinae.hpp"
@@ -223,9 +224,14 @@ std::expected<void, std::string> IpcCommandHandler::handleUrl(const QUrl &url) {
 
     if (segments.size() != 2) return std::unexpected("Usage: vicinae://extensions/<author>/<extension-name>");
 
+    auto scheme = url.scheme();
+    BaseView *host = (scheme == "raycast" || scheme == "com.raycast")
+                         ? static_cast<BaseView *>(new RaycastStoreDetailHost(segments[0], segments[1]))
+                         : static_cast<BaseView *>(new VicinaeStoreDetailHost(segments[0], segments[1]));
+
     m_ctx.navigation->popToRoot({.clearSearch = false});
     m_ctx.navigation->setInstantDismiss();
-    m_ctx.navigation->pushView(new VicinaeStoreDetailHost(segments[0], segments[1]));
+    m_ctx.navigation->pushView(host);
     m_ctx.navigation->setBackButtonVisibility(false);
     m_ctx.navigation->showWindow();
 

--- a/src/server/src/qml/qml/StoreDetailView.qml
+++ b/src/server/src/qml/qml/StoreDetailView.qml
@@ -55,6 +55,7 @@ Item {
         clip: true
         flickableDirection: Flickable.VerticalFlick
         boundsBehavior: Flickable.StopAtBounds
+        visible: root.host.isReady
 
         ColumnLayout {
             id: _content

--- a/src/server/src/qml/raycast-store-detail-host.cpp
+++ b/src/server/src/qml/raycast-store-detail-host.cpp
@@ -1,5 +1,6 @@
 #include "raycast-store-detail-host.hpp"
 #include "actions/extension/extension-actions.hpp"
+#include "empty-view-host.hpp"
 #include "navigation-controller.hpp"
 #include "vicinae.hpp"
 #include "view-utils.hpp"
@@ -13,6 +14,9 @@
 
 RaycastStoreDetailHost::RaycastStoreDetailHost(const Raycast::Extension &extension) : m_ext(extension) {}
 
+RaycastStoreDetailHost::RaycastStoreDetailHost(const QString &authorHandle, const QString &extensionName)
+    : m_authorHandle(authorHandle), m_extensionName(extensionName) {}
+
 QUrl RaycastStoreDetailHost::qmlComponentUrl() const {
   return QUrl(QStringLiteral("qrc:/Vicinae/StoreDetailView.qml"));
 }
@@ -24,9 +28,66 @@ QVariantMap RaycastStoreDetailHost::qmlProperties() {
 void RaycastStoreDetailHost::initialize() {
   BaseView::initialize();
 
+  if (!m_extensionName.isEmpty()) {
+    setLoading(true);
+    auto store = context()->services->raycastStore();
+    auto *watcher = new QFutureWatcher<Raycast::ExtensionResult>(this);
+    watcher->setFuture(store->fetchExtension(m_authorHandle, m_extensionName));
+
+    connect(watcher, &QFutureWatcher<Raycast::ExtensionResult>::finished, this, [this, watcher]() {
+      watcher->deleteLater();
+      auto result = watcher->result();
+      if (!result) {
+        auto id = QString("%1/%2").arg(m_authorHandle, m_extensionName);
+        context()->navigation->replaceView(new EmptyViewHost(
+            "Failed to load extension",
+            QString("The extension \"%1\" could not be loaded. It may not exist or the store may be "
+                    "unreachable.")
+                .arg(id),
+            ImageURL(BuiltinIcon::Exclamationmark).setFill(SemanticColor::Red)));
+        return;
+      }
+
+      hydrate(*result);
+      setLoading(false);
+    });
+    return;
+  }
+
+  hydrate(m_ext);
+}
+
+void RaycastStoreDetailHost::hydrate(const Raycast::Extension &extension) {
+  m_ext = extension;
+  m_isReady = true;
+
   auto registry = context()->services->extensionRegistry();
   m_isInstalled = registry->isInstalled(m_ext.id);
 
+  buildAlert();
+
+  auto icon = m_ext.themedIcon();
+  setNavigationIcon(icon);
+  setNavigationTitle(QString("Extension Store - %1").arg(m_ext.title));
+  createActions();
+  emit extensionChanged();
+
+  connect(registry, &ExtensionRegistry::extensionAdded, this, [this](const QString &id) {
+    if (id != m_ext.id) return;
+    m_isInstalled = true;
+    emit extensionChanged();
+    createActions();
+  });
+
+  connect(registry, &ExtensionRegistry::extensionUninstalled, this, [this](const QString &id) {
+    if (id != m_ext.id) return;
+    m_isInstalled = false;
+    emit extensionChanged();
+    createActions();
+  });
+}
+
+void RaycastStoreDetailHost::buildAlert() {
   const auto &compat = context()->services->raycastStore()->compatMap();
   if (auto it = compat.find(m_ext.name.toStdString()); it != compat.end()) {
     auto tier = Raycast::compatTierFromInfo(it->second);
@@ -72,22 +133,6 @@ void RaycastStoreDetailHost::initialize() {
          QStringLiteral("No compatibility data is available — this extension may or may not work.")},
     };
   }
-
-  createActions();
-
-  connect(registry, &ExtensionRegistry::extensionAdded, this, [this](const QString &id) {
-    if (id != m_ext.id) return;
-    m_isInstalled = true;
-    emit extensionChanged();
-    createActions();
-  });
-
-  connect(registry, &ExtensionRegistry::extensionUninstalled, this, [this](const QString &id) {
-    if (id != m_ext.id) return;
-    m_isInstalled = false;
-    emit extensionChanged();
-    createActions();
-  });
 }
 
 QString RaycastStoreDetailHost::title() const { return m_ext.title; }
@@ -107,6 +152,8 @@ QStringList RaycastStoreDetailHost::platforms() const {
   if (!m_ext.platforms) return {};
   return QStringList(m_ext.platforms->begin(), m_ext.platforms->end());
 }
+
+bool RaycastStoreDetailHost::isReady() const { return m_isReady; }
 bool RaycastStoreDetailHost::isInstalled() const { return m_isInstalled; }
 bool RaycastStoreDetailHost::hasScreenshots() const { return m_ext.metadata_count > 0; }
 
@@ -158,9 +205,7 @@ void RaycastStoreDetailHost::openUrl(const QString &url) {
   ServiceRegistry::instance()->appDb()->openTarget(url);
 }
 
-QString RaycastStoreDetailHost::initialNavigationTitle() const {
-  return QString("%1 - %2").arg(BaseView::initialNavigationTitle()).arg(m_ext.title);
-}
+QString RaycastStoreDetailHost::initialNavigationTitle() const { return QStringLiteral("Extension Store"); }
 
 void RaycastStoreDetailHost::createActions() {
   auto panel = std::make_unique<FormActionPanelState>();

--- a/src/server/src/qml/raycast-store-detail-host.hpp
+++ b/src/server/src/qml/raycast-store-detail-host.hpp
@@ -28,8 +28,10 @@ public:
   Q_PROPERTY(QVariantList contributors READ contributors NOTIFY extensionChanged)
   Q_PROPERTY(QStringList categories READ categories NOTIFY extensionChanged)
   Q_PROPERTY(QVariantMap alert READ alert NOTIFY extensionChanged)
+  Q_PROPERTY(bool isReady READ isReady NOTIFY extensionChanged)
 
   explicit RaycastStoreDetailHost(const Raycast::Extension &extension);
+  RaycastStoreDetailHost(const QString &authorHandle, const QString &extensionName);
 
   QUrl qmlComponentUrl() const override;
   QVariantMap qmlProperties() override;
@@ -42,6 +44,7 @@ public:
   QString authorAvatar() const;
   QString downloadCount() const;
   QStringList platforms() const;
+  bool isReady() const;
   bool isInstalled() const;
   bool hasScreenshots() const;
   QStringList screenshots() const;
@@ -58,8 +61,13 @@ public:
 private:
   QString initialNavigationTitle() const override;
   void createActions();
+  void hydrate(const Raycast::Extension &extension);
+  void buildAlert();
 
   Raycast::Extension m_ext;
+  QString m_authorHandle;
+  QString m_extensionName;
+  bool m_isReady = false;
   bool m_isInstalled = false;
   QVariantMap m_alert;
 };

--- a/src/server/src/qml/vicinae-store-detail-host.cpp
+++ b/src/server/src/qml/vicinae-store-detail-host.cpp
@@ -34,8 +34,9 @@ void VicinaeStoreDetailHost::initialize() {
     watcher->deleteLater();
     auto result = watcher->result();
     if (!result) {
-      context()->services->toastService()->setToast("Failed to fetch extensions", ToastStyle::Danger);
-      setLoading(false);
+      context()->navigation->replaceView(
+          new EmptyViewHost("Failed to load extension", "Could not fetch extension data from the store.",
+                            ImageURL(BuiltinIcon::Exclamationmark).setFill(SemanticColor::Red)));
       return;
     }
 

--- a/src/server/src/qml/vicinae-store-detail-host.cpp
+++ b/src/server/src/qml/vicinae-store-detail-host.cpp
@@ -1,5 +1,6 @@
 #include "vicinae-store-detail-host.hpp"
 #include "actions/extension/extension-actions.hpp"
+#include "empty-view-host.hpp"
 #include "navigation-controller.hpp"
 #include "vicinae.hpp"
 #include "view-utils.hpp"
@@ -10,7 +11,8 @@
 #include "utils/utils.hpp"
 #include <QFutureWatcher>
 
-VicinaeStoreDetailHost::VicinaeStoreDetailHost(const VicinaeStore::Extension &extension) : m_ext(extension) {}
+VicinaeStoreDetailHost::VicinaeStoreDetailHost(const QString &authorHandle, const QString &extensionName)
+    : m_authorHandle(authorHandle), m_extensionName(extensionName) {}
 
 QUrl VicinaeStoreDetailHost::qmlComponentUrl() const {
   return QUrl(QStringLiteral("qrc:/Vicinae/StoreDetailView.qml"));
@@ -23,10 +25,49 @@ QVariantMap VicinaeStoreDetailHost::qmlProperties() {
 void VicinaeStoreDetailHost::initialize() {
   BaseView::initialize();
 
+  setLoading(true);
+  auto store = context()->services->vicinaeStore();
+  auto *watcher = new QFutureWatcher<VicinaeStore::ListResult>(this);
+  watcher->setFuture(store->fetchAll());
+
+  connect(watcher, &QFutureWatcher<VicinaeStore::ListResult>::finished, this, [this, watcher]() {
+    watcher->deleteLater();
+    auto result = watcher->result();
+    if (!result) {
+      context()->services->toastService()->setToast("Failed to fetch extensions", ToastStyle::Danger);
+      setLoading(false);
+      return;
+    }
+
+    auto it = std::ranges::find_if(result->extensions, [&](const auto &ext) {
+      return ext.author.handle == m_authorHandle && ext.name == m_extensionName;
+    });
+    if (it == result->extensions.end()) {
+      auto id = QString("%1/%2").arg(m_authorHandle, m_extensionName);
+      context()->navigation->replaceView(new EmptyViewHost(
+          "Extension not found", QString("The extension \"%1\" could not be found in the store.").arg(id),
+          ImageURL(BuiltinIcon::MagnifyingGlass).setFill(SemanticColor::Red)));
+      return;
+    }
+
+    hydrate(*it);
+    setLoading(false);
+  });
+}
+
+void VicinaeStoreDetailHost::hydrate(const VicinaeStore::Extension &extension) {
+  m_ext = extension;
+  m_isReady = true;
+
   auto registry = context()->services->extensionRegistry();
   m_isInstalled = registry->isInstalled(m_ext.id);
 
+  auto icon = ImageURL::builtin("cart");
+  icon.setBackgroundTint(Omnicast::ACCENT_COLOR);
+  setNavigationIcon(icon);
+  setNavigationTitle(QString("Extension Store - %1").arg(m_ext.title));
   createActions();
+  emit extensionChanged();
 
   connect(registry, &ExtensionRegistry::extensionAdded, this, [this](const QString &id) {
     if (id != m_ext.id) return;
@@ -61,6 +102,7 @@ QStringList VicinaeStoreDetailHost::platforms() const {
   return QStringList(m_ext.platforms.begin(), m_ext.platforms.end());
 }
 
+bool VicinaeStoreDetailHost::isReady() const { return m_isReady; }
 bool VicinaeStoreDetailHost::isInstalled() const { return m_isInstalled; }
 bool VicinaeStoreDetailHost::hasScreenshots() const { return false; }
 QStringList VicinaeStoreDetailHost::screenshots() const { return {}; }
@@ -96,9 +138,7 @@ void VicinaeStoreDetailHost::openUrl(const QString &url) {
   ServiceRegistry::instance()->appDb()->openTarget(url);
 }
 
-QString VicinaeStoreDetailHost::initialNavigationTitle() const {
-  return QString("%1 - %2").arg(BaseView::initialNavigationTitle()).arg(m_ext.title);
-}
+QString VicinaeStoreDetailHost::initialNavigationTitle() const { return QStringLiteral("Extension Store"); }
 
 void VicinaeStoreDetailHost::createActions() {
   auto panel = std::make_unique<FormActionPanelState>();

--- a/src/server/src/qml/vicinae-store-detail-host.hpp
+++ b/src/server/src/qml/vicinae-store-detail-host.hpp
@@ -27,8 +27,9 @@ public:
   Q_PROPERTY(QString lastUpdate READ lastUpdate NOTIFY extensionChanged)
   Q_PROPERTY(QVariantList contributors READ contributors NOTIFY extensionChanged)
   Q_PROPERTY(QStringList categories READ categories NOTIFY extensionChanged)
+  Q_PROPERTY(bool isReady READ isReady NOTIFY extensionChanged)
 
-  explicit VicinaeStoreDetailHost(const VicinaeStore::Extension &extension);
+  VicinaeStoreDetailHost(const QString &authorHandle, const QString &extensionName);
 
   QUrl qmlComponentUrl() const override;
   QVariantMap qmlProperties() override;
@@ -41,6 +42,7 @@ public:
   QString authorAvatar() const;
   QString downloadCount() const;
   QStringList platforms() const;
+  bool isReady() const;
   bool isInstalled() const;
   bool hasScreenshots() const;
   QStringList screenshots() const;
@@ -57,6 +59,11 @@ private:
   QString initialNavigationTitle() const override;
   void createActions();
 
+  void hydrate(const VicinaeStore::Extension &extension);
+
   VicinaeStore::Extension m_ext;
+  QString m_authorHandle;
+  QString m_extensionName;
+  bool m_isReady = false;
   bool m_isInstalled = false;
 };

--- a/src/server/src/qml/vicinae-store-model.cpp
+++ b/src/server/src/qml/vicinae-store-model.cpp
@@ -6,6 +6,15 @@
 #include "services/extension-registry/extension-registry.hpp"
 #include "utils/utils.hpp"
 
+template <> struct fuzzy::FuzzySearchable<VicinaeStoreModel::Entry> {
+  static int score(const VicinaeStoreModel::Entry &entry, std::string_view query) {
+    auto title = entry.extension.title.toStdString();
+    auto author = entry.extension.author.name.toStdString();
+    auto desc = entry.extension.description.toStdString();
+    return fuzzy::scoreWeighted({{title, 1.0}, {author, 0.5}, {desc, 0.3}}, query);
+  }
+};
+
 VicinaeStoreModel::VicinaeStoreModel(QObject *parent) : CommandListModel(parent) {}
 
 void VicinaeStoreModel::setEntries(const std::vector<VicinaeStore::Extension> &extensions,
@@ -15,12 +24,27 @@ void VicinaeStoreModel::setEntries(const std::vector<VicinaeStore::Extension> &e
   for (const auto &ext : extensions) {
     m_entries.push_back({.extension = ext, .installed = registry->isInstalled(ext.id)});
   }
+  m_sectionName = sectionName;
+  applyFilter();
+}
+
+void VicinaeStoreModel::setFilter(const QString &text) {
+  m_query = text.toStdString();
+  applyFilter();
+}
+
+void VicinaeStoreModel::applyFilter() {
+  fuzzy::fuzzyFilter<Entry>(std::span<const Entry>(m_entries), m_query, m_filtered);
 
   std::vector<SectionInfo> sections;
-  if (!m_entries.empty()) {
-    sections.push_back({.name = sectionName, .count = static_cast<int>(m_entries.size())});
+  if (!m_filtered.empty()) {
+    sections.push_back({.name = m_sectionName, .count = static_cast<int>(m_filtered.size())});
   }
   setSections(sections);
+}
+
+const VicinaeStoreModel::Entry &VicinaeStoreModel::resolvedEntry(int i) const {
+  return m_entries[m_filtered[i].data];
 }
 
 QHash<int, QByteArray> VicinaeStoreModel::roleNames() const {
@@ -38,14 +62,14 @@ QVariant VicinaeStoreModel::data(const QModelIndex &index, int role) const {
 
   switch (role) {
   case DownloadCount:
-    return formatCount(m_entries[i].extension.downloadCount);
+    return formatCount(resolvedEntry(i).extension.downloadCount);
   case AuthorAvatar: {
-    const auto &avatar = m_entries[i].extension.author.avatarUrl;
+    const auto &avatar = resolvedEntry(i).extension.author.avatarUrl;
     if (avatar.isEmpty()) return imageSourceFor(ImageURL::builtin("person"));
     return imageSourceFor(ImageURL::http(QUrl(avatar)).circle());
   }
   case IsInstalled:
-    return m_entries[i].installed;
+    return resolvedEntry(i).installed;
   case CompatTierRole:
     return -1;
   default:
@@ -53,23 +77,25 @@ QVariant VicinaeStoreModel::data(const QModelIndex &index, int role) const {
   }
 }
 
-QString VicinaeStoreModel::itemTitle(int, int i) const { return m_entries[i].extension.title; }
+QString VicinaeStoreModel::itemTitle(int, int i) const { return resolvedEntry(i).extension.title; }
 
-QString VicinaeStoreModel::itemSubtitle(int, int i) const { return m_entries[i].extension.description; }
+QString VicinaeStoreModel::itemSubtitle(int, int i) const { return resolvedEntry(i).extension.description; }
 
 QString VicinaeStoreModel::itemIconSource(int, int i) const {
-  return imageSourceFor(m_entries[i].extension.themedIcon());
+  return imageSourceFor(resolvedEntry(i).extension.themedIcon());
 }
 
 std::unique_ptr<ActionPanelState> VicinaeStoreModel::createActionPanel(int, int i) const {
-  const auto &entry = m_entries[i];
+  const auto &entry = resolvedEntry(i);
   auto panel = std::make_unique<ActionPanelState>();
   auto section = panel->createSection();
   auto danger = panel->createSection();
 
   auto showDetails = new StaticAction(
       "Show details", ImageURL::builtin("computer-chip"),
-      [ext = entry.extension, scope = this->scope()]() { scope.pushView(new VicinaeStoreDetailHost(ext)); });
+      [author = entry.extension.author.handle, name = entry.extension.name, scope = this->scope()]() {
+        scope.pushView(new VicinaeStoreDetailHost(author, name));
+      });
   auto uninstall = new UninstallExtensionAction(entry.extension.id);
 
   showDetails->setShortcut(Keyboard::Shortcut::enter());

--- a/src/server/src/qml/vicinae-store-model.hpp
+++ b/src/server/src/qml/vicinae-store-model.hpp
@@ -1,5 +1,8 @@
 #pragma once
+#include <string>
+#include <vector>
 #include "command-list-model.hpp"
+#include "fuzzy/fuzzy-searchable.hpp"
 #include "services/extension-store/vicinae-store.hpp"
 
 class ExtensionRegistry;
@@ -10,6 +13,11 @@ class VicinaeStoreModel : public CommandListModel {
 signals:
 
 public:
+  struct Entry {
+    VicinaeStore::Extension extension;
+    bool installed = false;
+  };
+
   enum ExtraRole {
     DownloadCount = CommandListModel::Accessory + 1,
     AuthorAvatar,
@@ -21,7 +29,7 @@ public:
 
   void setEntries(const std::vector<VicinaeStore::Extension> &extensions, ExtensionRegistry *registry,
                   const QString &sectionName);
-  void setFilter(const QString &) override {}
+  void setFilter(const QString &text) override;
 
   QHash<int, QByteArray> roleNames() const override;
   QVariant data(const QModelIndex &index, int role) const override;
@@ -33,9 +41,11 @@ protected:
   std::unique_ptr<ActionPanelState> createActionPanel(int s, int i) const override;
 
 private:
-  struct Entry {
-    VicinaeStore::Extension extension;
-    bool installed = false;
-  };
+  void applyFilter();
+  const Entry &resolvedEntry(int i) const;
+
   std::vector<Entry> m_entries;
+  std::vector<Scored<int>> m_filtered;
+  std::string m_query;
+  QString m_sectionName;
 };

--- a/src/server/src/qml/vicinae-store-view-host.cpp
+++ b/src/server/src/qml/vicinae-store-view-host.cpp
@@ -3,17 +3,10 @@
 #include "service-registry.hpp"
 #include "services/extension-registry/extension-registry.hpp"
 #include "services/toast/toast-service.hpp"
-#include <chrono>
 
 VicinaeStoreViewHost::VicinaeStoreViewHost() {
-  m_debounce.setSingleShot(true);
-  m_debounce.setInterval(std::chrono::milliseconds(200));
-
-  connect(&m_debounce, &QTimer::timeout, this, &VicinaeStoreViewHost::handleDebounce);
-  connect(&m_listResultWatcher, &QFutureWatcher<VicinaeStore::ListResult>::finished, this,
-          &VicinaeStoreViewHost::handleFinishedPage);
-  connect(&m_queryResultWatcher, &QFutureWatcher<VicinaeStore::ListResult>::finished, this,
-          &VicinaeStoreViewHost::handleFinishedQuery);
+  connect(&m_watcher, &QFutureWatcher<VicinaeStore::ListResult>::finished, this,
+          &VicinaeStoreViewHost::handleFinished);
 }
 
 QUrl VicinaeStoreViewHost::qmlComponentUrl() const {
@@ -40,13 +33,7 @@ void VicinaeStoreViewHost::initialize() {
 
 void VicinaeStoreViewHost::loadInitialData() { fetchExtensions(); }
 
-void VicinaeStoreViewHost::textChanged(const QString &text) {
-  if (text.isEmpty()) {
-    fetchExtensions();
-    return;
-  }
-  m_debounce.start();
-}
+void VicinaeStoreViewHost::textChanged(const QString &text) { m_model->setFilter(text); }
 
 void VicinaeStoreViewHost::onReactivated() { m_model->refreshActionPanel(); }
 
@@ -54,46 +41,27 @@ QObject *VicinaeStoreViewHost::listModel() const { return m_model; }
 
 void VicinaeStoreViewHost::fetchExtensions() {
   setLoading(true);
-  m_listResultWatcher.setFuture(m_store->fetchExtensions());
+  m_watcher.setFuture(m_store->fetchAll());
 }
 
-void VicinaeStoreViewHost::handleFinishedPage() {
-  if (!searchText().isEmpty()) return;
+void VicinaeStoreViewHost::handleFinished() {
+  auto result = m_watcher.result();
+  setLoading(false);
 
-  auto result = m_listResultWatcher.result();
   if (!result) {
     qWarning() << "[VicinaeStore] fetch error:" << result.error();
     context()->services->toastService()->setToast("Failed to fetch extensions", ToastStyle::Danger);
     return;
   }
 
-  setLoading(false);
-
   m_model->setEntries(result->extensions, context()->services->extensionRegistry(),
                       QStringLiteral("Extensions"));
 }
 
-void VicinaeStoreViewHost::handleFinishedQuery() {
-  if (searchText() != m_lastQueryText) return;
-
-  auto result = m_queryResultWatcher.result();
-  if (!result) {
-    context()->services->toastService()->setToast("Failed to search extensions", ToastStyle::Danger);
-    return;
+void VicinaeStoreViewHost::refresh() {
+  if (auto *cached = m_store->cached()) {
+    m_model->setEntries(*cached, context()->services->extensionRegistry(), QStringLiteral("Extensions"));
+  } else {
+    fetchExtensions();
   }
-
-  setLoading(false);
-
-  m_model->setEntries(result->extensions, context()->services->extensionRegistry(),
-                      QStringLiteral("Results"));
 }
-
-void VicinaeStoreViewHost::handleDebounce() {
-  if (searchText().isEmpty()) return;
-
-  setLoading(true);
-  m_lastQueryText = searchText();
-  m_queryResultWatcher.setFuture(m_store->search(m_lastQueryText));
-}
-
-void VicinaeStoreViewHost::refresh() { textChanged(searchText()); }

--- a/src/server/src/qml/vicinae-store-view-host.hpp
+++ b/src/server/src/qml/vicinae-store-view-host.hpp
@@ -2,7 +2,6 @@
 #include "bridge-view.hpp"
 #include "services/extension-store/vicinae-store.hpp"
 #include <QFutureWatcher>
-#include <QTimer>
 
 class VicinaeStoreModel;
 
@@ -27,15 +26,10 @@ public:
 
 private:
   void fetchExtensions();
-  void handleFinishedPage();
-  void handleFinishedQuery();
-  void handleDebounce();
+  void handleFinished();
   void refresh();
 
   VicinaeStoreModel *m_model = nullptr;
   VicinaeStoreService *m_store = nullptr;
-  QFutureWatcher<VicinaeStore::ListResult> m_listResultWatcher;
-  QFutureWatcher<VicinaeStore::ListResult> m_queryResultWatcher;
-  QString m_lastQueryText;
-  QTimer m_debounce;
+  QFutureWatcher<VicinaeStore::ListResult> m_watcher;
 };

--- a/src/server/src/services/extension-store/vicinae-store.cpp
+++ b/src/server/src/services/extension-store/vicinae-store.cpp
@@ -55,6 +55,24 @@ VicinaeStoreService::fetchExtensions(const VicinaeStore::ListPaginationOptions &
       });
 }
 
+QFuture<VicinaeStore::ListResult> VicinaeStoreService::fetchAll() {
+  if (m_cache) {
+    return QtFuture::makeReadyValueFuture(VicinaeStore::ListResult{VicinaeStore::ListResponse{*m_cache, {}}});
+  }
+
+  return fetchExtensions({.limit = 500})
+      .then(this, [this](VicinaeStore::ListResult result) -> VicinaeStore::ListResult {
+        if (result) { m_cache = result->extensions; }
+        return result;
+      });
+}
+
+const std::vector<VicinaeStore::Extension> *VicinaeStoreService::cached() const {
+  return m_cache ? &*m_cache : nullptr;
+}
+
+void VicinaeStoreService::invalidateCache() { m_cache.reset(); }
+
 QFuture<VicinaeStore::ListResult> VicinaeStoreService::search(const QString &query) {
   auto url = QString("/store/search?q=%1").arg(query);
 

--- a/src/server/src/services/extension-store/vicinae-store.hpp
+++ b/src/server/src/services/extension-store/vicinae-store.hpp
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <QString>
 #include <expected>
+#include <optional>
 #include <vector>
 #include "lib/http-client.hpp"
 #include "ui/image/url.hpp"
@@ -98,9 +99,14 @@ public:
 
   QFuture<VicinaeStore::ListResult> fetchExtensions(const VicinaeStore::ListPaginationOptions &opts = {});
 
+  QFuture<VicinaeStore::ListResult> fetchAll();
+
   QFuture<VicinaeStore::ListResult> search(const QString &query);
 
   QFuture<VicinaeStore::DownloadExtensionResult> downloadExtension(const QUrl &url);
+
+  const std::vector<VicinaeStore::Extension> *cached() const;
+  void invalidateCache();
 
   void setBaseUrl(const QString &url);
   QString baseUrl() const;
@@ -109,4 +115,5 @@ private:
   static const http::RequestOptions s_requestOpts;
 
   http::Client m_client;
+  std::optional<std::vector<VicinaeStore::Extension>> m_cache;
 };

--- a/src/server/src/services/raycast/raycast-store.cpp
+++ b/src/server/src/services/raycast/raycast-store.cpp
@@ -13,13 +13,29 @@ const http::RequestOptions RaycastStoreService::s_requestOpts = {
     .contentType = QStringLiteral("application/json"),
 };
 
+void RaycastStoreService::postProcess(Raycast::Extension &ext) {
+  ext.id = QString("store.raycast.%1").arg(ext.name);
+  for (auto &cmd : ext.commands) {
+    cmd.extensionIcons = ext.icons;
+  }
+}
+
 void RaycastStoreService::postProcess(std::vector<Raycast::Extension> &extensions) {
   for (auto &ext : extensions) {
-    ext.id = QString("store.raycast.%1").arg(ext.name);
-    for (auto &cmd : ext.commands) {
-      cmd.extensionIcons = ext.icons;
-    }
+    postProcess(ext);
   }
+}
+
+QFuture<Raycast::ExtensionResult> RaycastStoreService::fetchExtension(const QString &author,
+                                                                      const QString &name) {
+  auto url = QString("/extensions/%1/%2").arg(author, name);
+
+  return m_client.get<Raycast::Extension>(url, s_requestOpts)
+      .then([](http::Client::Result<Raycast::Extension> result) -> Raycast::ExtensionResult {
+        if (!result) return std::unexpected(result.error());
+        postProcess(*result);
+        return *std::move(result);
+      });
 }
 
 QFuture<Raycast::ListResult> RaycastStoreService::search(const QString &query) {

--- a/src/server/src/services/raycast/raycast-store.hpp
+++ b/src/server/src/services/raycast/raycast-store.hpp
@@ -161,6 +161,7 @@ using CompatMap = std::unordered_map<std::string, CompatInfo>;
 using CompatResult = std::expected<CompatMap, std::string>;
 
 using ListResult = std::expected<ListResponse, std::string>;
+using ExtensionResult = std::expected<Extension, std::string>;
 using DownloadExtensionResult = std::expected<QByteArray, std::string>;
 
 } // namespace Raycast
@@ -171,6 +172,7 @@ public:
 
   QFuture<Raycast::DownloadExtensionResult> downloadExtension(const QUrl &url);
   QFuture<Raycast::ListResult> fetchExtensions(const Raycast::ListPaginationOptions &opts = {});
+  QFuture<Raycast::ExtensionResult> fetchExtension(const QString &author, const QString &name);
   QFuture<Raycast::ListResult> search(const QString &query);
   QFuture<Raycast::CompatResult> fetchCompat();
 
@@ -178,6 +180,7 @@ public:
 
 private:
   static const http::RequestOptions s_requestOpts;
+  static void postProcess(Raycast::Extension &extension);
   static void postProcess(std::vector<Raycast::Extension> &extensions);
 
   std::unordered_map<int, Raycast::ListResponse> m_cachedPages;


### PR DESCRIPTION
- support for `raycast://extensions/<author>/<ext_id>` (works with e.g https://www.raycast.com/store)
- support for `vicinae://extensions/<author>/<ext_id>` same but applied to the vicinae store

Replaces the legacy deeplink