### PR TITLE
feat: proper kwin window detection

### DIFF
--- a/src/server/src/services/window-manager/kde/kde-window-manager.cpp
+++ b/src/server/src/services/window-manager/kde/kde-window-manager.cpp
@@ -1,91 +1,266 @@
-#include <QGuiApplication>
-#include <qdbusargument.h>
-#include <qguiapplication_platform.h>
+#include <QCoreApplication>
+#include <algorithm>
+#include <qdbusconnection.h>
+#include <qdbusconnectioninterface.h>
+#include <qdbusinterface.h>
+#include <qdbusmessage.h>
+#include <qdbusservicewatcher.h>
+#include <qdir.h>
 #include <qlogging.h>
-#include <QWindow>
-#include <ranges>
-#include "utils/qt-wayland-utils.hpp"
+#include <qtemporaryfile.h>
+#include <quuid.h>
+#include <string_view>
 #include "kde-window-manager.hpp"
-#include "services/window-manager/abstract-window-manager.hpp"
-#include <wayland-client-protocol.h>
 
 namespace KDE {
 
-QDBusInterface WindowManager::getKRunnerInterface() {
-  return QDBusInterface("org.kde.KWin", "/WindowsRunner", "org.kde.krunner1");
+static constexpr const char *KWIN_SERVICE = "org.kde.KWin";
+static constexpr const char *SCRIPTING_PATH = "/Scripting";
+static constexpr const char *SCRIPTING_IFACE = "org.kde.kwin.Scripting";
+static constexpr const char *SCRIPT_IFACE = "org.kde.kwin.Script";
+static constexpr const char *TRACKER_SERVICE = "org.vicinae.WindowTracker";
+static constexpr const char *TRACKER_PATH = "/";
+static constexpr const char *TRACKER_PLUGIN = "vicinae-window-tracker";
+
+// Persistent tracker. Walks stackingOrder once at load to seed our cache,
+// then forwards windowAdded / windowRemoved / windowActivated events for the
+// rest of the KWin session. Captions can change after add(); we re-emit add()
+// from captionChanged so the cache stays current.
+static constexpr std::string_view TRACKER_JS = R"JS(
+(function () {
+  const SVC = "org.vicinae.WindowTracker";
+  const P = "/";
+  const IF = "org.vicinae.WindowTracker";
+
+  function push(w) {
+    if (!w || !w.normalWindow) return;
+    callDBus(SVC, P, IF, "add",
+      String(w.internalId),
+      String(w.resourceClass || ""),
+      String(w.resourceName || ""),
+      String(w.caption || ""),
+      w.pid | 0);
+  }
+
+  function hook(w) {
+    if (!w || !w.normalWindow) return;
+    push(w);
+    if (w.captionChanged) {
+      w.captionChanged.connect(function () { push(w); });
+    }
+  }
+
+  try {
+    const list = workspace.stackingOrder;
+    for (let i = 0; i < list.length; ++i) hook(list[i]);
+
+    const a = workspace.activeWindow;
+    callDBus(SVC, P, IF, "activated", a ? String(a.internalId) : "");
+
+    workspace.windowAdded.connect(hook);
+    workspace.windowRemoved.connect(function (w) {
+      if (w) callDBus(SVC, P, IF, "remove", String(w.internalId));
+    });
+    workspace.windowActivated.connect(function (w) {
+      callDBus(SVC, P, IF, "activated", w ? String(w.internalId) : "");
+    });
+  } catch (e) {
+    callDBus(SVC, P, IF, "error", String(e));
+  }
+})();
+)JS";
+
+// One-shot focus. %1 is replaced with the target UUID before loading.
+static constexpr std::string_view FOCUS_JS_TEMPLATE = R"JS(
+(function () {
+  const target = "%1";
+  const list = workspace.stackingOrder;
+  for (let i = 0; i < list.length; ++i) {
+    if (list[i] && String(list[i].internalId) === target) {
+      workspace.activeWindow = list[i];
+      return;
+    }
+  }
+})();
+)JS";
+
+static QDBusInterface kwinScripting() {
+  return QDBusInterface(KWIN_SERVICE, SCRIPTING_PATH, SCRIPTING_IFACE);
 }
 
