### PR TITLE
fix: update theme icons for light and dark variants

### DIFF
--- a/extra/themes/nord-light.toml
+++ b/extra/themes/nord-light.toml
@@ -6,7 +6,7 @@ version = 1
 name = "Nord Light"
 description = "Arctic, north-bluish clean and elegant theme"
 variant = "light"
-icon = "icons/nord.svg"
+icon = "icons/nord@light.svg"
 
 [colors.core]
 background = "#ECEFF4"        # nord6 (Snow Storm)

--- a/extra/themes/nord.toml
+++ b/extra/themes/nord.toml
@@ -6,7 +6,7 @@ version = 1
 name = "Nord"
 description = "Arctic, north-bluish clean and elegant theme"
 variant = "dark"
-icon = "icons/nord.svg"
+icon = "icons/nord@dark.svg"
 
 [colors.core]
 background = "#2E3440"        # nord0 (Polar Night)


### PR DESCRIPTION
Fix theme icons so they display correctly in both light and dark modes.