### PR TITLE
feat: proper extension handshake

### DIFF
--- a/figura/manager.fig
+++ b/figura/manager.fig
@@ -36,6 +36,12 @@ service Manager {
   fn load(opts: LoadOptions) => LoadResponse;
   fn unload(session_id: string) => bool;
 
+  // C++ side signals to extension manager that its ready to process messages from said extension
+  // Happens right after the C++ side gets the session id from `load` and stores it.
+  // It is important to synchronize this way otherwise we can theoretically miss the first messages if the
+  // extension loads too fast.
+  fn ready(session_id: string) => bool;
+
   fn messageExtension(session_id: string, payload: string) => bool;
 
   event extensionMessage(session_id: string, payload: string);

--- a/src/server/src/extension/extension-command-runtime.cpp
+++ b/src/server/src/extension/extension-command-runtime.cpp
@@ -2,6 +2,7 @@
 #include "common.hpp"
 #include "common/context.hpp"
 #include "extension-error-view-host.hpp"
+#include "extension-view-host.hpp"
 #include "extension/services/application-service.hpp"
 #include "extension/services/clipboard-service.hpp"
 #include "extension/services/command-service.hpp"
@@ -121,7 +122,7 @@ void ExtensionCommandRuntime::load(const LaunchProps &props) {
             nav->setNavigationIcon(m_command->iconUrl());
           });
 
