### PR TITLE
fix(extensions): state sync issues

### DIFF
--- a/src/server/include/extend/event-counted.hpp
+++ b/src/server/include/extend/event-counted.hpp
@@ -1,0 +1,8 @@
+#pragma once
+#include <optional>
+#include <cstdint>
+
+template <typename T> struct EventCounted {
+  T value;
+  std::optional<uint32_t> eventCount;
+};

--- a/src/server/include/extend/event-counted.hpp
+++ b/src/server/include/extend/event-counted.hpp
@@ -1,8 +1,15 @@
 #pragma once
-#include <optional>
 #include <cstdint>
+#include <qjsonobject.h>
+#include <qjsonvalue.h>
+
+inline constexpr uint32_t EVENT_COUNT_UNTRACKED = UINT32_MAX;
 
 template <typename T> struct EventCounted {
   T value;
-  std::optional<uint32_t> eventCount;
+  uint32_t eventCount;
 };
+
+template <typename T> EventCounted<T> parseEventCounted(const QJsonObject &obj, T value) {
+  return {std::move(value), static_cast<uint32_t>(obj.value("eventCount").toInt())};
+}

--- a/src/server/include/extend/form-model.hpp
+++ b/src/server/include/extend/form-model.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "extend/action-model.hpp"
+#include "extend/event-counted.hpp"
 #include "extend/list-model.hpp"
 #include "extend/model.hpp"
 #include <memory>
@@ -24,7 +25,7 @@ struct FormModel {
     std::optional<EventHandler> onChange;
     std::optional<EventHandler> onFocus;
     std::optional<QString> title;
-    std::optional<QJsonValue> value;
+    std::optional<EventCounted<QJsonValue>> value;
     bool storeValue;
   };
 

--- a/src/server/include/extend/grid-model.hpp
+++ b/src/server/include/extend/grid-model.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "extend/action-model.hpp"
 #include "extend/empty-view-model.hpp"
+#include "extend/event-counted.hpp"
 #include "extend/image-model.hpp"
 #include "extend/pagination-model.hpp"
 #include "extend/dropdown-model.hpp"