-WindowManager::WindowList WindowManager::listWindowsSync() const {
-  auto iface = getKRunnerInterface();
+WindowTracker::WindowTracker(QObject *parent) : QObject(parent) {}
 
-  if (!iface.isValid()) {
-    qWarning() << "krunner interface is not valid";
-    return {};
-  }
-
-  auto res = iface.call("Match", "");
-
-  if (auto msg = res.errorMessage(); !msg.isEmpty()) {
-    qWarning() << "listWindowsSync: failed to find matching windows" << msg;
-    return {};
-  }
-
-  auto args = res.arguments();
-
-  if (args.empty()) {
-    qWarning() << "listWindowsSync: empty list of arguments";
-    return {};
-  }
-
-  KDE::KRunnerWindowList lst;
-
-  args.front().value<QDBusArgument>() >> lst;
-
-  // we get rid of duplicates, as for some reason some windows seem to be duplicated
-  std::ranges::sort(lst.windows, [](const auto &w1, const auto &w2) { return w1.id < w2.id; });
-  const auto [first, last] =
-      std::ranges::unique(lst.windows, [](const auto &w1, const auto &w2) { return w1.id == w2.id; });
-  lst.windows.erase(first, last);
-
-  return lst.windows | std::views::filter([](auto &&w) { return !w.title.isEmpty(); }) |
-         std::views::transform(
-             [](auto &&w) -> AbstractWindowManager::WindowPtr { return std::make_shared<Window>(w); }) |
-         std::ranges::to<std::vector>();
+void WindowTracker::reset() {
+  bool hadWindows = !m_windows.empty();
+  bool hadFocus = !m_focused.isEmpty();
+  m_windows.clear();
+  m_focused.clear();
+  if (hadWindows) emit windowsChanged();
+  if (hadFocus) emit focusChanged();
 }
 
-void WindowManager::focusWindowSync(const AbstractWindow &window) const {
-  QDBusInterface iface = getKRunnerInterface();
-  iface.call("Run", window.id(), "");
+void WindowTracker::add(const QString &id, const QString &resourceClass, const QString &resourceName,
+                        const QString &caption, int pid) {
+  WindowInfo info{
+      .id = id, .resourceClass = resourceClass, .resourceName = resourceName, .caption = caption, .pid = pid};
+  auto it = std::ranges::find_if(m_windows, [&](const auto &w) { return w.id == id; });
+  if (it != m_windows.end()) {
+    *it = std::move(info);
+  } else {
+    m_windows.emplace_back(std::move(info));
+  }
+  emit windowsChanged();
+}
+
+void WindowTracker::remove(const QString &id) {
+  auto erased = std::erase_if(m_windows, [&](const auto &w) { return w.id == id; });
+  if (erased > 0) emit windowsChanged();
+}
+
+void WindowTracker::activated(const QString &id) {
+  if (m_focused == id) return;
+  m_focused = id;
+  emit focusChanged();
+}
+
+void WindowTracker::error(const QString &message) { qWarning() << "[kde] tracker script error:" << message; }
+
+WindowManager::WindowManager() = default;
+
+WindowManager::~WindowManager() {
+  if (m_serviceOwned) unloadScriptByName(TRACKER_PLUGIN);
+}
+
+bool WindowManager::ping() const {
+  return QDBusConnection::sessionBus().interface()->isServiceRegistered(KWIN_SERVICE);
 }
 
 void WindowManager::start() {
-  qWarning() << "KDE window management is currently experimental. App to window matching may not work for "
-                "some applications.";
-}
+  m_tracker = std::make_unique<WindowTracker>(this);
+  connect(m_tracker.get(), &WindowTracker::windowsChanged, this,
+          [this]() { emit AbstractWindowManager::windowsChanged(); });
 
-}; // namespace KDE
-
-// NOLINTBEGIN(bugprone-return-const-ref-from-parameter)
-const QDBusArgument &operator>>(const QDBusArgument &arg, KDE::KRunnerWindowList &lst) {
-  arg.beginArray();
-  while (!arg.atEnd()) {
-    KDE::KRunnerWindowData win;
-    arg >> win;
-    lst.windows.emplace_back(win);
+  auto bus = QDBusConnection::sessionBus();
+  if (!bus.registerService(TRACKER_SERVICE)) {
+    qWarning() << "[kde] could not register" << TRACKER_SERVICE
+               << "- another vicinae instance may be running";
+    return;
   }
-  arg.endArray();
+  if (!bus.registerObject(TRACKER_PATH, m_tracker.get(), QDBusConnection::ExportScriptableSlots)) {
+    qWarning() << "[kde] could not register tracker object";
+    bus.unregisterService(TRACKER_SERVICE);
+    return;
+  }
+  m_serviceOwned = true;
 
-  return arg;
+  m_watcher = std::make_unique<QDBusServiceWatcher>(
+      KWIN_SERVICE, bus,
+      QDBusServiceWatcher::WatchForRegistration | QDBusServiceWatcher::WatchForUnregistration, this);
+  connect(m_watcher.get(), &QDBusServiceWatcher::serviceRegistered, this,
+          [this](const QString &) { loadTrackerScript(); });
+  connect(m_watcher.get(), &QDBusServiceWatcher::serviceUnregistered, this,
+          [this](const QString &) { m_tracker->reset(); });
+
+  // we can't do this in destructor because we need to make sure the event loop is still running when we
+  // unload
+  if (auto *app = QCoreApplication::instance()) {
+    connect(app, &QCoreApplication::aboutToQuit, this, [this]() { unloadScriptByName(TRACKER_PLUGIN); });
+  }
+
+  loadTrackerScript();
 }
 
-const QDBusArgument &operator>>(const QDBusArgument &arg, KDE::KRunnerWindowData &win) {
-  arg.beginStructure();
-  arg >> win.id >> win.title >> win.category >> win.i >> win.d;
-  arg.beginStructure();
-  arg >> win.s >> win.v;
-  arg.endStructure();
-  arg.endStructure();
+bool WindowManager::loadTrackerScript() {
+  unloadScriptByName(TRACKER_PLUGIN);
+  m_tracker->reset();
 
-  return arg;
+  // QTemporaryFile auto-removes on destruction. KWin opens the path during run(), not loadScript(),
+  // so we must keep the file alive until after the run reply arrives.
+  QTemporaryFile tmp(QDir::tempPath() + "/vicinae-kwin-XXXXXX.js");
+  if (!tmp.open()) {
+    qWarning() << "[kde] could not create temp file for tracker script";
+    return false;
+  }
+  tmp.write(TRACKER_JS.data(), static_cast<qint64>(TRACKER_JS.size()));
+  tmp.flush();
+
+  auto scripting = kwinScripting();
+  auto loadReply = scripting.call("loadScript", tmp.fileName(), QString::fromLatin1(TRACKER_PLUGIN));
+
+  if (loadReply.type() == QDBusMessage::ErrorMessage) {
+    qWarning() << "[kde] loadScript failed:" << loadReply.errorMessage();
+    return false;
+  }
+  int scriptId = loadReply.arguments().value(0).toInt();
+  if (scriptId < 0) {
+    qWarning() << "[kde] loadScript returned" << scriptId;
+    return false;
+  }
+
+  QDBusInterface script(KWIN_SERVICE, QString("/Scripting/Script%1").arg(scriptId), SCRIPT_IFACE);
+  auto runReply = script.call("run");
+  if (runReply.type() == QDBusMessage::ErrorMessage) {
+    qWarning() << "[kde] tracker script run failed:" << runReply.errorMessage();
+    return false;
+  }
+  return true;
 }
-// NOLINTEND(bugprone-return-const-ref-from-parameter)
+
+void WindowManager::unloadScriptByName(const QString &pluginName) const {
+  kwinScripting().call("unloadScript", pluginName);
+}
+
+bool WindowManager::runOneShot(const QString &source, const QString &pluginName) const {
+  QTemporaryFile tmp(QDir::tempPath() + "/vicinae-kwin-XXXXXX.js");
+  if (!tmp.open()) return false;
+  tmp.write(source.toUtf8());
+  tmp.flush();
+
+  auto scripting = kwinScripting();
+  auto loadReply = scripting.call("loadScript", tmp.fileName(), pluginName);
+  if (loadReply.type() == QDBusMessage::ErrorMessage) {
+    qWarning() << "[kde] one-shot loadScript failed:" << loadReply.errorMessage();
+    return false;
+  }
+  int scriptId = loadReply.arguments().value(0).toInt();
+  if (scriptId < 0) {
+    qWarning() << "[kde] one-shot loadScript returned" << scriptId;
+    return false;
+  }
+  QDBusInterface script(KWIN_SERVICE, QString("/Scripting/Script%1").arg(scriptId), SCRIPT_IFACE);
+  script.call("run");
+  unloadScriptByName(pluginName);
+  return true;
+}
+
+WindowManager::WindowList WindowManager::listWindowsSync() const {
+  if (!m_tracker) return {};
+  auto snap = m_tracker->snapshot();
+  WindowList result;
+  result.reserve(snap.size());
+  for (auto &info : snap) {
+    result.emplace_back(std::make_shared<Window>(std::move(info)));
+  }
+  return result;
+}
+
+WindowManager::WindowPtr WindowManager::getFocusedWindowSync() const {
+  if (!m_tracker) return nullptr;
+  const auto id = m_tracker->focusedId();
+  if (id.isEmpty()) return nullptr;
+  for (auto &info : m_tracker->snapshot()) {
+    if (info.id == id) return std::make_shared<Window>(std::move(info));
+  }
+  return nullptr;
+}
+
+void WindowManager::focusWindowSync(const AbstractWindow &window) const {
+  const QString source =
+      QString::fromUtf8(FOCUS_JS_TEMPLATE.data(), static_cast<int>(FOCUS_JS_TEMPLATE.size()))
+          .arg(window.id());
+  const QString pluginName =
+      QString("vicinae-focus-%1").arg(QUuid::createUuid().toString(QUuid::WithoutBraces));
+  runOneShot(source, pluginName);
+}
+
+} // namespace KDE

--- a/src/server/src/services/window-manager/kde/kde-window-manager.hpp
+++ b/src/server/src/services/window-manager/kde/kde-window-manager.hpp
@@ -1,64 +1,93 @@
 #pragma once
+#include <memory>
+#include <optional>
+#include <qdbusservicewatcher.h>
+#include <qobject.h>
+#include <vector>
 #include "environment.hpp"
 #include "services/window-manager/abstract-window-manager.hpp"
-#include <qdbusargument.h>
-#include <qdbusinterface.h>
 
 namespace KDE {
-struct KRunnerWindowData {
-  QString id;
-  QString title;
-  QString category;
-  int i;    // not sure what this is
-  double d; // not sure what this is
-  QString s;
-  QVariant v;
-};
 
-struct KRunnerWindowList {
-  std::vector<KRunnerWindowData> windows;
+struct WindowInfo {
+  QString id;
+  QString resourceClass;
+  QString resourceName;
+  QString caption;
+  int pid = 0;
 };
 
 class Window : public AbstractWindowManager::AbstractWindow {
 public:
-  Window(const KRunnerWindowData &data) : m_data(data) {}
+  explicit Window(WindowInfo info) : m_info(std::move(info)) {}
 
-  QString id() const override { return m_data.id; }
-  QString title() const override { return m_data.title; }
-  QString wmClass() const override {
-    // we don't have direct window class access, so we try to extract what is the most likely
-    // to match with it
-
-    for (const char *sep : {" - ", " — "}) {
-      if (m_data.title.contains(sep)) { return m_data.title.split(sep).last().trimmed(); }
-    }
-
-    return m_data.title;
+  QString id() const override { return m_info.id; }
+  QString title() const override { return m_info.caption; }
+  QString wmClass() const override { return m_info.resourceClass; }
+  std::optional<int> pid() const override {
+    if (m_info.pid <= 0) return std::nullopt;
+    return m_info.pid;
   }
 
 private:
-  KRunnerWindowData m_data;
+  WindowInfo m_info;
 };
 
-// only for KDE Wayland, X11 uses its own generic window manager implementation
-class WindowManager : public AbstractWindowManager {
+class WindowTracker : public QObject {
+  Q_OBJECT
+  Q_CLASSINFO("D-Bus Interface", "org.vicinae.WindowTracker")
+
+signals:
+  void windowsChanged();
+  void focusChanged();
+
 public:
+  explicit WindowTracker(QObject *parent = nullptr);
+
+  std::vector<WindowInfo> snapshot() const { return m_windows; }
+  QString focusedId() const { return m_focused; }
+  void reset();
+
+public slots:
+  Q_SCRIPTABLE void add(const QString &id, const QString &resourceClass, const QString &resourceName,
+                        const QString &caption, int pid);
+  Q_SCRIPTABLE void remove(const QString &id);
+  Q_SCRIPTABLE void activated(const QString &id);
+  Q_SCRIPTABLE void error(const QString &message);
+
+private:
+  std::vector<WindowInfo> m_windows;
+  QString m_focused;
+};
+
+class WindowManager : public AbstractWindowManager {
+  Q_OBJECT
+
+public:
+  WindowManager();
+  ~WindowManager() override;
+
   QString id() const override { return "kde"; }
   QString displayName() const override { return "KDE"; }
 
   WindowList listWindowsSync() const override;
+  WindowPtr getFocusedWindowSync() const override;
   void focusWindowSync(const AbstractWindow &window) const override;
 
+  bool supportsFocusTracking() const override { return true; }
   bool isActivatable() const override { return Environment::isWaylandPlasmaDesktop(); }
-
-  bool ping() const override { return true; }
+  bool ping() const override;
 
   void start() override;
 
 private:
-  static QDBusInterface getKRunnerInterface();
-};
-} // namespace KDE
+  bool loadTrackerScript();
+  void unloadScriptByName(const QString &pluginName) const;
+  bool runOneShot(const QString &source, const QString &pluginName) const;
 
-const QDBusArgument &operator>>(const QDBusArgument &argument, KDE::KRunnerWindowList &window);
-const QDBusArgument &operator>>(const QDBusArgument &argument, KDE::KRunnerWindowData &window);
+  std::unique_ptr<WindowTracker> m_tracker;
+  std::unique_ptr<QDBusServiceWatcher> m_watcher;
+  bool m_serviceOwned = false;
+};
+
+} // namespace KDE

--- a/src/server/src/services/window-manager/kde/kde-window-manager.hpp
+++ b/src/server/src/services/window-manager/kde/kde-window-manager.hpp
@@ -28,6 +28,7 @@ public:
     if (m_info.pid <= 0) return std::nullopt;
     return m_info.pid;
   }
+  bool canClose() const override { return false; }
 
 private:
   WindowInfo m_info;


### PR DESCRIPTION
So far we have been relying on a private krunner API for window listing on KDE.
This was weak and missed a lot of app-to-window associations. 
This uses the kwin scripting API to get windows "the proper way"

For now, we still don't have support for closing windows, enumerating workspaces and so on, but this lays the foundation to implement these later if needed.

This was made a priority because we need this in order to properly support paste and snippet expansion.