### PR TITLE
feat: better qalculate otb experience

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -727,6 +727,7 @@ set(VICINAE_QML_FILES
 	src/qml/qml/ShortcutBadge.qml
 	src/qml/qml/TextBadge.qml
 	src/qml/qml/CommandListView.qml
+	src/qml/qml/CalcHistoryListView.qml
 	src/qml/qml/CalculatorResultDelegate.qml
 	src/qml/qml/ThemeListView.qml
 	src/qml/qml/ThemeItemDelegate.qml

--- a/src/server/src/qml/calc-history-view-host.cpp
+++ b/src/server/src/qml/calc-history-view-host.cpp
@@ -1,5 +1,78 @@
 #include "calc-history-view-host.hpp"
+#include "actions/calculator/calculator-actions.hpp"
 #include "service-registry.hpp"
+#include "services/calculator-service/abstract-calculator-backend.hpp"
+
+using namespace std::chrono_literals;
+
+void CalcLiveSection::setResult(std::optional<AbstractCalculatorBackend::CalculatorResult> result) {
+  m_result = std::move(result);
+  notifyChanged();
+}
+
+void CalcLiveSection::clear() {
+  if (!m_result) return;
+  m_result.reset();
+  notifyItemsRefreshed();
+}
+
+QString CalcLiveSection::itemTitle(int) const {
+  if (!m_result) return {};
+  return m_result->question.text + QStringLiteral(" = ") + m_result->answer.text;
+}
+
+QString CalcLiveSection::itemIconSource(int) const { return imageSourceFor(ImageURL::builtin("calculator")); }
+
+QVariantList CalcLiveSection::itemAccessories(int) const { return {}; }
+
+QHash<int, QByteArray> CalcLiveSection::customRoleNames() const {
+  return {
+      {IsCalculator, "isCalculator"},         {CalcQuestion, "calcQuestion"},
+      {CalcQuestionUnit, "calcQuestionUnit"}, {CalcAnswer, "calcAnswer"},
+      {CalcAnswerUnit, "calcAnswerUnit"},
+  };
+}
+
+QHash<int, QVariant> CalcLiveSection::customRoleDefaults() const {
+  return {
+      {IsCalculator, false},   {CalcQuestion, QString()},   {CalcQuestionUnit, QString()},
+      {CalcAnswer, QString()}, {CalcAnswerUnit, QString()},
+  };
+}
+
+QVariant CalcLiveSection::customData(int, int role) const {
+  if (!m_result) {
+    if (role == IsCalculator) return false;
+    return {};
+  }
+  switch (role) {
+  case IsCalculator:
+    return true;
+  case CalcQuestion:
+    return m_result->question.text;
+  case CalcQuestionUnit:
+    return m_result->question.unit ? m_result->question.unit->displayName : QString();
+  case CalcAnswer:
+    return m_result->answer.text;
+  case CalcAnswerUnit:
+    return m_result->answer.unit ? m_result->answer.unit->displayName : QString();
+  default:
+    return {};
+  }
+}
+
+std::unique_ptr<ActionPanelState> CalcLiveSection::actionPanel(int) const {
+  if (!m_result) return nullptr;
+
+  auto panel = std::make_unique<ListActionPanelState>();
+  auto *main = panel->createSection();
+  auto *copyAnswer = new CopyCalculatorAnswerAction(*m_result);
+  copyAnswer->setPrimary(true);
+  main->addAction(copyAnswer);
+  main->addAction(new CopyCalculatorQuestionAndAnswerAction(*m_result));
+
+  return panel;
+}
 
 void CalcHistoryViewHost::initialize() {
   BaseView::initialize();
@@ -9,18 +82,32 @@ void CalcHistoryViewHost::initialize() {
 
   setSearchPlaceholderText("Search past calculations...");
 
+  m_calculatorDebounce.setInterval(200ms);
+  m_calculatorDebounce.setSingleShot(true);
+
+  connect(&m_calculatorDebounce, &QTimer::timeout, this, &CalcHistoryViewHost::startCalculator);
+  connect(&m_calcWatcher, &CalculatorWatcher::finished, this, &CalcHistoryViewHost::handleCalculatorFinished);
+
   connect(m_calc, &CalculatorService::recordPinned, this, &CalcHistoryViewHost::refresh);
   connect(m_calc, &CalculatorService::recordUnpinned, this, &CalcHistoryViewHost::refresh);
   connect(m_calc, &CalculatorService::recordRemoved, this, &CalcHistoryViewHost::refresh);
   connect(m_calc, &CalculatorService::allRecordsRemoved, this, &CalcHistoryViewHost::refresh);
+
+  model()->addSource(&m_liveSection);
 }
 
 void CalcHistoryViewHost::loadInitialData() { textChanged(searchText()); }
 
 void CalcHistoryViewHost::textChanged(const QString &text) {
   m_query = text;
+
+  m_calculatorDebounce.stop();
+  m_liveSection.clear();
+
   auto data = m_calc->groupRecordsByTime(m_calc->query(text));
   applyGroupedData(std::move(data));
+
+  if (!text.isEmpty()) { m_calculatorDebounce.start(); }
 }
 
 void CalcHistoryViewHost::refresh() { textChanged(m_query); }
@@ -29,6 +116,8 @@ void CalcHistoryViewHost::applyGroupedData(CalculatorService::GroupedRecordList 
   model()->clearSources();
   m_sections.clear();
   m_sections.reserve(data.size());
+
+  model()->addSource(&m_liveSection);
 
   for (auto &[name, records] : data) {
     if (records.empty()) continue;
@@ -39,4 +128,23 @@ void CalcHistoryViewHost::applyGroupedData(CalculatorService::GroupedRecordList 
   }
 
   model()->rebuild();
+}
+
+void CalcHistoryViewHost::startCalculator() {
+  if (m_calcWatcher.isRunning()) {
+    m_calc->backend()->abort();
+    m_calcWatcher.waitForFinished();
+  }
+
+  if (!m_calc->backend() || m_query.isEmpty()) return;
+
+  m_calcWatcher.setFuture(m_calc->backend()->asyncCompute(m_query));
+}
+
+void CalcHistoryViewHost::handleCalculatorFinished() {
+  if (!m_calcWatcher.isFinished()) return;
+  auto res = m_calcWatcher.result();
+  if (!res) return;
+
+  m_liveSection.setResult(std::move(res.value()));
 }

--- a/src/server/src/qml/calc-history-view-host.hpp
+++ b/src/server/src/qml/calc-history-view-host.hpp
@@ -1,10 +1,43 @@
 #pragma once
 #include "calc-history-model.hpp"
 #include "list-view-host.hpp"
+#include "services/calculator-service/abstract-calculator-backend.hpp"
+#include <QFutureWatcher>
+#include <QTimer>
 #include <memory>
 #include <vector>
 
 class CalculatorService;
+
+class CalcLiveSection : public SectionSource {
+public:
+  enum CustomRole {
+    IsCalculator = Qt::UserRole + 100,
+    CalcQuestion,
+    CalcQuestionUnit,
+    CalcAnswer,
+    CalcAnswerUnit,
+  };
+
+  void setResult(std::optional<AbstractCalculatorBackend::CalculatorResult> result);
+  void clear();
+
+  QString sectionName() const override { return QStringLiteral("Calculator"); }
+  int count() const override { return m_result ? 1 : 0; }
+
+  QHash<int, QByteArray> customRoleNames() const override;
+  QHash<int, QVariant> customRoleDefaults() const override;
+  QVariant customData(int i, int role) const override;
+
+protected:
+  QString itemTitle(int i) const override;
+  QString itemIconSource(int i) const override;
+  QVariantList itemAccessories(int i) const override;
+  std::unique_ptr<ActionPanelState> actionPanel(int i) const override;
+
+private:
+  std::optional<AbstractCalculatorBackend::CalculatorResult> m_result;
+};
 
 class CalcHistoryViewHost : public ListViewHost {
   Q_OBJECT
@@ -13,12 +46,23 @@ public:
   void initialize() override;
   void loadInitialData() override;
   void textChanged(const QString &text) override;
+  QUrl qmlComponentUrl() const override {
+    return QUrl(QStringLiteral("qrc:/Vicinae/CalcHistoryListView.qml"));
+  }
 
 private:
+  using CalculatorWatcher = QFutureWatcher<AbstractCalculatorBackend::ComputeResult>;
+
   void refresh();
   void applyGroupedData(CalculatorService::GroupedRecordList data);
+  void startCalculator();
+  void handleCalculatorFinished();
 
   CalculatorService *m_calc = nullptr;
   QString m_query;
   std::vector<std::unique_ptr<CalcHistorySection>> m_sections;
+
+  CalcLiveSection m_liveSection;
+  CalculatorWatcher m_calcWatcher;
+  QTimer m_calculatorDebounce;
 };

--- a/src/server/src/qml/qml/CalcHistoryListView.qml
+++ b/src/server/src/qml/qml/CalcHistoryListView.qml
@@ -1,0 +1,84 @@
+import QtQuick
+import QtQuick.Controls
+
+GenericListView {
+    id: calcHistoryView
+    property var cmdModel: null
+    model: cmdModel
+    listModel: cmdModel
+    autoWireModel: true
+    selectFirstOnReset: cmdModel ? cmdModel.selectFirstOnReset : true
+
+    emptyTitle: cmdModel && cmdModel.emptyTitle || "No results"
+    emptyDescription: (cmdModel && cmdModel.emptyDescription) || ""
+    emptyIcon: {
+        var _ = Theme.foreground;
+        var icon = cmdModel ? (cmdModel.emptyIcon || "") : "";
+        return icon !== "" ? icon : "image://vicinae/builtin:magnifying-glass?fg=" + Theme.foreground;
+    }
+
+    delegate: Loader {
+        id: delegateLoader
+        width: ListView.view.width
+
+        required property int index
+        required property bool isSection
+        required property bool isSelectable
+        required property string sectionName
+        required property string title
+        required property string subtitle
+        required property string iconSource
+        required property var itemAccessory
+        required property bool isCalculator
+        required property string calcQuestion
+        required property string calcQuestionUnit
+        required property string calcAnswer
+        required property string calcAnswerUnit
+
+        sourceComponent: {
+            if (isSection)
+                return sectionComponent;
+            if (isCalculator)
+                return calculatorComponent;
+            return itemComponent;
+        }
+
+        Component {
+            id: sectionComponent
+            SectionHeader {
+                width: delegateLoader.width
+                text: delegateLoader.sectionName
+            }
+        }
+
+        Component {
+            id: calculatorComponent
+            CalculatorResultDelegate {
+                width: delegateLoader.width
+                calcQuestion: delegateLoader.calcQuestion
+                calcQuestionUnit: delegateLoader.calcQuestionUnit
+                calcAnswer: delegateLoader.calcAnswer
+                calcAnswerUnit: delegateLoader.calcAnswerUnit
+                selected: calcHistoryView.currentIndex === delegateLoader.index
+                onClicked: calcHistoryView.currentIndex = delegateLoader.index
+                onActivated: calcHistoryView.itemActivated(delegateLoader.index)
+            }
+        }
+
+        Component {
+            id: itemComponent
+            ListItemDelegate {
+                width: delegateLoader.width
+                itemTitle: delegateLoader.title
+                itemSubtitle: delegateLoader.subtitle
+                itemIconSource: delegateLoader.iconSource
+                itemAlias: ""
+                itemIsActive: false
+                itemAccessory: delegateLoader.itemAccessory
+                selected: calcHistoryView.currentIndex === delegateLoader.index
+                onClicked: calcHistoryView.currentIndex = delegateLoader.index
+                onActivated: calcHistoryView.itemActivated(delegateLoader.index)
+            }
+        }
+    }
+}

--- a/src/server/src/qml/root-search-model.cpp
+++ b/src/server/src/qml/root-search-model.cpp
@@ -890,7 +890,10 @@ QVariantList RootSearchModel::primaryActionShortcutTokens() const {
 }
 
 void RootSearchModel::startCalculator() {
-  if (m_calcWatcher.isRunning()) { m_calcWatcher.cancel(); }
+  if (m_calcWatcher.isRunning()) {
+    m_calculator->backend()->abort();
+    m_calcWatcher.waitForFinished();
+  }
 
   auto expression = QString::fromStdString(m_query);
   m_calculatorSearchQuery = m_query;

--- a/src/server/src/qml/root-search-model.cpp
+++ b/src/server/src/qml/root-search-model.cpp
@@ -895,25 +895,20 @@ void RootSearchModel::startCalculator() {
     m_calcWatcher.waitForFinished();
   }
 
-  auto expression = QString::fromStdString(m_query);
   m_calculatorSearchQuery = m_query;
 
+  if (!m_calculator->backend()) return;
+
+  auto expression = QString::fromStdString(m_query);
   if (expression.startsWith("=") && expression.size() > 1) {
-    auto stripped = expression.mid(1);
-    m_calcWatcher.setFuture(m_calculator->backend()->asyncCompute(stripped));
+    m_calcWatcher.setFuture(m_calculator->backend()->asyncCompute(expression.mid(1)));
     return;
   }
 
-  bool const containsNonAlnum =
+  bool const looksComputable =
       std::ranges::any_of(m_query, [](QChar ch) { return !ch.isLetterOrNumber(); }) ||
       m_query.starts_with("0x") || m_query.starts_with("0b") || m_query.starts_with("0o");
-  const auto isAllowedLeadingChar = [&](QChar c) {
-    return c == '-' || c == '(' || c == ')' || c.isLetterOrNumber() || c.category() == QChar::Symbol_Currency;
-  };
-  bool const isComputable =
-      expression.size() > 1 && isAllowedLeadingChar(expression.at(0)) && containsNonAlnum;
-
-  if (!isComputable || !m_calculator->backend()) { return; }
+  if (!looksComputable) return;
 
   m_calcWatcher.setFuture(m_calculator->backend()->asyncCompute(expression));
 }

--- a/src/server/src/qml/section-list-model.cpp
+++ b/src/server/src/qml/section-list-model.cpp
@@ -22,12 +22,14 @@ void SectionListModel::addSource(SectionSource *source) {
       rebuild();
     }
   });
+  rebuildCustomRoleDefaults();
 }
 
 void SectionListModel::clearSources() {
   for (auto *source : m_sources)
     source->setOnChanged(nullptr);
   m_sources.clear();
+  m_customRoleDefaults.clear();
 }
 
 void SectionListModel::setSelectFirstOnReset(bool value) {
@@ -77,8 +79,10 @@ QVariant SectionListModel::data(const QModelIndex &index, int role) const {
       return QString();
     case Accessory:
       return {};
-    default:
-      return {};
+    default: {
+      auto it = m_customRoleDefaults.find(role);
+      return it != m_customRoleDefaults.end() ? it.value() : QVariant{};
+    }
     }
   }
 