-  connect(watcher, &QFutureWatcherBase::finished, this, [this, watcher]() {
+  connect(watcher, &QFutureWatcherBase::finished, this, [this, manager, watcher]() {
     if (!watcher->isCanceled()) {
       auto res = watcher->result();
 
@@ -130,6 +131,7 @@ void ExtensionCommandRuntime::load(const LaunchProps &props) {
       } else {
         m_sessionId = res->session_id;
         m_bus->setSessionId(m_sessionId);
+        manager->client().manager()->ready(res->session_id);
       }
     }
 

--- a/src/typescript/extension-manager/src/index.ts
+++ b/src/typescript/extension-manager/src/index.ts
@@ -7,17 +7,20 @@ import { main as workerMain } from "./worker";
 import * as manager from "./proto/manager";
 import * as extension from "./proto/manager-extension";
 import * as path from "node:path";
-import * as fsp from "node:fs/promises";
 
 import type { EnvironmentType } from "./types";
 
 const WORKER_GRACE_PERIOD_MS = 5000;
 const WORKER_MAX_HEAP_SIZE_MB = 1000; // really high limit just to make sure an extension command can't exhaust RAM by itself
 
+type WorkerStatus = "unloading" | "running" | "handshake";
+
 type WorkerInfo = {
 	worker: Worker;
 	pendingTermination?: NodeJS.Timeout;
 	client: extension.Client;
+	status: WorkerStatus;
+	payload: extension.LaunchEventData;
 };
 
 class ExtensionManager extends manager.ManagerService {
@@ -34,14 +37,30 @@ class ExtensionManager extends manager.ManagerService {
 		return new extension.Client(transport);
 	}
 
+	async ready(sessionId: string): Promise<boolean> {
+		const worker = this.workerMap.get(sessionId);
+
+		if (!worker) return false;
+
+		worker.status = "running";
+		await worker.client.Lifecycle.launch(worker.payload);
+
+		return true;
+	}
+
 	async load(load: manager.LoadOptions): Promise<manager.LoadResponse> {
 		const sessionId = randomUUID();
+		const worker = this.acquireWorker(load.env);
+		const client = this.createExtensionClient(worker);
 		const supportPath = path.join(
 			load.vicinae_path,
 			"support",
 			load.extension_id,
 		);
 		const supportInternal = path.join(supportPath, ".vicinae"); // for log stream, cli pid file...
+
+		const stdoutLog = path.join(supportInternal, "stdout.txt");
+		const stderrLog = path.join(supportInternal, "stderr.txt");
 		const assetsPath = path.join(
 			load.vicinae_path,
 			"extensions",
@@ -49,25 +68,33 @@ class ExtensionManager extends manager.ManagerService {
 			"assets",
 		);
 
-		await Promise.all([
-			fsp.mkdir(assetsPath, { recursive: true }),
-			fsp.mkdir(supportInternal, { recursive: true }),
-		]);
+		const workerInfo: WorkerInfo = {
+			worker,
+			client,
+			status: "handshake",
+			payload: {
+				entrypoint: load.entrypoint,
+				argumentValues: load.arguments,
+				preferenceValues: load.preferences,
+				mode: load.mode,
+				support_path: supportPath,
+				asset_path: assetsPath,
+				is_raycast: load.is_raycast,
+				extension_name: load.extension_name,
+				owner_or_author_name: load.owner_or_author_name,
+				command_name: load.command_name,
+			},
+		};
 
-		const stdoutLog = path.join(supportInternal, "stdout.txt");
-		const stderrLog = path.join(supportInternal, "stderr.txt");
-
-		const worker = this.acquireWorker(load.env);
-		const client = this.createExtensionClient(worker);
-		const workerInfo: WorkerInfo = { worker, client };
+		this.workerMap.set(sessionId, workerInfo);
 
 		client.Lifecycle.extension_message((message) => {
 			this.emit_extensionMessage(sessionId, message);
 		});
 
-		this.workerMap.set(sessionId, workerInfo);
-
 		worker.on("message", (data) => {
+			if (workerInfo.status !== "running") return;
+
 			const { result } = JSON.parse(data);
 			if (result !== undefined) client.route(data); // response
 			this.emit_extensionMessage(sessionId, data); // regular extension stuff
@@ -78,6 +105,7 @@ class ExtensionManager extends manager.ManagerService {
 		});
 
 		const sendCrash = (text: string) => {
+			if (workerInfo.status !== "running") return;
 			this.emit_extensionCrash(sessionId, text);
 		};
 
@@ -118,19 +146,6 @@ class ExtensionManager extends manager.ManagerService {
 			this.workerMap.delete(sessionId);
 		});
 
-		await client.Lifecycle.launch({
-			entrypoint: load.entrypoint,
-			argumentValues: load.arguments,
-			preferenceValues: load.preferences,
-			mode: load.mode,
-			support_path: supportPath,
-			asset_path: assetsPath,
-			is_raycast: load.is_raycast,
-			extension_name: load.extension_name,
-			owner_or_author_name: load.owner_or_author_name,
-			command_name: load.command_name,
-		});
-
 		return { session_id: sessionId };
 	}
 
@@ -141,9 +156,10 @@ class ExtensionManager extends manager.ManagerService {
 			return false;
 		}
 
+		workerInfo.status = "unloading";
 		await workerInfo.client.Lifecycle.shutdown();
 
-		// force kill after 10s
+		// force kill after
 		workerInfo.pendingTermination = setTimeout(() => {
 			workerInfo.worker.terminate();
 		}, WORKER_GRACE_PERIOD_MS);

--- a/src/typescript/extension-manager/src/index.ts
+++ b/src/typescript/extension-manager/src/index.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import * as fs from "node:fs";
 import { isatty } from "node:tty";
 import { isMainThread, Worker } from "node:worker_threads";
+import * as fsp from "node:fs/promises";
 import { main as workerMain } from "./worker";
 
 import * as manager from "./proto/manager";
@@ -67,6 +68,11 @@ class ExtensionManager extends manager.ManagerService {
 			load.extension_id,
 			"assets",
 		);
+
+		await Promise.all([
+			fsp.mkdir(assetsPath, { recursive: true }),
+			fsp.mkdir(supportInternal, { recursive: true }),
+		]);
 
 		const workerInfo: WorkerInfo = {
 			worker,

--- a/src/typescript/extension-manager/src/reconciler.ts
+++ b/src/typescript/extension-manager/src/reconciler.ts
@@ -342,14 +342,14 @@ export const createRenderer = (config: RendererConfig) => {
 	let root: OpaqueRoot | undefined;
 	let debounce: NodeJS.Timer | null = null;
 	const debounceInterval = 1000 / MAX_RENDER_PER_SECOND;
-	let lastRender = performance.now();
+	//let lastRender = performance.now();
 
 	const renderImpl = () => {
 		if (!debounce) {
 			debounce = setTimeout(() => {
 				debounce = null;
 
-				const start = performance.now();
+				//const start = performance.now();
 
 				const views = (container.children ?? []).map<ViewData>((viewSlot) => {
 					const viewRoot = viewSlot.children?.at(-1);
@@ -363,12 +363,14 @@ export const createRenderer = (config: RendererConfig) => {
 				callbackManager.flushDeferredRemovals();
 				frameGen++;
 
-				const end = performance.now();
+				//const end = performance.now();
 
+				/*
 				console.error(
 					`[PERF] reconciler frame: ${(end - start).toFixed(2)}ms (since last: ${(end - lastRender).toFixed(1)}ms)`,
 				);
-				lastRender = end;
+				*/
+				//lastRender = end;
 			}, debounceInterval);
 		}
 	};


### PR DESCRIPTION
Add a `ready` request the C++ extension runtime sends to the extension manager when it successfully gets and store the session ID returned by the `load` request. Only then the extension worker is fully started.

Before this was implemented, it was technically possible for an extension to start sending messages before the C++ side was ready to process them, resulting in a race condition where we would just skip the first API calls.

The extension would have to initialize extremely fast for this scenario to realistically happen and I've only seen this play out a few times, but better to fix it now.