@@ -58,7 +59,7 @@ struct GridModel {
   std::string searchPlaceholderText;
   std::optional<std::string> onSelectionChanged;
   std::optional<std::string> onSearchTextChange;
-  std::optional<std::string> searchText;
+  std::optional<EventCounted<std::string>> searchText;
   std::vector<GridChild> items;
   std::optional<ActionPannelModel> actions;
   std::optional<EmptyViewModel> emptyView;

--- a/src/server/include/extend/list-model.hpp
+++ b/src/server/include/extend/list-model.hpp
@@ -3,6 +3,7 @@
 #include "extend/action-model.hpp"
 #include "extend/detail-model.hpp"
 #include "extend/empty-view-model.hpp"
+#include "extend/event-counted.hpp"
 #include "extend/image-model.hpp"
 #include "extend/dropdown-model.hpp"
 #include "extend/pagination-model.hpp"
@@ -41,7 +42,7 @@ struct ListModel {
   std::string searchPlaceholderText;
   std::optional<std::string> onSelectionChanged;
   std::optional<std::string> onSearchTextChange;
-  std::optional<std::string> searchText;
+  std::optional<EventCounted<std::string>> searchText;
   std::vector<ListChild> items;
   std::optional<ActionPannelModel> actions;
   std::optional<EmptyViewModel> emptyView;

--- a/src/server/src/extend/form-model.cpp
+++ b/src/server/src/extend/form-model.cpp
@@ -58,7 +58,16 @@ FormModel FormModel::fromJson(const QJsonObject &json) {
       base.autoFocus = props.value("autoFocus").toBool();
 
       if (props.contains("title")) base.title = props.value("title").toString();
-      if (props.contains("value")) base.value = props.value("value");
+      if (props.contains("value")) {
+        auto val = props.value("value");
+        if (val.isObject() && val.toObject().contains("eventCount")) {
+          auto obj = val.toObject();
+          base.value = EventCounted<QJsonValue>{obj.value("value"),
+                                                static_cast<uint32_t>(obj.value("eventCount").toInt())};
+        } else {
+          base.value = EventCounted<QJsonValue>{val, std::nullopt};
+        }
+      }
       if (props.contains("error")) base.error = props.value("error").toString();
       if (props.contains("info")) base.info = props.value("info").toString();
       if (props.contains("onBlur")) base.onBlur = props.value("onBlur").toString();

--- a/src/server/src/extend/form-model.cpp
+++ b/src/server/src/extend/form-model.cpp
@@ -62,10 +62,9 @@ FormModel FormModel::fromJson(const QJsonObject &json) {
         auto val = props.value("value");
         if (val.isObject() && val.toObject().contains("eventCount")) {
           auto obj = val.toObject();
-          base.value = EventCounted<QJsonValue>{obj.value("value"),
-                                                static_cast<uint32_t>(obj.value("eventCount").toInt())};
+          base.value = parseEventCounted(obj, obj.value("value"));
         } else {
-          base.value = EventCounted<QJsonValue>{val, std::nullopt};
+          base.value = EventCounted<QJsonValue>{val, EVENT_COUNT_UNTRACKED};
         }
       }
       if (props.contains("error")) base.error = props.value("error").toString();

--- a/src/server/src/extend/grid-model.cpp
+++ b/src/server/src/extend/grid-model.cpp
@@ -135,7 +135,17 @@ GridModel GridModelParser::parse(const QJsonObject &instance) {
   if (props.contains("selectedItemId")) {
     model.selectedItemId = props.value("selectedItemId").toString().toStdString();
   }
-  if (props.contains("searchText")) { model.searchText = props.value("searchText").toString().toStdString(); }
+  if (props.contains("searchText")) {
+    auto val = props.value("searchText");
+    if (val.isObject()) {
+      auto obj = val.toObject();
+      EventCounted<std::string> ec{obj.value("value").toString().toStdString(), std::nullopt};
+      if (obj.contains("eventCount")) ec.eventCount = static_cast<uint32_t>(obj.value("eventCount").toInt());
+      model.searchText = ec;
+    } else {
+      model.searchText = EventCounted<std::string>{val.toString().toStdString(), std::nullopt};
+    }
+  }
   if (props.contains("pagination")) {
     model.pagination = PaginationModel::fromJson(props.value("pagination").toObject());
   }

--- a/src/server/src/extend/grid-model.cpp
+++ b/src/server/src/extend/grid-model.cpp
@@ -136,15 +136,8 @@ GridModel GridModelParser::parse(const QJsonObject &instance) {
     model.selectedItemId = props.value("selectedItemId").toString().toStdString();
   }
   if (props.contains("searchText")) {
-    auto val = props.value("searchText");
-    if (val.isObject()) {
-      auto obj = val.toObject();
-      EventCounted<std::string> ec{obj.value("value").toString().toStdString(), std::nullopt};
-      if (obj.contains("eventCount")) ec.eventCount = static_cast<uint32_t>(obj.value("eventCount").toInt());
-      model.searchText = ec;
-    } else {
-      model.searchText = EventCounted<std::string>{val.toString().toStdString(), std::nullopt};
-    }
+    auto obj = props.value("searchText").toObject();
+    model.searchText = parseEventCounted(obj, obj.value("value").toString().toStdString());
   }
   if (props.contains("pagination")) {
     model.pagination = PaginationModel::fromJson(props.value("pagination").toObject());

--- a/src/server/src/extend/list-model.cpp
+++ b/src/server/src/extend/list-model.cpp
@@ -124,15 +124,8 @@ ListModel ListModelParser::parse(const QJsonObject &instance) {
   }
 
   if (props.contains("searchText")) {
-    auto val = props.value("searchText");
-    if (val.isObject()) {
-      auto obj = val.toObject();
-      EventCounted<std::string> ec{obj.value("value").toString().toStdString(), std::nullopt};
-      if (obj.contains("eventCount")) ec.eventCount = static_cast<uint32_t>(obj.value("eventCount").toInt());
-      model.searchText = ec;
-    } else {
-      model.searchText = EventCounted<std::string>{val.toString().toStdString(), std::nullopt};
-    }
+    auto obj = props.value("searchText").toObject();
+    model.searchText = parseEventCounted(obj, obj.value("value").toString().toStdString());
   }
   if (props.contains("pagination")) {
     model.pagination = PaginationModel::fromJson(props.value("pagination").toObject());

--- a/src/server/src/extend/list-model.cpp
+++ b/src/server/src/extend/list-model.cpp
@@ -123,7 +123,17 @@ ListModel ListModelParser::parse(const QJsonObject &instance) {
     model.onSelectionChanged = props.value("onSelectionChange").toString().toStdString();
   }
 
-  if (props.contains("searchText")) { model.searchText = props.value("searchText").toString().toStdString(); }
+  if (props.contains("searchText")) {
+    auto val = props.value("searchText");
+    if (val.isObject()) {
+      auto obj = val.toObject();
+      EventCounted<std::string> ec{obj.value("value").toString().toStdString(), std::nullopt};
+      if (obj.contains("eventCount")) ec.eventCount = static_cast<uint32_t>(obj.value("eventCount").toInt());
+      model.searchText = ec;
+    } else {
+      model.searchText = EventCounted<std::string>{val.toString().toStdString(), std::nullopt};
+    }
+  }
   if (props.contains("pagination")) {
     model.pagination = PaginationModel::fromJson(props.value("pagination").toObject());
   }

--- a/src/server/src/extension/services/ui-service.hpp
+++ b/src/server/src/extension/services/ui-service.hpp
@@ -12,6 +12,7 @@
 #include <QtConcurrent/QtConcurrent>
 #include <qfuturewatcher.h>
 #include <qlogging.h>
+#include <queue>
 
 class ExtUIService : public tsapi::AbstractUI {
   Q_OBJECT
@@ -38,18 +39,8 @@ public:
   }
 
   Void::Future render(std::string json) override {
-    if (m_modelWatcher.isRunning()) {
-      m_modelWatcher.cancel();
-      m_modelWatcher.waitForFinished();
-    }
-
-    m_modelWatcher.setFuture(QtConcurrent::run([json = std::move(json)]() -> ParsedRenderData {
-      QJsonParseError parseError;
-      auto doc = QJsonDocument::fromJson(QByteArray::fromStdString(json), &parseError);
-      if (parseError.error) return {};
-      return ModelParser().parse(doc.object().value("views").toArray());
-    }));
-
+    m_renderQueue.push(std::move(json));
+    processNextRender();
     return Void::ok();
   }
 
@@ -145,17 +136,17 @@ public:
 
 private slots:
   void modelCreated() {
-    if (m_modelWatcher.isCanceled()) return;
-
     auto models = m_modelWatcher.result();
 
     for (size_t i = 0; i < models.items.size() && i < m_views.size(); ++i) {
-      auto &model = models.items[i];
+      const auto &model = models.items[i];
       const auto &entry = m_views[i];
       bool const shouldSkipRender = !model.dirty && !model.propsDirty;
 
       if (!shouldSkipRender) entry.renderFn(model.root);
     }
+
+    processNextRender();
   }
 
   void handleViewPoped(const BaseView *view) {
@@ -169,6 +160,20 @@ private slots:
   }
 
 private:
+  void processNextRender() {
+    if (m_modelWatcher.isRunning() || m_renderQueue.empty()) return;
+
+    auto json = std::move(m_renderQueue.front());
+    m_renderQueue.pop();
+
+    m_modelWatcher.setFuture(QtConcurrent::run([json = std::move(json)]() -> ParsedRenderData {
+      QJsonParseError parseError;
+      auto doc = QJsonDocument::fromJson(QByteArray::fromStdString(json), &parseError);
+      if (parseError.error) return {};
+      return ModelParser().parse(doc.object().value("views").toArray());
+    }));
+  }
+
   ExtensionActionPanelBuilder::NotifyFn makeNotifyFn() {
     return [this](const QString &handler, const QJsonArray &args) {
       m_eventCore->emithandlerActivated(handler.toStdString(), qJsonValueToGlazeGeneric(args).get_array());
@@ -204,6 +209,7 @@ private:
   }
 
   std::vector<ViewEntry> m_views;
+  std::queue<std::string> m_renderQueue;
   QFutureWatcher<ParsedRenderData> m_modelWatcher;
   NavigationController *m_navigation;
   std::shared_ptr<ExtensionCommand> m_command;

--- a/src/server/src/qml/extension-form-model.cpp
+++ b/src/server/src/qml/extension-form-model.cpp
@@ -56,9 +56,12 @@ void ExtensionFormModel::setFieldValue(int index, const QVariant &value) {
 
   item.userValue = QJsonValue::fromVariant(value);
   item.hasUserValue = true;
+  ++item.eventCount;
   emit dataChanged(createIndex(index, 0), createIndex(index, 0), {ValueRole});
 
-  if (item.onChange) { m_notify(*item.onChange, QJsonArray{item.userValue}); }
+  if (item.onChange) {
+    m_notify(*item.onChange, QJsonArray{item.userValue, static_cast<int>(item.eventCount)});
+  }
 }
 
 void ExtensionFormModel::fieldFocused(int index) {
@@ -210,7 +213,7 @@ ExtensionFormModel::FormItemData ExtensionFormModel::createItem(const FormModel:
     data.fieldData = buildFieldData(*field);
 
     if (field->value) {
-      data.modelValue = *field->value;
+      data.modelValue = field->value->value;
     } else if (field->defaultValue) {
       data.modelValue = *field->defaultValue;
     }
@@ -238,7 +241,8 @@ void ExtensionFormModel::updateItem(FormItemData &existing, const FormModel::Ite
     existing.fieldData = buildFieldData(*field);
 
     if (field->value) {
-      existing.modelValue = *field->value;
+      if (field->value->eventCount && *field->value->eventCount < existing.eventCount) return;
+      existing.modelValue = field->value->value;
       existing.hasUserValue = false;
     }
   } else if (auto *desc = std::get_if<FormModel::Description>(&newItem)) {

--- a/src/server/src/qml/extension-form-model.cpp
+++ b/src/server/src/qml/extension-form-model.cpp
@@ -241,7 +241,7 @@ void ExtensionFormModel::updateItem(FormItemData &existing, const FormModel::Ite
     existing.fieldData = buildFieldData(*field);
 
     if (field->value) {
-      if (field->value->eventCount && *field->value->eventCount < existing.eventCount) return;
+      if (field->value->eventCount < existing.eventCount) return;
       existing.modelValue = field->value->value;
       existing.hasUserValue = false;
     }

--- a/src/server/src/qml/extension-form-model.hpp
+++ b/src/server/src/qml/extension-form-model.hpp
@@ -74,6 +74,7 @@ private:
     QJsonValue modelValue;
     QJsonValue userValue;
     bool hasUserValue = false;
+    uint32_t eventCount = 0;
 
     std::optional<EventHandler> onChange;
     std::optional<EventHandler> onBlur;

--- a/src/server/src/qml/extension-view-host.cpp
+++ b/src/server/src/qml/extension-view-host.cpp
@@ -127,7 +127,7 @@ void ExtensionViewHost::renderList(const ListModel &model) {
 
   if (!model.navigationTitle.empty()) { setNavigationTitle(model.navigationTitle.c_str()); }
   if (!model.searchPlaceholderText.empty()) { setSearchPlaceholderText(model.searchPlaceholderText.c_str()); }
-  if (auto text = model.searchText) { setSearchText(text->c_str()); }
+  if (model.searchText) { applyControlledSearchText(*model.searchText); }
 
   bool const wasLoading = m_isLoading;
   m_isLoading = model.isLoading;
@@ -167,7 +167,7 @@ void ExtensionViewHost::renderGrid(const GridModel &model) {
 
   if (!model.navigationTitle.empty()) { setNavigationTitle(model.navigationTitle.c_str()); }
   if (!model.searchPlaceholderText.empty()) { setSearchPlaceholderText(model.searchPlaceholderText.c_str()); }
-  if (auto text = model.searchText) { setSearchText(text->c_str()); }
+  if (model.searchText) { applyControlledSearchText(*model.searchText); }
 
   bool const wasLoading = m_isLoading;
   m_isLoading = model.isLoading;
@@ -191,6 +191,8 @@ void ExtensionViewHost::renderGrid(const GridModel &model) {
 }
 
 void ExtensionViewHost::textChanged(const QString &text) {
+  if (m_settingSearchText) return;
+
   bool const had = m_hasSearchText;
   m_hasSearchText = !text.isEmpty();
   if (had != m_hasSearchText) emit suppressEmptyViewChanged();
@@ -200,6 +202,17 @@ void ExtensionViewHost::textChanged(const QString &text) {
   } else {
     handleDebouncedSearch();
   }
+}
+
+void ExtensionViewHost::applyControlledSearchText(const EventCounted<std::string> &incoming) {
+  QString value = QString::fromStdString(incoming.value);
+  if (value == searchText()) return;
+
+  if (incoming.eventCount && *incoming.eventCount < m_searchEventCount) return;
+
+  m_settingSearchText = true;
+  setSearchText(value);
+  m_settingSearchText = false;
 }
 
 void ExtensionViewHost::handleDebouncedSearch() {
@@ -212,8 +225,9 @@ void ExtensionViewHost::handleDebouncedSearch() {
   }
 
   if (m_onSearchTextChange) {
+    ++m_searchEventCount;
     m_shouldResetSelection = !m_filtering;
-    notifyExtension(m_onSearchTextChange->c_str(), {text});
+    notifyExtension(m_onSearchTextChange->c_str(), {text, static_cast<int>(m_searchEventCount)});
   }
 }
 

--- a/src/server/src/qml/extension-view-host.cpp
+++ b/src/server/src/qml/extension-view-host.cpp
@@ -208,7 +208,7 @@ void ExtensionViewHost::applyControlledSearchText(const EventCounted<std::string
   QString value = QString::fromStdString(incoming.value);
   if (value == searchText()) return;
 
-  if (incoming.eventCount && *incoming.eventCount < m_searchEventCount) return;
+  if (incoming.eventCount < m_searchEventCount) return;
 
   m_settingSearchText = true;
   setSearchText(value);

--- a/src/server/src/qml/extension-view-host.hpp
+++ b/src/server/src/qml/extension-view-host.hpp
@@ -80,6 +80,7 @@ private:
   void notifyExtension(const QString &handler, const QJsonArray &args);
   void handleDebouncedSearch();
   void updateDropdown(const DropdownModel *dropdown);
+  void applyControlledSearchText(const EventCounted<std::string> &incoming);
 
   template <typename T> T *activeModel() const {
     auto p = std::get_if<T *>(&m_model);
@@ -96,6 +97,8 @@ private:
 
   bool m_throttle = false;
   bool m_filtering = false;
+  bool m_settingSearchText = false;
+  uint32_t m_searchEventCount = 0;
   std::optional<std::string> m_onSearchTextChange;
   bool m_shouldResetSelection = false;
   bool m_selectFirstOnReset = true;

--- a/src/typescript/api/src/api/components/form.tsx
+++ b/src/typescript/api/src/api/components/form.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode, Ref } from "react";
 import { useImperativeFormHandle } from "../hooks/use-imperative-form-handle";
+import { useEventCounted } from "../hooks/use-event-counted";
 import { type ImageLike, serializeProtoImage } from "../image";
 import { Dropdown as MainDropdown } from "./dropdown";
 
@@ -197,19 +198,23 @@ const FormRoot: React.FC<Form.Props> = ({
 	);
 };
 
-const TextField: React.FC<Form.TextField.Props> = ({ ref, ...props }) => {
+const TextField: React.FC<Form.TextField.Props> = ({ ref, value, onChange, ...props }) => {
 	useImperativeFormHandle(ref);
+	const [countedValue, wrappedOnChange] = useEventCounted(value, onChange);
 
-	return <text-field {...wrapFormItemProps(props)} />;
+	return <text-field {...wrapFormItemProps(props)} value={countedValue} onChange={wrappedOnChange} />;
 };
 
 const PasswordField: React.FC<Form.PasswordField.Props> = ({
 	ref,
+	value,
+	onChange,
 	...props
 }) => {
 	useImperativeFormHandle(ref);
+	const [countedValue, wrappedOnChange] = useEventCounted(value, onChange);
 
-	return <password-field {...props} />;
+	return <password-field {...props} value={countedValue} onChange={wrappedOnChange} />;
 };
 
 export enum DatePickerType {
@@ -298,10 +303,11 @@ const TagPicker = Object.assign(TagPickerRoot, {
 	Item: TagPickerItem,
 });
 
-const TextArea: React.FC<Form.TextArea.Props> = ({ ref, ...props }) => {
+const TextArea: React.FC<Form.TextArea.Props> = ({ ref, value, onChange, ...props }) => {
 	useImperativeFormHandle(ref);
+	const [countedValue, wrappedOnChange] = useEventCounted(value, onChange);
 
-	return <text-area-field {...wrapFormItemProps(props)} />;
+	return <text-area-field {...wrapFormItemProps(props)} value={countedValue} onChange={wrappedOnChange} />;
 };
 
 const FilePicker: React.FC<Form.FilePicker.Props> = ({ ref, ...props }) => {

--- a/src/typescript/api/src/api/components/grid.tsx
+++ b/src/typescript/api/src/api/components/grid.tsx
@@ -4,6 +4,7 @@ import { randomUUID } from "crypto";
 import { EmptyView } from "./empty-view";
 import { type ColorLike, serializeColorLike } from "../color";
 import { Dropdown } from "./dropdown";
+import { useEventCounted } from "../hooks/use-event-counted";
 
 enum GridInset {
 	Zero = "zero",
@@ -179,6 +180,8 @@ const GridRoot: React.FC<Grid.Props> = ({
 	itemSize,
 	fit = GridFit.Contain,
 	aspectRatio = "1",
+	searchText,
+	onSearchTextChange,
 	...props
 }) => {
 	if (
@@ -196,11 +199,18 @@ const GridRoot: React.FC<Grid.Props> = ({
 		}[itemSize];
 	}
 
+	const [countedSearchText, wrappedOnSearchTextChange] = useEventCounted(
+		searchText,
+		onSearchTextChange,
+	);
+
 	return (
 		<grid
 			fit={fit}
 			inset={inset}
 			aspectRatio={aspectRatioMap[aspectRatio]}
+			searchText={countedSearchText}
+			onSearchTextChange={wrappedOnSearchTextChange}
 			{...props}
 		>
 			{searchBarAccessory}

--- a/src/typescript/api/src/api/components/list.tsx
+++ b/src/typescript/api/src/api/components/list.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { useRef } from "react";
+import { useEventCounted } from "../hooks/use-event-counted";
 import {
 	type Image,
 	type ImageLike,
@@ -304,6 +305,8 @@ const ListRoot: React.FC<List.Props> = ({
 	searchBarAccessory,
 	children,
 	actions,
+	searchText,
+	onSearchTextChange,
 	...props
 }) => {
 	if (
@@ -313,8 +316,17 @@ const ListRoot: React.FC<List.Props> = ({
 		props.filtering = props.enableFiltering;
 	}
 
+	const [countedSearchText, wrappedOnSearchTextChange] = useEventCounted(
+		searchText,
+		onSearchTextChange,
+	);
+
 	return (
-		<list {...props}>
+		<list
+			{...props}
+			searchText={countedSearchText}
+			onSearchTextChange={wrappedOnSearchTextChange}
+		>
 			{searchBarAccessory}
 			{children}
 			{actions}

--- a/src/typescript/api/src/api/hooks/index.ts
+++ b/src/typescript/api/src/api/hooks/index.ts
@@ -1,1 +1,2 @@
+export * from "./use-event-counted";
 export * from "./use-navigation";

--- a/src/typescript/api/src/api/hooks/use-event-counted.ts
+++ b/src/typescript/api/src/api/hooks/use-event-counted.ts
@@ -1,0 +1,23 @@
+import { useCallback, useRef } from "react";
+
+export type EventCounted<T> = { value: T; eventCount: number };
+
+export function useEventCounted<T>(
+	value: T | undefined,
+	onChange?: (value: T) => void,
+): [EventCounted<T> | undefined, ((...args: any[]) => void) | undefined] {
+	const ref = useRef(0);
+
+	const handler = useCallback(
+		(...args: any[]) => {
+			if (typeof args[1] === "number") ref.current = args[1];
+			onChange?.(args[0]);
+		},
+		[onChange],
+	);
+
+	const counted: EventCounted<T> | undefined =
+		value != null ? { value, eventCount: ref.current } : undefined;
+
+	return [counted, onChange ? handler : undefined];
+}

--- a/src/typescript/api/types/jsx.d.ts
+++ b/src/typescript/api/types/jsx.d.ts
@@ -1,6 +1,7 @@
 import type * as React from "react";
 import type {
 	DatePickerType,
+	EventCounted,
 	Grid,
 	Keyboard,
 	List,
@@ -13,6 +14,7 @@ type BaseFormField = {
 	onBlur?: Function;
 	onFocus?: Function;
 	onChange?: Function;
+	value?: any;
 };
 
 declare module "react" {
@@ -30,9 +32,10 @@ declare module "react" {
 				filtering?: boolean;
 				isLoading?: boolean;
 				isShowingDetail?: boolean;
+				searchText?: EventCounted<string>;
 				searchBarPlaceholder?: string;
 				navigationTitle?: string;
-				onSearchTextChange?: (text: string) => void;
+				onSearchTextChange?: (...args: any[]) => void;
 				onSelectionChange?: (selectedItemId: string) => void;
 			};
 			"list-section": {
@@ -67,9 +70,10 @@ declare module "react" {
 				filtering?: boolean;
 				isLoading?: boolean;
 				isShowingDetail?: boolean;
+				searchText?: EventCounted<string>;
 				searchBarPlaceholder?: string;
 				navigationTitle?: string;
-				onSearchTextChange?: (text: string) => void;
+				onSearchTextChange?: (...args: any[]) => void;
 				onSelectionChange?: (selectedItemId: string) => void;
 			};
 			"grid-section": {
@@ -193,7 +197,7 @@ declare module "react" {
 				type?: DatePickerType;
 			};
 			"checkbox-field": BaseFormField & {};
-			"password-field": {};
+			"password-field": BaseFormField & {};
 			"textarea-field": {};
 
 			dropdown: {

--- a/src/typescript/extension-manager/src/callback.ts
+++ b/src/typescript/extension-manager/src/callback.ts
@@ -4,6 +4,10 @@ export type CallbackHandler = (...args: any[]) => void;
 
 class CallbackManager {
 	activateHandler(id: string, args: any[]) {
+		if (this.pendingCleanup.has(id) || this.previousCleanup.has(id)) {
+			return;
+		}
+
 		const handler = this.handlers.get(id);
 
 		if (!handler) {
@@ -15,11 +19,20 @@ class CallbackManager {
 		handler(...args);
 	}
 
-	/**
-	 * Removes callback associated with this ID if there is one.
-	 */
 	removeHandler(id: string): void {
 		this.handlers.delete(id);
+	}
+
+	deferRemoval(id: string): void {
+		this.pendingCleanup.add(id);
+	}
+
+	flushDeferredRemovals(): void {
+		for (const id of this.previousCleanup) {
+			this.handlers.delete(id);
+		}
+		this.previousCleanup = this.pendingCleanup;
+		this.pendingCleanup = new Set();
 	}
 
 	setHandler(id: string, handler: CallbackHandler) {
@@ -43,6 +56,8 @@ class CallbackManager {
 	}
 
 	private readonly handlers = new Map<string, CallbackHandler>();
+	private pendingCleanup = new Set<string>();
+	private previousCleanup = new Set<string>();
 }
 
 export const callbackManager = new CallbackManager();

--- a/src/typescript/extension-manager/src/reconciler.ts
+++ b/src/typescript/extension-manager/src/reconciler.ts
@@ -70,7 +70,7 @@ const processProps = (props: Record<string, any>): Record<string, any> => {
  */
 const detachInstance = (instance: Instance) => {
 	for (const handler of instance._handlers)
-		callbackManager.removeHandler(handler);
+		callbackManager.deferRemoval(handler);
 	for (const child of instance.children) {
 		detachInstance(child);
 	}
@@ -299,12 +299,11 @@ const createHostConfig = (hostCtx: HostContext, callback: () => void) => {
 				}
 
 				if (typeof v === "function") {
-					const old = prevProps[k];
+					const oldHandlerId = instance.props[k];
 
-					if (typeof old === "string") {
-						// TODO: verify this still works
-						callbackManager.setHandler(k, v);
-						props[k] = old;
+					if (typeof oldHandlerId === "string") {
+						callbackManager.setHandler(oldHandlerId, v);
+						props[k] = oldHandlerId;
 						continue;
 					}
 
@@ -407,14 +406,6 @@ const serializeInstance = (instance: Instance): SerializedInstance => {
 	instance.dirty = false;
 	instance.propsDirty = false;
 
-	/*
-	let i = 0;
-
-	for (const child of instance.children) {
-		obj.children[i++] = serializeInstance(child);
-	}
-	*/
-
 	return obj;
 };
 
@@ -454,6 +445,7 @@ export const createRenderer = (config: RendererConfig) => {
 				}));
 
 				config.onUpdate?.(views);
+				callbackManager.flushDeferredRemovals();
 
 				const end = performance.now();
 


### PR DESCRIPTION
- Fixes an issue where an event handler would be destroyed while still referenced by the QT/C++ side. We now defer deletion so that it happens after two render passes.
- Fixes a long lasting issue (here from day one I'm pretty sure) where controlled state (such as search text) is not properly synchronized resulting in chopped characters and ugly flickering. Especially when each keystroke triggers a big re-render. We now use an event counter, similarly to what react native does.