### PR TITLE
fix: limit file preview size

### DIFF
--- a/src/server/src/qml/clipboard-history-view-host.cpp
+++ b/src/server/src/qml/clipboard-history-view-host.cpp
@@ -5,7 +5,6 @@
 #include "services/clipboard/clipboard-service.hpp"
 #include "utils/utils.hpp"
 #include <QDateTime>
-#include <QMimeDatabase>
 #include <QUrl>
 
 static std::optional<ClipboardOfferKind> kindFromFilterIndex(int index) {
@@ -216,20 +215,12 @@ void ClipboardHistoryViewHost::loadDetail(const ClipboardHistoryEntry &entry) {
         std::error_code ec;
         std::filesystem::path const path = url.path().toStdString();
         if (std::filesystem::is_regular_file(path, ec)) {
-          auto fileMime = QMimeDatabase().mimeTypeForFile(path.c_str());
-          if (fileMime.name().startsWith("image/")) {
-            m_detailImageSource = qml::imageSourceFor(ImageURL::local(path));
-            m_hasDetail = true;
-            emit detailChanged();
-            return;
-          }
-          if (Utils::isTextMimeType(fileMime)) {
-            QFile file(path.c_str());
-            if (file.open(QIODevice::ReadOnly)) { m_detailTextContent = QString::fromUtf8(file.readAll()); }
-            m_hasDetail = true;
-            emit detailChanged();
-            return;
-          }
+          auto preview = qml::resolveFilePreview(path, m_mimeDb);
+          m_detailImageSource = preview.imageSource;
+          m_detailTextContent = preview.textContent;
+          m_hasDetail = true;
+          emit detailChanged();
+          return;
         }
       }
     }
@@ -250,7 +241,8 @@ void ClipboardHistoryViewHost::loadDetail(const ClipboardHistoryEntry &entry) {
   }
 
   if (Utils::isTextMimeType(mime) || mime == "text/uri-list") {
-    m_detailTextContent = QString::fromUtf8(rawData);
+    static constexpr qsizetype MAX_DISPLAY = 10 * 1024;
+    m_detailTextContent = QString::fromUtf8(rawData.first(qMin<qsizetype>(rawData.size(), MAX_DISPLAY)));
     m_hasDetail = true;
     emit detailChanged();
     return;

--- a/src/server/src/qml/clipboard-history-view-host.hpp
+++ b/src/server/src/qml/clipboard-history-view-host.hpp
@@ -3,6 +3,7 @@
 #include "bridge-view.hpp"
 #include "section-list-model.hpp"
 #include "services/clipboard/clipboard-db.hpp"
+#include "view-utils.hpp"
 #include <QTemporaryFile>
 #include <memory>
 
@@ -80,6 +81,7 @@ private:
   ClipboardHistorySection m_section;
   ClipboardHistoryController *m_controller = nullptr;
   ClipboardService *m_clipman = nullptr;
+  QMimeDatabase m_mimeDb;
 
   QString m_itemCountText = QStringLiteral("Loading...");
   QString m_clipboardStatusText;

--- a/src/server/src/qml/dmenu-view-host.cpp
+++ b/src/server/src/qml/dmenu-view-host.cpp
@@ -66,12 +66,11 @@ void DMenuViewHost::beforePop() {
 }
 
 void DMenuViewHost::loadDetail(std::string_view path) {
-  auto qpath = QString::fromUtf8(path.data(), path.size());
   auto fspath = fs::path(path);
 
   m_hasDetail = true;
   m_detailName = QString::fromStdString(getLastPathComponent(fspath));
-  m_detailPath = qpath;
+  m_detailPath = QString::fromUtf8(path.data(), path.size());
 
   auto preview = qml::resolveFilePreview(fspath, m_mimeDb);
   m_detailMimeType = preview.mimeType;

--- a/src/server/src/qml/qml/TextViewer.qml
+++ b/src/server/src/qml/qml/TextViewer.qml
@@ -10,14 +10,17 @@ ScrollView {
     clip: true
     contentWidth: availableWidth
 
-    Text {
+    TextEdit {
         width: root.availableWidth
         text: root.text
-        textFormat: Text.PlainText
+        textFormat: TextEdit.PlainText
         color: Theme.foreground
         font.pointSize: Theme.smallerFontSize
         font.family: root.monospace ? Theme.monoFontFamily : undefined
-        wrapMode: Text.WrapAtWordBoundaryOrAnywhere
+        wrapMode: TextEdit.WrapAtWordBoundaryOrAnywhere
         padding: 12
+        readOnly: true
+        selectByMouse: true
+        selectionColor: Theme.textSelectionBg
     }
 }

--- a/src/server/src/qml/view-utils.cpp
+++ b/src/server/src/qml/view-utils.cpp
@@ -19,9 +19,9 @@ FilePreviewContent resolveFilePreview(const std::filesystem::path &path, QMimeDa
     result.imageSource = imageSourceFor(ImageURL::local(path));
   } else if (Utils::isTextMimeType(mime)) {
     QFile file(qpath);
-    if (file.open(QIODevice::ReadOnly)) {
-      static constexpr qint64 MAX_PREVIEW = static_cast<qint64>(32 * 1024);
-      result.textContent = QString::fromUtf8(file.read(MAX_PREVIEW));
+    if (file.open(QIODevice::ReadOnly) && file.size() <= MAX_PREVIEW_SIZE) {
+      static constexpr qint64 MAX_DISPLAY = 10 * 1024;
+      result.textContent = QString::fromUtf8(file.read(MAX_DISPLAY));
     }
   } else {
     result.imageSource = imageSourceFor(

--- a/src/server/src/qml/view-utils.hpp
+++ b/src/server/src/qml/view-utils.hpp
@@ -4,13 +4,16 @@
 #include "extend/metadata-model.hpp"
 #include "image-url.hpp"
 #include "ui/image/url.hpp"
-#include <QString>
 #include <QMimeDatabase>
+#include <QString>
 #include <QVariantList>
+#include <cstdint>
 #include <filesystem>
 #include <vector>
 
 namespace qml {
+
+inline constexpr int64_t MAX_PREVIEW_SIZE = 2 * 1024 * 1024;
 
 struct FilePreviewContent {
   QString mimeType;


### PR DESCRIPTION
prevents the UI thread from locking up when the file is too big.
These views are not meant to display the full text content of files anyways.