### PR TITLE
Feat/action panel state rework

### DIFF
--- a/extra/extension-boilerplate/package.json
+++ b/extra/extension-boilerplate/package.json
@@ -78,6 +78,12 @@
 			"title": "Nested Form",
 			"description": "Test form views pushed from a list (nested navigation)",
 			"mode": "view"
+		},
+		{
+			"name": "action-panel-stress",
+			"title": "Action Panel Stress Test",
+			"description": "Test action panel reconciliation, deep submenus, dynamic content, and filter preservation",
+			"mode": "view"
 		}
 	],
 	"preferences": [],

--- a/extra/extension-boilerplate/src/action-panel-stress.tsx
+++ b/extra/extension-boilerplate/src/action-panel-stress.tsx
@@ -18,15 +18,6 @@ function useTick(ms: number) {
 	return tick;
 }
 
-// ---------------------------------------------------------------------------
-// Test 1 — Reconciliation
-//
-// List re-renders on a timer while the action panel is open.
-// The per-item panel has a stable ID so it should update in place:
-// actions update their titles but the panel stays open, filter text
-// is preserved, and selection doesn't jump.
-// ---------------------------------------------------------------------------
-
 function ReconciliationTest() {
 	const tick = useTick(1500);
 	const [extra, setExtra] = useState(false);
@@ -109,14 +100,6 @@ function ReconciliationTest() {
 	);
 }
 
