### PR TITLE
feat(theme): added LibAdwaita themes

### DIFF
--- a/extra/themes/icons/libadwaita.svg
+++ b/extra/themes/icons/libadwaita.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="48" height="48" viewBox="0 0 12.7 12.7" version="1.1" id="svg1077"
+   inkscape:version="1.1-beta1 (77e7b44db3, 2021-03-28)" sodipodi:docname="libadwaita.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+   <sodipodi:namedview id="namedview1079" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0"
+      objecttolerance="10.0" gridtolerance="10.0" guidetolerance="10.0" inkscape:pageshadow="2"
+      inkscape:pageopacity="0.0" inkscape:pagecheckerboard="0" inkscape:document-units="px" showgrid="false"
+      inkscape:zoom="5.0457912" inkscape:cx="42.510677" inkscape:cy="7.9273989" inkscape:window-width="1920"
+      inkscape:window-height="1011" inkscape:window-x="0" inkscape:window-y="0" inkscape:window-maximized="1"
+      inkscape:current-layer="layer1" units="px" />
+   <defs id="defs1074">
+      <linearGradient inkscape:collect="always" xlink:href="#linearGradient15144" id="linearGradient15146"
+         x1="78.052086" y1="86.518761" x2="92.074997" y2="86.254173" gradientUnits="userSpaceOnUse"
+         gradientTransform="translate(-185.98349,-5.7118018)" />
+      <linearGradient inkscape:collect="always" id="linearGradient15144">
+         <stop style="stop-color:#8ff0a4;stop-opacity:1" offset="0" id="stop15140" />
+         <stop style="stop-color:#3584e4;stop-opacity:1" offset="1" id="stop15142" />
+      </linearGradient>
+   </defs>
+   <g inkscape:label="Layer 1" inkscape:groupmode="layer" id="layer1" transform="translate(-74.192375,-93.908467)">
+      <rect
+         style="fill:url(#linearGradient15146);fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-dashoffset:26.4"
+         id="rect4789" width="12.7" height="12.7" x="-106.60847" y="74.192375" transform="rotate(-90)"
+         inkscape:export-xdpi="384" inkscape:export-ydpi="384" ry="6.3499999" rx="6.3499999" />
+      <g id="g14982" transform="translate(-5.182627,14.004305)">
+         <rect style="opacity:0.5;fill:#000000;fill-opacity:0;stroke:none;stroke-width:0.264583;stroke-dashoffset:26.4"
+            id="rect4791" width="8.4666672" height="8.4666672" x="81.491669" y="82.020836" />
+         <g id="g1405-3" transform="matrix(0.79375001,0,0,0.79375001,-33.262333,-105.35835)"
+            style="display:inline;fill:#ffffff;stroke-width:2;enable-background:new">
+            <path
+               style="display:inline;opacity:0.95;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.916672px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+               d="m 144.57197,241.06826 h 5.66667 v 5.66667 z" id="path1358-3-6" sodipodi:nodetypes="cccc" />
+            <path
+               style="display:inline;opacity:0.75;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.611114px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+               d="m 154.23864,237.06826 h -4 v 4 z" id="path1360-6-7" sodipodi:nodetypes="cccc" />
+            <path
+               style="display:inline;opacity:0.4;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.458336px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+               d="m 150.23864,241.06826 h 3 v 3 z" id="path1362-7-5" sodipodi:nodetypes="cccc" />
+         </g>
+      </g>
+   </g>
+</svg>

--- a/extra/themes/libadwaita-dark.toml
+++ b/extra/themes/libadwaita-dark.toml
@@ -1,0 +1,84 @@
+# Vicinae theme based on GNOME's LibAdwaita dark palette.
+# Colours are sourced directly from LibAdwaita CSS variables
+
+[meta]
+name = "Adwaita Dark"
+description = "GNOME LibAdwaita inspired dark theme for Vicinae"
+variant = "dark"
+inherits = "vicinae-dark"
+icon = "icons/libadwaita.svg"
+
+# swap core.accent below to any of these to match your systems accent colour
+[colors.accents]
+blue = "#3584e4"  # --accent-blue
+green = "#3a944a"  # --accent-green
+magenta = "#d56199"  # --accent-pink
+orange = "#ed5b00"  # --accent-orange
+red = "#e62d42"  # --accent-red
+yellow = "#c88800"  # --accent-yellow
+cyan = "#2190a4"  # --accent-teal
+purple = "#9141ac"  # --accent-purple
+
+# swap to any accents value from the list above to match your systems accent colour
+[colors.core]
+accent = "colors.accents.blue"
+accent_foreground = "colors.accents.blue"
+background = "#222226"
+foreground = "#ffffff"
+secondary_background = "#2e2e32"
+border = "#383838"
+
+[colors.main_window]
+border = "colors.core.border"
+footer = { background = "colors.core.secondary_background" }
+
+[colors.settings_window]
+border = "#48484c"
+
+[colors.shortcut]
+border = "colors.core.border"
+
+[colors.text]
+default = "colors.core.foreground"
+muted = "#c0bfbc"
+danger = "#ff938c"
+success = "#78e9ab"
+placeholder = "#77767b"
+selection = { background = "colors.core.accent", foreground = "#ffffff" }
+
+[colors.text.links]
+default = "#81d0ff"
+visited = "#fba7ff"
+
+[colors.input]
+border = "#48484c"
+border_focus = "colors.core.accent"
+border_error = "#ff938c"
+
+[colors.button.primary]
+background = "#2e2e32"
+foreground = "#ffffff"
+hover = { background = "#bb2e2e32" }
+focus = { outline = "colors.core.accent" }
+
+[colors.list.item.hover]
+foreground = "#ffffff"
+secondary_foreground = "#c0bfbc"
+
+[colors.list.item.selection]
+background = "colors.core.accent"
+foreground = "#ffffff"
+secondary_background = "colors.core.accent"
+secondary_foreground = "#ffffff"
+
+[colors.grid.item]
+background = "#2e2e32"
+hover = { outline = "colors.core.accent" }
+selection = { outline = "colors.core.accent" }
+
+[colors.scrollbars]
+background = "#48484c"
+
+[colors.loading]
+bar = "colors.core.accent"
+spinner = "#ffffff"