@@ -99,8 +103,12 @@ QVariant SectionListModel::data(const QModelIndex &index, int role) const {
     return source->itemIconSource(flat.itemIdx);
   case Accessory:
     return source->itemAccessories(flat.itemIdx);
-  default:
-    return source->customData(flat.itemIdx, role);
+  default: {
+    auto v = source->customData(flat.itemIdx, role);
+    if (v.isValid()) return v;
+    auto it = m_customRoleDefaults.find(role);
+    return it != m_customRoleDefaults.end() ? it.value() : QVariant{};
+  }
   }
 }
 
@@ -263,6 +271,12 @@ bool SectionListModel::dataItemAt(int row, int &sourceIdx, int &itemIdx) const {
   sourceIdx = flat.sourceIdx;
   itemIdx = flat.itemIdx;
   return true;
+}
+
+void SectionListModel::rebuildCustomRoleDefaults() {
+  m_customRoleDefaults.clear();
+  for (auto *source : m_sources)
+    m_customRoleDefaults.insert(source->customRoleDefaults());
 }
 
 void SectionListModel::rebuildFlatList() {

--- a/src/server/src/qml/section-list-model.hpp
+++ b/src/server/src/qml/section-list-model.hpp
@@ -71,10 +71,12 @@ private:
   };
 
   void rebuildFlatList();
