### PR TITLE
fix: Navigation with keyboard now scroll view

### DIFF
--- a/src/server/src/qml/qml/SettingsSidebar.qml
+++ b/src/server/src/qml/qml/SettingsSidebar.qml
@@ -33,6 +33,9 @@ Item {
         } else {
             _highlightedIndex = Math.max(0, Math.min(_navItems.length - 1, _highlightedIndex + delta));
         }
+        const listIdx = _highlightedListIndex();
+        if (listIdx >= 0)
+            navList.positionViewAtIndex(listIdx, ListView.Contain);
     }
 
     function _activateHighlighted() {


### PR DESCRIPTION
Previously if keyboard focused item goes outside of visible view it was not following it.