### PR TITLE
Vacuum file-indexer after rebuild to reclaim disk space

### DIFF
--- a/src/server/src/services/files-service/file-indexer/db-writer.cpp
+++ b/src/server/src/services/files-service/file-indexer/db-writer.cpp
@@ -73,6 +73,13 @@ void DbWriter::deleteAllIndexedFiles(std::function<void()> onComplete) {
   });
 }
 
+void DbWriter::compact(std::function<void()> onComplete) {
+  submit([onComplete = std::move(onComplete)](FileIndexerDatabase &db) {
+    db.compact();
+    if (onComplete) { onComplete(); }
+  });
+}
+
 void DbWriter::indexEvents(std::vector<FileEvent> events) {
   submit([events = std::move(events)](FileIndexerDatabase &db) { db.indexEvents(events); });
 }

--- a/src/server/src/services/files-service/file-indexer/db-writer.hpp
+++ b/src/server/src/services/files-service/file-indexer/db-writer.hpp
@@ -40,6 +40,7 @@ public:
   void indexFiles(std::vector<std::filesystem::path> paths);
   void deleteIndexedFiles(std::vector<std::filesystem::path> paths);
   void deleteAllIndexedFiles(std::function<void()> onComplete = nullptr);
+  void compact(std::function<void()> onComplete = nullptr);
 
   void indexEvents(std::vector<FileEvent> events);
 };

--- a/src/server/src/services/files-service/file-indexer/file-indexer-db.cpp
+++ b/src/server/src/services/files-service/file-indexer/file-indexer-db.cpp
@@ -312,6 +312,19 @@ void FileIndexerDatabase::deleteAllIndexedFiles() {
   }
 }
 
+void FileIndexerDatabase::compact() {
+  QSqlQuery query(m_db);
+
+  if (!query.exec("VACUUM")) {
+    qWarning() << "VACUUM failed" << query.lastError();
+    return;
+  }
+
+  if (!query.exec("PRAGMA wal_checkpoint(TRUNCATE)")) {
+    qWarning() << "wal_checkpoint(TRUNCATE) failed" << query.lastError();
+  }
+}
+
 void FileIndexerDatabase::indexEvents(const std::vector<FileEvent> &events) {
   if (!m_db.transaction()) {
     qWarning() << "Failed to start batch transaction" << m_db.lastError();

--- a/src/server/src/services/files-service/file-indexer/file-indexer-db.hpp
+++ b/src/server/src/services/files-service/file-indexer/file-indexer-db.hpp
@@ -47,6 +47,7 @@ public:
   std::vector<std::filesystem::path> listIndexedDirectoryFiles(const std::filesystem::path &path) const;
 
   void deleteAllIndexedFiles();
+  void compact();
   void deleteIndexedFiles(const std::vector<std::filesystem::path> &paths);
   void indexFiles(const std::vector<std::filesystem::path> &paths);
   std::vector<std::filesystem::path> search(std::string_view searchQuery,

--- a/src/server/src/services/files-service/file-indexer/file-indexer.cpp
+++ b/src/server/src/services/files-service/file-indexer/file-indexer.cpp
@@ -30,20 +30,25 @@ void FileIndexer::startFullScan() {
 
     // Delete all indexed files, then enqueue new scans in the completion callback
     m_writer->deleteAllIndexedFiles([this]() {
-      qInfo() << "Existing index cleared, enqueuing full scan tasks...";
+      qInfo() << "Existing index cleared, compacting database...";
 
-      for (const auto &entrypoint : m_entrypoints) {
-        qInfo() << "Enqueuing full scan for" << entrypoint.c_str();
-        // For now we don't exclude filenames during full scans, though this might change in the future.
-        // The reason being that we still want to know where the db file is (current use case), just not watch
-        // it. May want to split the list in two later (scan vs watch).
-        m_dispatcher.enqueue({.type = ScanType::Full, .path = entrypoint, .excludedPaths = m_excludedPaths});
-      }
+      m_writer->compact([this]() {
+        qInfo() << "Database compacted, enqueuing full scan tasks...";
 
-      for (const auto &entrypoint : m_watcherPaths) {
-        qInfo() << "Enqueuing watcher scan for" << entrypoint.c_str();
-        startSingleScan(entrypoint, ScanType::Watcher, m_excludedFilenames);
-      }
+        for (const auto &entrypoint : m_entrypoints) {
+          qInfo() << "Enqueuing full scan for" << entrypoint.c_str();
+          // For now we don't exclude filenames during full scans, though this might change in the future.
+          // The reason being that we still want to know where the db file is (current use case), just not
+          // watch it. May want to split the list in two later (scan vs watch).
+          m_dispatcher.enqueue(
+              {.type = ScanType::Full, .path = entrypoint, .excludedPaths = m_excludedPaths});
+        }
+
+        for (const auto &entrypoint : m_watcherPaths) {
+          qInfo() << "Enqueuing watcher scan for" << entrypoint.c_str();
+          startSingleScan(entrypoint, ScanType::Watcher, m_excludedFilenames);
+        }
+      });
     });
   }).detach();
 }


### PR DESCRIPTION
## Summary

After reducing search paths and running `Rebuild File Index`, `file-indexer.db` and `file-indexer.db-wal` stayed the same size (or grew). The rebuild deletes all rows but never tells SQLite to hand the freed space back to disk, so the file size only ever reflects the largest the index has ever been.

## Fix

After the bulk delete, run `VACUUM` and a truncating WAL checkpoint on the writer thread, then start the new scans. The compact happens while the database is empty, so it's fast. Errors are logged and don't block the rebuild.

## Testing

- Built and ran locally.
- Indexed a broad set of paths, noted the file sizes.
- Reduced the paths, hit `Rebuild File Index`.
- Both files shrank to match the new content.

## clang-tidy

`make check-format` is clean, and `clang-tidy` reports no new issues from this PR. Two pre-existing `bugprone-throwing-static-initialization` errors on `main` (`SQLITE_PRAGMAS` and `EXCLUDED_PATHS`) are left as-is.

## AI disclosure

The code was reviewed but not written by Claude Opus 4.7 using Claude Code.
The PR text was also drafted by it.