### PR TITLE
feat: move all image loading off the main thread

### DIFF
--- a/src/server/src/qml/async-image-provider.cpp
+++ b/src/server/src/qml/async-image-provider.cpp
@@ -1,4 +1,5 @@
 #include "async-image-provider.hpp"
+#include "builtin_icon.hpp"
 #include "favicon/favicon-service.hpp"
 #include "font-service.hpp"
 #include "image-fetcher.hpp"
@@ -22,19 +23,15 @@
 #include "image-data-cache.hpp"
 #include <atomic>
 #include <mutex>
-#include <set>
 
 static bool isGif(const QByteArray &data) {
   return data.size() >= 6 && (data.startsWith("GIF87a") || data.startsWith("GIF89a"));
 }
 
-static std::mutex s_failedCacheMutex;
-static std::set<QString> s_failedImageIds;
-
 static QThreadPool &imageDecodingPool() {
   static QThreadPool pool;
   static std::once_flag flag;
-  std::call_once(flag, []() { pool.setMaxThreadCount(2); });
+  std::call_once(flag, []() { pool.setMaxThreadCount(1); });
   return pool;
 }
 
@@ -72,7 +69,6 @@ public:
       return;
     }
     tryFallback(image);
-    cacheIfFailed(image);
     image.setDevicePixelRatio(m_dpr);
     m_image = std::move(image);
     emit finished();
@@ -86,7 +82,6 @@ public:
       return;
     }
     tryFallback(image);
-    cacheIfFailed(image);
     image.setDevicePixelRatio(m_dpr);
     m_image = std::move(image);
     QTimer::singleShot(0, this, &QQuickImageResponse::finished);
@@ -94,12 +89,6 @@ public:
 
 private:
   void tryFallback(QImage &image);
-
-  void cacheIfFailed(const QImage &image) {
-    if (!image.isNull() || m_id.isEmpty()) return;
-    std::scoped_lock const lock(s_failedCacheMutex);
-    s_failedImageIds.insert(m_id);
-  }
 
   QString m_id;
   qreal m_dpr;