+  void rebuildCustomRoleDefaults();
 
   ViewScope m_scope;
   std::vector<SectionSource *> m_sources;
   std::vector<FlatItem> m_flat;
+  QHash<int, QVariant> m_customRoleDefaults;
   int m_selectedIndex = -1;
   QString m_lastSelectedItemId;
   bool m_selectFirstOnReset = true;

--- a/src/server/src/qml/section-source.hpp
+++ b/src/server/src/qml/section-source.hpp
@@ -26,6 +26,7 @@ public:
 
   virtual QVariant customData(int, int) const { return {}; }
   virtual QHash<int, QByteArray> customRoleNames() const { return {}; }
+  virtual QHash<int, QVariant> customRoleDefaults() const { return {}; }
 
   virtual std::unique_ptr<ActionPanelState> actionPanel(int i) const = 0;
   virtual void onSelected(int) {}

--- a/src/server/src/services/calculator-service/abstract-calculator-backend.hpp
+++ b/src/server/src/services/calculator-service/abstract-calculator-backend.hpp
@@ -41,8 +41,10 @@ public:
   virtual QString id() const = 0;
   virtual QString displayName() const { return id(); }
 
-  virtual ComputeResult compute(const QString &question) const = 0;
-  virtual QFuture<ComputeResult> asyncCompute(const QString &question) const = 0;
+  virtual ComputeResult compute(const QString &question) = 0;
+  virtual QFuture<ComputeResult> asyncCompute(const QString &question) = 0;
+
+  virtual void abort() {}
 
   virtual bool supportsCurrencyConversion() const { return false; }
 

