### PR TITLE
feat: client side drop shadows

### DIFF
--- a/extra/config.jsonc
+++ b/extra/config.jsonc
@@ -106,7 +106,8 @@
 		"client_side_decorations": {
 			"enabled": true,
 			"rounding": 10,
-			"border_width": 1
+			"border_width": 1,
+			"shadow_size": 16
 		},
 
 		// In compact mode, vicinae only shows a search bar in the root search if no query is entered, only expanding to its full size when searching.

--- a/extra/config.jsonc
+++ b/extra/config.jsonc
@@ -111,9 +111,8 @@
 
 			// Draws drop shadows on the client side, ONLY if we are a layer surface.
 			// We assume that non layer surfaces may already have drop shadows drawn by the compositor.
-			// In order for this to work together with blur, the compositor or whatever blur plugin is needed
-			// needs to be able to only blur a specific region of the window (so that the shadows themselves do not get blurred).
-			// Compositors implementing the ext-background-effect protocol will have no issue with this.
+			// In order to play well with blur, we do NOT allow drop shadows if the compositor doesn't support
+			// the ext-background-effect protocol (which allows defining a specific region to blur).
 			"shadow_size": 12
 		},
 

--- a/extra/config.jsonc
+++ b/extra/config.jsonc
@@ -97,6 +97,7 @@
 		
 		// Blur the window background.
 		// Supported on wayland compositors that implement ext-background-effect
+		// Make sure the window opacity above is < 1
 		"blur": {
 			"enabled": true
 		},
@@ -107,13 +108,17 @@
 			"enabled": true,
 			"rounding": 10,
 			"border_width": 1,
-			"shadow_size": 16
+
+			// Draws drop shadows on the client side, ONLY if we are a layer surface.
+			// We assume that non layer surfaces may already have drop shadows drawn by the compositor.
+			// In order for this to work together with blur, the compositor or whatever blur plugin is needed
+			// needs to be able to only blur a specific region of the window (so that the shadows themselves do not get blurred).
+			// Compositors implementing the ext-background-effect protocol will have no issue with this.
+			"shadow_size": 12
 		},
 
 		// In compact mode, vicinae only shows a search bar in the root search if no query is entered, only expanding to its full size when searching.
 		// WARNING: compact mode works best when vicinae is rendered as a layer surface (the default if available), as opposed to a regular floating window.
-		// That's because the part that is not rendered in compact mode is still part of the full window size, allowing the window to be gracefully expanded without having to deal
-		// with a compositor window resize which can generate a lot of visual noise. Server side borders and blur will look notably out of place.
 		"compact_mode": {
 			"enabled": false
 		},

