### PR TITLE
nix support for snippets

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -78,5 +78,15 @@
         mkRayCastExtension = prev.callPackage ./nix/mkRayCastExtension.nix { };
       };
       homeManagerModules.default = import ./nix/module.nix self;
+
+      nixosModules.default = {pkgs, ...}: {
+        nixpkgs.overlays = [self.overlays.default];
+        security.wrappers.vicinae-input-server = {
+          source = "${pkgs.vicinae}/libexec/vicinae/vicinae-input-server";
+          capabilities = "cap_dac_override+ep";
+          owner = "root";
+          group = "root";
+        };
+      };
     };
 }

--- a/nix/vicinae.nix
+++ b/nix/vicinae.nix
@@ -96,6 +96,7 @@ gcc15Stdenv.mkDerivation (finalAttrs: {
         (placeholder "out")
       ]
     }"
+    "--set VICINAE_INPUT_SERVER_BIN /run/wrappers/bin/vicinae-input-server"
   ];
 
   meta = {


### PR DESCRIPTION
creates a nix wrapper for vicinae-input-server so we can give it cap_dac_override+ep without having any problems

if any nix users want to test this before it gets merged:

change vicinae.url to `github:vMohammad24/vicinae/nix-input-server`

add `inputs.vicinae.nixosModules.default` to your flake input modules