### PR TITLE
fix: cap arg completer width to enable text auto-scroll

### DIFF
--- a/src/server/src/qml/qml/ArgCompleter.qml
+++ b/src/server/src/qml/qml/ArgCompleter.qml
@@ -60,6 +60,10 @@ RowLayout {
             required property var modelData
 
             readonly property bool isLast: index === root.visibleArgs.length - 1
+            readonly property real maxArgWidth: {
+                var totalSpacing = root.spacing * (root.visibleArgs.length + 1);
+                return Math.max((root.width - 25 - totalSpacing) / root.visibleArgs.length, 60);
+            }
 
             Layout.alignment: Qt.AlignVCenter
 
@@ -73,7 +77,7 @@ RowLayout {
                     property string currentValue: textField.text
                     property bool showError: false
 
-                    implicitWidth: textMetrics.advanceWidth + 16
+                    implicitWidth: Math.min(textMetrics.advanceWidth + 16, argLoader.maxArgWidth)
                     implicitHeight: 26
                     radius: 4
                     color: "transparent"
@@ -158,7 +162,7 @@ RowLayout {
                     property string currentValue: ""
                     property bool showError: false
 
-                    implicitWidth: Math.max(dropdownMetrics.advanceWidth + 36, 80)
+                    implicitWidth: Math.min(Math.max(dropdownMetrics.advanceWidth + 36, 80), argLoader.maxArgWidth)
                     implicitHeight: 26
                     radius: 4
                     color: "transparent"

--- a/src/server/src/qml/qml/ArgCompleter.qml
+++ b/src/server/src/qml/qml/ArgCompleter.qml
@@ -77,7 +77,7 @@ RowLayout {
                     property string currentValue: textField.text
                     property bool showError: false
 
-                    implicitWidth: Math.min(textMetrics.advanceWidth + 16, argLoader.maxArgWidth)
+                    implicitWidth: Math.min((textField.text ? textField.contentWidth : textMetrics.advanceWidth) + 16, argLoader.maxArgWidth)
                     implicitHeight: 26
                     radius: 4
                     color: "transparent"


### PR DESCRIPTION
## Summary

- Inline command argument text fields (`ArgCompleter.qml`) grew unboundedly with text content via `implicitWidth: textMetrics.advanceWidth + 16`, preventing QML's native `TextInput` horizontal auto-scroll from ever engaging
- Caps each arg delegate's `implicitWidth` to a proportional share of available width (minus icon and spacing), floored at 60px
- The existing `clip: true` on `TextInput` then triggers auto-scroll naturally once text exceeds the bounded container
- Same fix applied to dropdown delegates for consistency

Closes #1116

## Test plan

- [ ] Open a command with text argument(s), type a long string — text should now scroll horizontally instead of overflowing
- [ ] Short arguments should still grow-to-fit naturally (no visual change)
- [ ] Commands with multiple arguments should split available width evenly
- [ ] Dropdown arguments should also remain bounded