@@ -232,16 +221,12 @@ static QImage renderLocalRaster(const QString &path, const QSize &size) {
 }
 
 static QImage decodeImageData(const QByteArray &data, const QSize &size) {
-  QImageReader reader;
-  QBuffer *buf = new QBuffer;
-  buf->setData(data);
-  buf->open(QIODevice::ReadOnly);
-  reader.setDevice(buf);
+  QBuffer buf;
+  buf.setData(data);
+  buf.open(QIODevice::ReadOnly);
 
-  if (!reader.canRead()) {
-    delete buf;
-    return {};
-  }
+  QImageReader reader(&buf);
+  if (!reader.canRead()) return {};
 
   if (size.isValid()) {
     auto original = reader.size();
@@ -250,9 +235,7 @@ static QImage decodeImageData(const QByteArray &data, const QSize &size) {
   }
 
   QImage result = reader.read();
-  delete buf;
 
-  // Scale down if the format ignored setScaledSize (see renderLocalRaster).
   if (!result.isNull() && size.isValid() &&
       (result.width() > size.width() || result.height() > size.height())) {
     result = result.scaled(size, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
@@ -365,15 +348,6 @@ void ViciImageResponse::tryFallback(QImage &image) {
 
 QQuickImageResponse *AsyncImageProvider::requestImageResponse(const QString &id, const QSize &requestedSize) {
 
-  {
-    std::scoped_lock const lock(s_failedCacheMutex);
-    if (s_failedImageIds.contains(id)) {
-      auto *response = new ViciImageResponse(qGuiApp->devicePixelRatio());
-      response->finishDeferred({});
-      return response;
-    }
-  }
-
   qreal const dpr = std::max(qGuiApp->devicePixelRatio(), 4.0);
   auto *response = new ViciImageResponse(dpr);
   response->setId(id);
@@ -381,42 +355,50 @@ QQuickImageResponse *AsyncImageProvider::requestImageResponse(const QString &id,
   QSize const size(qCeil(logical.width() * dpr), qCeil(logical.height() * dpr));
   auto parsed = parseId(id);
 
-  if (!parsed.fallback.isEmpty()) response->setFallback(parsed.fallback, size);
+  static const QString DEFAULT_FALLBACK =
+      QStringLiteral("builtin:") + BuiltinIconService::nameForIcon(BuiltinIconService::unknownIcon());
+
+  if (!parsed.fallback.isEmpty())
+    response->setFallback(parsed.fallback, size);
+  else if (parsed.type != QStringLiteral("builtin"))
+    response->setFallback(DEFAULT_FALLBACK, size);
 
   if (parsed.type == QStringLiteral("builtin")) {
     QColor fg = parsed.fg;
     if (!fg.isValid()) fg = ThemeService::instance().theme().resolve(SemanticColor::Foreground);
-    QImage img = renderBuiltinSvg(parsed.name, size, fg, parsed.bg);
-    if (parsed.circleMask && !img.isNull()) applyCircleMask(img);
-    response->finishDeferred(std::move(img));
+    bool const circle = parsed.circleMask;
+    QColor const bg = parsed.bg;
+    imageDecodingPool().start([response, name = parsed.name, size, fg, bg, circle]() {
+      if (response->isCancelled()) {
+        response->finish({});
+        return;
+      }
+      QImage img = renderBuiltinSvg(name, size, fg, bg);
+      if (circle && !img.isNull()) applyCircleMask(img);
+      response->finish(std::move(img));
+    });
 
   } else if (parsed.type == QStringLiteral("emoji")) {
-    QMetaObject::invokeMethod(
-        qApp,
-        [response, name = parsed.name, size]() {
-          if (response->isCancelled()) {
-            response->finish({});
-            return;
-          }
-          QImage img = renderEmoji(name, size);
-          response->finish(std::move(img));
-        },
-        Qt::QueuedConnection);
+    imageDecodingPool().start([response, name = parsed.name, size]() {
+      if (response->isCancelled()) {
+        response->finish({});
+        return;
+      }
+      QImage img = renderEmoji(name, size);
+      response->finish(std::move(img));
+    });
 
   } else if (parsed.type == QStringLiteral("system")) {
     QColor const fg = parsed.fg;
-    QMetaObject::invokeMethod(
-        qApp,
-        [response, name = parsed.name, size, fg]() {
-          if (response->isCancelled()) {
-            response->finish({});
-            return;
-          }
-          QImage img = renderSystemIcon(name, size);
-          if (!img.isNull()) applyFillColor(img, fg);
-          response->finish(std::move(img));
-        },
-        Qt::QueuedConnection);
+    imageDecodingPool().start([response, name = parsed.name, size, fg]() {
+      if (response->isCancelled()) {
+        response->finish({});
+        return;
+      }
+      QImage img = renderSystemIcon(name, size);
+      if (!img.isNull()) applyFillColor(img, fg);
+      response->finish(std::move(img));
+    });
 
   } else if (parsed.type == QStringLiteral("local")) {
     QString const path = parsed.name;
@@ -424,10 +406,16 @@ QQuickImageResponse *AsyncImageProvider::requestImageResponse(const QString &id,
     QColor const fg = parsed.fg;
 
     if (path.endsWith(QStringLiteral(".svg"), Qt::CaseInsensitive)) {
-      QImage img = renderLocalSvg(path, size);
-      if (!img.isNull()) applyFillColor(img, fg);
-      if (circle && !img.isNull()) applyCircleMask(img);
-      response->finishDeferred(std::move(img));
+      imageDecodingPool().start([response, path, size, circle, fg]() {
+        if (response->isCancelled()) {
+          response->finish({});
+          return;
+        }
+        QImage img = renderLocalSvg(path, size);
+        if (!img.isNull()) applyFillColor(img, fg);
+        if (circle && !img.isNull()) applyCircleMask(img);
+        response->finish(std::move(img));
+      });
     } else {
       imageDecodingPool().start([response, path, size, circle, fg]() {
         if (response->isCancelled()) {

--- a/src/server/src/qml/launcher-window.cpp
+++ b/src/server/src/qml/launcher-window.cpp
@@ -34,6 +34,10 @@
 #include <qcoreevent.h>
 #include <qlogging.h>
 
+#ifdef __GLIBC__
+#include <malloc.h>
+#endif
+
 LauncherWindow::LauncherWindow(ApplicationContext &ctx, QObject *parent)
     : QObject(parent), m_ctx(ctx), m_actionPanel(new ActionPanelController(ctx, this)),
       m_alertModel(new AlertModel(*ctx.navigation, this)), m_configBridge(new ConfigBridge(this)),
@@ -85,6 +89,23 @@ LauncherWindow::LauncherWindow(ApplicationContext &ctx, QObject *parent)
             [this]() { m_ctx.navigation->setWindowActivated(m_window->isActive()); });
     m_window->installEventFilter(this);
   }
+
+  using namespace std::chrono_literals;
+
+  // Sometime after we close the window, we release some of our cached resources to lower
+  // memory usage.
+  static constexpr auto CACHE_EVICTION_DELAY = 10s;
+
+  m_cacheEvictionTimer.setSingleShot(true);
+  m_cacheEvictionTimer.setInterval(CACHE_EVICTION_DELAY);
+
+  connect(&m_cacheEvictionTimer, &QTimer::timeout, this, [this]() {
+    if (m_window) m_window->releaseResources();
+    m_engine.trimComponentCache();
+#ifdef __GLIBC__
+    malloc_trim(0);
+#endif
+  });
 
   m_closeOnFocusLoss = ctx.services->config()->value().closeOnFocusLoss;
 
@@ -303,6 +324,7 @@ void LauncherWindow::handleVisibilityChanged(bool visible) {
   if (!m_window) return;
 
   if (visible) {
+    m_cacheEvictionTimer.stop();
     applyWindowConfig();
     tryCompaction();
     m_window->show();
@@ -310,6 +332,7 @@ void LauncherWindow::handleVisibilityChanged(bool visible) {
     m_window->requestActivate();
   } else {
     m_window->hide();
+    m_cacheEvictionTimer.start();
   }
 }
 

--- a/src/server/src/qml/launcher-window.hpp
+++ b/src/server/src/qml/launcher-window.hpp
@@ -3,6 +3,7 @@
 #include "image-url.hpp"
 #include <QObject>
 #include <QQmlApplicationEngine>
+#include <QTimer>
 #include <qtmetamacros.h>
 
 class ActionPanelController;
@@ -176,6 +177,7 @@ private:
   QUrl m_overlayUrl;
   QObject *m_overlayHost = nullptr;
 
+  QTimer m_cacheEvictionTimer;
   bool m_closeOnFocusLoss = false;
   int m_lsLayer = 2;                 // LayerShellQt::Window::LayerTop
   int m_lsKeyboardInteractivity = 2; // LayerShellQt::Window::KeyboardInteractivityOnDemand

--- a/src/server/src/qml/qml/ViciImage.qml
+++ b/src/server/src/qml/qml/ViciImage.qml
@@ -11,9 +11,6 @@ Item {
     implicitWidth: root.sourceSize.width >= 0 ? (animImg.animated ? animImg.implicitWidth : staticImg.implicitWidth) : 0
     implicitHeight: root.sourceSize.height >= 0 ? (animImg.animated ? animImg.implicitHeight : staticImg.implicitHeight) : 0
 
-    property bool _errored: false
-    onSourceChanged: _errored = false
-
     readonly property int _effectiveW: root.sourceSize.width >= 0 ? root.sourceSize.width : root.width
     readonly property int _effectiveH: root.sourceSize.height >= 0 ? root.sourceSize.height : root.height
     readonly property bool _hasValidSize: _effectiveW > 0 && _effectiveH > 0
@@ -32,24 +29,19 @@ Item {
         return s.toSource();
     }
 
-    readonly property string _fallbackSource: "image://vicinae/builtin:question-mark-circle?fg=" + Theme.foreground
-
     Image {
         id: staticImg
         anchors.fill: parent
         visible: !animImg.animated
         fillMode: root.fillMode
         cache: root.cache
-        source: root._hasValidSize ? (root._errored ? root._fallbackSource : root._resolvedSource) : ""
+        source: root._hasValidSize ? root._resolvedSource : ""
         asynchronous: true
         mipmap: true
         sourceSize.width: root._effectiveW
         sourceSize.height: root._effectiveH
         onStatusChanged: {
-            if (status === Image.Error && !root._errored) {
-                console.warn("ViciImage: failed to load", root._resolvedSource);
-                root._errored = true;
-            } else if (status === Image.Ready && !root._errored)
+            if (status === Image.Ready)
                 animImg.source = staticImg.source;
         }
     }


### PR DESCRIPTION
Some of our image loading was still done synchronously on the main thread (emoji, svg rasterization, builtin icons...). Under some circumstances, this was slowing down the UI in unnecessary ways.

We keep one single thread for all image matters because using too many threads can blow up glyph cache and stuff like that, resulting in high memory usage.

We also introduce in this PR an automatic cleanup of most cached resources some time after the main window is closed.