### PR TITLE
fix: support escaping dynamic placeholders

### DIFF
--- a/src/server/src/placeholder.cpp
+++ b/src/server/src/placeholder.cpp
@@ -12,7 +12,7 @@ PlaceholderString PlaceholderString::parseShortcutText(const QString &link) {
 
 PlaceholderString PlaceholderString::parse(const QString &link, std::span<const QString> reserved) {
   PlaceholderString pstr;
-  enum class State : std::uint8_t { BkNormal, PhId, PhKeyStart, PhKey, PhValueStart, PhValue, PhValueQuoted };
+  enum class State : std::uint8_t { BkNormal, BkEscape, PhId, PhKeyStart, PhKey, PhValueStart, PhValue, PhValueQuoted };
   using enum State;
   State state = BkNormal;
   size_t i = 0;
@@ -49,11 +49,25 @@ PlaceholderString PlaceholderString::parse(const QString &link, std::span<const 
 
     switch (state) {
     case BkNormal:
+      if (ch == '\\') {
+        pstr.m_parts.emplace_back(link.sliced(startPos, i - startPos));
+        state = BkEscape;
+        break;
+      }
       if (ch == '{') {
         pstr.m_parts.emplace_back(link.sliced(startPos, i - startPos));
         state = PhId;
         startPos = i + 1;
       }
+      break;
+    case BkEscape:
+      if (ch == '\\') {
+        pstr.m_parts.emplace_back(QStringLiteral("\\"));
+        startPos = i + 1;
+      } else {
+        startPos = i;
+      }
+      state = BkNormal;
       break;
     case PhId:
       if (!ch.isLetterOrNumber()) {
@@ -117,6 +131,8 @@ PlaceholderString PlaceholderString::parse(const QString &link, std::span<const 
 
   if (state == BkNormal && i - startPos > 0) {
     pstr.m_parts.emplace_back(link.sliced(startPos, i - startPos));
+  } else if (state == BkEscape) {
+    pstr.m_parts.emplace_back(QStringLiteral("\\"));
   }
 
   return pstr;

--- a/src/server/src/placeholder.cpp
+++ b/src/server/src/placeholder.cpp
@@ -12,7 +12,16 @@ PlaceholderString PlaceholderString::parseShortcutText(const QString &link) {
 
 PlaceholderString PlaceholderString::parse(const QString &link, std::span<const QString> reserved) {
   PlaceholderString pstr;
-  enum class State : std::uint8_t { BkNormal, BkEscape, PhId, PhKeyStart, PhKey, PhValueStart, PhValue, PhValueQuoted };
+  enum class State : std::uint8_t {
+    BkNormal,
+    BkEscape,
+    PhId,
+    PhKeyStart,
+    PhKey,
+    PhValueStart,
+    PhValue,
+    PhValueQuoted
+  };
   using enum State;
   State state = BkNormal;
   size_t i = 0;

--- a/src/server/src/qml/qml/PlaceholderCompleter.qml
+++ b/src/server/src/qml/qml/PlaceholderCompleter.qml
@@ -18,8 +18,11 @@ Item {
             const c = txt.charAt(i);
             if (c === '}')
                 return -1;
-            if (c === root.triggerChar)
+            if (c === root.triggerChar) {
+                if (i > 0 && txt.charAt(i - 1) === '\\')
+                    return -1;
                 return i;
+            }
         }
         return -1;
     }


### PR DESCRIPTION
`\{` for literal curly braces