--- a/src/server/src/config/config.hpp
+++ b/src/server/src/config/config.hpp
@@ -90,12 +90,14 @@ struct WindowCSD {
   bool enabled = true;
   int rounding = 10;
   int borderWidth = 3;
+  int shadowSize = 16;
 };
 
 template <> struct Partial<WindowCSD> {
   std::optional<bool> enabled;
   std::optional<int> rounding;
   std::optional<int> borderWidth;
+  std::optional<int> shadowSize;
 };
 
 struct WindowCompactMode {

--- a/src/server/src/config/config.hpp
+++ b/src/server/src/config/config.hpp
@@ -90,7 +90,7 @@ struct WindowCSD {
   bool enabled = true;
   int rounding = 10;
   int borderWidth = 3;
-  int shadowSize = 16;
+  int shadowSize = 12;
 };
 
 template <> struct Partial<WindowCSD> {

--- a/src/server/src/qml/background-effect-attached.cpp
+++ b/src/server/src/qml/background-effect-attached.cpp
@@ -31,6 +31,11 @@ void BackgroundEffectAttached::setRadius(int value) {
   apply();
 }
 
+bool BackgroundEffectAttached::supportsRegionalBlur() {
+  auto *mgr = BackgroundEffect::manager();
+  return mgr && mgr->supportsBlur();
+}
+
 void BackgroundEffectAttached::setRegion(const QRect &value) {
   if (m_hasExplicitRegion && m_region == value) return;
   m_region = value;

--- a/src/server/src/qml/background-effect-attached.hpp
+++ b/src/server/src/qml/background-effect-attached.hpp
@@ -13,6 +13,7 @@ class BackgroundEffectAttached : public QObject {
   Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged)
   Q_PROPERTY(int radius READ radius WRITE setRadius NOTIFY radiusChanged)
   Q_PROPERTY(QRect region READ region WRITE setRegion NOTIFY regionChanged)
+  Q_PROPERTY(bool supportsRegionalBlur READ supportsRegionalBlur CONSTANT)
 
 public:
   explicit BackgroundEffectAttached(QObject *parent);
@@ -25,6 +26,8 @@ public:
 
   QRect region() const { return m_region; }
   void setRegion(const QRect &value);
+
+  static bool supportsRegionalBlur();
 
 signals:
   void enabledChanged();

--- a/src/server/src/qml/config-bridge.hpp
+++ b/src/server/src/qml/config-bridge.hpp
@@ -9,6 +9,7 @@ class ConfigBridge : public QObject {
   Q_PROPERTY(qreal windowOpacity READ windowOpacity NOTIFY changed)
   Q_PROPERTY(int borderWidth READ borderWidth NOTIFY changed)
   Q_PROPERTY(int borderRounding READ borderRounding NOTIFY changed)
+  Q_PROPERTY(int shadowSize READ shadowSize NOTIFY changed)
   Q_PROPERTY(int windowWidth READ windowWidth NOTIFY changed)
   Q_PROPERTY(int windowHeight READ windowHeight NOTIFY changed)
   Q_PROPERTY(bool emacsMode READ emacsMode NOTIFY changed)
@@ -35,6 +36,11 @@ public:
   int borderRounding() const {
     auto &csd = cfg().launcherWindow.clientSideDecorations;
     return csd.enabled ? csd.rounding : 0;
+  }
+
+  int shadowSize() const {
+    auto &csd = cfg().launcherWindow.clientSideDecorations;
+    return csd.enabled ? csd.shadowSize : 0;
   }
 
   int windowWidth() const { return cfg().launcherWindow.size.width; }

--- a/src/server/src/qml/qml/LauncherWindow.qml
+++ b/src/server/src/qml/qml/LauncherWindow.qml
@@ -62,8 +62,9 @@ Window {
         layer.effect: MultiEffect {
             autoPaddingEnabled: false
             shadowEnabled: true
-            shadowBlur: 1.0
-            shadowColor: Qt.rgba(0, 0, 0, 0.4)
+            shadowBlur: 0.5
+            shadowVerticalOffset: 3
+            shadowColor: Qt.rgba(0, 0, 0, 0.3)
             maskEnabled: true
             maskInverted: true
             maskSource: shadowMask

--- a/src/server/src/qml/qml/LauncherWindow.qml
+++ b/src/server/src/qml/qml/LauncherWindow.qml
@@ -2,17 +2,22 @@ import QtQuick
 import QtQuick.Window
 import QtQuick.Layouts
 import QtQuick.Controls
+import QtQuick.Effects
 
 Window {
     id: root
+    property int shadowPadding: 0
+
     readonly property int _w: launcher.overrideWidth || Config.windowWidth
     readonly property int _h: launcher.overrideHeight || Config.windowHeight
-    width: _w
-    height: _h
-    minimumWidth: _w
-    maximumWidth: _w
-    minimumHeight: _h
-    maximumHeight: _h
+    readonly property int _contentH: launcher.compacted ? 60 + 2 * Config.borderWidth : _h
+
+    width: _w + 2 * shadowPadding
+    height: _h + 2 * shadowPadding
+    minimumWidth: _w + 2 * shadowPadding
+    maximumWidth: _w + 2 * shadowPadding
+    minimumHeight: _h + 2 * shadowPadding
+    maximumHeight: _h + 2 * shadowPadding
     title: "Vicinae Launcher"
     flags: Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint
     color: "transparent"
@@ -20,127 +25,188 @@ Window {
 
     BackgroundEffect.enabled: Config.blurEnabled
     BackgroundEffect.radius: Config.borderRounding
-    BackgroundEffect.region: Qt.rect(0, 0, root.width, launcher.compacted ? 60 : root.height)
+    BackgroundEffect.region: Qt.rect(shadowPadding, shadowPadding, _w, launcher.compacted ? 60 : _h)
 
-    Rectangle {
-        visible: launcher.compacted
+    Item {
+        id: shadowMask
         width: root.width
-        height: 60 + 2 * Config.borderWidth
-        radius: Config.borderRounding
-        color: Qt.rgba(Theme.background.r, Theme.background.g, Theme.background.b, Config.windowOpacity)
-        border.color: Theme.mainWindowBorder
-        border.width: Config.borderWidth
+        height: root.height
+        visible: false
+        layer.enabled: true
+
+        Rectangle {
+            x: root.shadowPadding
+            y: root.shadowPadding
+            width: _w
+            height: _contentH
+            radius: Config.borderRounding
+            color: "white"
+        }
     }
 
     Item {
-        visible: !launcher.compacted
+        id: shadowCaster
         anchors.fill: parent
-        anchors.bottomMargin: launcher.hasOverlay || !launcher.statusBarVisible ? 0 : footer.height + Config.borderWidth
-        clip: true
+        visible: root.shadowPadding > 0
 
         Rectangle {
-            width: root.width
-            height: root.height
+            x: root.shadowPadding
+            y: root.shadowPadding
+            width: _w
+            height: _contentH
+            radius: Config.borderRounding
+            color: "black"
+        }
+
+        layer.enabled: root.shadowPadding > 0
+        layer.effect: MultiEffect {
+            autoPaddingEnabled: false
+            shadowEnabled: true
+            shadowBlur: 1.0
+            shadowColor: Qt.rgba(0, 0, 0, 0.4)
+            maskEnabled: true
+            maskInverted: true
+            maskSource: shadowMask
+        }
+    }
+
+    Item {
+        id: content
+        x: root.shadowPadding
+        y: root.shadowPadding
+        width: _w
+        height: _h
+
+        Rectangle {
+            visible: launcher.compacted
+            width: _w
+            height: 60 + 2 * Config.borderWidth
             radius: Config.borderRounding
             color: Qt.rgba(Theme.background.r, Theme.background.g, Theme.background.b, Config.windowOpacity)
-        }
-    }
-
-    Item {
-        visible: !launcher.compacted && !launcher.hasOverlay && launcher.statusBarVisible
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.bottom: parent.bottom
-        height: footer.height + Config.borderWidth
-        clip: true
-
-        Rectangle {
-            width: root.width
-            height: root.height
-            anchors.bottom: parent.bottom
-            radius: Config.borderRounding
-            color: Qt.rgba(Theme.statusBarBackground.r, Theme.statusBarBackground.g, Theme.statusBarBackground.b, Config.windowOpacity)
-        }
-    }
-
-    Rectangle {
-        visible: !launcher.compacted
-        anchors.fill: parent
-        radius: Config.borderRounding
-        color: "transparent"
-        border.color: Theme.mainWindowBorder
-        border.width: Config.borderWidth
-    }
-
-    ColumnLayout {
-        anchors.fill: parent
-        anchors.margins: Config.borderWidth
-        spacing: 0
-        visible: !launcher.hasOverlay
-
-        SearchBar {
-            id: searchBar
-            Layout.fillWidth: true
-            Layout.preferredHeight: launcher.searchVisible ? 60 : 0
-            visible: launcher.searchVisible
-            enabled: !launcher.alertModel.visible
-        }
-
-        HorizontalLoadingBar {
-            Layout.fillWidth: true
-            implicitHeight: launcher.searchVisible ? 1 : 0
-            visible: launcher.searchVisible && !launcher.compacted
-            loading: launcher.isLoading
+            border.color: Theme.mainWindowBorder
+            border.width: Config.borderWidth
         }
 
         Item {
-            id: contentArea
-            objectName: "contentArea"
-            Layout.fillWidth: true
-            Layout.fillHeight: true
+            visible: !launcher.compacted
+            anchors.fill: parent
+            anchors.bottomMargin: launcher.hasOverlay || !launcher.statusBarVisible ? 0 : footer.height + Config.borderWidth
+            clip: true
 
-            StackView {
-                id: commandStack
-                anchors.fill: parent
-                visible: !launcher.compacted
-                initialItem: RootSearchList {}
+            Rectangle {
+                width: _w
+                height: _h
+                radius: Config.borderRounding
+                color: Qt.rgba(Theme.background.r, Theme.background.g, Theme.background.b, Config.windowOpacity)
+            }
+        }
+
+        Item {
+            visible: !launcher.compacted && !launcher.hasOverlay && launcher.statusBarVisible
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
+            height: footer.height + Config.borderWidth
+            clip: true
+
+            Rectangle {
+                width: _w
+                height: _h
+                anchors.bottom: parent.bottom
+                radius: Config.borderRounding
+                color: Qt.rgba(Theme.statusBarBackground.r, Theme.statusBarBackground.g, Theme.statusBarBackground.b, Config.windowOpacity)
             }
         }
 
         Rectangle {
-            visible: !launcher.compacted && launcher.statusBarVisible
-            Layout.fillWidth: true
-            implicitHeight: 1
-            color: Theme.divider
+            visible: !launcher.compacted
+            anchors.fill: parent
+            radius: Config.borderRounding
+            color: "transparent"
+            border.color: Theme.mainWindowBorder
+            border.width: Config.borderWidth
         }
 
-        Footer {
-            id: footer
-            visible: !launcher.compacted && launcher.statusBarVisible
-            Layout.fillWidth: true
-            Layout.preferredHeight: visible ? 40 : 0
+        ColumnLayout {
+            anchors.fill: parent
+            anchors.margins: Config.borderWidth
+            spacing: 0
+            visible: !launcher.hasOverlay
+
+            SearchBar {
+                id: searchBar
+                Layout.fillWidth: true
+                Layout.preferredHeight: launcher.searchVisible ? 60 : 0
+                visible: launcher.searchVisible
+                enabled: !launcher.alertModel.visible
+            }
+
+            HorizontalLoadingBar {
+                Layout.fillWidth: true
+                implicitHeight: launcher.searchVisible ? 1 : 0
+                visible: launcher.searchVisible && !launcher.compacted
+                loading: launcher.isLoading
+            }
+
+            Item {
+                id: contentArea
+                objectName: "contentArea"
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+
+                StackView {
+                    id: commandStack
+                    anchors.fill: parent
+                    visible: !launcher.compacted
+                    initialItem: RootSearchList {}
+                }
+            }
+
+            Rectangle {
+                visible: !launcher.compacted && launcher.statusBarVisible
+                Layout.fillWidth: true
+                implicitHeight: 1
+                color: Theme.divider
+            }
+
+            Footer {
+                id: footer
+                visible: !launcher.compacted && launcher.statusBarVisible
+                Layout.fillWidth: true
+                Layout.preferredHeight: visible ? 40 : 0
+            }
         }
-    }
 
-    Loader {
-        id: overlayLoader
-        anchors.fill: parent
-        anchors.margins: Config.borderWidth
-        visible: launcher.hasOverlay
+        Loader {
+            id: overlayLoader
+            anchors.fill: parent
+            anchors.margins: Config.borderWidth
+            visible: launcher.hasOverlay
 
-        onLoaded: if (item)
-            item.forceActiveFocus()
-    }
+            onLoaded: if (item)
+                item.forceActiveFocus()
+        }
 
-    ActionPanelPopover {
-        id: actionPanelPopover
-        z: 100
-        anchors.fill: parent
-        anchors.bottomMargin: footer.height + 1 + Config.borderWidth
-    }
+        ActionPanelPopover {
+            id: actionPanelPopover
+            z: 100
+            anchors.fill: parent
+            anchors.bottomMargin: footer.height + 1 + Config.borderWidth
+        }
 
-    AlertDialog {
-        id: alertDialog
+        AlertDialog {
+            id: alertDialog
+            Overlay.modal: Item {
+                Rectangle {
+                    x: root.shadowPadding
+                    y: root.shadowPadding
+                    width: parent.width - 2 * root.shadowPadding
+                    height: parent.height - 2 * root.shadowPadding
+                    radius: Config.borderRounding
+                    color: Qt.rgba(Theme.background.r, Theme.background.g, Theme.background.b, 0.5)
+                }
+            }
+        }
     }
 
     Connections {

--- a/src/server/src/qml/qml/LauncherWindow.qml
+++ b/src/server/src/qml/qml/LauncherWindow.qml
@@ -202,7 +202,7 @@ Window {
                     y: root.shadowPadding
                     width: parent.width - 2 * root.shadowPadding
                     height: parent.height - 2 * root.shadowPadding
-                    radius: Config.borderRounding
+                    radius: root.shadowPadding > 0 ? Config.borderRounding : 0
                     color: Qt.rgba(Theme.background.r, Theme.background.g, Theme.background.b, 0.5)
                 }
             }

--- a/src/server/src/qml/qml/LauncherWindowLayerShell.qml
+++ b/src/server/src/qml/qml/LauncherWindowLayerShell.qml
@@ -1,7 +1,7 @@
 import org.kde.layershell as LayerShell
 
 LauncherWindow {
-    shadowPadding: Config.shadowSize
+    shadowPadding: BackgroundEffect.supportsRegionalBlur ? Config.shadowSize : 0
 
     LayerShell.Window.anchors: LayerShell.Window.AnchorNone
     LayerShell.Window.scope: "vicinae"

--- a/src/server/src/qml/qml/LauncherWindowLayerShell.qml
+++ b/src/server/src/qml/qml/LauncherWindowLayerShell.qml
@@ -1,6 +1,8 @@
 import org.kde.layershell as LayerShell
 
 LauncherWindow {
+    shadowPadding: Config.shadowSize
+
     LayerShell.Window.anchors: LayerShell.Window.AnchorNone
     LayerShell.Window.scope: "vicinae"
     LayerShell.Window.wantsToBeOnActiveScreen: true

--- a/src/server/src/utils/qt-wayland-utils.hpp
+++ b/src/server/src/utils/qt-wayland-utils.hpp
@@ -31,15 +31,18 @@ inline ScopedRegion createRoundedRegion(QRect region, int radius) {
 
   wl_region_add(wlregion, region.x(), region.y(), w, h);
 
+  int x0 = region.x();
+  int y0 = region.y();
+
   for (int i = 0; i < r; i++) {
     int cut = r - static_cast<int>(std::sqrt(static_cast<double>((r * r) - ((r - i) * (r - i)))));
 
     if (cut <= 0) continue;
 
-    wl_region_subtract(wlregion, 0, i, cut, 1);
-    wl_region_subtract(wlregion, w - cut, i, cut, 1);
-    wl_region_subtract(wlregion, 0, h - 1 - i, cut, 1);
-    wl_region_subtract(wlregion, w - cut, h - 1 - i, cut, 1);
+    wl_region_subtract(wlregion, x0, y0 + i, cut, 1);
+    wl_region_subtract(wlregion, x0 + w - cut, y0 + i, cut, 1);
+    wl_region_subtract(wlregion, x0, y0 + h - 1 - i, cut, 1);
+    wl_region_subtract(wlregion, x0 + w - cut, y0 + h - 1 - i, cut, 1);
   }
 
   return ScopedRegion(wlregion);


### PR DESCRIPTION
draws drop shadows on the client side, only if we are a layer surface. We assume that non layer surfaces may already have drop shadows drawn by the compositor.

In order for this to work together with blur, the compositor must implement [ext-background-effect](https://wayland.app/protocols/ext-background-effect-v1) protocol. For compatibility reasons we don't allow drop shadows if the compositor doesn't implement it, at least for now.