--- a/extra/themes/libadwaita-dark.toml
+++ b/extra/themes/libadwaita-dark.toml
@@ -66,7 +66,7 @@ foreground = "#ffffff"
 secondary_foreground = "#c0bfbc"
 
 [colors.list.item.selection]
-background = "colors.core.accent"
+background = "#3D3D41"
 foreground = "#ffffff"
 secondary_background = "colors.core.accent"
 secondary_foreground = "#ffffff"

--- a/extra/themes/libadwaita-light.toml
+++ b/extra/themes/libadwaita-light.toml
@@ -1,0 +1,84 @@
+# Vicinae theme based on GNOME's LibAdwaita light palette.
+# Colours are sourced directly from LibAdwaita CSS variables
+
+[meta]
+name = "Adwaita Light"
+description = "GNOME LibAdwaita inspired light theme for Vicinae"
+variant = "light"
+inherits = "vicinae-light"
+icon = "icons/libadwaita.svg"
+
+# swap core.accent below to any of these to match your systems accent colour
+[colors.accents]
+blue = "#3584e4"  # --accent-blue
+green = "#3a944a"  # --accent-green
+magenta = "#d56199"  # --accent-pink
+orange = "#ed5b00"  # --accent-orange
+red = "#e62d42"  # --accent-red
+yellow = "#c88800"  # --accent-yellow
+cyan = "#2190a4"  # --accent-teal
+purple = "#9141ac"  # --accent-purple
+
+# swap to any accents value from the list above to match your systems accent colour
+[colors.core]
+accent = "colors.accents.blue"
+accent_foreground = "colors.accents.blue"
+background = "#fafafb"
+foreground = "#333338"
+secondary_background = "#ebebed"
+border = "#dddde0"
+
+[colors.main_window]
+border = "colors.core.border"
+footer = { background = "colors.core.secondary_background" }
+
+[colors.settings_window]
+border = "#dddde0"
+
+[colors.shortcut]
+border = "colors.core.border"
+
+[colors.text]
+default = "colors.core.foreground"
+muted = "#5e5c64"
+danger = "#c30000"
+success = "#007c3d"
+placeholder = "#9a9996"
+selection = { background = "colors.core.accent", foreground = "#ffffff" }
+
+[colors.text.links]
+default = "#0461be"
+visited = "#8939a4"
+
+[colors.input]
+border = "#dddde0"
+border_focus = "colors.core.accent"
+border_error = "#c30000"
+
+[colors.button.primary]
+background = "#ffffff"
+foreground = "#333338"
+hover = { background = "#bbffffff" }
+focus = { outline = "colors.core.accent" }
+
+[colors.list.item.hover]
+foreground = "#333338"
+secondary_foreground = "#5e5c64"
+
+[colors.list.item.selection]
+background = "colors.core.accent"
+foreground = "#ffffff"
+secondary_background = "colors.core.accent"
+secondary_foreground = "#ffffff"
+
+[colors.grid.item]
+background = "#ebebed"
+hover = { outline = "colors.core.accent" }
+selection = { outline = "colors.core.accent" }
+
+[colors.scrollbars]
+background = "#c0bfbc"
+
+[colors.loading]
+bar = "colors.core.accent"
+spinner = "#333338"

--- a/extra/themes/libadwaita-light.toml
+++ b/extra/themes/libadwaita-light.toml
@@ -66,10 +66,10 @@ foreground = "#333338"
 secondary_foreground = "#5e5c64"
 
 [colors.list.item.selection]
-background = "colors.core.accent"
-foreground = "#ffffff"
+background = "#DFDFE1"
+foreground = "#333338"
 secondary_background = "colors.core.accent"
-secondary_foreground = "#ffffff"
+secondary_foreground = "#5e5c64"
 
 [colors.grid.item]
 background = "#ebebed"


### PR DESCRIPTION
Heyyo! I created a Vicinae theme based on the LibAdwaita colour palette, so that Vicinae can blend in a bit better for GNOME users. :)

<img width="1000" height="650" alt="Vicinae theme switcher" src="https://github.com/user-attachments/assets/fd75864c-d87f-48f5-a7cb-ddfca705cc59" />


<img width="1000" height="650" alt="Vicinae About window" src="https://github.com/user-attachments/assets/d74d89f4-5300-4068-a361-c8437ee50cc4" />

<img width="1000" height="650" alt="Vicinae About window" src="https://github.com/user-attachments/assets/477b10ef-912c-48b5-90a1-cccbf8c87986" />
