### PR TITLE
fix: potential segv after extension crash during oauth

### DIFF
--- a/src/server/src/extension/services/oauth-service.hpp
+++ b/src/server/src/extension/services/oauth-service.hpp
@@ -5,6 +5,7 @@
 #include "overlay-controller/overlay-controller.hpp"
 #include "qml/oauth-overlay-host.hpp"
 #include "services/oauth/oauth-service.hpp"
+#include <QFutureWatcher>
 
 class ExtOAuthService : public tsapi::AbstractOAuth {
   using Void = tsapi::Result<void>;
@@ -22,12 +23,26 @@ public:
     auto host = new OAuthOverlayHost(&m_ctx, payload);
     m_ctx.overlay->setCurrent(host);
 
-    return m_oauth.authorize(state).then(
-        [host](const OAuthResponse &oauthRes) -> tsapi::Result<tsapi::AuthorizeResponse>::Type {
-          if (!oauthRes) return std::unexpected(oauthRes.error().toStdString());
-          host->showSuccess();
-          return tsapi::AuthorizeResponse{.code = oauthRes->code.toStdString()};
-        });
+    auto *watcher = new QFutureWatcher<OAuthResponse>(this);
+    QPromise<tsapi::Result<tsapi::AuthorizeResponse>::Type> promise;
+    auto future = promise.future();
+
+    connect(watcher, &QFutureWatcherBase::finished, this,
+            [host, watcher, promise = std::move(promise)]() mutable {
+              auto oauthRes = watcher->result();
+              if (!oauthRes) {
+                promise.addResult(std::unexpected(oauthRes.error().toStdString()));
+              } else {
+                host->showSuccess();
+                promise.addResult(tsapi::AuthorizeResponse{.code = oauthRes->code.toStdString()});
+              }
+              promise.finish();
+              watcher->deleteLater();
+            });
+
+    watcher->setFuture(m_oauth.authorize(state));
+
+    return future;
   }
 
   tsapi::Result<tsapi::TokenSetResponse>::Future getTokens(std::optional<std::string> id) override {

--- a/src/server/src/extension/services/oauth-service.hpp
+++ b/src/server/src/extension/services/oauth-service.hpp
@@ -6,6 +6,7 @@
 #include "qml/oauth-overlay-host.hpp"
 #include "services/oauth/oauth-service.hpp"
 #include <QFutureWatcher>
+#include <QPointer>
 
 class ExtOAuthService : public tsapi::AbstractOAuth {
   using Void = tsapi::Result<void>;
@@ -28,12 +29,12 @@ public:
     auto future = promise.future();
 
     connect(watcher, &QFutureWatcherBase::finished, this,
-            [host, watcher, promise = std::move(promise)]() mutable {
+            [host = QPointer(host), watcher, promise = std::move(promise)]() mutable {
               auto oauthRes = watcher->result();
               if (!oauthRes) {
                 promise.addResult(std::unexpected(oauthRes.error().toStdString()));
               } else {
-                host->showSuccess();
+                if (host) host->showSuccess();
                 promise.addResult(tsapi::AuthorizeResponse{.code = oauthRes->code.toStdString()});
               }
               promise.finish();

--- a/src/server/src/ipc-command-handler.cpp
+++ b/src/server/src/ipc-command-handler.cpp
@@ -46,6 +46,7 @@ std::expected<void, std::string> IpcCommandHandler::handleUrl(const QUrl &url) {
 
   if (command.isEmpty() && !path.isEmpty()) {
     QStringList const pathParts = path.split('/', Qt::SkipEmptyParts);
+    if (pathParts.isEmpty()) return std::unexpected("Empty path in deeplink");
     command = pathParts.at(0);
     path = "/" + pathParts.mid(1).join('/');
   }


### PR DESCRIPTION
MAY fix #1398
I wasn't able to reproduce the crash but this is the only pausible cause.

We now use `QFutureWatcher` so that the connection gets automatically cleaned up if the extension crashes.