-// ---------------------------------------------------------------------------
-// Test 2 — Deep submenu navigation
-//
-// Three levels of submenus. Tests step-by-step pop with Escape:
-// Level 3 → Level 2 → Level 1 → Root panel → Close.
-// Also tests that backspace in an empty filter does NOT pop.
-// ---------------------------------------------------------------------------
-
 function DeepSubmenuTest() {
 	return (
 		<List
@@ -197,14 +180,6 @@ function DeepSubmenuTest() {
 	);
 }
 
-// ---------------------------------------------------------------------------
-// Test 3 — Dynamic submenu content
-//
-// Submenu fires onOpen, which triggers a state update that populates
-// the submenu with async-loaded items. Subsequent re-renders update
-// the submenu content while it stays open.
-// ---------------------------------------------------------------------------
-
 function DynamicSubmenuTest() {
 	const tick = useTick(2000);
 	const [loadedItems, setLoadedItems] = useState<string[]>([]);
@@ -279,15 +254,6 @@ function DynamicSubmenuTest() {
 	);
 }
 
-// ---------------------------------------------------------------------------
-// Test 4 — Large action panel
-//
-// An action panel with many actions to test filter performance and
-// verify the list virtualizes correctly. Also exercises the filter
-// input: type to filter, verify results narrow down, then verify
-// backspace does NOT pop the panel.
-// ---------------------------------------------------------------------------
-
 function LargeActionPanelTest() {
 	const categories = ["Network", "File", "System", "UI", "Data", "Auth"];
 
@@ -337,14 +303,6 @@ function LargeActionPanelTest() {
 		</List>
 	);
 }
-
-// ---------------------------------------------------------------------------
-// Test 5 — Reconciliation stress
-//
-// Rapid re-renders (every 500ms) with per-item panels that grow/shrink,
-// change sections, and swap action order. Panel must stay open and
-// coherent throughout.
-// ---------------------------------------------------------------------------
 
 function StressTest() {
 	const tick = useTick(500);
@@ -447,10 +405,6 @@ function StressTest() {
 		</List>
 	);
 }
-
-// ---------------------------------------------------------------------------
-// Root
-// ---------------------------------------------------------------------------
 
 export default function ActionPanelStress() {
 	const { push } = useNavigation();

--- a/extra/extension-boilerplate/src/action-panel-stress.tsx
+++ b/extra/extension-boilerplate/src/action-panel-stress.tsx
@@ -1,0 +1,517 @@
+import {
+	Action,
+	ActionPanel,
+	Icon,
+	List,
+	showToast,
+	Toast,
+	useNavigation,
+} from "@vicinae/api";
+import { useState, useEffect, useCallback } from "react";
+
+function useTick(ms: number) {
+	const [tick, setTick] = useState(0);
+	useEffect(() => {
+		const id = setInterval(() => setTick((t) => t + 1), ms);
+		return () => clearInterval(id);
+	}, [ms]);
+	return tick;
+}
+
+// ---------------------------------------------------------------------------
+// Test 1 — Reconciliation
+//
+// List re-renders on a timer while the action panel is open.
+// The per-item panel has a stable ID so it should update in place:
+// actions update their titles but the panel stays open, filter text
+// is preserved, and selection doesn't jump.
+// ---------------------------------------------------------------------------
+
+function ReconciliationTest() {
+	const tick = useTick(1500);
+	const [extra, setExtra] = useState(false);
+
+	const items = Array.from({ length: 8 }, (_, i) => ({
+		id: `item-${i}`,
+		title: `Item ${i}`,
+		subtitle: `Render #${tick}`,
+	}));
+
+	return (
+		<List
+			navigationTitle={`Reconciliation (render #${tick})`}
+			searchBarPlaceholder="Select an item and open the action panel..."
+		>
+			<List.Section title="Items re-render every 1.5s">
+				{items.map((item) => (
+					<List.Item
+						key={item.id}
+						title={item.title}
+						subtitle={item.subtitle}
+						accessories={[{ tag: { value: `r${tick}` } }]}
+						actions={
+							<ActionPanel title={`Panel for ${item.title}`}>
+								<Action
+									title={`Primary — render #${tick}`}
+									icon={Icon.Star}
+									onAction={() =>
+										showToast(Toast.Style.Success, `${item.id} at render ${tick}`)
+									}
+								/>
+								<Action
+									title={`Secondary — render #${tick}`}
+									icon={Icon.Clipboard}
+									onAction={() =>
+										showToast(Toast.Style.Success, "Secondary action")
+									}
+								/>
+								{extra && (
+									<Action
+										title={`Extra action (toggled) — render #${tick}`}
+										icon={Icon.Plus}
+										onAction={() => showToast(Toast.Style.Success, "Extra!")}
+									/>
+								)}
+								<ActionPanel.Section title={`Section — render #${tick}`}>
+									<Action
+										title={extra ? "Remove extra action" : "Add extra action"}
+										icon={extra ? Icon.Minus : Icon.Plus}
+										shortcut={{ key: "e", modifiers: ["cmd"] }}
+										onAction={() => setExtra((v) => !v)}
+									/>
+								</ActionPanel.Section>
+								<ActionPanel.Submenu
+									title="Submenu (should survive re-render)"
+									icon={Icon.List}
+									shortcut={{ key: "s", modifiers: ["cmd"] }}
+								>
+									<Action
+										title={`Submenu action A — render #${tick}`}
+										onAction={() => showToast(Toast.Style.Success, "A")}
+									/>
+									<Action
+										title={`Submenu action B — render #${tick}`}
+										onAction={() => showToast(Toast.Style.Success, "B")}
+									/>
+									<ActionPanel.Section title="Nested">
+										<Action
+											title={`Nested C — render #${tick}`}
+											onAction={() => showToast(Toast.Style.Success, "C")}
+										/>
+									</ActionPanel.Section>
+								</ActionPanel.Submenu>
+							</ActionPanel>
+						}
+					/>
+				))}
+			</List.Section>
+		</List>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Test 2 — Deep submenu navigation
+//
+// Three levels of submenus. Tests step-by-step pop with Escape:
+// Level 3 → Level 2 → Level 1 → Root panel → Close.
+// Also tests that backspace in an empty filter does NOT pop.
+// ---------------------------------------------------------------------------
+
+function DeepSubmenuTest() {
+	return (
+		<List
+			navigationTitle="Deep Submenus"
+			searchBarPlaceholder="Open the action panel and navigate submenus..."
+		>
+			<List.Item
+				title="Item with deep submenus"
+				subtitle="Open panel, navigate 3 levels deep, then Escape back"
+				icon={Icon.Layers}
+				actions={
+					<ActionPanel>
+						<Action
+							title="Root action"
+							icon={Icon.Star}
+							onAction={() => showToast(Toast.Style.Success, "Root")}
+						/>
+						<ActionPanel.Submenu title="Level 1" icon={Icon.ChevronRight}>
+							<Action
+								title="Level 1 action"
+								onAction={() => showToast(Toast.Style.Success, "L1")}
+							/>
+							<ActionPanel.Submenu title="Level 2" icon={Icon.ChevronRight}>
+								<Action
+									title="Level 2 action"
+									onAction={() => showToast(Toast.Style.Success, "L2")}
+								/>
+								<ActionPanel.Submenu title="Level 3" icon={Icon.ChevronRight}>
+									<Action
+										title="Level 3 action A"
+										onAction={() => showToast(Toast.Style.Success, "L3-A")}
+									/>
+									<Action
+										title="Level 3 action B"
+										onAction={() => showToast(Toast.Style.Success, "L3-B")}
+									/>
+									<ActionPanel.Section title="Deep section">
+										<Action
+											title="Level 3 sectioned action"
+											onAction={() =>
+												showToast(Toast.Style.Success, "L3-section")
+											}
+										/>
+									</ActionPanel.Section>
+								</ActionPanel.Submenu>
+							</ActionPanel.Submenu>
+							<ActionPanel.Section title="L1 extras">
+								<Action
+									title="L1 extra action"
+									onAction={() => showToast(Toast.Style.Success, "L1-extra")}
+								/>
+							</ActionPanel.Section>
+						</ActionPanel.Submenu>
+						<ActionPanel.Submenu title="Sibling submenu" icon={Icon.Sidebar}>
+							<Action
+								title="Sibling action"
+								onAction={() => showToast(Toast.Style.Success, "Sibling")}
+							/>
+						</ActionPanel.Submenu>
+					</ActionPanel>
+				}
+			/>
+			<List.Item
+				title="Second item (different panel)"
+				subtitle="Switching items should replace the panel"
+				icon={Icon.Document}
+				actions={
+					<ActionPanel>
+						<Action
+							title="Different panel action"
+							icon={Icon.Hammer}
+							onAction={() => showToast(Toast.Style.Success, "Different panel")}
+						/>
+					</ActionPanel>
+				}
+			/>
+		</List>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Test 3 — Dynamic submenu content
+//
+// Submenu fires onOpen, which triggers a state update that populates
+// the submenu with async-loaded items. Subsequent re-renders update
+// the submenu content while it stays open.
+// ---------------------------------------------------------------------------
+
+function DynamicSubmenuTest() {
+	const tick = useTick(2000);
+	const [loadedItems, setLoadedItems] = useState<string[]>([]);
+	const [loadCount, setLoadCount] = useState(0);
+
+	const handleSubmenuOpen = useCallback(() => {
+		setLoadCount((c) => c + 1);
+		setLoadedItems([]);
+		setTimeout(() => {
+			setLoadedItems(["Async item 1", "Async item 2", "Async item 3"]);
+		}, 500);
+	}, []);
+
+	return (
+		<List
+			navigationTitle={`Dynamic Submenu (render #${tick})`}
+			searchBarPlaceholder="Open a submenu to trigger onOpen..."
+		>
+			<List.Item
+				title="Item with dynamic submenu"
+				subtitle={`Loaded ${loadCount} times — list render #${tick}`}
+				icon={Icon.Download}
+				actions={
+					<ActionPanel>
+						<Action
+							title={`Primary — render #${tick}`}
+							icon={Icon.Star}
+							onAction={() => showToast(Toast.Style.Success, "Primary")}
+						/>
+						<ActionPanel.Submenu
+							title={`Dynamic submenu (${loadedItems.length} items)`}
+							icon={Icon.Download}
+							onOpen={handleSubmenuOpen}
+						>
+							{loadedItems.length === 0 ? (
+								<Action title="Loading..." icon={Icon.Clock} onAction={() => {}} />
+							) : (
+								loadedItems.map((item, i) => (
+									<Action
+										key={item}
+										title={`${item} — render #${tick}`}
+										icon={Icon.Checkmark}
+										onAction={() => showToast(Toast.Style.Success, item)}
+									/>
+								))
+							)}
+							<ActionPanel.Section title="Always present">
+								<Action
+									title={`Reload count: ${loadCount}`}
+									icon={Icon.ArrowClockwise}
+									onAction={() => handleSubmenuOpen()}
+								/>
+							</ActionPanel.Section>
+						</ActionPanel.Submenu>
+						<ActionPanel.Submenu
+							title="Static submenu (control)"
+							icon={Icon.List}
+						>
+							<Action
+								title={`Static A — render #${tick}`}
+								onAction={() => showToast(Toast.Style.Success, "Static A")}
+							/>
+							<Action
+								title={`Static B — render #${tick}`}
+								onAction={() => showToast(Toast.Style.Success, "Static B")}
+							/>
+						</ActionPanel.Submenu>
+					</ActionPanel>
+				}
+			/>
+		</List>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Test 4 — Large action panel
+//
+// An action panel with many actions to test filter performance and
+// verify the list virtualizes correctly. Also exercises the filter
+// input: type to filter, verify results narrow down, then verify
+// backspace does NOT pop the panel.
+// ---------------------------------------------------------------------------
+
+function LargeActionPanelTest() {
+	const categories = ["Network", "File", "System", "UI", "Data", "Auth"];
+
+	return (
+		<List
+			navigationTitle="Large Action Panel"
+			searchBarPlaceholder="Open the panel and try filtering..."
+		>
+			<List.Item
+				title="Item with many actions"
+				subtitle={`${categories.length} sections, ~${categories.length * 15} actions total`}
+				icon={Icon.MagnifyingGlass}
+				actions={
+					<ActionPanel>
+						{categories.map((cat) => (
+							<ActionPanel.Section key={cat} title={cat}>
+								{Array.from({ length: 15 }, (_, i) => (
+									<Action
+										key={`${cat}-${i}`}
+										title={`${cat} Action ${i + 1}`}
+										icon={Icon.Dot}
+										onAction={() =>
+											showToast(
+												Toast.Style.Success,
+												`${cat} #${i + 1}`,
+											)
+										}
+									/>
+								))}
+							</ActionPanel.Section>
+						))}
+						<ActionPanel.Submenu title="Overflow submenu" icon={Icon.Ellipsis}>
+							{Array.from({ length: 30 }, (_, i) => (
+								<Action
+									key={`overflow-${i}`}
+									title={`Overflow action ${i + 1}`}
+									icon={Icon.Dot}
+									onAction={() =>
+										showToast(Toast.Style.Success, `Overflow #${i + 1}`)
+									}
+								/>
+							))}
+						</ActionPanel.Submenu>
+					</ActionPanel>
+				}
+			/>
+		</List>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Test 5 — Reconciliation stress
+//
+// Rapid re-renders (every 500ms) with per-item panels that grow/shrink,
+// change sections, and swap action order. Panel must stay open and
+// coherent throughout.
+// ---------------------------------------------------------------------------
+
+function StressTest() {
+	const tick = useTick(500);
+	const phase = tick % 4;
+
+	const actionSets: Record<number, { title: string; icon: Icon }[]> = {
+		0: [
+			{ title: "Alpha", icon: Icon.Star },
+			{ title: "Beta", icon: Icon.Hammer },
+		],
+		1: [
+			{ title: "Alpha", icon: Icon.Star },
+			{ title: "Beta", icon: Icon.Hammer },
+			{ title: "Gamma", icon: Icon.Plus },
+		],
+		2: [
+			{ title: "Gamma", icon: Icon.Plus },
+			{ title: "Alpha", icon: Icon.Star },
+		],
+		3: [
+			{ title: "Delta", icon: Icon.LightBulb },
+			{ title: "Alpha", icon: Icon.Star },
+			{ title: "Beta", icon: Icon.Hammer },
+			{ title: "Gamma", icon: Icon.Plus },
+		],
+	};
+
+	const actions = actionSets[phase];
+
+	return (
+		<List
+			navigationTitle={`Stress (phase ${phase}, tick ${tick})`}
+			searchBarPlaceholder="Open panel — actions change every 500ms"
+		>
+			{Array.from({ length: 5 }, (_, i) => (
+				<List.Item
+					key={`s-${i}`}
+					title={`Item ${i}`}
+					subtitle={`Phase ${phase} — ${actions.length} actions`}
+					accessories={[{ tag: { value: `p${phase}` } }]}
+					actions={
+						<ActionPanel>
+							{phase % 2 === 0 ? (
+								actions.map((a) => (
+									<Action
+										key={a.title}
+										title={`${a.title} — tick ${tick}`}
+										icon={a.icon}
+										onAction={() =>
+											showToast(Toast.Style.Success, `${a.title} at ${tick}`)
+										}
+									/>
+								))
+							) : (
+								<>
+									<ActionPanel.Section title={`Group A (tick ${tick})`}>
+										{actions.slice(0, 2).map((a) => (
+											<Action
+												key={a.title}
+												title={`${a.title} — tick ${tick}`}
+												icon={a.icon}
+												onAction={() =>
+													showToast(Toast.Style.Success, a.title)
+												}
+											/>
+										))}
+									</ActionPanel.Section>
+									{actions.length > 2 && (
+										<ActionPanel.Section title="Group B">
+											{actions.slice(2).map((a) => (
+												<Action
+													key={a.title}
+													title={`${a.title} — tick ${tick}`}
+													icon={a.icon}
+													onAction={() =>
+														showToast(Toast.Style.Success, a.title)
+													}
+												/>
+											))}
+										</ActionPanel.Section>
+									)}
+								</>
+							)}
+							<ActionPanel.Submenu title={`Submenu (phase ${phase})`} icon={Icon.List}>
+								{actions.map((a) => (
+									<Action
+										key={a.title}
+										title={`Sub: ${a.title} — tick ${tick}`}
+										icon={a.icon}
+										onAction={() =>
+											showToast(Toast.Style.Success, `Sub: ${a.title}`)
+										}
+									/>
+								))}
+							</ActionPanel.Submenu>
+						</ActionPanel>
+					}
+				/>
+			))}
+		</List>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Root
+// ---------------------------------------------------------------------------
+
+export default function ActionPanelStress() {
+	const { push } = useNavigation();
+
+	return (
+		<List
+			searchBarPlaceholder="Pick an action panel test..."
+			navigationTitle="Action Panel Tests"
+		>
+			<List.Section title="Action Panel Tests">
+				<List.Item
+					title="Reconciliation"
+					subtitle="Panel survives list re-renders, filter & selection preserved"
+					icon={Icon.ArrowClockwise}
+					actions={
+						<ActionPanel>
+							<Action.Push title="Run" target={<ReconciliationTest />} />
+						</ActionPanel>
+					}
+				/>
+				<List.Item
+					title="Deep Submenus"
+					subtitle="3 levels deep, step-by-step Escape, backspace doesn't pop"
+					icon={Icon.Layers}
+					actions={
+						<ActionPanel>
+							<Action.Push title="Run" target={<DeepSubmenuTest />} />
+						</ActionPanel>
+					}
+				/>
+				<List.Item
+					title="Dynamic Submenu"
+					subtitle="onOpen loads content, re-renders update open submenu"
+					icon={Icon.Download}
+					actions={
+						<ActionPanel>
+							<Action.Push title="Run" target={<DynamicSubmenuTest />} />
+						</ActionPanel>
+					}
+				/>
+				<List.Item
+					title="Large Action Panel"
+					subtitle="~90 actions across 6 sections, filter performance"
+					icon={Icon.MagnifyingGlass}
+					actions={
+						<ActionPanel>
+							<Action.Push title="Run" target={<LargeActionPanelTest />} />
+						</ActionPanel>
+					}
+				/>
+				<List.Item
+					title="Stress"
+					subtitle="500ms re-renders, actions grow/shrink/reorder"
+					icon={Icon.Bug}
+					actions={
+						<ActionPanel>
+							<Action.Push title="Run" target={<StressTest />} />
+						</ActionPanel>
+					}
+				/>
+			</List.Section>
+		</List>
+	);
+}

--- a/extra/extension-boilerplate/src/app-utils.tsx
+++ b/extra/extension-boilerplate/src/app-utils.tsx
@@ -76,10 +76,7 @@ export default function AppUtils() {
 										icon={defaultApp.icon}
 										target={searchText}
 									/>
-									<Action.Push
-										title="Open in..."
-										target={<OpenInView target={searchText} />}
-									/>
+									<Action.OpenWith title="Open with..." path={searchText} />
 								</ActionPanel>
 							}
 						/>

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -181,6 +181,10 @@ set(SRCS
 
 	include/ui/action-pannel/action.hpp
 	src/ui/action-pannel/action.cpp
+	include/ui/action-pannel/action-panel-state.hpp
+	include/ui/action-pannel/action-panel-view.hpp
+	include/ui/action-pannel/action-list-view.hpp
+	src/ui/action-pannel/action-list-view.cpp
 
 	src/lib/crypto.cpp
 

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -193,6 +193,8 @@ set(SRCS
 
 	src/extension/extension-action-panel-builder.hpp
 	src/extension/extension-action-panel-builder.cpp
+	src/extension/extension-action-list-view.hpp
+	src/extension/extension-action-list-view.cpp
 
 	include/extension/extension.hpp
 	src/extension/extension.cpp

--- a/src/server/include/ui/action-pannel/action-list-view.hpp
+++ b/src/server/include/ui/action-pannel/action-list-view.hpp
@@ -3,23 +3,8 @@
 #include <memory>
 
 class ActionPanelState;
-class ActionPanelSectionState;
+class ActionPanelModel;
 
-/**
- * Default action panel view: a fuzzy-searchable list of actions, optionally
- * grouped into sections. This is what every action panel rendered today
- * actually is.
- *
- * Internally wraps an `ActionPanelState` so that existing call sites can
- * adopt the view abstraction without rebuilding their action panels. The
- * legacy `setActions(unique_ptr<ActionPanelState>)` overload constructs an
- * `ActionListView` and calls `adoptState()` to forward the wrapped state.
- *
- * Step 1 note: `componentUrl`/`componentProps` are placeholders. The
- * controller still operates on `ActionPanelState` snapshots, so these methods
- * are not yet called by anything. They will be wired up in the controller
- * refactor that follows.
- */
 class ActionListView : public ActionPanelView {
   Q_OBJECT
 
@@ -27,37 +12,19 @@ public:
   explicit ActionListView(QObject *parent = nullptr);
   ~ActionListView() override;
 
-  /**
-   * Replace the wrapped state. Used by the legacy compat shim to wrap an
-   * externally-built `ActionPanelState` (including `ListActionPanelState` /
-   * `FormActionPanelState` subclasses, whose preset is preserved through the
-   * `unique_ptr` upcast).
-   */
   void adoptState(std::unique_ptr<ActionPanelState> state);
-
-  /**
-   * Read-only access to the wrapped state.
-   *
-   * Transitional: exists so the legacy `NavigationController::setActions`
-   * path can extract the state out of the view and forward it through the
-   * existing snapshot machinery. Will be removed once the controller operates
-   * on views directly.
-   */
   const ActionPanelState *state() const { return m_state.get(); }
 
-  /**
-   * Take ownership of the wrapped state, leaving the view empty.
-   *
-   * Transitional: see `state()` above.
-   */
-  std::unique_ptr<ActionPanelState> takeState();
-
-  // ActionPanelView overrides:
   QUrl componentUrl() const override;
-  QVariantMap componentProps() const override;
+  QVariantMap componentProps() override;
   AbstractAction *findBoundAction(const QKeyEvent *event) const override;
   AbstractAction *primaryAction() const override;
+  std::shared_ptr<AbstractAction> retainAction(AbstractAction *action) const override;
+  bool hasActions() const override;
+  bool hasMultipleActions() const override;
+  void resetState() override;
 
 private:
   std::unique_ptr<ActionPanelState> m_state;
+  ActionPanelModel *m_model = nullptr;
 };

--- a/src/server/include/ui/action-pannel/action-list-view.hpp
+++ b/src/server/include/ui/action-pannel/action-list-view.hpp
@@ -1,0 +1,63 @@
+#pragma once
+#include "ui/action-pannel/action-panel-view.hpp"
+#include <memory>
+
+class ActionPanelState;
+class ActionPanelSectionState;
+
+/**
+ * Default action panel view: a fuzzy-searchable list of actions, optionally
+ * grouped into sections. This is what every action panel rendered today
+ * actually is.
+ *
+ * Internally wraps an `ActionPanelState` so that existing call sites can
+ * adopt the view abstraction without rebuilding their action panels. The
+ * legacy `setActions(unique_ptr<ActionPanelState>)` overload constructs an
+ * `ActionListView` and calls `adoptState()` to forward the wrapped state.
+ *
+ * Step 1 note: `componentUrl`/`componentProps` are placeholders. The
+ * controller still operates on `ActionPanelState` snapshots, so these methods
+ * are not yet called by anything. They will be wired up in the controller
+ * refactor that follows.
+ */
+class ActionListView : public ActionPanelView {
+  Q_OBJECT
+
+public:
+  explicit ActionListView(QObject *parent = nullptr);
+  ~ActionListView() override;
+
+  /**
+   * Replace the wrapped state. Used by the legacy compat shim to wrap an
+   * externally-built `ActionPanelState` (including `ListActionPanelState` /
+   * `FormActionPanelState` subclasses, whose preset is preserved through the
+   * `unique_ptr` upcast).
+   */
+  void adoptState(std::unique_ptr<ActionPanelState> state);
+
+  /**
+   * Read-only access to the wrapped state.
+   *
+   * Transitional: exists so the legacy `NavigationController::setActions`
+   * path can extract the state out of the view and forward it through the
+   * existing snapshot machinery. Will be removed once the controller operates
+   * on views directly.
+   */
+  const ActionPanelState *state() const { return m_state.get(); }
+
+  /**
+   * Take ownership of the wrapped state, leaving the view empty.
+   *
+   * Transitional: see `state()` above.
+   */
+  std::unique_ptr<ActionPanelState> takeState();
+
+  // ActionPanelView overrides:
+  QUrl componentUrl() const override;
+  QVariantMap componentProps() const override;
+  AbstractAction *findBoundAction(const QKeyEvent *event) const override;
+  AbstractAction *primaryAction() const override;
+
+private:
+  std::unique_ptr<ActionPanelState> m_state;
+};

--- a/src/server/include/ui/action-pannel/action-list-view.hpp
+++ b/src/server/include/ui/action-pannel/action-list-view.hpp
@@ -4,6 +4,7 @@
 
 class ActionPanelState;
 class ActionPanelModel;
+class SubmenuAction;
 
 class ActionListView : public ActionPanelView {
   Q_OBJECT
@@ -23,6 +24,10 @@ public:
   bool hasActions() const override;
   bool hasMultipleActions() const override;
   void resetState() override;
+
+protected:
+  virtual ActionListView *createSubmenuChild(SubmenuAction *action);
+  ActionPanelModel *model() const { return m_model; }
 
 private:
   std::unique_ptr<ActionPanelState> m_state;

--- a/src/server/include/ui/action-pannel/action-panel-state.hpp
+++ b/src/server/include/ui/action-pannel/action-panel-state.hpp
@@ -1,0 +1,146 @@
+#pragma once
+#include "common/types.hpp"
+#include "lib/keyboard/keyboard.hpp"
+#include "ui/action-pannel/action.hpp"
+#include <QString>
+#include <cstdint>
+#include <memory>
+#include <numeric>
+#include <vector>
+
+struct ActionPanelSectionState {
+  QString m_name;
+  std::vector<std::shared_ptr<AbstractAction>> m_actions;
+
+  auto actions() const { return m_actions; }
+  QString name() const { return m_name; };
+  void setName(const QString &text) { m_name = text; }
+  void addAction(AbstractAction *action) { m_actions.emplace_back(action); }
+};
+
+class ActionPanelState : public NonCopyable {
+public:
+  enum class ShortcutPreset : std::uint8_t {
+    None,
+    List,
+    Form,
+  };
+
+  AbstractAction *primaryAction() const { return m_primary; }
+
+  /**
+   * Apply shortcut presets and other things that need to be computed
+   * at a given time.
+   */
+  void finalize() {
+    computePrimaryAction();
+    applyShortcuts();
+  }
+
+  const std::vector<std::unique_ptr<ActionPanelSectionState>> &sections() const { return m_sections; }
+
+  ActionPanelSectionState *createSection(const QString &name = "") {
+    auto section = std::make_unique<ActionPanelSectionState>();
+    auto handle = section.get();
+
+    section->setName(name);
+    m_sections.emplace_back(std::move(section));
+
+    return handle;
+  }
+
+  /**
+   * The first action will be considered as the primary one, unless another
+   * action was explicitly marked as primary.
+   */
+  void setAutoSelectPrimary(bool value = true) { m_autoSelectPrimary = value; }
+
+  void setTitle(const QString &title) { m_title = title; }
+  QString title() const { return m_title; }
+
+  void setId(const QString &id) { m_id = id; }
+  QString id() const { return m_id; }
+
+  void setShortcutPreset(ShortcutPreset preset) { m_defaultShortcuts = shortcutsForPreset(preset); }
+
+  ActionPanelState() { setShortcutPreset(ShortcutPreset::None); }
+
+  int actionCount() const {
+    auto acc = [](int acc, auto &&cur) { return acc + cur->actions().size(); };
+
+    return std::accumulate(m_sections.begin(), m_sections.end(), 0, acc);
+  }
+
+  void setDirty(bool value) { m_dirty = value; }
+  bool dirty() const { return m_dirty; }
+
+private:
+  void computePrimaryAction() {
+    AbstractAction *first = nullptr;
+
+    for (const auto &section : m_sections) {
+      for (const auto &action : section->actions()) {
+        if (!first) first = action.get();
+        if (action->isPrimary()) {
+          m_primarySection = section.get();
+          m_primary = action.get();
+          return;
+        }
+      }
+    }
+
+    if (m_autoSelectPrimary) {
+      m_primary = first;
+      if (first) { first->setPrimary(true); }
+    }
+
+    m_primarySection = !m_sections.empty() ? m_sections.front().get() : nullptr;
+  }
+
+  void applyShortcuts() {
+    if (!m_primarySection) return;
+
+    auto actions = m_primarySection->actions();
+
+    for (size_t i = 0; i != actions.size() && i != m_defaultShortcuts.size(); ++i) {
+      auto &action = actions[i];
+      auto &shortcut = m_defaultShortcuts[i];
+      auto existing = action->shortcut();
+
+      // always prioritize default shortcut, but still keeps the one
+      // that was set before as a secondary shortcut (usually not shown in UI).
+      action->setShortcut(shortcut);
+      if (existing) { action->addShortcut(*existing); }
+    }
+  }
+
+  std::vector<Keyboard::Shortcut> shortcutsForPreset(ShortcutPreset preset) {
+    switch (preset) {
+    case ShortcutPreset::List:
+      return {Keyboard::Shortcut::enter(), Keyboard::Shortcut::submit()};
+    case ShortcutPreset::Form:
+      return {Keyboard::Shortcut::submit()};
+    default:
+      return {};
+    }
+  }
+
+  bool m_autoSelectPrimary = true;
+  bool m_dirty = true;
+  QString m_title;
+  QString m_id;
+  std::vector<std::unique_ptr<ActionPanelSectionState>> m_sections;
+  std::vector<Keyboard::Shortcut> m_defaultShortcuts;
+  AbstractAction *m_primary = nullptr;
+  ActionPanelSectionState *m_primarySection = nullptr;
+};
+
+class ListActionPanelState : public ActionPanelState {
+public:
+  ListActionPanelState() { setShortcutPreset(ShortcutPreset::List); }
+};
+
+class FormActionPanelState : public ActionPanelState {
+public:
+  FormActionPanelState() { setShortcutPreset(ShortcutPreset::Form); }
+};

--- a/src/server/include/ui/action-pannel/action-panel-state.hpp
+++ b/src/server/include/ui/action-pannel/action-panel-state.hpp
@@ -74,6 +74,16 @@ public:
   void setDirty(bool value) { m_dirty = value; }
   bool dirty() const { return m_dirty; }
 
+  SubmenuAction *findSubmenuAction(const QString &id) const {
+    for (const auto &section : m_sections) {
+      for (const auto &action : section->actions()) {
+        auto *submenu = dynamic_cast<SubmenuAction *>(action.get());
+        if (submenu && submenu->id() == id) return submenu;
+      }
+    }
+    return nullptr;
+  }
+
 private:
   void computePrimaryAction() {
     AbstractAction *first = nullptr;

--- a/src/server/include/ui/action-pannel/action-panel-view.hpp
+++ b/src/server/include/ui/action-pannel/action-panel-view.hpp
@@ -35,6 +35,9 @@ public:
 
 signals:
   void contentChanged();
+  void actionExecuted(AbstractAction *action);
+  void closeRequested();
+  void pushViewRequested(ActionPanelView *view);
 
 private:
   QString m_id;

--- a/src/server/include/ui/action-pannel/action-panel-view.hpp
+++ b/src/server/include/ui/action-pannel/action-panel-view.hpp
@@ -1,0 +1,87 @@
+#pragma once
+#include <QObject>
+#include <QString>
+#include <QUrl>
+#include <QVariantMap>
+
+class AbstractAction;
+class QKeyEvent;
+
+/**
+ * Base class for any view rendered as a frame inside the action panel stack.
+ *
+ * An action panel view is the action-panel-side analogue of `BaseView`: it owns
+ * its own state, has a lifecycle, and renders a QML component. Subclasses
+ * supply the component to render and respond to lifecycle events.
+ *
+ * The default subclass `ActionListView` wraps the existing `ActionPanelState`
+ * and renders the standard fuzzy-searchable action list. Custom subclasses can
+ * implement entirely different UIs (date pickers, color pickers, embedded
+ * forms, etc.) without going through the action list machinery.
+ *
+ * Step 1 note: this interface is in place but the controller does not yet push
+ * views onto the QML stack — it still operates on `ActionPanelState` snapshots.
+ * Future commits will route push/pop/reconciliation through this interface.
+ */
+class ActionPanelView : public QObject {
+  Q_OBJECT
+
+public:
+  explicit ActionPanelView(QObject *parent = nullptr) : QObject(parent) {}
+  ~ActionPanelView() override = default;
+
+  /**
+   * Stable identity used for reconciliation across re-renders of the parent
+   * view. Native code can set this explicitly via `setId()`. Extension views
+   * inherit the React stable id automatically. An empty id means the view
+   * is anonymous and will be popped on parent re-render.
+   */
+  QString id() const { return m_id; }
+  void setId(const QString &id) { m_id = id; }
+
+  /**
+   * Lifecycle hooks called by the action panel controller. Default
+   * implementations are no-ops.
+   *
+   * Order: onMount → onActivate → (onDeactivate when child pushed above /
+   * onActivate again when child popped) → onUnmount.
+   */
+  virtual void onMount() {}
+  virtual void onActivate() {}
+  virtual void onDeactivate() {}
+  virtual void onUnmount() {}
+
+  /**
+   * QML component URL the controller should push when this view is
+   * activated. Subclasses point at their own QML file.
+   */
+  virtual QUrl componentUrl() const = 0;
+
+  /**
+   * Properties passed to the QML component when it is instantiated. Typically
+   * includes a model object the view exposes for binding.
+   */
+  virtual QVariantMap componentProps() const = 0;
+
+  /**
+   * Resolve a key event against this view's actions. Returns nullptr if no
+   * action is bound. Used by the controller's shortcut routing path.
+   */
+  virtual AbstractAction *findBoundAction(const QKeyEvent *event) const { return nullptr; }
+
+  /**
+   * The action that should run when the user presses Enter (or the equivalent
+   * primary-action shortcut). Returns nullptr if there is no primary action.
+   */
+  virtual AbstractAction *primaryAction() const { return nullptr; }
+
+signals:
+  /**
+   * Emitted when the view's content has changed and the QML side should
+   * refresh. Subclasses decide what counts as "content".
+   */
+  void contentChanged();
+
+private:
+  QString m_id;
+};

--- a/src/server/include/ui/action-pannel/action-panel-view.hpp
+++ b/src/server/include/ui/action-pannel/action-panel-view.hpp
@@ -3,26 +3,11 @@
 #include <QString>
 #include <QUrl>
 #include <QVariantMap>
+#include <memory>
 
 class AbstractAction;
 class QKeyEvent;
 
-/**
- * Base class for any view rendered as a frame inside the action panel stack.
- *
- * An action panel view is the action-panel-side analogue of `BaseView`: it owns
- * its own state, has a lifecycle, and renders a QML component. Subclasses
- * supply the component to render and respond to lifecycle events.
- *
- * The default subclass `ActionListView` wraps the existing `ActionPanelState`
- * and renders the standard fuzzy-searchable action list. Custom subclasses can
- * implement entirely different UIs (date pickers, color pickers, embedded
- * forms, etc.) without going through the action list machinery.
- *
- * Step 1 note: this interface is in place but the controller does not yet push
- * views onto the QML stack — it still operates on `ActionPanelState` snapshots.
- * Future commits will route push/pop/reconciliation through this interface.
- */
 class ActionPanelView : public QObject {
   Q_OBJECT
 
@@ -30,56 +15,25 @@ public:
   explicit ActionPanelView(QObject *parent = nullptr) : QObject(parent) {}
   ~ActionPanelView() override = default;
 
-  /**
-   * Stable identity used for reconciliation across re-renders of the parent
-   * view. Native code can set this explicitly via `setId()`. Extension views
-   * inherit the React stable id automatically. An empty id means the view
-   * is anonymous and will be popped on parent re-render.
-   */
   QString id() const { return m_id; }
   void setId(const QString &id) { m_id = id; }
 
-  /**
-   * Lifecycle hooks called by the action panel controller. Default
-   * implementations are no-ops.
-   *
-   * Order: onMount → onActivate → (onDeactivate when child pushed above /
-   * onActivate again when child popped) → onUnmount.
-   */
   virtual void onMount() {}
   virtual void onActivate() {}
   virtual void onDeactivate() {}
   virtual void onUnmount() {}
 
-  /**
-   * QML component URL the controller should push when this view is
-   * activated. Subclasses point at their own QML file.
-   */
   virtual QUrl componentUrl() const = 0;
+  virtual QVariantMap componentProps() = 0;
 
-  /**
-   * Properties passed to the QML component when it is instantiated. Typically
-   * includes a model object the view exposes for binding.
-   */
-  virtual QVariantMap componentProps() const = 0;
-
-  /**
-   * Resolve a key event against this view's actions. Returns nullptr if no
-   * action is bound. Used by the controller's shortcut routing path.
-   */
   virtual AbstractAction *findBoundAction(const QKeyEvent *event) const { return nullptr; }
-
-  /**
-   * The action that should run when the user presses Enter (or the equivalent
-   * primary-action shortcut). Returns nullptr if there is no primary action.
-   */
   virtual AbstractAction *primaryAction() const { return nullptr; }
+  virtual std::shared_ptr<AbstractAction> retainAction(AbstractAction *action) const { return nullptr; }
+  virtual bool hasActions() const { return false; }
+  virtual bool hasMultipleActions() const { return false; }
+  virtual void resetState() {}
 
 signals:
-  /**
-   * Emitted when the view's content has changed and the QML side should
-   * refresh. Subclasses decide what counts as "content".
-   */
   void contentChanged();
 
 private:

--- a/src/server/include/ui/action-pannel/action.hpp
+++ b/src/server/include/ui/action-pannel/action.hpp
@@ -163,10 +163,14 @@ public:
 
   void setSubmenuStateFactory(SubmenuStateFactory fn) { m_stateFactory = std::move(fn); }
 
+  void setOnSearchTextChangeHandler(const QString &handler) { m_onSearchTextChangeHandler = handler; }
+  QString onSearchTextChangeHandler() const { return m_onSearchTextChangeHandler; }
+
   // Defined out-of-line because ActionPanelState is incomplete here
   std::unique_ptr<ActionPanelState> createSubmenuState() const;
   std::unique_ptr<ActionPanelState> createSubmenuStateStealthily() const;
 
 private:
   SubmenuStateFactory m_stateFactory;
+  QString m_onSearchTextChangeHandler;
 };

--- a/src/server/src/extension/extension-action-list-view.cpp
+++ b/src/server/src/extension/extension-action-list-view.cpp
@@ -4,11 +4,9 @@
 #include <utility>
 
 ExtensionActionListView::ExtensionActionListView(ExtensionActionPanelBuilder::NotifyFn notify,
-                                                 const QString &onSearchTextChangeHandler,
-                                                 ExtensionActionPanelBuilder::SubmenuCache *cache,
-                                                 QObject *parent)
+                                                 const QString &onSearchTextChangeHandler, QObject *parent)
     : ActionListView(parent), m_notify(std::move(notify)),
-      m_onSearchTextChangeHandler(onSearchTextChangeHandler), m_cache(cache) {}
+      m_onSearchTextChangeHandler(onSearchTextChangeHandler) {}
 
 QVariantMap ExtensionActionListView::componentProps() {
   auto props = ActionListView::componentProps();
@@ -25,15 +23,7 @@ ActionListView *ExtensionActionListView::createSubmenuChild(SubmenuAction *actio
   auto state = action->createSubmenuState();
   if (!state) return nullptr;
 
-  QString onSearchTextChange;
-  QString const stableId = action->id();
-
-  if (m_cache && !stableId.isEmpty()) {
-    auto it = m_cache->find(stableId);
-    if (it != m_cache->end()) { onSearchTextChange = it->second->onSearchTextChange; }
-  }
-
-  auto *child = new ExtensionActionListView(m_notify, onSearchTextChange, m_cache, this);
+  auto *child = new ExtensionActionListView(m_notify, action->onSearchTextChangeHandler(), this);
   child->adoptState(std::move(state));
   return child;
 }

--- a/src/server/src/extension/extension-action-list-view.cpp
+++ b/src/server/src/extension/extension-action-list-view.cpp
@@ -1,0 +1,39 @@
+#include "extension-action-list-view.hpp"
+#include "action-panel-model.hpp"
+#include "ui/action-pannel/action.hpp"
+#include <utility>
+
+ExtensionActionListView::ExtensionActionListView(ExtensionActionPanelBuilder::NotifyFn notify,
+                                                 const QString &onSearchTextChangeHandler,
+                                                 ExtensionActionPanelBuilder::SubmenuCache *cache,
+                                                 QObject *parent)
+    : ActionListView(parent), m_notify(std::move(notify)),
+      m_onSearchTextChangeHandler(onSearchTextChangeHandler), m_cache(cache) {}
+
+QVariantMap ExtensionActionListView::componentProps() {
+  auto props = ActionListView::componentProps();
+
+  if (!m_onSearchTextChangeHandler.isEmpty() && model()) {
+    connect(model(), &ActionPanelModel::filterChanged, this,
+            [this](const QString &text) { m_notify(m_onSearchTextChangeHandler, {text}); });
+  }
+
+  return props;
+}
+
+ActionListView *ExtensionActionListView::createSubmenuChild(SubmenuAction *action) {
+  auto state = action->createSubmenuState();
+  if (!state) return nullptr;
+
+  QString onSearchTextChange;
+  QString const stableId = action->id();
+
+  if (m_cache && !stableId.isEmpty()) {
+    auto it = m_cache->find(stableId);
+    if (it != m_cache->end()) { onSearchTextChange = it->second->onSearchTextChange; }
+  }
+
+  auto *child = new ExtensionActionListView(m_notify, onSearchTextChange, m_cache, this);
+  child->adoptState(std::move(state));
+  return child;
+}

--- a/src/server/src/extension/extension-action-list-view.cpp
+++ b/src/server/src/extension/extension-action-list-view.cpp
@@ -6,17 +6,11 @@
 ExtensionActionListView::ExtensionActionListView(ExtensionActionPanelBuilder::NotifyFn notify,
                                                  const QString &onSearchTextChangeHandler, QObject *parent)
     : ActionListView(parent), m_notify(std::move(notify)),
-      m_onSearchTextChangeHandler(onSearchTextChangeHandler) {}
-
-QVariantMap ExtensionActionListView::componentProps() {
-  auto props = ActionListView::componentProps();
-
-  if (!m_onSearchTextChangeHandler.isEmpty() && model()) {
+      m_onSearchTextChangeHandler(onSearchTextChangeHandler) {
+  if (!m_onSearchTextChangeHandler.isEmpty()) {
     connect(model(), &ActionPanelModel::filterChanged, this,
             [this](const QString &text) { m_notify(m_onSearchTextChangeHandler, {text}); });
   }
-
-  return props;
 }
 
 ActionListView *ExtensionActionListView::createSubmenuChild(SubmenuAction *action) {

--- a/src/server/src/extension/extension-action-list-view.hpp
+++ b/src/server/src/extension/extension-action-list-view.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#include "extension/extension-action-panel-builder.hpp"
+#include "ui/action-pannel/action-list-view.hpp"
+
+class ExtensionActionListView : public ActionListView {
+  Q_OBJECT
+
+public:
+  ExtensionActionListView(ExtensionActionPanelBuilder::NotifyFn notify,
+                          const QString &onSearchTextChangeHandler,
+                          ExtensionActionPanelBuilder::SubmenuCache *cache, QObject *parent = nullptr);
+
+  QVariantMap componentProps() override;
+
+protected:
+  ActionListView *createSubmenuChild(SubmenuAction *action) override;
+
+private:
+  ExtensionActionPanelBuilder::NotifyFn m_notify;
+  QString m_onSearchTextChangeHandler;
+  ExtensionActionPanelBuilder::SubmenuCache *m_cache;
+};

--- a/src/server/src/extension/extension-action-list-view.hpp
+++ b/src/server/src/extension/extension-action-list-view.hpp
@@ -7,8 +7,7 @@ class ExtensionActionListView : public ActionListView {
 
 public:
   ExtensionActionListView(ExtensionActionPanelBuilder::NotifyFn notify,
-                          const QString &onSearchTextChangeHandler,
-                          ExtensionActionPanelBuilder::SubmenuCache *cache, QObject *parent = nullptr);
+                          const QString &onSearchTextChangeHandler, QObject *parent = nullptr);
 
   QVariantMap componentProps() override;
 
@@ -18,5 +17,4 @@ protected:
 private:
   ExtensionActionPanelBuilder::NotifyFn m_notify;
   QString m_onSearchTextChangeHandler;
-  ExtensionActionPanelBuilder::SubmenuCache *m_cache;
 };

--- a/src/server/src/extension/extension-action-list-view.hpp
+++ b/src/server/src/extension/extension-action-list-view.hpp
@@ -9,8 +9,6 @@ public:
   ExtensionActionListView(ExtensionActionPanelBuilder::NotifyFn notify,
                           const QString &onSearchTextChangeHandler, QObject *parent = nullptr);
 
-  QVariantMap componentProps() override;
-
 protected:
   ActionListView *createSubmenuChild(SubmenuAction *action) override;
 

--- a/src/server/src/extension/extension-action-panel-builder.cpp
+++ b/src/server/src/extension/extension-action-panel-builder.cpp
@@ -10,8 +10,7 @@ namespace ExtensionActionPanelBuilder {
 static AbstractAction *createActionFromModel(const ActionModel &model, const NotifyFn &notify,
                                              const SubmitFn &submit);
 static AbstractAction *createSubmenuAction(const ActionPannelSubmenuPtr &submenuModel, const NotifyFn &notify,
-                                           SubmenuCache *submenuCache, const SubmitFn &submit);
-static void updateSubmenuCache(SubmenuCache *cache, const ActionPannelModel &model);
+                                           const SubmitFn &submit);
 
 static AbstractAction *createActionFromModel(const ActionModel &model, const NotifyFn &notify,
                                              const SubmitFn &submit) {
@@ -62,10 +61,8 @@ static AbstractAction *createActionFromModel(const ActionModel &model, const Not
 }
 
 static AbstractAction *createSubmenuAction(const ActionPannelSubmenuPtr &submenuModel, const NotifyFn &notify,
-                                           SubmenuCache *submenuCache, const SubmitFn &submit) {
+                                           const SubmitFn &submit) {
   if (!submenuModel) return nullptr;
-
-  if (submenuModel->stableId) { (*submenuCache)[*submenuModel->stableId] = submenuModel; }
 
   std::optional<ImageURL> icon;
   if (submenuModel->icon) { icon = ImageURL(*submenuModel->icon); }
@@ -77,62 +74,23 @@ static AbstractAction *createSubmenuAction(const ActionPannelSubmenuPtr &submenu
     };
   }
 
-  QString const stableId = submenuModel->stableId.value_or(QString());
-
   auto action = new SubmenuAction(submenuModel->title, icon, onOpen);
   if (submenuModel->stableId) { action->setId(*submenuModel->stableId); }
   if (submenuModel->shortcut) { action->addShortcut(submenuModel->shortcut.value()); }
+  if (!submenuModel->onSearchTextChange.isEmpty()) {
+    action->setOnSearchTextChangeHandler(submenuModel->onSearchTextChange);
+  }
 
-  auto stateFactory = [notify, submenuCache, submit, stableId]() -> std::unique_ptr<ActionPanelState> {
-    if (!stableId.isEmpty()) {
-      auto it = submenuCache->find(stableId);
-      if (it != submenuCache->end()) { return buildSubmenuState(it->second, notify, submenuCache, submit); }
-    }
-    qWarning() << "Submenu state model not found in map for stableId:" << stableId;
-    return nullptr;
+  auto stateFactory = [notify, submenuModel, submit]() -> std::unique_ptr<ActionPanelState> {
+    return buildSubmenuState(submenuModel, notify, submit);
   };
   action->setSubmenuStateFactory(stateFactory);
 
   return action;
 }
 
-static void updateSubmenuCache(SubmenuCache *cache, const ActionPannelModel &model) {
-  std::function<void(const ActionPannelSubmenuPtr &)> updateSubmenuModel =
-      [&](const ActionPannelSubmenuPtr &submenu) {
-        if (submenu && submenu->stableId) {
-          (*cache)[*submenu->stableId] = submenu;
-          for (const auto &child : submenu->children) {
-            if (auto nestedSubmenuPtr = std::get_if<ActionPannelSubmenuPtr>(&child)) {
-              updateSubmenuModel(*nestedSubmenuPtr);
-            } else if (auto sectionPtr = std::get_if<ActionPannelSectionPtr>(&child)) {
-              if (*sectionPtr) {
-                for (const auto &sectionItem : (*sectionPtr)->items) {
-                  if (auto submenuInSection = std::get_if<ActionPannelSubmenuPtr>(&sectionItem)) {
-                    updateSubmenuModel(*submenuInSection);
-                  }
-                }
-              }
-            }
-          }
-        }
-      };
-
-  for (const auto &item : model.children) {
-    if (auto submenuPtr = std::get_if<ActionPannelSubmenuPtr>(&item)) {
-      updateSubmenuModel(*submenuPtr);
-    } else if (auto sectionPtr = std::get_if<ActionPannelSectionPtr>(&item)) {
-      for (const auto &sectionItem : (*sectionPtr)->items) {
-        if (auto submenuPtr = std::get_if<ActionPannelSubmenuPtr>(&sectionItem)) {
-          updateSubmenuModel(*submenuPtr);
-        }
-      }
-    }
-  }
-}
-
 std::unique_ptr<ActionPanelState> buildSubmenuState(const ActionPannelSubmenuPtr &submenuModel,
-                                                    const NotifyFn &notify, SubmenuCache *submenuCache,
-                                                    const SubmitFn &submit) {
+                                                    const NotifyFn &notify, const SubmitFn &submit) {
   if (!submenuModel) return nullptr;
 
   auto state = std::make_unique<ActionPanelState>();
@@ -155,7 +113,7 @@ std::unique_ptr<ActionPanelState> buildSubmenuState(const ActionPannelSubmenuPtr
           if (actionModel->shortcut) { action->addShortcut(actionModel->shortcut.value()); }
           sec->addAction(action);
         } else if (auto submenuPtr = std::get_if<ActionPannelSubmenuPtr>(&item)) {
-          auto action = createSubmenuAction(*submenuPtr, notify, submenuCache, submit);
+          auto action = createSubmenuAction(*submenuPtr, notify, submit);
           if (action) { sec->addAction(action); }
         }
       }
@@ -166,7 +124,7 @@ std::unique_ptr<ActionPanelState> buildSubmenuState(const ActionPannelSubmenuPtr
       outsideSection->addAction(action);
     } else if (auto submenuPtr = std::get_if<ActionPannelSubmenuPtr>(&child)) {
       if (!outsideSection) { outsideSection = state->createSection(); }
-      auto action = createSubmenuAction(*submenuPtr, notify, submenuCache, submit);
+      auto action = createSubmenuAction(*submenuPtr, notify, submit);
       if (action) { outsideSection->addAction(action); }
     }
   }
@@ -175,10 +133,7 @@ std::unique_ptr<ActionPanelState> buildSubmenuState(const ActionPannelSubmenuPtr
 }
 
 std::unique_ptr<ActionPanelState> build(const ActionPannelModel &model, const NotifyFn &notify,
-                                        SubmenuCache *submenuCache, ActionPanelState::ShortcutPreset preset,
-                                        const SubmitFn &submit) {
-  updateSubmenuCache(submenuCache, model);
-
+                                        ActionPanelState::ShortcutPreset preset, const SubmitFn &submit) {
   auto panel = std::make_unique<ActionPanelState>();
   panel->setDirty(model.dirty);
   panel->setTitle(model.title);
@@ -206,7 +161,7 @@ std::unique_ptr<ActionPanelState> build(const ActionPannelModel &model, const No
           sec->addAction(action);
           ++idx;
         } else if (auto submenuPtr = std::get_if<ActionPannelSubmenuPtr>(&sectionItem)) {
-          auto action = createSubmenuAction(*submenuPtr, notify, submenuCache, submit);
+          auto action = createSubmenuAction(*submenuPtr, notify, submit);
 
           if (!action) continue;
           if (idx == 0) { action->setPrimary(true); }
@@ -231,7 +186,7 @@ std::unique_ptr<ActionPanelState> build(const ActionPannelModel &model, const No
     if (auto submenuPtr = std::get_if<ActionPannelSubmenuPtr>(&item)) {
       if (!outsideSection) { outsideSection = panel->createSection(); }
 
-      auto action = createSubmenuAction(*submenuPtr, notify, submenuCache, submit);
+      auto action = createSubmenuAction(*submenuPtr, notify, submit);
       if (!action) continue;
       if (idx == 0) { action->setPrimary(true); }
 

--- a/src/server/src/extension/extension-action-panel-builder.hpp
+++ b/src/server/src/extension/extension-action-panel-builder.hpp
@@ -6,28 +6,18 @@
 #include <expected>
 #include <functional>
 #include <memory>
-#include <unordered_map>
 
 namespace ExtensionActionPanelBuilder {
 
 using NotifyFn = std::function<void(const QString &handler, const QJsonArray &args)>;
 using SubmitFn = std::function<std::expected<QJsonObject, QString>()>;
-using SubmenuCache = std::unordered_map<QString, ActionPannelSubmenuPtr>;
 
-/// Build an ActionPanelState from an extension ActionPannelModel.
-/// @param model        The action panel model from the extension.
-/// @param notify       Callback to send notifications to the extension.
-/// @param submenuCache Pointer to a mutable cache of submenu models (must outlive the returned panel).
-/// @param preset       Shortcut preset to apply.
-/// @param submit       Optional submit callback for form actions.
 std::unique_ptr<ActionPanelState>
-build(const ActionPannelModel &model, const NotifyFn &notify, SubmenuCache *submenuCache,
+build(const ActionPannelModel &model, const NotifyFn &notify,
       ActionPanelState::ShortcutPreset preset = ActionPanelState::ShortcutPreset::None,
       const SubmitFn &submit = nullptr);
 
-/// Build an ActionPanelState for a submenu (data path, for QML).
 std::unique_ptr<ActionPanelState> buildSubmenuState(const ActionPannelSubmenuPtr &submenu,
-                                                    const NotifyFn &notify, SubmenuCache *submenuCache,
-                                                    const SubmitFn &submit = nullptr);
+                                                    const NotifyFn &notify, const SubmitFn &submit = nullptr);
 
 } // namespace ExtensionActionPanelBuilder

--- a/src/server/src/navigation-controller.cpp
+++ b/src/server/src/navigation-controller.cpp
@@ -8,6 +8,8 @@
 #include "extension/manager/extension-manager.hpp"
 #include "services/toast/toast-service.hpp"
 #include "root-search/extensions/extension-root-provider.hpp"
+#include "ui/action-pannel/action-list-view.hpp"
+#include "ui/action-pannel/action-panel-view.hpp"
 #include "ui/alert/alert.hpp"
 #include "ui/views/base-view.hpp"
 #include "utils/environment.hpp"
@@ -515,6 +517,26 @@ void NavigationController::setActions(std::unique_ptr<ActionPanelState> panel, c
     state->actionPanelState = std::move(panel);
     if (state->sender == topView()) { emit actionsChanged(*state->actionPanelState); }
   }
+}
+
+void NavigationController::setActions(std::unique_ptr<ActionPanelView> view, const BaseView *caller) {
+  if (!view) {
+    qDebug() << "setActions(view) called with a null pointer";
+    return;
+  }
+
+  // Step 1 transitional path: extract the wrapped state out of the view and
+  // forward through the existing snapshot pipeline. The dynamic_cast is the
+  // bridge between the new view abstraction and the legacy state-based
+  // controller; it goes away once the controller is refactored to operate on
+  // views directly.
+  if (auto *list = dynamic_cast<ActionListView *>(view.get())) {
+    if (auto state = list->takeState()) { setActions(std::move(state), caller); }
+    return;
+  }
+
+  qWarning() << "setActions(view): non-ActionListView views are not yet supported by the legacy "
+                "snapshot path; ignoring";
 }
 
 size_t NavigationController::viewStackSize() const { return m_views.size(); }

--- a/src/server/src/navigation-controller.cpp
+++ b/src/server/src/navigation-controller.cpp
@@ -8,7 +8,6 @@
 #include "extension/manager/extension-manager.hpp"
 #include "services/toast/toast-service.hpp"
 #include "root-search/extensions/extension-root-provider.hpp"
-#include "ui/action-pannel/action-list-view.hpp"
 #include "ui/action-pannel/action-panel-view.hpp"
 #include "ui/alert/alert.hpp"
 #include "ui/views/base-view.hpp"
@@ -263,7 +262,7 @@ void NavigationController::popCurrentView() {
     destroyCurrentCompletion();
   }
 
-  if (auto &ac = next->actionPanelState) emit actionsChanged(*ac);
+  emit activeActionPanelChanged();
 
   selectSearchText();
 
@@ -302,7 +301,7 @@ bool NavigationController::isLoading(const BaseView *caller) const {
 }
 
 void NavigationController::clearActions(const BaseView *caller) {
-  setActions(std::make_unique<ActionPanelState>(), caller);
+  if (auto vs = findViewState(VALUE_OR(caller, topView()))) { vs->sender->clearActions(); }
 }
 
 QString NavigationController::navigationTitle(const BaseView *caller) const {
@@ -367,19 +366,15 @@ void searchPlaceholderText(const QString &text) {}
 
 bool NavigationController::executePrimaryAction() {
   auto state = topState();
-
   if (!state) return false;
 
-  auto &panel = state->actionPanelState;
+  auto *root = state->sender->actionPanelRoot();
+  if (!root) return false;
 
-  if (!panel) return false;
-
-  auto action = panel->primaryAction();
-
+  auto *action = root->primaryAction();
   if (!action) return false;
 
   executeAction(action);
-
   return false;
 }
 
@@ -413,24 +408,10 @@ void NavigationController::setStatusBarVisibility(bool value, const BaseView *ca
 
 void NavigationController::executeAction(AbstractAction *action) {
   auto state = topState();
-
   if (!state) return;
 
-  // Keep the action alive during execution. Side effects of execute()
-  // (e.g. launch() triggering a root search refresh via itemsChanged)
-  // can clear the action panel, dropping the last shared_ptr to this action.
   std::shared_ptr<AbstractAction> guard;
-  if (auto &panel = state->actionPanelState) {
-    for (const auto &sec : panel->sections()) {
-      for (const auto &a : sec->m_actions) {
-        if (a.get() == action) {
-          guard = a;
-          break;
-        }
-      }
-      if (guard) break;
-    }
-  }
+  if (auto *root = state->sender->actionPanelRoot()) { guard = root->retainAction(action); }
 
   if (action->isSubmenu()) {
     openActionPanel();
@@ -457,17 +438,12 @@ void NavigationController::executeAction(AbstractAction *action) {
 
 AbstractAction *NavigationController::findBoundAction(const QKeyEvent *event) const {
   auto state = topState();
-
   if (!state) return nullptr;
-  if (!state->actionPanelState) return nullptr;
 
-  for (const auto &section : state->actionPanelState->sections()) {
-    for (const auto &action : section->actions()) {
-      if (action->isBoundTo(event)) { return action.get(); }
-    }
-  }
+  auto *root = state->sender->actionPanelRoot();
+  if (!root) return nullptr;
 
-  return nullptr;
+  return root->findBoundAction(event);
 }
 
 void NavigationController::activateView(const ViewState &state) {
@@ -477,7 +453,7 @@ void NavigationController::activateView(const ViewState &state) {
   emit statusBarVisiblityChanged(state.needsStatusBar);
   emit backButtonVisibilityChanged(state.showBackButton);
   emit loadingChanged(state.isLoading);
-  emit actionsChanged({});
+  emit activeActionPanelChanged();
   emit searchPlaceholderTextChanged(state.placeholderText);
   destroyCurrentCompletion();
 
@@ -505,38 +481,15 @@ void NavigationController::pushView(BaseView *view) {
 }
 
 void NavigationController::setActions(std::unique_ptr<ActionPanelState> panel, const BaseView *caller) {
-  if (!panel) {
-    qDebug() << "setActions called with a null pointer";
-    return;
-  }
-
-  // Important: apply default shortcuts, select primary action...
-  panel->finalize();
-
-  if (auto state = findViewState(VALUE_OR(caller, topView()))) {
-    state->actionPanelState = std::move(panel);
-    if (state->sender == topView()) { emit actionsChanged(*state->actionPanelState); }
-  }
+  if (auto vs = findViewState(VALUE_OR(caller, topView()))) { vs->sender->setActions(std::move(panel)); }
 }
 
-void NavigationController::setActions(std::unique_ptr<ActionPanelView> view, const BaseView *caller) {
-  if (!view) {
-    qDebug() << "setActions(view) called with a null pointer";
-    return;
-  }
+void NavigationController::setActions(ActionPanelView *view, const BaseView *caller) {
+  if (auto vs = findViewState(VALUE_OR(caller, topView()))) { vs->sender->setActions(view); }
+}
 
-  // Step 1 transitional path: extract the wrapped state out of the view and
-  // forward through the existing snapshot pipeline. The dynamic_cast is the
-  // bridge between the new view abstraction and the legacy state-based
-  // controller; it goes away once the controller is refactored to operate on
-  // views directly.
-  if (auto *list = dynamic_cast<ActionListView *>(view.get())) {
-    if (auto state = list->takeState()) { setActions(std::move(state), caller); }
-    return;
-  }
-
-  qWarning() << "setActions(view): non-ActionListView views are not yet supported by the legacy "
-                "snapshot path; ignoring";
+void NavigationController::notifyActionPanelChanged(const BaseView *caller) {
+  if (VALUE_OR(caller, topView()) == topView()) { emit activeActionPanelChanged(); }
 }
 
 size_t NavigationController::viewStackSize() const { return m_views.size(); }

--- a/src/server/src/navigation-controller.hpp
+++ b/src/server/src/navigation-controller.hpp
@@ -75,7 +75,6 @@ public:
     QString placeholderText;
     QString searchText;
     std::optional<CompleterState> completer;
-    std::unique_ptr<ActionPanelState> actionPanelState;
 
     bool isLoading = false;
     bool supportsSearch = true;
@@ -95,7 +94,7 @@ signals:
   void viewPoped(const BaseView *view);
   void viewReplaced();
   void actionPanelVisibilityChanged(bool visible);
-  void actionsChanged(const ActionPanelState &actions) const;
+  void activeActionPanelChanged();
   void windowVisiblityChanged(bool visible);
   void windowSizeRequested(QSize size);
   void searchTextSelected() const;
@@ -179,8 +178,9 @@ public:
   void toggleActionPanel();
 
   void setActions(std::unique_ptr<ActionPanelState> state, const BaseView *caller = nullptr);
-  void setActions(std::unique_ptr<ActionPanelView> view, const BaseView *caller = nullptr);
+  void setActions(ActionPanelView *view, const BaseView *caller = nullptr);
   void clearActions(const BaseView *caller = nullptr);
+  void notifyActionPanelChanged(const BaseView *caller = nullptr);
 
   void clearSearchText();
   void setNavigationTitle(const QString &navigationTitle, const BaseView *caller = nullptr);

--- a/src/server/src/navigation-controller.hpp
+++ b/src/server/src/navigation-controller.hpp
@@ -6,6 +6,7 @@
 #include "command.hpp"
 #include "common.hpp"
 #include "ui/action-pannel/action.hpp"
+#include "ui/action-pannel/action-panel-state.hpp"
 #include "ui/dialog/dialog.hpp"
 #include "ui/image/url.hpp"
 #include <QString>
@@ -16,18 +17,9 @@
 
 class BaseView;
 class DialogContentWidget;
+class ActionPanelView;
 
 #define VALUE_OR(VALUE, FALLBACK) (VALUE ? VALUE : FALLBACK)
-
-struct ActionPanelSectionState {
-  QString m_name;
-  std::vector<std::shared_ptr<AbstractAction>> m_actions;
-
-  auto actions() const { return m_actions; }
-  QString name() const { return m_name; };
-  void setName(const QString &text) { m_name = text; }
-  void addAction(AbstractAction *action) { m_actions.emplace_back(action); }
-};
 
 // matches raycast pop to root type policiy
 // https://developers.raycast.com/api-reference/window-and-search-bar#poptoroottype
@@ -40,133 +32,6 @@ struct CloseWindowOptions {
 
 struct PopToRootOptions {
   bool clearSearch = true;
-};
-
-class ActionPanelState : public NonCopyable {
-public:
-  enum class ShortcutPreset : std::uint8_t {
-    None,
-    List,
-    Form,
-  };
-
-  AbstractAction *primaryAction() const { return m_primary; }
-
-  /**
-   * Apply shortcut presets and other things that need to be computed
-   * at a given time.
-   */
-  void finalize() {
-    computePrimaryAction();
-    applyShortcuts();
-  }
-
-  const std::vector<std::unique_ptr<ActionPanelSectionState>> &sections() const { return m_sections; }
-
-  ActionPanelSectionState *createSection(const QString &name = "") {
-    auto section = std::make_unique<ActionPanelSectionState>();
-    auto handle = section.get();
-
-    section->setName(name);
-    m_sections.emplace_back(std::move(section));
-
-    return handle;
-  }
-
-  /**
-   * The first action will be considered as the primary one, unless another
-   * action was explicitly marked as primary.
-   */
-  void setAutoSelectPrimary(bool value = true) { m_autoSelectPrimary = value; }
-
-  void setTitle(const QString &title) { m_title = title; }
-  QString title() const { return m_title; }
-
-  void setId(const QString &id) { m_id = id; }
-  QString id() const { return m_id; }
-
-  void setShortcutPreset(ShortcutPreset preset) { m_defaultShortcuts = shortcutsForPreset(preset); }
-
-  ActionPanelState() { setShortcutPreset(ShortcutPreset::None); }
-
-  int actionCount() const {
-    auto acc = [](int acc, auto &&cur) { return acc + cur->actions().size(); };
-
-    return std::accumulate(m_sections.begin(), m_sections.end(), 0, acc);
-  }
-
-  void setDirty(bool value) { m_dirty = value; }
-  bool dirty() const { return m_dirty; }
-
-private:
-  void computePrimaryAction() {
-    AbstractAction *first = nullptr;
-
-    for (const auto &section : m_sections) {
-      for (const auto &action : section->actions()) {
-        if (!first) first = action.get();
-        if (action->isPrimary()) {
-          m_primarySection = section.get();
-          m_primary = action.get();
-          return;
-        }
-      }
-    }
-
-    if (m_autoSelectPrimary) {
-      m_primary = first;
-      if (first) { first->setPrimary(true); }
-    }
-
-    m_primarySection = !m_sections.empty() ? m_sections.front().get() : nullptr;
-  }
-
-  void applyShortcuts() {
-    if (!m_primarySection) return;
-
-    auto actions = m_primarySection->actions();
-
-    for (size_t i = 0; i != actions.size() && i != m_defaultShortcuts.size(); ++i) {
-      auto &action = actions[i];
-      auto &shortcut = m_defaultShortcuts[i];
-      auto existing = action->shortcut();
-
-      // always prioritize default shortcut, but still keeps the one
-      // that was set before as a secondary shortcut (usually not shown in UI).
-      action->setShortcut(shortcut);
-      if (existing) { action->addShortcut(*existing); }
-    }
-  }
-
-  std::vector<Keyboard::Shortcut> shortcutsForPreset(ShortcutPreset preset) {
-    switch (preset) {
-    case ShortcutPreset::List:
-      return {Keyboard::Shortcut::enter(), Keyboard::Shortcut::submit()};
-    case ShortcutPreset::Form:
-      return {Keyboard::Shortcut::submit()};
-    default:
-      return {};
-    }
-  }
-
-  bool m_autoSelectPrimary = true;
-  bool m_dirty = true;
-  QString m_title;
-  QString m_id;
-  std::vector<std::unique_ptr<ActionPanelSectionState>> m_sections;
-  std::vector<Keyboard::Shortcut> m_defaultShortcuts;
-  AbstractAction *m_primary = nullptr;
-  ActionPanelSectionState *m_primarySection = nullptr;
-};
-
-class ListActionPanelState : public ActionPanelState {
-public:
-  ListActionPanelState() { setShortcutPreset(ShortcutPreset::List); }
-};
-
-class FormActionPanelState : public ActionPanelState {
-public:
-  FormActionPanelState() { setShortcutPreset(ShortcutPreset::Form); }
 };
 
 using ArgumentValues = std::vector<std::pair<QString, QString>>;
@@ -314,6 +179,7 @@ public:
   void toggleActionPanel();
 
   void setActions(std::unique_ptr<ActionPanelState> state, const BaseView *caller = nullptr);
+  void setActions(std::unique_ptr<ActionPanelView> view, const BaseView *caller = nullptr);
   void clearActions(const BaseView *caller = nullptr);
 
   void clearSearchText();

--- a/src/server/src/qml/action-panel-controller.cpp
+++ b/src/server/src/qml/action-panel-controller.cpp
@@ -75,42 +75,30 @@ void ActionPanelController::close() {
   emit stackClearRequested();
   m_depth = 0;
   m_currentPanel = nullptr;
-  m_rootModel = nullptr;
-  emit depthChanged();
+
+  if (auto *root = activeRoot()) root->onDeactivate();
+
+  delete m_connectionGuard;
+  m_connectionGuard = nullptr;
 
   if (m_activeView) { m_activeView->clearActionPanelStack(); }
+
+  emit depthChanged();
 }
 
 void ActionPanelController::openRootPanel() {
-  m_rootModel = nullptr;
+  delete m_connectionGuard;
+  m_connectionGuard = new QObject(this);
 
   auto *root = activeRoot();
   if (!root) return;
 
   root->onActivate();
+  connectView(root);
 
   auto url = root->componentUrl();
   auto props = root->componentProps();
-
-  auto modelVar = props.value(QStringLiteral("model"));
-  if (modelVar.isValid()) {
-    m_rootModel = qobject_cast<ActionPanelModel *>(modelVar.value<QObject *>());
-    if (m_rootModel) connectModel(m_rootModel);
-  }
-
   emit panelPushRequested(url, props);
-}
-
-void ActionPanelController::pushActionList(std::unique_ptr<ActionPanelState> state) {
-  if (!state) return;
-
-  state->finalize();
-  auto *model = new ActionPanelModel(std::move(state), m_rootModel);
-  connectModel(model);
-
-  QVariantMap props;
-  props[QStringLiteral("model")] = QVariant::fromValue(static_cast<QObject *>(model));
-  emit panelPushRequested(QUrl(QStringLiteral("qrc:/Vicinae/ActionListPanel.qml")), props);
 }
 
 void ActionPanelController::pushPanel(const QUrl &componentUrl, const QVariantMap &properties) {
@@ -134,6 +122,7 @@ void ActionPanelController::onPanelPushed(QObject *panel) {
 void ActionPanelController::onPanelPopped(QObject *currentPanel) {
   if (m_depth > 0) m_depth--;
   m_currentPanel = currentPanel;
+  if (m_activeView) m_activeView->popActionPanelView();
   emit depthChanged();
 }
 
@@ -163,18 +152,20 @@ void ActionPanelController::executeAction(AbstractAction *action) {
   close();
 }
 
-void ActionPanelController::connectModel(ActionPanelModel *model) {
-  connect(model, &ActionPanelModel::actionExecuted, this, [this](AbstractAction *action) {
+void ActionPanelController::connectView(ActionPanelView *view) {
+  connect(view, &ActionPanelView::actionExecuted, m_connectionGuard, [this](AbstractAction *action) {
     m_ctx.navigation->executeAction(action);
     close();
   });
 
-  connect(model, &ActionPanelModel::submenuRequested, this, [this](ActionPanelModel *subModel) {
-    connectModel(subModel);
-    QVariantMap props;
-    props[QStringLiteral("model")] = QVariant::fromValue(static_cast<QObject *>(subModel));
-    emit panelPushRequested(QUrl(QStringLiteral("qrc:/Vicinae/ActionListPanel.qml")), props);
-  });
+  connect(view, &ActionPanelView::closeRequested, m_connectionGuard, [this]() { close(); });
 
-  connect(model, &ActionPanelModel::closeRequested, this, [this]() { close(); });
+  connect(view, &ActionPanelView::pushViewRequested, m_connectionGuard, [this](ActionPanelView *child) {
+    if (!m_activeView) return;
+    m_activeView->pushActionPanelView(child);
+    connectView(child);
+    auto url = child->componentUrl();
+    auto props = child->componentProps();
+    emit panelPushRequested(url, props);
+  });
 }

--- a/src/server/src/qml/action-panel-controller.cpp
+++ b/src/server/src/qml/action-panel-controller.cpp
@@ -1,41 +1,41 @@
 #include "action-panel-controller.hpp"
 #include "action-panel-model.hpp"
-#include "navigation-controller.hpp"
 #include "lib/keyboard/keyboard.hpp"
+#include "navigation-controller.hpp"
+#include "ui/action-pannel/action-panel-view.hpp"
+#include "ui/views/base-view.hpp"
 #include <QKeyEvent>
 
 ActionPanelController::ActionPanelController(ApplicationContext &ctx, QObject *parent)
     : QObject(parent), m_ctx(ctx) {}
 
+ActionPanelView *ActionPanelController::activeRoot() const {
+  return m_activeView ? m_activeView->actionPanelRoot() : nullptr;
+}
+
 QString ActionPanelController::primaryActionTitle() const {
-  return m_primary ? m_primary->title() : QString();
+  auto *root = activeRoot();
+  if (!root) return {};
+  auto *primary = root->primaryAction();
+  return primary ? primary->title() : QString();
 }
 
 QVariantList ActionPanelController::primaryActionShortcutTokens() const {
-  if (!m_primary) return {};
-  auto shortcut = m_primary->shortcut().value_or(Keyboard::Shortcut::enter());
+  auto *root = activeRoot();
+  if (!root) return {};
+  auto *primary = root->primaryAction();
+  if (!primary) return {};
+  auto shortcut = primary->shortcut().value_or(Keyboard::Shortcut::enter());
   return shortcut.toDisplayTokens();
 }
 
-void ActionPanelController::setStateFrom(const ActionPanelState &state) {
-  m_allActions.clear();
-  m_sections.clear();
-  m_primary = nullptr;
+void ActionPanelController::syncToView(BaseView *view) {
+  m_activeView = view;
 
-  for (const auto &section : state.sections()) {
-    SectionSnapshot snap;
-    snap.name = section->name();
-    for (const auto &action : section->actions()) {
-      snap.actions.push_back(action);
-      m_allActions.push_back(action);
-    }
-    m_sections.push_back(std::move(snap));
-  }
+  auto *root = activeRoot();
 
-  m_primary = state.primaryAction();
-
-  bool const newHasActions = state.actionCount() > 0;
-  bool const newHasMultiple = state.actionCount() > 1;
+  bool const newHasActions = root && root->hasActions();
+  bool const newHasMultiple = root && root->hasMultipleActions();
 
   if (newHasActions != m_hasActions) {
     m_hasActions = newHasActions;
@@ -48,24 +48,6 @@ void ActionPanelController::setStateFrom(const ActionPanelState &state) {
   }
 
   emit primaryActionChanged();
-}
-
-void ActionPanelController::clearState() {
-  m_allActions.clear();
-  m_sections.clear();
-  m_primary = nullptr;
-
-  if (m_hasActions) {
-    m_hasActions = false;
-    emit hasActionsChanged();
-  }
-  if (m_hasMultipleActions) {
-    m_hasMultipleActions = false;
-    emit hasMultipleActionsChanged();
-  }
-
-  emit primaryActionChanged();
-  close();
 }
 
 void ActionPanelController::toggle() {
@@ -93,35 +75,30 @@ void ActionPanelController::close() {
   emit stackClearRequested();
   m_depth = 0;
   m_currentPanel = nullptr;
+  m_rootModel = nullptr;
   emit depthChanged();
-  destroyPanelModels();
-}
 
-void ActionPanelController::destroyPanelModels() {
-  if (m_rootModel) {
-    m_rootModel->deleteLater();
-    m_rootModel = nullptr;
-  }
+  if (m_activeView) { m_activeView->clearActionPanelStack(); }
 }
 
 void ActionPanelController::openRootPanel() {
-  destroyPanelModels();
+  m_rootModel = nullptr;
 
-  auto state = std::make_unique<ActionPanelState>();
-  for (const auto &snap : m_sections) {
-    auto *section = state->createSection(snap.name);
-    for (const auto &action : snap.actions) {
-      section->m_actions.push_back(action);
-    }
+  auto *root = activeRoot();
+  if (!root) return;
+
+  root->onActivate();
+
+  auto url = root->componentUrl();
+  auto props = root->componentProps();
+
+  auto modelVar = props.value(QStringLiteral("model"));
+  if (modelVar.isValid()) {
+    m_rootModel = qobject_cast<ActionPanelModel *>(modelVar.value<QObject *>());
+    if (m_rootModel) connectModel(m_rootModel);
   }
-  state->finalize();
 
-  m_rootModel = new ActionPanelModel(std::move(state), this);
-  connectModel(m_rootModel);
-
-  QVariantMap props;
-  props[QStringLiteral("model")] = QVariant::fromValue(static_cast<QObject *>(m_rootModel));
-  emit panelPushRequested(QUrl(QStringLiteral("qrc:/Vicinae/ActionListPanel.qml")), props);
+  emit panelPushRequested(url, props);
 }
 
 void ActionPanelController::pushActionList(std::unique_ptr<ActionPanelState> state) {
@@ -160,14 +137,6 @@ void ActionPanelController::onPanelPopped(QObject *currentPanel) {
   emit depthChanged();
 }
 
-AbstractAction *ActionPanelController::findBoundAction(const QKeyEvent *event) const {
-  for (const auto &action : m_allActions) {
-    if (action->isBoundTo(event)) return action.get();
-  }
-
-  return nullptr;
-}
-
 bool ActionPanelController::tryShortcut(int key, int modifiers) {
   if (!m_open || !m_currentPanel) return false;
 
@@ -181,8 +150,11 @@ bool ActionPanelController::tryShortcut(int key, int modifiers) {
 }
 
 bool ActionPanelController::executePrimaryAction() {
-  if (!m_primary) return false;
-  executeAction(m_primary);
+  auto *root = activeRoot();
+  if (!root) return false;
+  auto *primary = root->primaryAction();
+  if (!primary) return false;
+  executeAction(primary);
   return true;
 }
 

--- a/src/server/src/qml/action-panel-controller.hpp
+++ b/src/server/src/qml/action-panel-controller.hpp
@@ -6,9 +6,7 @@
 #include <QVariantList>
 
 class AbstractAction;
-class ActionPanelState;
 class ActionPanelView;
-class ActionPanelModel;
 class BaseView;
 class QKeyEvent;
 
@@ -48,7 +46,6 @@ public:
   Q_INVOKABLE void open();
   Q_INVOKABLE void close();
 
-  void pushActionList(std::unique_ptr<ActionPanelState> state);
   void pushPanel(const QUrl &componentUrl, const QVariantMap &properties);
   Q_INVOKABLE void pop();
 
@@ -62,7 +59,7 @@ public:
 
 private:
   void openRootPanel();
-  void connectModel(ActionPanelModel *model);
+  void connectView(ActionPanelView *view);
 
   ActionPanelView *activeRoot() const;
 
@@ -72,6 +69,6 @@ private:
   bool m_hasMultipleActions = false;
   int m_depth = 0;
   QObject *m_currentPanel = nullptr;
-  ActionPanelModel *m_rootModel = nullptr;
+  QObject *m_connectionGuard = nullptr;
   BaseView *m_activeView = nullptr;
 };

--- a/src/server/src/qml/action-panel-controller.hpp
+++ b/src/server/src/qml/action-panel-controller.hpp
@@ -4,13 +4,13 @@
 #include <QUrl>
 #include <QVariantMap>
 #include <QVariantList>
-#include <memory>
-#include <vector>
 
 class AbstractAction;
 class ActionPanelState;
-class QKeyEvent;
+class ActionPanelView;
 class ActionPanelModel;
+class BaseView;
+class QKeyEvent;
 
 class ActionPanelController : public QObject {
   Q_OBJECT
@@ -42,8 +42,7 @@ public:
   QVariantList primaryActionShortcutTokens() const;
   int depth() const { return m_depth; }
 
-  void setStateFrom(const ActionPanelState &state);
-  void clearState();
+  void syncToView(BaseView *view);
 
   Q_INVOKABLE void toggle();
   Q_INVOKABLE void open();
@@ -56,7 +55,6 @@ public:
   Q_INVOKABLE void onPanelPushed(QObject *panel);
   Q_INVOKABLE void onPanelPopped(QObject *currentPanel);
 
-  AbstractAction *findBoundAction(const QKeyEvent *event) const;
   Q_INVOKABLE bool tryShortcut(int key, int modifiers);
 
   bool executePrimaryAction();
@@ -66,7 +64,7 @@ private:
   void openRootPanel();
   void connectModel(ActionPanelModel *model);
 
-  void destroyPanelModels();
+  ActionPanelView *activeRoot() const;
 
   ApplicationContext &m_ctx;
   bool m_open = false;
@@ -75,12 +73,5 @@ private:
   int m_depth = 0;
   QObject *m_currentPanel = nullptr;
   ActionPanelModel *m_rootModel = nullptr;
-
-  std::vector<std::shared_ptr<AbstractAction>> m_allActions;
-  struct SectionSnapshot {
-    QString name;
-    std::vector<std::shared_ptr<AbstractAction>> actions;
-  };
-  std::vector<SectionSnapshot> m_sections;
-  AbstractAction *m_primary = nullptr;
+  BaseView *m_activeView = nullptr;
 };

--- a/src/server/src/qml/action-panel-model.cpp
+++ b/src/server/src/qml/action-panel-model.cpp
@@ -29,14 +29,10 @@ ActionPanelModel::ActionPanelModel(const ActionPanelState *state, QObject *paren
 
 void ActionPanelModel::setState(std::unique_ptr<ActionPanelState> state) { setStateFrom(state.get()); }
 
-void ActionPanelModel::setStateFrom(const ActionPanelState *state) {
-  beginResetModel();
-
-  m_title = state ? state->title() : QString();
+void ActionPanelModel::loadSections(const ActionPanelState *state) {
   m_allActions.clear();
   m_sections.clear();
-  m_flat.clear();
-  m_filterQuery.clear();
+  m_title = state ? state->title() : QString();
 
   if (state) {
     for (const auto &section : state->sections()) {
@@ -49,9 +45,40 @@ void ActionPanelModel::setStateFrom(const ActionPanelState *state) {
       m_sections.push_back(std::move(info));
     }
   }
+}
 
+void ActionPanelModel::setStateFrom(const ActionPanelState *state) {
+  beginResetModel();
+  loadSections(state);
+  m_filterQuery.clear();
   rebuildFlatList();
   endResetModel();
+  emit titleChanged();
+}
+
+void ActionPanelModel::reconcile(const ActionPanelState *state) {
+  loadSections(state);
+
+  int oldCount = static_cast<int>(m_flat.size());
+  std::vector<FlatItem> newFlat;
+  buildFlatList(newFlat);
+  int newCount = static_cast<int>(newFlat.size());
+
+  if (newCount > oldCount) {
+    beginInsertRows({}, oldCount, newCount - 1);
+    m_flat = std::move(newFlat);
+    endInsertRows();
+    if (oldCount > 0) emit dataChanged(index(0), index(oldCount - 1));
+  } else if (newCount < oldCount) {
+    beginRemoveRows({}, newCount, oldCount - 1);
+    m_flat = std::move(newFlat);
+    endRemoveRows();
+    if (newCount > 0) emit dataChanged(index(0), index(newCount - 1));
+  } else {
+    m_flat = std::move(newFlat);
+    if (newCount > 0) emit dataChanged(index(0), index(newCount - 1));
+  }
+
   emit titleChanged();
 }
 
@@ -144,13 +171,7 @@ void ActionPanelModel::activate(int index) {
 
   if (action->isSubmenu()) {
     auto *submenuAction = dynamic_cast<SubmenuAction *>(action.get());
-    if (!submenuAction) return;
-
-    auto subState = submenuAction->createSubmenuState();
-    if (!subState) return;
-
-    auto *subModel = new ActionPanelModel(std::move(subState), this);
-    emit submenuRequested(subModel);
+    if (submenuAction) emit submenuActivated(submenuAction);
     return;
   }
 
@@ -171,6 +192,7 @@ void ActionPanelModel::setFilter(const QString &text) {
   beginResetModel();
   rebuildFlatList();
   endResetModel();
+  emit filterChanged(text);
 }
 
 int ActionPanelModel::nextSelectableIndex(int from, int direction) const {
@@ -260,9 +282,9 @@ int ActionPanelModel::scrollTargetIndex(int index, int direction) const {
   return index;
 }
 
-void ActionPanelModel::rebuildFlatList() {
-  m_flat.clear();
-  m_flat.reserve(m_allActions.size() + m_sections.size() * 2);
+void ActionPanelModel::buildFlatList(std::vector<FlatItem> &out) const {
+  out.clear();
+  out.reserve(m_allActions.size() + m_sections.size() * 2);
 
   bool needsDivider = false;
   std::vector<Scored<int>> scored;
@@ -273,17 +295,19 @@ void ActionPanelModel::rebuildFlatList() {
 
     if (scored.empty()) continue;
 
-    if (needsDivider) { m_flat.emplace_back(FlatItem::Divider); }
+    if (needsDivider) { out.emplace_back(FlatItem::Divider); }
 
-    if (!section.name.isEmpty()) { m_flat.emplace_back(FlatItem::SectionHeader, s); }
+    if (!section.name.isEmpty()) { out.emplace_back(FlatItem::SectionHeader, s); }
 
     for (const auto &entry : scored) {
-      m_flat.emplace_back(FlatItem::ActionItem, s, entry.data);
+      out.emplace_back(FlatItem::ActionItem, s, entry.data);
     }
 
     needsDivider = true;
   }
 }
+
+void ActionPanelModel::rebuildFlatList() { buildFlatList(m_flat); }
 
 bool ActionPanelModel::activateByShortcut(int key, int modifiers) {
   auto mods = static_cast<Qt::KeyboardModifiers>(modifiers);

--- a/src/server/src/qml/action-panel-model.cpp
+++ b/src/server/src/qml/action-panel-model.cpp
@@ -64,7 +64,11 @@ void ActionPanelModel::reconcile(const ActionPanelState *state) {
   buildFlatList(newFlat);
   int newCount = static_cast<int>(newFlat.size());
 
-  if (newCount > oldCount) {
+  if (oldCount == 0 || newCount == 0) {
+    beginResetModel();
+    m_flat = std::move(newFlat);
+    endResetModel();
+  } else if (newCount > oldCount) {
     beginInsertRows({}, oldCount, newCount - 1);
     m_flat = std::move(newFlat);
     endInsertRows();

--- a/src/server/src/qml/action-panel-model.hpp
+++ b/src/server/src/qml/action-panel-model.hpp
@@ -7,6 +7,8 @@
 #include <string>
 #include <vector>
 
+class SubmenuAction;
+
 class ActionPanelModel : public QAbstractListModel {
   Q_OBJECT
   Q_PROPERTY(QString title READ title NOTIFY titleChanged)
@@ -28,6 +30,7 @@ public:
 
   void setState(std::unique_ptr<ActionPanelState> state);
   void setStateFrom(const ActionPanelState *state);
+  void reconcile(const ActionPanelState *state);
   QString title() const { return m_title; }
 
   int rowCount(const QModelIndex &parent = {}) const override;
@@ -45,9 +48,10 @@ public:
 signals:
   void titleChanged();
   void actionExecuted(AbstractAction *action);
-  void submenuRequested(ActionPanelModel *subModel);
+  void submenuActivated(SubmenuAction *action);
   void customPanelRequested(const QUrl &componentUrl, const QVariantMap &properties);
   void closeRequested();
+  void filterChanged(const QString &text);
 
 private:
   struct FlatItem {
@@ -57,6 +61,8 @@ private:
   };
 
   void rebuildFlatList();
+  void buildFlatList(std::vector<FlatItem> &out) const;
+  void loadSections(const ActionPanelState *state);
 
   QString m_title;
   std::string m_filterQuery;

--- a/src/server/src/qml/extension-grid-model.cpp
+++ b/src/server/src/qml/extension-grid-model.cpp
@@ -68,8 +68,8 @@ std::unique_ptr<ActionPanelState> ExtensionGridSection::actionPanel(int i) const
 
 // --- ExtensionGridModel ---
 
-ExtensionGridModel::ExtensionGridModel(NotifyFn notify, QObject *parent)
-    : SectionGridModel(parent), m_notify(std::move(notify)) {}
+ExtensionGridModel::ExtensionGridModel(NotifyFn notify, SubmenuCache *cache, QObject *parent)
+    : SectionGridModel(parent), m_notify(std::move(notify)), m_submenuCache(cache) {}
 
 void ExtensionGridModel::setExtensionData(const GridModel &model, bool resetSelection) {
   m_model = model;
@@ -125,7 +125,7 @@ void ExtensionGridModel::rebuildFromSections(bool resetSelection) {
     if (freeBuf.empty()) return;
     auto section = std::make_unique<ExtensionGridSection>(std::move(freeItems), std::move(freeBuf),
                                                           std::nullopt, std::nullopt, m_model.filtering,
-                                                          m_notify, &m_submenuCache, &m_model.actions);
+                                                          m_notify, m_submenuCache, &m_model.actions);
     section->setOnItemSelected([this](const GridItemViewModel *item) {
       if (auto handler = m_model.onSelectionChanged) {
         if (item) { m_notify(handler->c_str(), {item->id.c_str()}); }
@@ -144,7 +144,7 @@ void ExtensionGridModel::rebuildFromSections(bool resetSelection) {
       flushFree();
       auto section = std::make_unique<ExtensionGridSection>(sec->title, sec->children, sec->columns,
                                                             sec->aspectRatio, m_model.filtering, m_notify,
-                                                            &m_submenuCache, &m_model.actions);
+                                                            m_submenuCache, &m_model.actions);
       section->setOnItemSelected([this](const GridItemViewModel *item) {
         if (auto handler = m_model.onSelectionChanged) {
           if (item) { m_notify(handler->c_str(), {item->id.c_str()}); }
@@ -267,10 +267,10 @@ void ExtensionGridModel::onSelectionCleared() {
   std::unique_ptr<ActionPanelState> panel;
 
   if (m_model.emptyView && m_model.emptyView->actions) {
-    panel = ExtensionActionPanelBuilder::build(*m_model.emptyView->actions, m_notify, &m_submenuCache,
+    panel = ExtensionActionPanelBuilder::build(*m_model.emptyView->actions, m_notify, m_submenuCache,
                                                ActionPanelState::ShortcutPreset::List);
   } else if (m_model.actions) {
-    panel = ExtensionActionPanelBuilder::build(*m_model.actions, m_notify, &m_submenuCache,
+    panel = ExtensionActionPanelBuilder::build(*m_model.actions, m_notify, m_submenuCache,
                                                ActionPanelState::ShortcutPreset::List);
   }
 

--- a/src/server/src/qml/extension-grid-model.cpp
+++ b/src/server/src/qml/extension-grid-model.cpp
@@ -25,10 +25,10 @@ template <> struct fuzzy::FuzzySearchable<GridItemViewModel> {
 
 ExtensionGridSection::ExtensionGridSection(std::string name, std::vector<GridItemViewModel> items,
                                            std::optional<int> columns, std::optional<double> aspectRatio,
-                                           bool filtering, NotifyFn notify, SubmenuCache *cache,
+                                           bool filtering, NotifyFn notify,
                                            const std::optional<ActionPannelModel> *globalActions)
     : m_name(std::move(name)), m_items(std::move(items)), m_columns(columns), m_aspectRatio(aspectRatio),
-      m_filtering(filtering), m_notify(std::move(notify)), m_cache(cache), m_globalActions(globalActions) {}
+      m_filtering(filtering), m_notify(std::move(notify)), m_globalActions(globalActions) {}
 
 int ExtensionGridSection::count() const {
   if (m_filtering && !m_query.empty()) return static_cast<int>(m_filtered.size());
@@ -56,11 +56,11 @@ const GridItemViewModel *ExtensionGridSection::itemAt(int i) const {
 
 std::unique_ptr<ActionPanelState> ExtensionGridSection::actionPanel(int i) const {
   if (auto *it = itemAt(i); it && it->actionPannel) {
-    return ExtensionActionPanelBuilder::build(*it->actionPannel, m_notify, m_cache,
+    return ExtensionActionPanelBuilder::build(*it->actionPannel, m_notify,
                                               ActionPanelState::ShortcutPreset::List);
   }
   if (m_globalActions && *m_globalActions) {
-    return ExtensionActionPanelBuilder::build(**m_globalActions, m_notify, m_cache,
+    return ExtensionActionPanelBuilder::build(**m_globalActions, m_notify,
                                               ActionPanelState::ShortcutPreset::List);
   }
   return nullptr;
@@ -68,8 +68,8 @@ std::unique_ptr<ActionPanelState> ExtensionGridSection::actionPanel(int i) const
 
 // --- ExtensionGridModel ---
 
-ExtensionGridModel::ExtensionGridModel(NotifyFn notify, SubmenuCache *cache, QObject *parent)
-    : SectionGridModel(parent), m_notify(std::move(notify)), m_submenuCache(cache) {}
+ExtensionGridModel::ExtensionGridModel(NotifyFn notify, QObject *parent)
+    : SectionGridModel(parent), m_notify(std::move(notify)) {}
 
 void ExtensionGridModel::setExtensionData(const GridModel &model, bool resetSelection) {
   m_model = model;
@@ -123,9 +123,9 @@ void ExtensionGridModel::rebuildFromSections(bool resetSelection) {
 
   auto flushFree = [&]() {
     if (freeBuf.empty()) return;
-    auto section = std::make_unique<ExtensionGridSection>(std::move(freeItems), std::move(freeBuf),
-                                                          std::nullopt, std::nullopt, m_model.filtering,
-                                                          m_notify, m_submenuCache, &m_model.actions);
+    auto section =
+        std::make_unique<ExtensionGridSection>(std::move(freeItems), std::move(freeBuf), std::nullopt,
+                                               std::nullopt, m_model.filtering, m_notify, &m_model.actions);
     section->setOnItemSelected([this](const GridItemViewModel *item) {
       if (auto handler = m_model.onSelectionChanged) {
         if (item) { m_notify(handler->c_str(), {item->id.c_str()}); }
@@ -142,9 +142,9 @@ void ExtensionGridModel::rebuildFromSections(bool resetSelection) {
       freeBuf.push_back(*item);
     } else if (auto sec = std::get_if<GridSectionModel>(&child)) {
       flushFree();
-      auto section = std::make_unique<ExtensionGridSection>(sec->title, sec->children, sec->columns,
-                                                            sec->aspectRatio, m_model.filtering, m_notify,
-                                                            m_submenuCache, &m_model.actions);
+      auto section =
+          std::make_unique<ExtensionGridSection>(sec->title, sec->children, sec->columns, sec->aspectRatio,
+                                                 m_model.filtering, m_notify, &m_model.actions);
       section->setOnItemSelected([this](const GridItemViewModel *item) {
         if (auto handler = m_model.onSelectionChanged) {
           if (item) { m_notify(handler->c_str(), {item->id.c_str()}); }
@@ -267,10 +267,10 @@ void ExtensionGridModel::onSelectionCleared() {
   std::unique_ptr<ActionPanelState> panel;
 
   if (m_model.emptyView && m_model.emptyView->actions) {
-    panel = ExtensionActionPanelBuilder::build(*m_model.emptyView->actions, m_notify, m_submenuCache,
+    panel = ExtensionActionPanelBuilder::build(*m_model.emptyView->actions, m_notify,
                                                ActionPanelState::ShortcutPreset::List);
   } else if (m_model.actions) {
-    panel = ExtensionActionPanelBuilder::build(*m_model.actions, m_notify, m_submenuCache,
+    panel = ExtensionActionPanelBuilder::build(*m_model.actions, m_notify,
                                                ActionPanelState::ShortcutPreset::List);
   }
 

--- a/src/server/src/qml/extension-grid-model.hpp
+++ b/src/server/src/qml/extension-grid-model.hpp
@@ -11,11 +11,10 @@
 class ExtensionGridSection : public GridSource {
 public:
   using NotifyFn = ExtensionActionPanelBuilder::NotifyFn;
-  using SubmenuCache = ExtensionActionPanelBuilder::SubmenuCache;
 
   ExtensionGridSection(std::string name, std::vector<GridItemViewModel> items, std::optional<int> columns,
                        std::optional<double> aspectRatio, bool filtering, NotifyFn notify,
-                       SubmenuCache *cache, const std::optional<ActionPannelModel> *globalActions);
+                       const std::optional<ActionPannelModel> *globalActions);
 
   QString sectionName() const override { return QString::fromStdString(m_name); }
   int count() const override;
@@ -41,7 +40,6 @@ private:
   bool m_filtering;
   std::string m_query;
   NotifyFn m_notify;
-  SubmenuCache *m_cache;
   const std::optional<ActionPannelModel> *m_globalActions;
   std::function<void(const GridItemViewModel *)> m_onItemSelected;
 };
@@ -58,9 +56,7 @@ class ExtensionGridModel : public SectionGridModel {
 public:
   using NotifyFn = std::function<void(const QString &handler, const QJsonArray &args)>;
 
-  using SubmenuCache = ExtensionActionPanelBuilder::SubmenuCache;
-
-  explicit ExtensionGridModel(NotifyFn notify, SubmenuCache *cache, QObject *parent = nullptr);
+  explicit ExtensionGridModel(NotifyFn notify, QObject *parent = nullptr);
 
   void setExtensionData(const GridModel &model, bool resetSelection = true);
   void setFilter(const QString &text);
@@ -94,7 +90,6 @@ private:
   void rebuildFromSections(bool resetSelection);
 
   NotifyFn m_notify;
-  SubmenuCache *m_submenuCache;
   std::vector<std::unique_ptr<ExtensionGridSection>> m_ownedSections;
   GridModel m_model;
   ObjectFit m_fit = ObjectFit::Contain;

--- a/src/server/src/qml/extension-grid-model.hpp
+++ b/src/server/src/qml/extension-grid-model.hpp
@@ -58,7 +58,9 @@ class ExtensionGridModel : public SectionGridModel {
 public:
   using NotifyFn = std::function<void(const QString &handler, const QJsonArray &args)>;
 
-  explicit ExtensionGridModel(NotifyFn notify, QObject *parent = nullptr);
+  using SubmenuCache = ExtensionActionPanelBuilder::SubmenuCache;
+
+  explicit ExtensionGridModel(NotifyFn notify, SubmenuCache *cache, QObject *parent = nullptr);
 
   void setExtensionData(const GridModel &model, bool resetSelection = true);
   void setFilter(const QString &text);
@@ -92,7 +94,7 @@ private:
   void rebuildFromSections(bool resetSelection);
 
   NotifyFn m_notify;
-  mutable ExtensionActionPanelBuilder::SubmenuCache m_submenuCache;
+  SubmenuCache *m_submenuCache;
   std::vector<std::unique_ptr<ExtensionGridSection>> m_ownedSections;
   GridModel m_model;
   ObjectFit m_fit = ObjectFit::Contain;

--- a/src/server/src/qml/extension-list-model.cpp
+++ b/src/server/src/qml/extension-list-model.cpp
@@ -77,8 +77,8 @@ std::unique_ptr<ActionPanelState> ExtensionListSection::actionPanel(int i) const
 
 // --- ExtensionListModel ---
 
-ExtensionListModel::ExtensionListModel(NotifyFn notify, QObject *parent)
-    : SectionListModel(parent), m_notify(std::move(notify)) {}
+ExtensionListModel::ExtensionListModel(NotifyFn notify, SubmenuCache *cache, QObject *parent)
+    : SectionListModel(parent), m_notify(std::move(notify)), m_submenuCache(cache) {}
 
 void ExtensionListModel::setExtensionData(const ListModel &model, bool resetSelection) {
   m_model = model;
@@ -94,7 +94,7 @@ void ExtensionListModel::setExtensionData(const ListModel &model, bool resetSele
     if (freeBuf.empty()) return;
     auto section =
         std::make_unique<ExtensionListSection>(std::move(freeItems), std::move(freeBuf), model.filtering,
-                                               m_notify, &m_submenuCache, &m_model.actions);
+                                               m_notify, m_submenuCache, &m_model.actions);
     section->setOnItemSelected([this](const ListItemViewModel *item) { handleItemSelected(item); });
     addSource(section.get());
     m_ownedSections.push_back(std::move(section));
@@ -108,7 +108,7 @@ void ExtensionListModel::setExtensionData(const ListModel &model, bool resetSele
     } else if (auto sec = std::get_if<ListSectionModel>(&child)) {
       flushFree();
       auto section = std::make_unique<ExtensionListSection>(sec->title, sec->children, model.filtering,
-                                                            m_notify, &m_submenuCache, &m_model.actions);
+                                                            m_notify, m_submenuCache, &m_model.actions);
       section->setOnItemSelected([this](const ListItemViewModel *item) { handleItemSelected(item); });
       addSource(section.get());
       m_ownedSections.push_back(std::move(section));
@@ -176,10 +176,10 @@ void ExtensionListModel::onSelectionCleared() {
   std::unique_ptr<ActionPanelState> panel;
 
   if (m_model.emptyView && m_model.emptyView->actions) {
-    panel = ExtensionActionPanelBuilder::build(*m_model.emptyView->actions, m_notify, &m_submenuCache,
+    panel = ExtensionActionPanelBuilder::build(*m_model.emptyView->actions, m_notify, m_submenuCache,
                                                ActionPanelState::ShortcutPreset::List);
   } else if (m_model.actions) {
-    panel = ExtensionActionPanelBuilder::build(*m_model.actions, m_notify, &m_submenuCache,
+    panel = ExtensionActionPanelBuilder::build(*m_model.actions, m_notify, m_submenuCache,
                                                ActionPanelState::ShortcutPreset::List);
   }
 

--- a/src/server/src/qml/extension-list-model.cpp
+++ b/src/server/src/qml/extension-list-model.cpp
@@ -21,10 +21,10 @@ template <> struct fuzzy::FuzzySearchable<ListItemViewModel> {
 // --- ExtensionListSection ---
 
 ExtensionListSection::ExtensionListSection(std::string name, std::vector<ListItemViewModel> items,
-                                           bool filtering, NotifyFn notify, SubmenuCache *cache,
+                                           bool filtering, NotifyFn notify,
                                            const std::optional<ActionPannelModel> *globalActions)
     : m_name(std::move(name)), m_items(std::move(items)), m_filtering(filtering), m_notify(std::move(notify)),
-      m_cache(cache), m_globalActions(globalActions) {}
+      m_globalActions(globalActions) {}
 
 int ExtensionListSection::count() const {
   if (m_filtering && !m_query.empty()) return static_cast<int>(m_filtered.size());
@@ -65,11 +65,11 @@ QVariantList ExtensionListSection::itemAccessories(int i) const {
 std::unique_ptr<ActionPanelState> ExtensionListSection::actionPanel(int i) const {
   const auto &item = itemAt(i);
   if (item.actionPannel) {
-    return ExtensionActionPanelBuilder::build(*item.actionPannel, m_notify, m_cache,
+    return ExtensionActionPanelBuilder::build(*item.actionPannel, m_notify,
                                               ActionPanelState::ShortcutPreset::List);
   }
   if (m_globalActions && *m_globalActions) {
-    return ExtensionActionPanelBuilder::build(**m_globalActions, m_notify, m_cache,
+    return ExtensionActionPanelBuilder::build(**m_globalActions, m_notify,
                                               ActionPanelState::ShortcutPreset::List);
   }
   return nullptr;
@@ -77,8 +77,8 @@ std::unique_ptr<ActionPanelState> ExtensionListSection::actionPanel(int i) const
 
 // --- ExtensionListModel ---
 
-ExtensionListModel::ExtensionListModel(NotifyFn notify, SubmenuCache *cache, QObject *parent)
-    : SectionListModel(parent), m_notify(std::move(notify)), m_submenuCache(cache) {}
+ExtensionListModel::ExtensionListModel(NotifyFn notify, QObject *parent)
+    : SectionListModel(parent), m_notify(std::move(notify)) {}
 
 void ExtensionListModel::setExtensionData(const ListModel &model, bool resetSelection) {
   m_model = model;
@@ -92,9 +92,8 @@ void ExtensionListModel::setExtensionData(const ListModel &model, bool resetSele
 
   auto flushFree = [&]() {
     if (freeBuf.empty()) return;
-    auto section =
-        std::make_unique<ExtensionListSection>(std::move(freeItems), std::move(freeBuf), model.filtering,
-                                               m_notify, m_submenuCache, &m_model.actions);
+    auto section = std::make_unique<ExtensionListSection>(std::move(freeItems), std::move(freeBuf),
+                                                          model.filtering, m_notify, &m_model.actions);
     section->setOnItemSelected([this](const ListItemViewModel *item) { handleItemSelected(item); });
     addSource(section.get());
     m_ownedSections.push_back(std::move(section));
@@ -108,7 +107,7 @@ void ExtensionListModel::setExtensionData(const ListModel &model, bool resetSele
     } else if (auto sec = std::get_if<ListSectionModel>(&child)) {
       flushFree();
       auto section = std::make_unique<ExtensionListSection>(sec->title, sec->children, model.filtering,
-                                                            m_notify, m_submenuCache, &m_model.actions);
+                                                            m_notify, &m_model.actions);
       section->setOnItemSelected([this](const ListItemViewModel *item) { handleItemSelected(item); });
       addSource(section.get());
       m_ownedSections.push_back(std::move(section));
@@ -176,10 +175,10 @@ void ExtensionListModel::onSelectionCleared() {
   std::unique_ptr<ActionPanelState> panel;
 
   if (m_model.emptyView && m_model.emptyView->actions) {
-    panel = ExtensionActionPanelBuilder::build(*m_model.emptyView->actions, m_notify, m_submenuCache,
+    panel = ExtensionActionPanelBuilder::build(*m_model.emptyView->actions, m_notify,
                                                ActionPanelState::ShortcutPreset::List);
   } else if (m_model.actions) {
-    panel = ExtensionActionPanelBuilder::build(*m_model.actions, m_notify, m_submenuCache,
+    panel = ExtensionActionPanelBuilder::build(*m_model.actions, m_notify,
                                                ActionPanelState::ShortcutPreset::List);
   }
 

--- a/src/server/src/qml/extension-list-model.hpp
+++ b/src/server/src/qml/extension-list-model.hpp
@@ -11,11 +11,9 @@
 class ExtensionListSection : public SectionSource {
 public:
   using NotifyFn = ExtensionActionPanelBuilder::NotifyFn;
-  using SubmenuCache = ExtensionActionPanelBuilder::SubmenuCache;
 
   ExtensionListSection(std::string name, std::vector<ListItemViewModel> items, bool filtering,
-                       NotifyFn notify, SubmenuCache *cache,
-                       const std::optional<ActionPannelModel> *globalActions);
+                       NotifyFn notify, const std::optional<ActionPannelModel> *globalActions);
 
   QString sectionName() const override { return QString::fromStdString(m_name); }
   int count() const override;
@@ -42,7 +40,6 @@ private:
   bool m_filtering;
   std::string m_query;
   NotifyFn m_notify;
-  SubmenuCache *m_cache;
   const std::optional<ActionPannelModel> *m_globalActions;
   std::function<void(const ListItemViewModel *)> m_onItemSelected;
 };
@@ -60,9 +57,7 @@ class ExtensionListModel : public SectionListModel {
 public:
   using NotifyFn = ExtensionActionPanelBuilder::NotifyFn;
 
-  using SubmenuCache = ExtensionActionPanelBuilder::SubmenuCache;
-
-  explicit ExtensionListModel(NotifyFn notify, SubmenuCache *cache, QObject *parent = nullptr);
+  explicit ExtensionListModel(NotifyFn notify, QObject *parent = nullptr);
 
   void setExtensionData(const ListModel &model, bool resetSelection);
   void setFilter(const QString &text);
@@ -89,7 +84,6 @@ private:
   void handleItemSelected(const ListItemViewModel *item);
 
   NotifyFn m_notify;
-  SubmenuCache *m_submenuCache;
   std::optional<DetailModel> m_currentDetail;
   std::vector<std::unique_ptr<ExtensionListSection>> m_ownedSections;
   ListModel m_model;

--- a/src/server/src/qml/extension-list-model.hpp
+++ b/src/server/src/qml/extension-list-model.hpp
@@ -60,7 +60,9 @@ class ExtensionListModel : public SectionListModel {
 public:
   using NotifyFn = ExtensionActionPanelBuilder::NotifyFn;
 
-  explicit ExtensionListModel(NotifyFn notify, QObject *parent = nullptr);
+  using SubmenuCache = ExtensionActionPanelBuilder::SubmenuCache;
+
+  explicit ExtensionListModel(NotifyFn notify, SubmenuCache *cache, QObject *parent = nullptr);
 
   void setExtensionData(const ListModel &model, bool resetSelection);
   void setFilter(const QString &text);
@@ -87,7 +89,7 @@ private:
   void handleItemSelected(const ListItemViewModel *item);
 
   NotifyFn m_notify;
-  mutable ExtensionActionPanelBuilder::SubmenuCache m_submenuCache;
+  SubmenuCache *m_submenuCache;
   std::optional<DetailModel> m_currentDetail;
   std::vector<std::unique_ptr<ExtensionListSection>> m_ownedSections;
   ListModel m_model;

--- a/src/server/src/qml/extension-view-host.cpp
+++ b/src/server/src/qml/extension-view-host.cpp
@@ -41,13 +41,13 @@ void ExtensionViewHost::onReactivated() {
       auto notify = [this](const QString &handler, const QJsonArray &args) {
         notifyExtension(handler, args);
       };
-      setActions(ExtensionActionPanelBuilder::build(*detail->actions, notify, &m_submenuCache));
+      setActions(ExtensionActionPanelBuilder::build(*detail->actions, notify));
     }
   } else if (activeModel<ExtensionFormModel>() && m_formActions) {
     auto *form = activeModel<ExtensionFormModel>();
     auto notify = [this](const QString &handler, const QJsonArray &args) { notifyExtension(handler, args); };
     auto submit = [this, form]() -> std::expected<QJsonObject, QString> { return form->submit(); };
-    setActions(ExtensionActionPanelBuilder::build(*m_formActions, notify, &m_submenuCache,
+    setActions(ExtensionActionPanelBuilder::build(*m_formActions, notify,
                                                   ActionPanelState::ShortcutPreset::Form, submit));
   }
 }
@@ -56,20 +56,22 @@ void ExtensionViewHost::setActions(std::unique_ptr<ActionPanelState> actions) {
   auto &stack = actionPanelStack();
 
   if (!stack.empty() && !actions->id().isEmpty() && stack.front()->id() == actions->id()) {
+    auto *parentState = actions.get();
     auto *rootView = static_cast<ActionListView *>(stack.front());
     rootView->adoptState(std::move(actions));
 
-    auto notify = [this](const QString &h, const QJsonArray &a) { notifyExtension(h, a); };
     for (size_t i = 1; i < stack.size(); ++i) {
       QString viewId = stack[i]->id();
-      if (viewId.isEmpty()) continue;
+      if (viewId.isEmpty()) break;
 
-      auto it = m_submenuCache.find(viewId);
-      if (it != m_submenuCache.end()) {
-        auto submenuState =
-            ExtensionActionPanelBuilder::buildSubmenuState(it->second, notify, &m_submenuCache);
-        if (submenuState) { static_cast<ActionListView *>(stack[i])->adoptState(std::move(submenuState)); }
-      }
+      auto *submenuAction = parentState->findSubmenuAction(viewId);
+      if (!submenuAction) break;
+
+      auto submenuState = submenuAction->createSubmenuStateStealthily();
+      if (!submenuState) break;
+
+      parentState = submenuState.get();
+      static_cast<ActionListView *>(stack[i])->adoptState(std::move(submenuState));
     }
 
     if (context()) { context()->navigation->notifyActionPanelChanged(this); }
@@ -78,7 +80,7 @@ void ExtensionViewHost::setActions(std::unique_ptr<ActionPanelState> actions) {
 
   auto *view = new ExtensionActionListView(
       [this](const QString &handler, const QJsonArray &args) { notifyExtension(handler, args); }, QString(),
-      &m_submenuCache, this);
+      this);
   view->adoptState(std::move(actions));
   BaseView::setActions(static_cast<ActionPanelView *>(view));
 }
@@ -126,12 +128,12 @@ void ExtensionViewHost::switchViewType(const RenderModel &model) {
   auto notify = [this](const QString &handler, const QJsonArray &args) { notifyExtension(handler, args); };
 
   if (std::holds_alternative<ListModel>(model)) {
-    auto *m = new ExtensionListModel(notify, &m_submenuCache, this);
+    auto *m = new ExtensionListModel(notify, this);
     m->setScope(ViewScope(context(), this));
     m_model = m;
     setSearchInteractive(true);
   } else if (std::holds_alternative<GridModel>(model)) {
-    auto *m = new ExtensionGridModel(notify, &m_submenuCache, this);
+    auto *m = new ExtensionGridModel(notify, this);
     m->setScope(ViewScope(context(), this));
     m_model = m;
     setSearchInteractive(true);
@@ -320,7 +322,7 @@ void ExtensionViewHost::renderDetail(const RootDetailModel &model) {
   detail->actions = model.actions;
   if (model.actions) {
     auto notify = [this](const QString &handler, const QJsonArray &args) { notifyExtension(handler, args); };
-    setActions(ExtensionActionPanelBuilder::build(*model.actions, notify, &m_submenuCache));
+    setActions(ExtensionActionPanelBuilder::build(*model.actions, notify));
   }
 }
 
@@ -362,7 +364,7 @@ void ExtensionViewHost::renderForm(const FormModel &model) {
   if (model.actions) {
     auto notify = [this](const QString &handler, const QJsonArray &args) { notifyExtension(handler, args); };
     auto submit = [this, form]() -> std::expected<QJsonObject, QString> { return form->submit(); };
-    setActions(ExtensionActionPanelBuilder::build(*model.actions, notify, &m_submenuCache,
+    setActions(ExtensionActionPanelBuilder::build(*model.actions, notify,
                                                   ActionPanelState::ShortcutPreset::Form, submit));
   }
 }

--- a/src/server/src/qml/extension-view-host.cpp
+++ b/src/server/src/qml/extension-view-host.cpp
@@ -1,4 +1,5 @@
 #include "extension-view-host.hpp"
+#include "extension/extension-action-list-view.hpp"
 #include "navigation-controller.hpp"
 #include "view-utils.hpp"
 #include <chrono>
@@ -51,6 +52,37 @@ void ExtensionViewHost::onReactivated() {
   }
 }
 
+void ExtensionViewHost::setActions(std::unique_ptr<ActionPanelState> actions) {
+  auto &stack = actionPanelStack();
+
+  if (!stack.empty() && !actions->id().isEmpty() && stack.front()->id() == actions->id()) {
+    auto *rootView = static_cast<ActionListView *>(stack.front());
+    rootView->adoptState(std::move(actions));
+
+    auto notify = [this](const QString &h, const QJsonArray &a) { notifyExtension(h, a); };
+    for (size_t i = 1; i < stack.size(); ++i) {
+      QString viewId = stack[i]->id();
+      if (viewId.isEmpty()) continue;
+
+      auto it = m_submenuCache.find(viewId);
+      if (it != m_submenuCache.end()) {
+        auto submenuState =
+            ExtensionActionPanelBuilder::buildSubmenuState(it->second, notify, &m_submenuCache);
+        if (submenuState) { static_cast<ActionListView *>(stack[i])->adoptState(std::move(submenuState)); }
+      }
+    }
+
+    if (context()) { context()->navigation->notifyActionPanelChanged(this); }
+    return;
+  }
+
+  auto *view = new ExtensionActionListView(
+      [this](const QString &handler, const QJsonArray &args) { notifyExtension(handler, args); }, QString(),
+      &m_submenuCache, this);
+  view->adoptState(std::move(actions));
+  BaseView::setActions(static_cast<ActionPanelView *>(view));
+}
+
 void ExtensionViewHost::render(const RenderModel &model) {
   bool const wasFirstRender = m_firstRender;
 
@@ -94,12 +126,12 @@ void ExtensionViewHost::switchViewType(const RenderModel &model) {
   auto notify = [this](const QString &handler, const QJsonArray &args) { notifyExtension(handler, args); };
 
   if (std::holds_alternative<ListModel>(model)) {
-    auto *m = new ExtensionListModel(notify, this);
+    auto *m = new ExtensionListModel(notify, &m_submenuCache, this);
     m->setScope(ViewScope(context(), this));
     m_model = m;
     setSearchInteractive(true);
   } else if (std::holds_alternative<GridModel>(model)) {
-    auto *m = new ExtensionGridModel(notify, this);
+    auto *m = new ExtensionGridModel(notify, &m_submenuCache, this);
     m->setScope(ViewScope(context(), this));
     m_model = m;
     setSearchInteractive(true);

--- a/src/server/src/qml/extension-view-host.hpp
+++ b/src/server/src/qml/extension-view-host.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include "extend/model-parser.hpp"
-#include "extension/extension-action-panel-builder.hpp" // for NotifyFn
+#include "extension/extension-action-panel-builder.hpp"
 #include "bridge-view.hpp"
 #include "extension-form-model.hpp"
 #include "extension-grid-model.hpp"
@@ -103,8 +103,6 @@ private:
   std::optional<std::string> m_onSearchTextChange;
   bool m_shouldResetSelection = false;
   bool m_selectFirstOnReset = true;
-
-  mutable ExtensionActionPanelBuilder::SubmenuCache m_submenuCache;
 
   std::optional<ActionPannelModel> m_formActions;
   QString m_linkAccessoryText;

--- a/src/server/src/qml/extension-view-host.hpp
+++ b/src/server/src/qml/extension-view-host.hpp
@@ -33,6 +33,7 @@ public:
   void onReactivated() override;
 
   void render(const RenderModel &model);
+  void setActions(std::unique_ptr<ActionPanelState> actions) override;
 
   void textChanged(const QString &text) override;
   bool inputFilter(QKeyEvent *event) override;

--- a/src/server/src/qml/launcher-window.cpp
+++ b/src/server/src/qml/launcher-window.cpp
@@ -152,8 +152,8 @@ LauncherWindow::LauncherWindow(ApplicationContext &ctx, QObject *parent)
     }
   });
 
-  connect(nav, &NavigationController::actionsChanged, this,
-          [this](const ActionPanelState &state) { m_actionPanel->setStateFrom(state); });
+  connect(nav, &NavigationController::activeActionPanelChanged, this,
+          [this, nav]() { m_actionPanel->syncToView(nav->topState()->sender); });
 
   connect(nav, &NavigationController::viewPushed, this, [this](const BaseView *) { m_actionPanel->close(); });
 
@@ -440,8 +440,8 @@ bool LauncherWindow::forwardKey(int key, int modifiers) {
 
   QKeyEvent const event(QEvent::KeyPress, key, mods);
 
-  if (auto *action = m_actionPanel->findBoundAction(&event)) {
-    m_actionPanel->executeAction(action);
+  if (auto *action = m_ctx.navigation->findBoundAction(&event)) {
+    m_ctx.navigation->executeAction(action);
     return true;
   }
 

--- a/src/server/src/qml/launcher-window.cpp
+++ b/src/server/src/qml/launcher-window.cpp
@@ -442,6 +442,7 @@ bool LauncherWindow::forwardKey(int key, int modifiers) {
 
   if (auto *action = m_ctx.navigation->findBoundAction(&event)) {
     m_ctx.navigation->executeAction(action);
+    m_actionPanel->close();
     return true;
   }
 

--- a/src/server/src/qml/qml/ActionListPanel.qml
+++ b/src/server/src/qml/qml/ActionListPanel.qml
@@ -258,9 +258,6 @@ Item {
                             if (actionPanel.depth > 1)
                                 root.navigateBack();
                             event.accepted = true;
-                        } else if (event.key === Qt.Key_Backspace && filterInput.text === "" && actionPanel.depth > 1) {
-                            root.navigateBack();
-                            event.accepted = true;
                         } else if ((event.modifiers & (Qt.ControlModifier | Qt.AltModifier | Qt.MetaModifier)) && actionPanel.tryShortcut(event.key, event.modifiers)) {
                             event.accepted = true;
                         }

--- a/src/server/src/qml/qml/ActionPanelPopover.qml
+++ b/src/server/src/qml/qml/ActionPanelPopover.qml
@@ -117,7 +117,7 @@ FocusRestoringScope {
                 stack.currentItem.focusFilter();
         }
         function onPanelPopRequested() {
-            stack.pop(null, StackView.Immediate);
+            stack.pop();
             actionPanel.onPanelPopped(stack.currentItem);
             if (stack.currentItem && typeof stack.currentItem.focusFilter === "function")
                 stack.currentItem.focusFilter();
@@ -132,7 +132,7 @@ FocusRestoringScope {
         if (event.key === Qt.Key_Escape) {
             actionPanel.pop();
             event.accepted = true;
-        } else if (event.key === Qt.Key_Left || event.key === Qt.Key_Backspace || nav === 3) {
+        } else if (event.key === Qt.Key_Left || nav === 3) {
             if (actionPanel.depth > 1) {
                 actionPanel.pop();
                 event.accepted = true;

--- a/src/server/src/qml/root-search-model.cpp
+++ b/src/server/src/qml/root-search-model.cpp
@@ -1,5 +1,7 @@
 #include "root-search-model.hpp"
 #include "config/config.hpp"
+#include "ui/action-pannel/action-panel-view.hpp"
+#include "ui/views/base-view.hpp"
 #include "service-registry.hpp"
 #include "services/app-service/app-service.hpp"
 #include "services/calculator-service/calculator-service.hpp"
@@ -217,15 +219,19 @@ bool RootSearchModel::tryAliasFastTrack() {
 
 QString RootSearchModel::primaryActionTitle() const {
   auto *state = scope().topState();
-  if (!state || !state->actionPanelState) return {};
-  auto *action = state->actionPanelState->primaryAction();
+  if (!state) return {};
+  auto *root = state->sender->actionPanelRoot();
+  if (!root) return {};
+  auto *action = root->primaryAction();
   return action ? action->title() : QString();
 }
 
 QString RootSearchModel::primaryActionIcon() const {
   auto *state = scope().topState();
-  if (!state || !state->actionPanelState) return {};
-  auto *action = state->actionPanelState->primaryAction();
+  if (!state) return {};
+  auto *root = state->sender->actionPanelRoot();
+  if (!root) return {};
+  auto *action = root->primaryAction();
   if (!action) return {};
   auto icon = action->icon();
   return icon ? qml::imageSourceFor(*icon) : QString();
@@ -233,8 +239,10 @@ QString RootSearchModel::primaryActionIcon() const {
 
 QVariantList RootSearchModel::primaryActionShortcutTokens() const {
   auto *state = scope().topState();
-  if (!state || !state->actionPanelState) return {};
-  auto *action = state->actionPanelState->primaryAction();
+  if (!state) return {};
+  auto *root = state->sender->actionPanelRoot();
+  if (!root) return {};
+  auto *action = root->primaryAction();
   if (!action) return {};
   auto shortcut = action->shortcut().value_or(Keyboard::Shortcut::enter());
   return shortcut.toDisplayTokens();

--- a/src/server/src/ui/action-pannel/action-list-view.cpp
+++ b/src/server/src/ui/action-pannel/action-list-view.cpp
@@ -1,0 +1,45 @@
+#include "ui/action-pannel/action-list-view.hpp"
+#include "ui/action-pannel/action-panel-state.hpp"
+#include <QKeyEvent>
+
+ActionListView::ActionListView(QObject *parent)
+    : ActionPanelView(parent), m_state(std::make_unique<ActionPanelState>()) {}
+
+ActionListView::~ActionListView() = default;
+
+void ActionListView::adoptState(std::unique_ptr<ActionPanelState> state) {
+  if (!state) {
+    m_state = std::make_unique<ActionPanelState>();
+  } else {
+    m_state = std::move(state);
+  }
+  emit contentChanged();
+}
+
+std::unique_ptr<ActionPanelState> ActionListView::takeState() {
+  auto out = std::move(m_state);
+  m_state = std::make_unique<ActionPanelState>();
+  return out;
+}
+
+QUrl ActionListView::componentUrl() const { return QUrl(QStringLiteral("qrc:/Vicinae/ActionListPanel.qml")); }
+
+QVariantMap ActionListView::componentProps() const {
+  // Step 1: the controller does not yet push views onto the QML stack — it
+  // still constructs `ActionPanelModel`s on demand from snapshots. This will
+  // be filled in by the controller refactor that follows.
+  return {};
+}
+
+AbstractAction *ActionListView::findBoundAction(const QKeyEvent *event) const {
+  if (!m_state) return nullptr;
+
+  for (const auto &section : m_state->sections()) {
+    for (const auto &action : section->actions()) {
+      if (action->isBoundTo(event)) { return action.get(); }
+    }
+  }
+  return nullptr;
+}
+
+AbstractAction *ActionListView::primaryAction() const { return m_state ? m_state->primaryAction() : nullptr; }

--- a/src/server/src/ui/action-pannel/action-list-view.cpp
+++ b/src/server/src/ui/action-pannel/action-list-view.cpp
@@ -66,9 +66,7 @@ bool ActionListView::hasActions() const { return m_state && m_state->actionCount
 
 bool ActionListView::hasMultipleActions() const { return m_state && m_state->actionCount() > 1; }
 
-void ActionListView::resetState() {
-  m_model->setStateFrom(m_state.get());
-}
+void ActionListView::resetState() { m_model->setStateFrom(m_state.get()); }
 
 ActionListView *ActionListView::createSubmenuChild(SubmenuAction *action) {
   auto state = action->createSubmenuState();

--- a/src/server/src/ui/action-pannel/action-list-view.cpp
+++ b/src/server/src/ui/action-pannel/action-list-view.cpp
@@ -67,7 +67,7 @@ bool ActionListView::hasActions() const { return m_state && m_state->actionCount
 bool ActionListView::hasMultipleActions() const { return m_state && m_state->actionCount() > 1; }
 
 void ActionListView::resetState() {
-  if (m_model) { m_model->setStateFrom(m_state.get()); }
+  m_model->setStateFrom(m_state.get());
 }
 
 ActionListView *ActionListView::createSubmenuChild(SubmenuAction *action) {

--- a/src/server/src/ui/action-pannel/action-list-view.cpp
+++ b/src/server/src/ui/action-pannel/action-list-view.cpp
@@ -1,4 +1,5 @@
 #include "ui/action-pannel/action-list-view.hpp"
+#include "action-panel-model.hpp"
 #include "ui/action-pannel/action-panel-state.hpp"
 #include <QKeyEvent>
 
@@ -13,22 +14,19 @@ void ActionListView::adoptState(std::unique_ptr<ActionPanelState> state) {
   } else {
     m_state = std::move(state);
   }
+  m_state->finalize();
   emit contentChanged();
-}
-
-std::unique_ptr<ActionPanelState> ActionListView::takeState() {
-  auto out = std::move(m_state);
-  m_state = std::make_unique<ActionPanelState>();
-  return out;
 }
 
 QUrl ActionListView::componentUrl() const { return QUrl(QStringLiteral("qrc:/Vicinae/ActionListPanel.qml")); }
 
-QVariantMap ActionListView::componentProps() const {
-  // Step 1: the controller does not yet push views onto the QML stack — it
-  // still constructs `ActionPanelModel`s on demand from snapshots. This will
-  // be filled in by the controller refactor that follows.
-  return {};
+QVariantMap ActionListView::componentProps() {
+  delete m_model;
+  m_model = new ActionPanelModel(m_state.get(), this);
+
+  QVariantMap props;
+  props[QStringLiteral("model")] = QVariant::fromValue(static_cast<QObject *>(m_model));
+  return props;
 }
 
 AbstractAction *ActionListView::findBoundAction(const QKeyEvent *event) const {
@@ -43,3 +41,22 @@ AbstractAction *ActionListView::findBoundAction(const QKeyEvent *event) const {
 }
 
 AbstractAction *ActionListView::primaryAction() const { return m_state ? m_state->primaryAction() : nullptr; }
+
+std::shared_ptr<AbstractAction> ActionListView::retainAction(AbstractAction *action) const {
+  if (!m_state) return nullptr;
+
+  for (const auto &section : m_state->sections()) {
+    for (const auto &a : section->actions()) {
+      if (a.get() == action) return a;
+    }
+  }
+  return nullptr;
+}
+
+bool ActionListView::hasActions() const { return m_state && m_state->actionCount() > 0; }
+
+bool ActionListView::hasMultipleActions() const { return m_state && m_state->actionCount() > 1; }
+
+void ActionListView::resetState() {
+  if (m_model) { m_model->setStateFrom(m_state.get()); }
+}

--- a/src/server/src/ui/action-pannel/action-list-view.cpp
+++ b/src/server/src/ui/action-pannel/action-list-view.cpp
@@ -5,7 +5,15 @@
 #include <QKeyEvent>
 
 ActionListView::ActionListView(QObject *parent)
-    : ActionPanelView(parent), m_state(std::make_unique<ActionPanelState>()) {}
+    : ActionPanelView(parent), m_state(std::make_unique<ActionPanelState>()),
+      m_model(new ActionPanelModel(m_state.get(), this)) {
+  connect(m_model, &ActionPanelModel::actionExecuted, this, &ActionListView::actionExecuted);
+  connect(m_model, &ActionPanelModel::closeRequested, this, &ActionListView::closeRequested);
+  connect(m_model, &ActionPanelModel::submenuActivated, this, [this](SubmenuAction *action) {
+    auto *child = createSubmenuChild(action);
+    if (child) emit pushViewRequested(child);
+  });
+}
 
 ActionListView::~ActionListView() = default;
 
@@ -17,23 +25,14 @@ void ActionListView::adoptState(std::unique_ptr<ActionPanelState> state) {
   }
   setId(m_state->id());
   m_state->finalize();
-  if (m_model) { m_model->reconcile(m_state.get()); }
+
+  m_model->reconcile(m_state.get());
   emit contentChanged();
 }
 
 QUrl ActionListView::componentUrl() const { return QUrl(QStringLiteral("qrc:/Vicinae/ActionListPanel.qml")); }
 
 QVariantMap ActionListView::componentProps() {
-  delete m_model;
-  m_model = new ActionPanelModel(m_state.get(), this);
-
-  connect(m_model, &ActionPanelModel::actionExecuted, this, &ActionListView::actionExecuted);
-  connect(m_model, &ActionPanelModel::closeRequested, this, &ActionListView::closeRequested);
-  connect(m_model, &ActionPanelModel::submenuActivated, this, [this](SubmenuAction *action) {
-    auto *child = createSubmenuChild(action);
-    if (child) emit pushViewRequested(child);
-  });
-
   QVariantMap props;
   props[QStringLiteral("model")] = QVariant::fromValue(static_cast<QObject *>(m_model));
   return props;

--- a/src/server/src/ui/action-pannel/action-list-view.cpp
+++ b/src/server/src/ui/action-pannel/action-list-view.cpp
@@ -1,5 +1,6 @@
 #include "ui/action-pannel/action-list-view.hpp"
 #include "action-panel-model.hpp"
+#include "ui/action-pannel/action.hpp"
 #include "ui/action-pannel/action-panel-state.hpp"
 #include <QKeyEvent>
 
@@ -14,7 +15,9 @@ void ActionListView::adoptState(std::unique_ptr<ActionPanelState> state) {
   } else {
     m_state = std::move(state);
   }
+  setId(m_state->id());
   m_state->finalize();
+  if (m_model) { m_model->reconcile(m_state.get()); }
   emit contentChanged();
 }
 
@@ -23,6 +26,13 @@ QUrl ActionListView::componentUrl() const { return QUrl(QStringLiteral("qrc:/Vic
 QVariantMap ActionListView::componentProps() {
   delete m_model;
   m_model = new ActionPanelModel(m_state.get(), this);
+
+  connect(m_model, &ActionPanelModel::actionExecuted, this, &ActionListView::actionExecuted);
+  connect(m_model, &ActionPanelModel::closeRequested, this, &ActionListView::closeRequested);
+  connect(m_model, &ActionPanelModel::submenuActivated, this, [this](SubmenuAction *action) {
+    auto *child = createSubmenuChild(action);
+    if (child) emit pushViewRequested(child);
+  });
 
   QVariantMap props;
   props[QStringLiteral("model")] = QVariant::fromValue(static_cast<QObject *>(m_model));
@@ -59,4 +69,12 @@ bool ActionListView::hasMultipleActions() const { return m_state && m_state->act
 
 void ActionListView::resetState() {
   if (m_model) { m_model->setStateFrom(m_state.get()); }
+}
+
+ActionListView *ActionListView::createSubmenuChild(SubmenuAction *action) {
+  auto state = action->createSubmenuState();
+  if (!state) return nullptr;
+  auto *child = new ActionListView(this);
+  child->adoptState(std::move(state));
+  return child;
 }

--- a/src/server/src/ui/views/base-view.cpp
+++ b/src/server/src/ui/views/base-view.cpp
@@ -28,6 +28,7 @@ void BaseView::setProxy(BaseView *proxy) {
 
 void BaseView::clearActions() {
   for (auto *view : m_actionPanelStack) {
+    view->onUnmount();
     view->deleteLater();
   }
   m_actionPanelStack.clear();
@@ -43,6 +44,7 @@ void BaseView::setActions(std::unique_ptr<ActionPanelState> actions) {
 
 void BaseView::setActions(ActionPanelView *view) {
   for (auto *old : m_actionPanelStack) {
+    old->onUnmount();
     old->deleteLater();
   }
   m_actionPanelStack.clear();
@@ -50,6 +52,7 @@ void BaseView::setActions(ActionPanelView *view) {
   if (view) {
     view->setParent(this);
     m_actionPanelStack.push_back(view);
+    view->onMount();
   }
 
   if (m_ctx) { m_ctx->navigation->notifyActionPanelChanged(m_navProxy); }
@@ -63,17 +66,21 @@ void BaseView::pushActionPanelView(ActionPanelView *view) {
   if (!view) return;
   view->setParent(this);
   m_actionPanelStack.push_back(view);
+  view->onMount();
 }
 
 void BaseView::popActionPanelView() {
   if (m_actionPanelStack.size() <= 1) return;
-  m_actionPanelStack.back()->deleteLater();
+  auto *view = m_actionPanelStack.back();
+  view->onUnmount();
+  view->deleteLater();
   m_actionPanelStack.pop_back();
 }
 
 void BaseView::clearActionPanelStack() {
   if (m_actionPanelStack.size() <= 1) return;
   for (size_t i = m_actionPanelStack.size() - 1; i >= 1; --i) {
+    m_actionPanelStack[i]->onUnmount();
     m_actionPanelStack[i]->deleteLater();
   }
   m_actionPanelStack.resize(1);

--- a/src/server/src/ui/views/base-view.cpp
+++ b/src/server/src/ui/views/base-view.cpp
@@ -1,6 +1,8 @@
 #include "ui/views/base-view.hpp"
 #include "common.hpp"
 #include "navigation-controller.hpp"
+#include "ui/action-pannel/action-list-view.hpp"
+#include "ui/action-pannel/action-panel-view.hpp"
 #include <qlogging.h>
 #include <stdexcept>
 
@@ -27,8 +29,19 @@ void BaseView::setProxy(BaseView *proxy) {
 void BaseView::clearActions() { setActions(std::make_unique<ActionPanelState>()); }
 
 void BaseView::setActions(std::unique_ptr<ActionPanelState> actions) {
+  // Wrap the legacy state into the default view type so every call site
+  // exercises the new abstraction. The view is unwrapped again inside
+  // NavigationController::setActions(view, ...) and forwarded through the
+  // existing snapshot path. Once the controller is refactored to operate on
+  // views directly, this wrap/unwrap will collapse.
+  auto view = std::make_unique<ActionListView>();
+  view->adoptState(std::move(actions));
+  setActions(std::move(view));
+}
+
+void BaseView::setActions(std::unique_ptr<ActionPanelView> view) {
   if (!m_ctx) return;
-  m_ctx->navigation->setActions(std::move(actions), m_navProxy);
+  m_ctx->navigation->setActions(std::move(view), m_navProxy);
 }
 
 bool BaseView::supportsSearch() const { return true; }

--- a/src/server/src/ui/views/base-view.cpp
+++ b/src/server/src/ui/views/base-view.cpp
@@ -26,22 +26,58 @@ void BaseView::setProxy(BaseView *proxy) {
   setContext(proxy->context());
 }
 
-void BaseView::clearActions() { setActions(std::make_unique<ActionPanelState>()); }
+void BaseView::clearActions() {
+  for (auto *view : m_actionPanelStack) {
+    view->deleteLater();
+  }
+  m_actionPanelStack.clear();
 
-void BaseView::setActions(std::unique_ptr<ActionPanelState> actions) {
-  // Wrap the legacy state into the default view type so every call site
-  // exercises the new abstraction. The view is unwrapped again inside
-  // NavigationController::setActions(view, ...) and forwarded through the
-  // existing snapshot path. Once the controller is refactored to operate on
-  // views directly, this wrap/unwrap will collapse.
-  auto view = std::make_unique<ActionListView>();
-  view->adoptState(std::move(actions));
-  setActions(std::move(view));
+  if (m_ctx) { m_ctx->navigation->notifyActionPanelChanged(m_navProxy); }
 }
 
-void BaseView::setActions(std::unique_ptr<ActionPanelView> view) {
-  if (!m_ctx) return;
-  m_ctx->navigation->setActions(std::move(view), m_navProxy);
+void BaseView::setActions(std::unique_ptr<ActionPanelState> actions) {
+  auto *view = new ActionListView(this);
+  view->adoptState(std::move(actions));
+  setActions(view);
+}
+
+void BaseView::setActions(ActionPanelView *view) {
+  for (auto *old : m_actionPanelStack) {
+    old->deleteLater();
+  }
+  m_actionPanelStack.clear();
+
+  if (view) {
+    view->setParent(this);
+    m_actionPanelStack.push_back(view);
+  }
+
+  if (m_ctx) { m_ctx->navigation->notifyActionPanelChanged(m_navProxy); }
+}
+
+ActionPanelView *BaseView::actionPanelRoot() const {
+  return m_actionPanelStack.empty() ? nullptr : m_actionPanelStack.front();
+}
+
+void BaseView::pushActionPanelView(ActionPanelView *view) {
+  if (!view) return;
+  view->setParent(this);
+  m_actionPanelStack.push_back(view);
+}
+
+void BaseView::popActionPanelView() {
+  if (m_actionPanelStack.size() <= 1) return;
+  m_actionPanelStack.back()->deleteLater();
+  m_actionPanelStack.pop_back();
+}
+
+void BaseView::clearActionPanelStack() {
+  if (m_actionPanelStack.size() <= 1) return;
+  for (size_t i = m_actionPanelStack.size() - 1; i >= 1; --i) {
+    m_actionPanelStack[i]->deleteLater();
+  }
+  m_actionPanelStack.resize(1);
+  if (auto *root = actionPanelRoot()) { root->resetState(); }
 }
 
 bool BaseView::supportsSearch() const { return true; }

--- a/src/server/src/ui/views/base-view.hpp
+++ b/src/server/src/ui/views/base-view.hpp
@@ -6,6 +6,7 @@
 
 class ApplicationContext;
 class ActionPanelState;
+class ActionPanelView;
 class Toast;
 class ImageURL;
 class QKeyEvent;
@@ -20,6 +21,7 @@ public:
   void setProxy(BaseView *proxy);
 
   void setActions(std::unique_ptr<ActionPanelState> actions);
+  void setActions(std::unique_ptr<ActionPanelView> view);
   void clearActions();
 
   virtual bool supportsSearch() const;

--- a/src/server/src/ui/views/base-view.hpp
+++ b/src/server/src/ui/views/base-view.hpp
@@ -3,6 +3,7 @@
 #include "command-controller.hpp"
 #include "common.hpp"
 #include <QObject>
+#include <vector>
 
 class ApplicationContext;
 class ActionPanelState;
@@ -21,8 +22,14 @@ public:
   void setProxy(BaseView *proxy);
 
   void setActions(std::unique_ptr<ActionPanelState> actions);
-  void setActions(std::unique_ptr<ActionPanelView> view);
+  void setActions(ActionPanelView *view);
   void clearActions();
+
+  ActionPanelView *actionPanelRoot() const;
+  const std::vector<ActionPanelView *> &actionPanelStack() const { return m_actionPanelStack; }
+  void pushActionPanelView(ActionPanelView *view);
+  void popActionPanelView();
+  void clearActionPanelStack();
 
   virtual bool supportsSearch() const;
   virtual bool searchInteractive() const;
@@ -90,4 +97,5 @@ private:
   CommandController *m_cmd = nullptr;
 
   const BaseView *m_navProxy = this;
+  std::vector<ActionPanelView *> m_actionPanelStack;
 };

--- a/src/server/src/ui/views/base-view.hpp
+++ b/src/server/src/ui/views/base-view.hpp
@@ -21,7 +21,7 @@ public:
 
   void setProxy(BaseView *proxy);
 
-  void setActions(std::unique_ptr<ActionPanelState> actions);
+  virtual void setActions(std::unique_ptr<ActionPanelState> actions);
   void setActions(ActionPanelView *view);
   void clearActions();
 

--- a/src/typescript/api/src/api/components/actions.tsx
+++ b/src/typescript/api/src/api/components/actions.tsx
@@ -18,6 +18,7 @@ import type { Form } from "./form";
 import { Icon } from "../icon";
 import { closeMainWindow } from "../controls";
 import { ActionPanel } from "./action-pannel";
+import { showToast } from "../toast";
 
 type BaseActionProps = {
 	title: string;
@@ -66,14 +67,12 @@ export namespace Action {
 		};
 	}
 
-	/*
 	export namespace OpenWith {
 		export type Props = BaseActionProps & {
 			path: string;
 			onOpen?: (path: string) => void;
 		};
 	}
-	*/
 
 	export namespace Trash {
 		type PathArg = PathLike | PathLike[];
@@ -214,11 +213,6 @@ const Open: React.FC<Action.Open.Props> = ({ target, app, ...props }) => {
 	);
 };
 
-// TODO: export when action panel is less buggy
-
-const OpenWith = () => null;
-
-/*
 const OpenWith: React.FC<Action.OpenWith.Props> = ({
 	path,
 	title = "Open with...",
@@ -246,13 +240,22 @@ const OpenWith: React.FC<Action.OpenWith.Props> = ({
 					key={app.id}
 					title={`Open in ${app.name}`}
 					icon={app.icon}
-					onAction={() => props.onOpen?.(path)}
+					onAction={() => {
+						closeMainWindow();
+						open(path, app)
+							.then(() => {
+								props.onOpen?.(path);
+							})
+							.catch(async (error) => {
+								showToast({ title: `Failed to open app` });
+								console.error("Failed to open app", error);
+							});
+					}}
 				/>
 			))}
 		</ActionPanel.Submenu>
 	);
 };
-*/
 
 const Trash: React.FC<Action.Trash.Props> = ({ title, paths, ...props }) => {
 	const actionTitle = title ?? `Delete item${Array.isArray(paths) ? "s" : ""}`;


### PR DESCRIPTION
Get rid of the previous hacks we relied on to have an action panel with submenus kinda work
Now we have a proper architecture that mirrors the main navigation controller and that should handle all kinds of action panel.
Also, we properly emit the events when action panel search text changes, or when a submenu is opened