--- a/src/server/src/services/calculator-service/qalculate/qalculate-backend.cpp
+++ b/src/server/src/services/calculator-service/qalculate/qalculate-backend.cpp
@@ -72,22 +72,13 @@ std::expected<CalculatorResult, CalculatorError> QalculateBackend::compute(const
 }
 
 QString QalculateBackend::stripTrailingOperators(QString expr) {
-  static constexpr std::string_view asciiOps = "+-*/^&|!<>=~\\(";
+  static constexpr std::string_view ops = "+-*/^&|!<>=~\\(";
   while (!expr.isEmpty()) {
     QChar last = expr.back();
-    if (last.unicode() < 128 && asciiOps.find(static_cast<char>(last.unicode())) != std::string_view::npos) {
+    if (last.unicode() < 128 && ops.find(static_cast<char>(last.unicode())) != std::string_view::npos) {
       expr.chop(1);
     } else {
-      auto bytes = expr.last(1).toUtf8();
-      std::string_view tail(bytes.constData(), bytes.size());
-      // Unicode operators: × ÷ − ∧ ∨ ⊻ ≤ ≥ ≠
-      if (tail == "\xc3\x97" || tail == "\xc3\xb7" || tail == "\xe2\x88\x92" || tail == "\xe2\x88\xa7" ||
-          tail == "\xe2\x88\xa8" || tail == "\xe2\x8a\xbb" || tail == "\xe2\x89\xa4" ||
-          tail == "\xe2\x89\xa5" || tail == "\xe2\x89\xa0") {
-        expr.chop(1);
-      } else {
-        break;
-      }
+      break;
     }
   }
   return expr.trimmed();

--- a/src/server/src/services/calculator-service/qalculate/qalculate-backend.cpp
+++ b/src/server/src/services/calculator-service/qalculate/qalculate-backend.cpp
@@ -1,28 +1,26 @@
 #include "services/calculator-service/qalculate/qalculate-backend.hpp"
 #include "services/calculator-service/abstract-calculator-backend.hpp"
 #include <QDebug>
+#include <QRegularExpression>
 #include <format>
 #include <libqalculate/MathStructure.h>
 #include <libqalculate/QalculateDateTime.h>
 #include <libqalculate/includes.h>
 #include <libqalculate/Unit.h>
+#include <libqalculate/Variable.h>
+#include <libqalculate/Function.h>
 #include <libqalculate/Prefix.h>
 #include <qlogging.h>
 #include <QtConcurrent/QtConcurrent>
 #include <qobjectdefs.h>
+#include <ranges>
 
 using CalculatorResult = QalculateBackend::CalculatorResult;
 using CalculatorError = QalculateBackend::CalculatorError;
 
 QalculateBackend::QalculateBackend() = default;
 
-bool QalculateBackend::isActivatable() const {
-  /**
-   * if QalculateBackend is considered as an option, it means support for it was compiled in
-   * and the vicinae binary links to the qalculate library already. That's why we don't need complex checks.
-   */
-  return true;
-}
+bool QalculateBackend::isActivatable() const { return true; }
 
 bool QalculateBackend::start() {
   if (!m_initialized) {
@@ -33,11 +31,18 @@ bool QalculateBackend::start() {
   return true;
 }
 
-std::expected<CalculatorResult, CalculatorError> QalculateBackend::compute(const QString &question) const {
-  QString const expression = preprocessQuestion(question);
-  std::string const localizedExpression = CALCULATOR->unlocalizeExpression(expression.toStdString());
-  std::string res;
-  res = CALCULATOR->calculateAndPrint(localizedExpression, 10000, m_evalOpts, m_printOpts);
+std::expected<CalculatorResult, CalculatorError> QalculateBackend::compute(const QString &question) {
+  QString expression = preprocessQuestion(question);
+  expression = stripTrailingOperators(expression);
+  if (expression.isEmpty()) return std::unexpected(CalculatorError("Empty expression"));
+
+  auto stdExpr = expression.toStdString();
+  if (!isComputableExpression(stdExpr)) return std::unexpected(CalculatorError("Not computable"));
+
+  std::string const localizedExpression = CALCULATOR->unlocalizeExpression(stdExpr);
+  std::string res = CALCULATOR->calculateAndPrint(localizedExpression, 10000, m_evalOpts, m_printOpts);
+
+  if (CALCULATOR->aborted()) return std::unexpected(CalculatorError("Computation aborted"));
 
   MathStructure const in = CALCULATOR->parse(localizedExpression);
   MathStructure const result = CALCULATOR->parse(res);
@@ -66,14 +71,93 @@ std::expected<CalculatorResult, CalculatorError> QalculateBackend::compute(const
   return calcRes;
 }
 
-QString QalculateBackend::preprocessQuestion(const QString &query) const { return query.simplified(); }
-
-QFuture<QalculateBackend::ComputeResult> QalculateBackend::asyncCompute(const QString &question) const {
-  QPromise<ComputeResult> promise;
-  promise.addResult(compute(question));
-  promise.finish();
-  return promise.future();
+QString QalculateBackend::stripTrailingOperators(QString expr) {
+  static constexpr std::string_view asciiOps = "+-*/^&|!<>=~\\(";
+  while (!expr.isEmpty()) {
+    QChar last = expr.back();
+    if (last.unicode() < 128 && asciiOps.find(static_cast<char>(last.unicode())) != std::string_view::npos) {
+      expr.chop(1);
+    } else {
+      auto bytes = expr.last(1).toUtf8();
+      std::string_view tail(bytes.constData(), bytes.size());
+      // Unicode operators: × ÷ − ∧ ∨ ⊻ ≤ ≥ ≠
+      if (tail == "\xc3\x97" || tail == "\xc3\xb7" || tail == "\xe2\x88\x92" || tail == "\xe2\x88\xa7" ||
+          tail == "\xe2\x88\xa8" || tail == "\xe2\x8a\xbb" || tail == "\xe2\x89\xa4" ||
+          tail == "\xe2\x89\xa5" || tail == "\xe2\x89\xa0") {
+        expr.chop(1);
+      } else {
+        break;
+      }
+    }
+  }
+  return expr.trimmed();
 }
+
+bool QalculateBackend::isComputableExpression(const std::string &expr) {
+  static constexpr std::string_view opsAndParens = "~+-*/^&|!<>=() \t";
+  bool allOpsOrWhitespace =
+      std::ranges::all_of(expr, [](char c) { return opsAndParens.find(c) != std::string_view::npos; });
+  if (allOpsOrWhitespace) return false;
+
+  static constexpr std::string_view numberElements = "0123456789.:";
+  static constexpr std::string_view ops = "~+-*/^&|!<>=";
+
+  bool hasOps = std::ranges::any_of(expr, [](char c) { return ops.find(c) != std::string_view::npos; });
+  bool hasNumbers =
+      std::ranges::any_of(expr, [](char c) { return numberElements.find(c) != std::string_view::npos; });
+  bool hasSpaces = expr.find(' ') != std::string::npos;
+
+  if (hasOps || hasNumbers || hasSpaces) return true;
+
+  // Bare word — check if it's a known variable or zero-arg function
+  if (auto *var = CALCULATOR->getActiveVariable(expr); var && var->isKnown()) return true;
+  if (auto *fn = CALCULATOR->getActiveFunction(expr); fn && fn->minargs() == 0) return true;
+  if (CALCULATOR->hasToExpression(expr, false, EvaluationOptions())) return true;
+
+  return false;
+}
+
+QString QalculateBackend::preprocessQuestion(const QString &query) {
+  QString q = query.simplified();
+
+  // Rewrite " in " to " to " for unit conversion (avoids "in" being parsed as inches)
+  if (int idx = q.indexOf(QStringLiteral(" in ")); idx > 0 && idx + 4 < q.size()) {
+    q.replace(idx, 4, QStringLiteral(" to "));
+  }
+
+  struct Rule {
+    QRegularExpression re;
+    QString replacement;
+  };
+  static const auto storageNorms = std::array{
+      Rule{QRegularExpression(R"((?<![a-zA-Z])tb(?![a-zA-Z]))"), "TB"},
+      Rule{QRegularExpression(R"((?<![a-zA-Z])gb(?![a-zA-Z]))"), "GB"},
+      Rule{QRegularExpression(R"((?<![a-zA-Z])mb(?![a-zA-Z]))"), "MB"},
+      Rule{QRegularExpression(R"((?<![a-zA-Z])kb(?![a-zA-Z]))"), "kB"},
+      Rule{QRegularExpression(R"((?<![a-zA-Z])pb(?![a-zA-Z]))"), "PB"},
+      Rule{QRegularExpression(R"((?<![a-zA-Z])eb(?![a-zA-Z]))"), "EB"},
+      Rule{QRegularExpression(R"((?<![a-zA-Z])tib(?![a-zA-Z]))"), "TiB"},
+      Rule{QRegularExpression(R"((?<![a-zA-Z])gib(?![a-zA-Z]))"), "GiB"},
+      Rule{QRegularExpression(R"((?<![a-zA-Z])mib(?![a-zA-Z]))"), "MiB"},
+      Rule{QRegularExpression(R"((?<![a-zA-Z])kib(?![a-zA-Z]))"), "KiB"},
+      Rule{QRegularExpression(R"((?<![a-zA-Z])tbit(?![a-zA-Z]))"), "Tbit"},
+      Rule{QRegularExpression(R"((?<![a-zA-Z])gbit(?![a-zA-Z]))"), "Gbit"},
+      Rule{QRegularExpression(R"((?<![a-zA-Z])mbit(?![a-zA-Z]))"), "Mbit"},
+      Rule{QRegularExpression(R"((?<![a-zA-Z])kbit(?![a-zA-Z]))"), "kbit"},
+  };
+
+  for (const auto &[re, replacement] : storageNorms) {
+    q.replace(re, replacement);
+  }
+
+  return q;
+}
+
+QFuture<QalculateBackend::ComputeResult> QalculateBackend::asyncCompute(const QString &question) {
+  return QtConcurrent::run([this, question]() -> ComputeResult { return compute(question); });
+}
+
+void QalculateBackend::abort() { CALCULATOR->abort(); }
 
 QString QalculateBackend::id() const { return "qalculate"; }
 
@@ -100,16 +184,21 @@ bool QalculateBackend::supportsCurrencyConversion() const { return true; }
 void QalculateBackend::initializeCalculator() {
   m_evalOpts.auto_post_conversion = POST_CONVERSION_BEST;
   m_evalOpts.structuring = STRUCTURING_SIMPLIFY;
-  m_evalOpts.parse_options.limit_implicit_multiplication = true;
-  m_evalOpts.parse_options.parsing_mode = PARSING_MODE_CONVENTIONAL;
+  m_evalOpts.parse_options.parsing_mode = PARSING_MODE_ADAPTIVE;
   m_evalOpts.parse_options.units_enabled = true;
   m_evalOpts.parse_options.unknowns_enabled = false;
 
   m_printOpts.indicate_infinite_series = false;
   m_printOpts.interval_display = INTERVAL_DISPLAY_SIGNIFICANT_DIGITS;
   m_printOpts.use_unicode_signs = true;
-  m_printOpts.base_display = BASE_DISPLAY_ALTERNATIVE;
+  m_printOpts.base_display = BASE_DISPLAY_NORMAL;
   m_printOpts.number_fraction_format = FRACTION_DECIMAL;
+  m_printOpts.abbreviate_names = true;
+  m_printOpts.use_unit_prefixes = true;
+  m_printOpts.place_units_separately = true;
+  m_printOpts.short_multiplication = true;
+  m_printOpts.show_ending_zeroes = true;
+  m_printOpts.min_exp = EXP_PRECISION;
 
   m_calc.reset();
   m_calc.loadGlobalDefinitions();
@@ -119,6 +208,9 @@ void QalculateBackend::initializeCalculator() {
   m_calc.loadGlobalUnits();
   m_calc.loadGlobalVariables();
   m_calc.loadGlobalFunctions();
+
+  CALCULATOR->setTemperatureCalculationMode(TEMPERATURE_CALCULATION_HYBRID);
+  CALCULATOR->setPrecision(10);
 }
 
 std::optional<std::string> QalculateBackend::getUnitDisplayName(const MathStructure &s,

--- a/src/server/src/services/calculator-service/qalculate/qalculate-backend.hpp
+++ b/src/server/src/services/calculator-service/qalculate/qalculate-backend.hpp
@@ -4,6 +4,7 @@
 #include <libqalculate/MathStructure.h>
 #include <libqalculate/includes.h>
 
+
 class QalculateBackend : public AbstractCalculatorBackend {
 
   QString displayName() const override;
@@ -11,8 +12,9 @@ class QalculateBackend : public AbstractCalculatorBackend {
   bool supportsCurrencyConversion() const override;
   QFuture<RefreshExchangeRatesResult> refreshExchangeRates() override;
   bool start() override;
-  ComputeResult compute(const QString &question) const override;
-  QFuture<ComputeResult> asyncCompute(const QString &question) const override;
+  ComputeResult compute(const QString &question) override;
+  QFuture<ComputeResult> asyncCompute(const QString &question) override;
+  void abort() override;
   bool supportsRefreshExchangeRates() const override;
 
   bool isActivatable() const override;
@@ -24,7 +26,9 @@ private:
   static std::optional<std::string> getUnitDisplayName(const MathStructure &s, std::string_view prefix = "");
 
   void initializeCalculator();
-  QString preprocessQuestion(const QString &question) const;
+  static QString preprocessQuestion(const QString &question);
+  static QString stripTrailingOperators(QString expr);
+  static bool isComputableExpression(const std::string &expr);
 
   Calculator m_calc;
   bool m_initialized = false;

--- a/src/server/src/services/calculator-service/qalculate/qalculate-backend.hpp
+++ b/src/server/src/services/calculator-service/qalculate/qalculate-backend.hpp
@@ -4,7 +4,6 @@
 #include <libqalculate/MathStructure.h>
 #include <libqalculate/includes.h>
 
-
 class QalculateBackend : public AbstractCalculatorBackend {
 
   QString displayName() const override;

--- a/src/server/src/services/calculator-service/soulver-core/soulver-core.cpp
+++ b/src/server/src/services/calculator-service/soulver-core/soulver-core.cpp
@@ -57,7 +57,7 @@ std::vector<fs::path> SoulverCoreCalculator::availableResourcePaths() const {
 }
 
 std::expected<AbstractCalculatorBackend::CalculatorResult, AbstractCalculatorBackend::CalculatorError>
-SoulverCoreCalculator::compute(const QString &question) const {
+SoulverCoreCalculator::compute(const QString &question) {
   auto soulverRes = calculate(question);
 
   if (!soulverRes) { return std::unexpected(CalculatorError(soulverRes.error())); }
@@ -72,8 +72,7 @@ SoulverCoreCalculator::compute(const QString &question) const {
   return result;
 };
 
-QFuture<SoulverCoreCalculator::ComputeResult>
-SoulverCoreCalculator::asyncCompute(const QString &question) const {
+QFuture<SoulverCoreCalculator::ComputeResult> SoulverCoreCalculator::asyncCompute(const QString &question) {
   QPromise<ComputeResult> promise;
   promise.addResult(compute(question));
   promise.finish();

--- a/src/server/src/services/calculator-service/soulver-core/soulver-core.hpp
+++ b/src/server/src/services/calculator-service/soulver-core/soulver-core.hpp
@@ -14,8 +14,8 @@ public:
 
   bool isActivatable() const override;
   bool start() override;
-  ComputeResult compute(const QString &question) const override;
-  QFuture<ComputeResult> asyncCompute(const QString &question) const override;
+  ComputeResult compute(const QString &question) override;
+  QFuture<ComputeResult> asyncCompute(const QString &question) override;
 
   QString displayName() const override { return "SoulverCore"; }
   QString id() const override { return "soulver-core"; }


### PR DESCRIPTION
- "mb" is now interpreted as "megabytes" instead of "millibarns" by default. Similar story for other storage units. This was done because it's usually much more intuitive for most users.
- calculator is now available in calculator history view
- computation is done in a separate thread