### PR TITLE
feat: Expose app actions from the footer logo

### DIFF
--- a/src/server/src/extensions/vicinae/bug-report-url.hpp
+++ b/src/server/src/extensions/vicinae/bug-report-url.hpp
@@ -1,0 +1,60 @@
+#pragma once
+#include "environment.hpp"
+#include "generated/version.h"
+#include "lib/os-release.hpp"
+#include "vicinae.hpp"
+#include <QGuiApplication>
+#include <QUrlQuery>
+
+static const QString ISSUE_TEMPLATE = R"(**System information**
+
+- Version: %1 (%2)
+- Build info: %3
+- Provenance: %4
+- OS: %5
+- QT Platform: %6
+- DE: %7
+
+**Describe the bug**
+
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+
+Steps to reproduce the behavior.
+
+**Expected behavior**
+
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+
+Add any other context about the problem here.
+)";
+
+inline QUrl makeVicinaeBugReportUrl(const QString &title = {}) {
+  OsRelease os;
+  QString osString = os.isValid() ? QString("%1 - %2").arg(os.prettyName()).arg(os.version()) : "Unknown OS";
+
+  QString content = ISSUE_TEMPLATE.arg(VICINAE_GIT_TAG)
+                        .arg(VICINAE_GIT_COMMIT_HASH)
+                        .arg(BUILD_INFO)
+                        .arg(VICINAE_PROVENANCE)
+                        .arg(osString)
+                        .arg(QGuiApplication::platformName())
+                        .arg(Environment::getEnvironmentDescription());
+  QUrl url(Omnicast::GH_REPO_CREATE_ISSUE);
+  QUrlQuery query;
+
+  if (!title.isEmpty()) { query.addQueryItem("title", title); }
+
+  query.addQueryItem("body", content);
+  query.addQueryItem("type", "bug");
+  url.setQuery(query);
+
+  return url;
+}

--- a/src/server/src/extensions/vicinae/report-bug-command.hpp
+++ b/src/server/src/extensions/vicinae/report-bug-command.hpp
@@ -1,40 +1,6 @@
 #pragma once
+#include "bug-report-url.hpp"
 #include "builtin-url-command.hpp"
-#include <QGuiApplication>
-#include <qurlquery.h>
-#include "environment.hpp"
-#include "lib/os-release.hpp"
-#include "generated/version.h"
-
-static const QString ISSUE_TEMPLATE = R"(**System information**
-
-- Version: %1 (%2)
-- Build info: %3
-- Provenance: %4
-- OS: %5
-- QT Platform: %6
-- DE: %7
-
-**Describe the bug**
-
-A clear and concise description of what the bug is.
-
-**To Reproduce**
-
-Steps to reproduce the behavior.
-
-**Expected behavior**
-
-A clear and concise description of what you expected to happen.
-
-**Screenshots**
-
-If applicable, add screenshots to help explain your problem.
-
-**Additional context**
-
-Add any other context about the problem here.
-)";
 
 class ReportVicinaeBugCommand : public BuiltinUrlCommand {
 
@@ -56,26 +22,6 @@ class ReportVicinaeBugCommand : public BuiltinUrlCommand {
   std::vector<QString> keywords() const override { return {"create issue"}; }
 
   QUrl url(const ArgumentValues &values) const override {
-    OsRelease os;
-    QString osString =
-        os.isValid() ? QString("%1 - %2").arg(os.prettyName()).arg(os.version()) : "Unknown OS";
-
-    QString content = ISSUE_TEMPLATE.arg(VICINAE_GIT_TAG)
-                          .arg(VICINAE_GIT_COMMIT_HASH)
-                          .arg(BUILD_INFO)
-                          .arg(VICINAE_PROVENANCE)
-                          .arg(osString)
-                          .arg(QGuiApplication::platformName())
-                          .arg(Environment::getEnvironmentDescription());
-    QUrl url(Omnicast::GH_REPO_CREATE_ISSUE);
-    QUrlQuery query;
-
-    if (!values.empty()) { query.addQueryItem("title", values.front().second); }
-
-    query.addQueryItem("body", content);
-    query.addQueryItem("type", "bug");
-    url.setQuery(query);
-
-    return url;
+    return makeVicinaeBugReportUrl(values.empty() ? QString() : values.front().second);
   }
 };

--- a/src/server/src/qml/action-panel-controller.cpp
+++ b/src/server/src/qml/action-panel-controller.cpp
@@ -71,13 +71,15 @@ void ActionPanelController::open() {
 void ActionPanelController::close() {
   if (!m_open) return;
 
+  auto *root = activeRoot();
+
   m_open = false;
   emit openChanged();
   emit stackClearRequested();
   m_depth = 0;
   m_currentPanel = nullptr;
 
-  if (auto *root = activeRoot()) root->onDeactivate();
+  if (root) root->onDeactivate();
 
   delete m_connectionGuard;
   m_connectionGuard = nullptr;

--- a/src/server/src/qml/action-panel-controller.cpp
+++ b/src/server/src/qml/action-panel-controller.cpp
@@ -3,6 +3,7 @@
 #include "lib/keyboard/keyboard.hpp"
 #include "navigation-controller.hpp"
 #include "ui/action-pannel/action-list-view.hpp"
+#include "ui/action-pannel/action-panel-state.hpp"
 #include "ui/action-pannel/action-panel-view.hpp"
 #include "ui/views/base-view.hpp"
 #include <QKeyEvent>
@@ -10,7 +11,18 @@
 ActionPanelController::ActionPanelController(ApplicationContext &ctx, QObject *parent)
     : QObject(parent), m_ctx(ctx) {}
 
+bool ActionPanelController::hasActions() const {
+  auto *r = activeRoot();
+  return r && r->hasActions();
+}
+
+bool ActionPanelController::hasMultipleActions() const {
+  auto *r = activeRoot();
+  return r && r->hasMultipleActions();
+}
+
 ActionPanelView *ActionPanelController::activeRoot() const {
+  if (m_ownedRoot) return m_ownedRoot.get();
   return m_activeView ? m_activeView->actionPanelRoot() : nullptr;
 }
 
@@ -30,25 +42,40 @@ QVariantList ActionPanelController::primaryActionShortcutTokens() const {
   return shortcut.toDisplayTokens();
 }
 
+void ActionPanelController::setActions(std::unique_ptr<ActionPanelState> actions) {
+  close();
+
+  auto *prevRoot = activeRoot();
+  if (prevRoot) prevRoot->onUnmount();
+
+  m_activeView = nullptr;
+  m_ownedRoot = std::make_unique<ActionListView>(this);
+  m_ownedRoot->adoptState(std::move(actions));
+  m_ownedRoot->onMount();
+
+  emit actionsChanged();
+  emit primaryActionChanged();
+}
+
 void ActionPanelController::syncToView(BaseView *view) {
+  auto *prevRoot = activeRoot();
+  auto prevOwned = std::move(m_ownedRoot);
+
   m_activeView = view;
 
   auto *root = activeRoot();
 
-  bool const newHasActions = root && root->hasActions();
-  bool const newHasMultiple = root && root->hasMultipleActions();
+  if (prevRoot != root) {
+    if (prevRoot) prevRoot->onUnmount();
+    if (root) root->onMount();
+  }
 
-  if (newHasActions != m_hasActions) {
-    m_hasActions = newHasActions;
-    emit hasActionsChanged();
-    if (!m_hasActions) close();
-  }
-  if (newHasMultiple != m_hasMultipleActions) {
-    m_hasMultipleActions = newHasMultiple;
-    emit hasMultipleActionsChanged();
-  }
+  emit actionsChanged();
+  if (!hasActions()) close();
 
   emit primaryActionChanged();
+
+  refreshSubmenus();
 }
 
 void ActionPanelController::toggle() {
@@ -61,7 +88,7 @@ void ActionPanelController::toggle() {
 
 void ActionPanelController::open() {
   if (m_open) return;
-  if (!m_hasActions) return;
+  if (!hasActions()) return;
 
   m_open = true;
   emit openChanged();
@@ -76,7 +103,6 @@ void ActionPanelController::close() {
   m_open = false;
   emit openChanged();
   emit stackClearRequested();
-  m_depth = 0;
   m_currentPanel = nullptr;
 
   if (root) root->onDeactivate();
@@ -84,7 +110,7 @@ void ActionPanelController::close() {
   delete m_connectionGuard;
   m_connectionGuard = nullptr;
 
-  if (m_activeView) { m_activeView->clearActionPanelStack(); }
+  clearSubmenuStack();
 
   emit depthChanged();
 }
@@ -96,6 +122,7 @@ void ActionPanelController::openRootPanel() {
   auto *root = activeRoot();
   if (!root) return;
 
+  root->resetState();
   root->onActivate();
   connectView(root);
 
@@ -109,7 +136,7 @@ void ActionPanelController::pushPanel(const QUrl &componentUrl, const QVariantMa
 }
 
 void ActionPanelController::pop() {
-  if (m_depth > 1) {
+  if (!m_submenuStack.empty()) {
     emit panelPopRequested();
   } else {
     close();
@@ -118,14 +145,19 @@ void ActionPanelController::pop() {
 
 void ActionPanelController::onPanelPushed(QObject *panel) {
   m_currentPanel = panel;
-  m_depth++;
   emit depthChanged();
 }
 
 void ActionPanelController::onPanelPopped(QObject *currentPanel) {
-  if (m_depth > 0) m_depth--;
   m_currentPanel = currentPanel;
-  if (m_activeView) m_activeView->popActionPanelView();
+
+  if (!m_submenuStack.empty()) {
+    auto *view = m_submenuStack.back();
+    view->onUnmount();
+    view->deleteLater();
+    m_submenuStack.pop_back();
+  }
+
   emit depthChanged();
 }
 
@@ -171,11 +203,43 @@ void ActionPanelController::connectView(ActionPanelView *view) {
   connect(view, &ActionPanelView::closeRequested, m_connectionGuard, [this]() { close(); });
 
   connect(view, &ActionPanelView::pushViewRequested, m_connectionGuard, [this](ActionPanelView *child) {
-    if (!m_activeView) return;
-    m_activeView->pushActionPanelView(child);
+    child->setParent(this);
+    m_submenuStack.push_back(child);
+    child->onMount();
     connectView(child);
     auto url = child->componentUrl();
     auto props = child->componentProps();
     emit panelPushRequested(url, props);
   });
+}
+
+void ActionPanelController::clearSubmenuStack() {
+  for (auto it = m_submenuStack.rbegin(); it != m_submenuStack.rend(); ++it) {
+    (*it)->onUnmount();
+    (*it)->deleteLater();
+  }
+  m_submenuStack.clear();
+}
+
+void ActionPanelController::refreshSubmenus() {
+  if (m_submenuStack.empty()) return;
+
+  auto *root = dynamic_cast<ActionListView *>(activeRoot());
+  if (!root || !root->state()) return;
+
+  const auto *parentState = root->state();
+
+  for (auto *view : m_submenuStack) {
+    auto viewId = view->id();
+    if (viewId.isEmpty()) break;
+
+    auto *submenuAction = parentState->findSubmenuAction(viewId);
+    if (!submenuAction) break;
+
+    auto submenuState = submenuAction->createSubmenuStateStealthily();
+    if (!submenuState) break;
+
+    parentState = submenuState.get();
+    static_cast<ActionListView *>(view)->adoptState(std::move(submenuState));
+  }
 }

--- a/src/server/src/qml/action-panel-controller.hpp
+++ b/src/server/src/qml/action-panel-controller.hpp
@@ -4,8 +4,12 @@
 #include <QUrl>
 #include <QVariantMap>
 #include <QVariantList>
+#include <memory>
+#include <vector>
 
 class AbstractAction;
+class ActionListView;
+class ActionPanelState;
 class ActionPanelView;
 class BaseView;
 class QKeyEvent;
@@ -14,8 +18,8 @@ class SubmenuAction;
 class ActionPanelController : public QObject {
   Q_OBJECT
   Q_PROPERTY(bool open READ isOpen NOTIFY openChanged)
-  Q_PROPERTY(bool hasActions READ hasActions NOTIFY hasActionsChanged)
-  Q_PROPERTY(bool hasMultipleActions READ hasMultipleActions NOTIFY hasMultipleActionsChanged)
+  Q_PROPERTY(bool hasActions READ hasActions NOTIFY actionsChanged)
+  Q_PROPERTY(bool hasMultipleActions READ hasMultipleActions NOTIFY actionsChanged)
   Q_PROPERTY(QString primaryActionTitle READ primaryActionTitle NOTIFY primaryActionChanged)
   Q_PROPERTY(
       QVariantList primaryActionShortcutTokens READ primaryActionShortcutTokens NOTIFY primaryActionChanged)
@@ -23,8 +27,7 @@ class ActionPanelController : public QObject {
 
 signals:
   void openChanged();
-  void hasActionsChanged();
-  void hasMultipleActionsChanged();
+  void actionsChanged();
   void primaryActionChanged();
   void depthChanged();
   void panelPushRequested(const QUrl &componentUrl, const QVariantMap &properties);
@@ -35,13 +38,14 @@ public:
   explicit ActionPanelController(ApplicationContext &ctx, QObject *parent = nullptr);
 
   bool isOpen() const { return m_open; }
-  bool hasActions() const { return m_hasActions; }
-  bool hasMultipleActions() const { return m_hasMultipleActions; }
+  bool hasActions() const;
+  bool hasMultipleActions() const;
   QString primaryActionTitle() const;
   QVariantList primaryActionShortcutTokens() const;
-  int depth() const { return m_depth; }
+  int depth() const { return m_open ? 1 + static_cast<int>(m_submenuStack.size()) : 0; }
 
   void syncToView(BaseView *view);
+  void setActions(std::unique_ptr<ActionPanelState> actions);
 
   Q_INVOKABLE void toggle();
   Q_INVOKABLE void open();
@@ -62,15 +66,16 @@ public:
 private:
   void openRootPanel();
   void connectView(ActionPanelView *view);
+  void clearSubmenuStack();
+  void refreshSubmenus();
 
   ActionPanelView *activeRoot() const;
 
   ApplicationContext &m_ctx;
   bool m_open = false;
-  bool m_hasActions = false;
-  bool m_hasMultipleActions = false;
-  int m_depth = 0;
   QObject *m_currentPanel = nullptr;
   QObject *m_connectionGuard = nullptr;
   BaseView *m_activeView = nullptr;
+  std::unique_ptr<ActionListView> m_ownedRoot;
+  std::vector<ActionPanelView *> m_submenuStack;
 };

--- a/src/server/src/qml/extension-view-host.cpp
+++ b/src/server/src/qml/extension-view-host.cpp
@@ -53,27 +53,10 @@ void ExtensionViewHost::onReactivated() {
 }
 
 void ExtensionViewHost::setActions(std::unique_ptr<ActionPanelState> actions) {
-  auto &stack = actionPanelStack();
+  auto *root = actionPanelRoot();
 
-  if (!stack.empty() && !actions->id().isEmpty() && stack.front()->id() == actions->id()) {
-    auto *parentState = actions.get();
-    auto *rootView = static_cast<ActionListView *>(stack.front());
-    rootView->adoptState(std::move(actions));
-
-    for (size_t i = 1; i < stack.size(); ++i) {
-      QString viewId = stack[i]->id();
-      if (viewId.isEmpty()) break;
-
-      auto *submenuAction = parentState->findSubmenuAction(viewId);
-      if (!submenuAction) break;
-
-      auto submenuState = submenuAction->createSubmenuStateStealthily();
-      if (!submenuState) break;
-
-      parentState = submenuState.get();
-      static_cast<ActionListView *>(stack[i])->adoptState(std::move(submenuState));
-    }
-
+  if (root && !actions->id().isEmpty() && root->id() == actions->id()) {
+    static_cast<ActionListView *>(root)->adoptState(std::move(actions));
     if (context()) { context()->navigation->notifyActionPanelChanged(this); }
     return;
   }

--- a/src/server/src/qml/launcher-window.cpp
+++ b/src/server/src/qml/launcher-window.cpp
@@ -15,17 +15,21 @@
 #include "theme-bridge.hpp"
 #include "navigation-controller.hpp"
 #include "overlay-controller/overlay-controller.hpp"
+#include "extensions/vicinae/bug-report-url.hpp"
+#include "qml/vicinae-store-view-host.hpp"
 #include "settings-controller/settings-controller.hpp"
 #include "services/keybinding/keybinding-service.hpp"
 #include "services/toast/toast-service.hpp"
 #include "config/config.hpp"
 #include "service-registry.hpp"
+#include "services/app-service/app-service.hpp"
 #include "services/file-chooser/file-chooser-service.hpp"
 #include "services/window-manager/window-manager.hpp"
 #include "environment.hpp"
 #include "vicinae.hpp"
 #include "lib/keyboard/keyboard.hpp"
 #include "ui/views/base-view.hpp"
+#include "ui/action-pannel/action-panel-state.hpp"
 #include <QCursor>
 #include <QGuiApplication>
 #include <QQmlContext>
@@ -35,6 +39,7 @@
 #include <QKeyEvent>
 #include <qcoreevent.h>
 #include <qlogging.h>
+#include <memory>
 
 #ifdef __GLIBC__
 #include <malloc.h>
@@ -184,10 +189,18 @@ LauncherWindow::LauncherWindow(ApplicationContext &ctx, QObject *parent)
     }
   });
 
-  connect(nav, &NavigationController::activeActionPanelChanged, this,
-          [this, nav]() { m_actionPanel->syncToView(nav->topState()->sender); });
+  connect(nav, &NavigationController::activeActionPanelChanged, this, [this, nav]() {
+    if (!m_footerMenuOpen) { m_actionPanel->syncToView(nav->topState()->sender); }
+  });
 
   connect(nav, &NavigationController::viewPushed, this, [this](const BaseView *) { m_actionPanel->close(); });
+
+  connect(m_actionPanel, &ActionPanelController::openChanged, this, [this, nav]() {
+    if (!m_actionPanel->isOpen() && m_footerMenuOpen) {
+      closeFooterMenu();
+      QTimer::singleShot(0, this, [this, nav]() { m_actionPanel->syncToView(nav->topState()->sender); });
+    }
+  });
 
   connect(nav, &NavigationController::navigationStatusChanged, this,
           [this](const QString &title, const ImageURL &icon) {
@@ -537,6 +550,71 @@ QRect LauncherWindow::cursorScreenGeometry() const {
   auto *screen = QGuiApplication::screenAt(QCursor::pos());
   if (!screen) screen = QGuiApplication::primaryScreen();
   return screen ? screen->geometry() : QRect();
+}
+
+void LauncherWindow::openFooterMenu() {
+  if (m_footerMenuOpen) {
+    m_actionPanel->close();
+    return;
+  }
+
+  m_actionPanel->close();
+
+  auto state = std::make_unique<ActionPanelState>();
+  state->setAutoSelectPrimary(false);
+  state->setTitle(QStringLiteral("Vicinae"));
+  state->setId(QStringLiteral("footer-menu"));
+
+  auto *appSection = state->createSection();
+  appSection->addAction(new StaticAction(QStringLiteral("Open Settings"), ImageURL::builtin("cog"),
+                                         [](ApplicationContext *ctx) {
+                                           ctx->navigation->closeWindow();
+                                           ctx->settings->openWindow();
+                                         }));
+  appSection->addAction(new StaticAction(QStringLiteral("Keyboard Shortcuts"), ImageURL::builtin("keyboard"),
+                                         [](ApplicationContext *ctx) {
+                                           ctx->navigation->closeWindow();
+                                           ctx->settings->openTab(QStringLiteral("shortcuts"));
+                                         }));
+  appSection->addAction(new StaticAction(QStringLiteral("Extension Store"), ImageURL::builtin("cart"),
+                                         [](ApplicationContext *ctx) {
+                                           ctx->navigation->popToRoot();
+                                           ctx->navigation->clearSearchText();
+                                           ctx->navigation->pushView(new VicinaeStoreViewHost);
+                                         }));
+
+  auto *helpSection = state->createSection();
+  helpSection->addAction(new StaticAction(QStringLiteral("Documentation"), ImageURL::builtin("book"),
+                                          [](ApplicationContext *ctx) {
+                                            ctx->services->appDb()->openTarget(Omnicast::DOC_URL);
+                                            ctx->navigation->showHud(QStringLiteral("Opened in browser"));
+                                          }));
+  helpSection->addAction(
+      new StaticAction(QStringLiteral("Report a Bug"), ImageURL::builtin("bug"), [](ApplicationContext *ctx) {
+        ctx->services->appDb()->openTarget(makeVicinaeBugReportUrl());
+        ctx->navigation->showHud(QStringLiteral("Opened in browser"));
+      }));
+  helpSection->addAction(new StaticAction(QStringLiteral("About Vicinae"), ImageURL::builtin("info-01"),
+                                          [](ApplicationContext *ctx) {
+                                            ctx->navigation->closeWindow();
+                                            ctx->settings->openTab(QStringLiteral("about"));
+                                          }));
+
+  m_footerMenuView = new BaseView(this);
+  m_footerMenuView->setActions(std::move(state));
+  m_footerMenuOpen = true;
+  emit footerMenuOpenChanged();
+
+  m_actionPanel->syncToView(m_footerMenuView);
+  m_actionPanel->open();
+}
+
+void LauncherWindow::closeFooterMenu() {
+  m_footerMenuOpen = false;
+  auto *view = m_footerMenuView;
+  m_footerMenuView = nullptr;
+  if (view) { QTimer::singleShot(0, view, &QObject::deleteLater); }
+  emit footerMenuOpenChanged();
 }
 
 void LauncherWindow::expand() { setCompacted(false); }

--- a/src/server/src/qml/launcher-window.cpp
+++ b/src/server/src/qml/launcher-window.cpp
@@ -47,6 +47,7 @@
 
 LauncherWindow::LauncherWindow(ApplicationContext &ctx, QObject *parent)
     : QObject(parent), m_ctx(ctx), m_actionPanel(new ActionPanelController(ctx, this)),
+      m_footerPanel(new ActionPanelController(ctx, this)),
       m_alertModel(new AlertModel(*ctx.navigation, this)), m_configBridge(new ConfigBridge(this)),
       m_imgSource(new ImageSource(this)), m_keybindProxy(new KeybindBridge(this)),
       m_themeBridge(new ThemeBridge(this)) {
@@ -71,10 +72,12 @@ LauncherWindow::LauncherWindow(ApplicationContext &ctx, QObject *parent)
 
   rootCtx->setContextProperty(QStringLiteral("launcher"), this);
   rootCtx->setContextProperty(QStringLiteral("actionPanel"), m_actionPanel);
+  rootCtx->setContextProperty(QStringLiteral("footerPanel"), m_footerPanel);
   rootCtx->setContextProperty(QStringLiteral("Keybinds"), m_keybindProxy);
   rootCtx->setContextProperty(QStringLiteral("FileChooser"), ctx.services->fileChooserService());
 
   updateLayerShellProps();
+  buildFooterMenu();
 
   m_engine.load(QUrl(
 #ifdef Q_OS_MACOS
@@ -189,17 +192,19 @@ LauncherWindow::LauncherWindow(ApplicationContext &ctx, QObject *parent)
     }
   });
 
-  connect(nav, &NavigationController::activeActionPanelChanged, this, [this, nav]() {
-    if (!m_footerMenuOpen) { m_actionPanel->syncToView(nav->topState()->sender); }
+  connect(nav, &NavigationController::activeActionPanelChanged, this,
+          [this, nav]() { m_actionPanel->syncToView(nav->topState()->sender); });
+
+  connect(nav, &NavigationController::viewPushed, this, [this](const BaseView *) {
+    m_actionPanel->close();
+    m_footerPanel->close();
   });
 
-  connect(nav, &NavigationController::viewPushed, this, [this](const BaseView *) { m_actionPanel->close(); });
-
-  connect(m_actionPanel, &ActionPanelController::openChanged, this, [this, nav]() {
-    if (!m_actionPanel->isOpen() && m_footerMenuOpen) {
-      closeFooterMenu();
-      QTimer::singleShot(0, this, [this, nav]() { m_actionPanel->syncToView(nav->topState()->sender); });
-    }
+  connect(m_footerPanel, &ActionPanelController::openChanged, this, [this]() {
+    if (m_footerPanel->isOpen()) m_actionPanel->close();
+  });
+  connect(m_actionPanel, &ActionPanelController::openChanged, this, [this]() {
+    if (m_actionPanel->isOpen()) m_footerPanel->close();
   });
 
   connect(nav, &NavigationController::navigationStatusChanged, this,
@@ -552,14 +557,9 @@ QRect LauncherWindow::cursorScreenGeometry() const {
   return screen ? screen->geometry() : QRect();
 }
 
-void LauncherWindow::openFooterMenu() {
-  if (m_footerMenuOpen) {
-    m_actionPanel->close();
-    return;
-  }
+void LauncherWindow::openFooterMenu() { m_footerPanel->toggle(); }
 
-  m_actionPanel->close();
-
+void LauncherWindow::buildFooterMenu() {
   auto state = std::make_unique<ActionPanelState>();
   state->setAutoSelectPrimary(false);
   state->setTitle(QStringLiteral("Vicinae"));
@@ -600,21 +600,7 @@ void LauncherWindow::openFooterMenu() {
                                             ctx->settings->openTab(QStringLiteral("about"));
                                           }));
 
-  m_footerMenuView = new BaseView(this);
-  m_footerMenuView->setActions(std::move(state));
-  m_footerMenuOpen = true;
-  emit footerMenuOpenChanged();
-
-  m_actionPanel->syncToView(m_footerMenuView);
-  m_actionPanel->open();
-}
-
-void LauncherWindow::closeFooterMenu() {
-  m_footerMenuOpen = false;
-  auto *view = m_footerMenuView;
-  m_footerMenuView = nullptr;
-  if (view) { QTimer::singleShot(0, view, &QObject::deleteLater); }
-  emit footerMenuOpenChanged();
+  m_footerPanel->setActions(std::move(state));
 }
 
 void LauncherWindow::expand() { setCompacted(false); }

--- a/src/server/src/qml/launcher-window.hpp
+++ b/src/server/src/qml/launcher-window.hpp
@@ -51,7 +51,6 @@ class LauncherWindow : public QObject {
   Q_PROPERTY(QObject *overlayHost READ overlayHost NOTIFY overlayChanged)
   Q_PROPERTY(int lsLayer READ lsLayer NOTIFY lsChanged)
   Q_PROPERTY(int lsKeyboardInteractivity READ lsKeyboardInteractivity NOTIFY lsChanged)
-  Q_PROPERTY(bool footerMenuOpen READ footerMenuOpen NOTIFY footerMenuOpenChanged)
 
 public:
   explicit LauncherWindow(ApplicationContext &ctx, QObject *parent = nullptr);
@@ -86,7 +85,6 @@ public:
   QObject *overlayHost() const { return m_overlayHost; }
   int lsLayer() const { return m_lsLayer; }
   int lsKeyboardInteractivity() const { return m_lsKeyboardInteractivity; }
-  bool footerMenuOpen() const { return m_footerMenuOpen; }
 
   Q_INVOKABLE void expand();
   Q_INVOKABLE void forwardSearchText(const QString &text);
@@ -127,7 +125,6 @@ signals:
   void windowSizeOverrideChanged();
   void overlayChanged();
   void lsChanged();
-  void footerMenuOpenChanged();
 
 private:
   bool eventFilter(QObject *obj, QEvent *event) override;
@@ -140,10 +137,11 @@ private:
   bool isLayerShellActive() const;
   void setExclusiveFocus(bool exclusive);
   void updateLayerShellProps();
-  void closeFooterMenu();
+  void buildFooterMenu();
 
   ApplicationContext &m_ctx;
   ActionPanelController *m_actionPanel;
+  ActionPanelController *m_footerPanel;
   AlertModel *m_alertModel = nullptr;
   ConfigBridge *m_configBridge;
   ImageSource *m_imgSource;
@@ -192,6 +190,4 @@ private:
   QVariantList m_completerArgs;
   QString m_completerIcon;
   QVariantList m_completerValues;
-  bool m_footerMenuOpen = false;
-  BaseView *m_footerMenuView = nullptr;
 };

--- a/src/server/src/qml/launcher-window.hpp
+++ b/src/server/src/qml/launcher-window.hpp
@@ -51,6 +51,7 @@ class LauncherWindow : public QObject {
   Q_PROPERTY(QObject *overlayHost READ overlayHost NOTIFY overlayChanged)
   Q_PROPERTY(int lsLayer READ lsLayer NOTIFY lsChanged)
   Q_PROPERTY(int lsKeyboardInteractivity READ lsKeyboardInteractivity NOTIFY lsChanged)
+  Q_PROPERTY(bool footerMenuOpen READ footerMenuOpen NOTIFY footerMenuOpenChanged)
 
 public:
   explicit LauncherWindow(ApplicationContext &ctx, QObject *parent = nullptr);
@@ -85,6 +86,7 @@ public:
   QObject *overlayHost() const { return m_overlayHost; }
   int lsLayer() const { return m_lsLayer; }
   int lsKeyboardInteractivity() const { return m_lsKeyboardInteractivity; }
+  bool footerMenuOpen() const { return m_footerMenuOpen; }
 
   Q_INVOKABLE void expand();
   Q_INVOKABLE void forwardSearchText(const QString &text);
@@ -97,6 +99,7 @@ public:
   Q_INVOKABLE int matchNavigationKey(int key, int modifiers);
   Q_INVOKABLE void setCompleterValue(int index, const QString &value);
   Q_INVOKABLE QRect cursorScreenGeometry() const;
+  Q_INVOKABLE void openFooterMenu();
 
 signals:
   void compactedChanged();
@@ -124,6 +127,7 @@ signals:
   void windowSizeOverrideChanged();
   void overlayChanged();
   void lsChanged();
+  void footerMenuOpenChanged();
 
 private:
   bool eventFilter(QObject *obj, QEvent *event) override;
@@ -136,6 +140,7 @@ private:
   bool isLayerShellActive() const;
   void setExclusiveFocus(bool exclusive);
   void updateLayerShellProps();
+  void closeFooterMenu();
 
   ApplicationContext &m_ctx;
   ActionPanelController *m_actionPanel;
@@ -187,4 +192,6 @@ private:
   QVariantList m_completerArgs;
   QString m_completerIcon;
   QVariantList m_completerValues;
+  bool m_footerMenuOpen = false;
+  BaseView *m_footerMenuView = nullptr;
 };

--- a/src/server/src/qml/qml/ActionListPanel.qml
+++ b/src/server/src/qml/qml/ActionListPanel.qml
@@ -7,6 +7,7 @@ Item {
 
     required property var model
     property var boundActions: root.model
+    property var controller: actionPanel
 
     signal navigateBack
 
@@ -255,10 +256,10 @@ Item {
                             root.moveDown();
                             event.accepted = true;
                         } else if (nav === 3) {
-                            if (actionPanel.depth > 1)
+                            if (root.controller.depth > 1)
                                 root.navigateBack();
                             event.accepted = true;
-                        } else if ((event.modifiers & (Qt.ControlModifier | Qt.AltModifier | Qt.MetaModifier)) && actionPanel.tryShortcut(event.key, event.modifiers)) {
+                        } else if ((event.modifiers & (Qt.ControlModifier | Qt.AltModifier | Qt.MetaModifier)) && root.controller.tryShortcut(event.key, event.modifiers)) {
                             event.accepted = true;
                         }
                     }

--- a/src/server/src/qml/qml/ActionPanelPopover.qml
+++ b/src/server/src/qml/qml/ActionPanelPopover.qml
@@ -4,6 +4,9 @@ import QtQuick.Effects
 
 FocusRestoringScope {
     id: root
+
+    property bool alignLeft: false
+
     active: actionPanel.open
     visible: actionPanel.open || panel.opacity > 0
     enabled: actionPanel.open
@@ -24,16 +27,15 @@ FocusRestoringScope {
 
     Item {
         id: panel
-        anchors.right: parent.right
+        x: root.alignLeft ? 10 : parent.width - width - 10
         anchors.bottom: parent.bottom
-        anchors.rightMargin: 10
         anchors.bottomMargin: 10
         width: 400
         height: Math.min(stack.currentItem ? stack.currentItem.implicitHeight + 2 : 300, root.height * 0.6)
 
         opacity: 0
         scale: 0.95
-        transformOrigin: Item.BottomRight
+        transformOrigin: root.alignLeft ? Item.BottomLeft : Item.BottomRight
 
         states: State {
             name: "open"

--- a/src/server/src/qml/qml/ActionPanelPopover.qml
+++ b/src/server/src/qml/qml/ActionPanelPopover.qml
@@ -5,24 +5,25 @@ import QtQuick.Effects
 FocusRestoringScope {
     id: root
 
+    required property var controller
     property bool alignLeft: false
 
-    active: actionPanel.open
-    visible: actionPanel.open || panel.opacity > 0
-    enabled: actionPanel.open
+    active: root.controller.open
+    visible: root.controller.open || panel.opacity > 0
+    enabled: root.controller.open
 
     onVisibleChanged: {
         if (!visible)
             stack.clear(StackView.Immediate);
     }
     onActiveFocusChanged: {
-        if (!activeFocus && actionPanel.open)
-            actionPanel.close();
+        if (!activeFocus && root.controller.open)
+            root.controller.close();
     }
 
     MouseArea {
         anchors.fill: parent
-        onClicked: actionPanel.close()
+        onClicked: root.controller.close()
     }
 
     Item {
@@ -39,7 +40,7 @@ FocusRestoringScope {
 
         states: State {
             name: "open"
-            when: actionPanel.open
+            when: root.controller.open
             PropertyChanges {
                 target: panel
                 opacity: 1
@@ -106,21 +107,22 @@ FocusRestoringScope {
         target: stack.currentItem
         ignoreUnknownSignals: true
         function onNavigateBack() {
-            actionPanel.pop();
+            root.controller.pop();
         }
     }
 
     Connections {
-        target: actionPanel
+        target: root.controller
         function onPanelPushRequested(componentUrl, properties) {
             stack.push(componentUrl, properties, StackView.Immediate);
-            actionPanel.onPanelPushed(stack.currentItem);
+            stack.currentItem.controller = root.controller;
+            root.controller.onPanelPushed(stack.currentItem);
             if (typeof stack.currentItem.focusFilter === "function")
                 stack.currentItem.focusFilter();
         }
         function onPanelPopRequested() {
             stack.pop();
-            actionPanel.onPanelPopped(stack.currentItem);
+            root.controller.onPanelPopped(stack.currentItem);
             if (stack.currentItem && typeof stack.currentItem.focusFilter === "function")
                 stack.currentItem.focusFilter();
         }
@@ -132,11 +134,11 @@ FocusRestoringScope {
     Keys.onPressed: event => {
         const nav = launcher.matchNavigationKey(event.key, event.modifiers);
         if (event.key === Qt.Key_Escape) {
-            actionPanel.pop();
+            root.controller.pop();
             event.accepted = true;
         } else if (event.key === Qt.Key_Left || nav === 3) {
-            if (actionPanel.depth > 1) {
-                actionPanel.pop();
+            if (root.controller.depth > 1) {
+                root.controller.pop();
                 event.accepted = true;
             }
         } else if (event.key === Qt.Key_Up || nav === 1) {

--- a/src/server/src/qml/qml/Footer.qml
+++ b/src/server/src/qml/qml/Footer.qml
@@ -53,7 +53,7 @@ Item {
             Layout.alignment: Qt.AlignVCenter
             label: "Actions"
             shortcutTokens: Keybinds.toggleActionPanelTokens
-            highlighted: actionPanel.open && !launcher.footerMenuOpen
+            highlighted: actionPanel.open
             onClicked: actionPanel.toggle()
         }
     }

--- a/src/server/src/qml/qml/Footer.qml
+++ b/src/server/src/qml/qml/Footer.qml
@@ -53,7 +53,7 @@ Item {
             Layout.alignment: Qt.AlignVCenter
             label: "Actions"
             shortcutTokens: Keybinds.toggleActionPanelTokens
-            highlighted: actionPanel.open
+            highlighted: actionPanel.open && !launcher.footerMenuOpen
             onClicked: actionPanel.toggle()
         }
     }

--- a/src/server/src/qml/qml/Footer.qml
+++ b/src/server/src/qml/qml/Footer.qml
@@ -14,7 +14,9 @@ Item {
 
             FooterNavStatus {
                 visible: !launcher.toastActive
+                clickable: launcher.isRootSearch
                 anchors.verticalCenter: parent.verticalCenter
+                onClicked: launcher.openFooterMenu()
             }
 
             FooterToast {

--- a/src/server/src/qml/qml/FooterNavStatus.qml
+++ b/src/server/src/qml/qml/FooterNavStatus.qml
@@ -1,22 +1,60 @@
 import QtQuick
 
-Row {
-    spacing: 6
+Item {
+    id: root
 
-    ViciImage {
-        width: 20
-        height: 20
-        source: launcher.navigationIcon
-        visible: launcher.navigationIcon.valid
+    property bool clickable: false
+
+    signal clicked
+
+    readonly property int buttonSize: 26
+
+    implicitWidth: clickable ? 20 : row.implicitWidth
+    implicitHeight: Math.max(row.implicitHeight, clickable ? 26 : 0)
+
+    Rectangle {
+        visible: root.clickable && (mouseArea.containsMouse || launcher.footerMenuOpen)
+        x: -Math.round((root.buttonSize - root.width) / 2)
         anchors.verticalCenter: parent.verticalCenter
+        width: root.buttonSize
+        height: root.buttonSize
+        radius: 6
+        color: Theme.listItemHoverBg
     }
 
-    Text {
-        text: launcher.navigationTitle
-        color: Theme.textMuted
-        font.family: Theme.fontFamily
-        font.pointSize: Theme.smallerFontSize
+    Row {
+        id: row
+        anchors.left: parent.left
         anchors.verticalCenter: parent.verticalCenter
-        visible: launcher.navigationTitle !== ""
+        spacing: 6
+
+        ViciImage {
+            width: 20
+            height: 20
+            source: root.clickable ? Img.builtin("vicinae").withFillColor(Theme.textMuted) : launcher.navigationIcon
+            visible: root.clickable || launcher.navigationIcon.valid
+            anchors.verticalCenter: parent.verticalCenter
+        }
+
+        Text {
+            text: launcher.navigationTitle
+            color: Theme.textMuted
+            font.family: Theme.fontFamily
+            font.pointSize: Theme.smallerFontSize
+            anchors.verticalCenter: parent.verticalCenter
+            visible: launcher.navigationTitle !== ""
+        }
+    }
+
+    MouseArea {
+        id: mouseArea
+        x: -Math.round((root.buttonSize - root.width) / 2)
+        anchors.verticalCenter: parent.verticalCenter
+        width: root.buttonSize
+        height: root.buttonSize
+        enabled: root.clickable
+        hoverEnabled: enabled
+        cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+        onClicked: root.clicked()
     }
 }

--- a/src/server/src/qml/qml/FooterNavStatus.qml
+++ b/src/server/src/qml/qml/FooterNavStatus.qml
@@ -13,7 +13,7 @@ Item {
     implicitHeight: Math.max(row.implicitHeight, clickable ? 26 : 0)
 
     Rectangle {
-        visible: root.clickable && (mouseArea.containsMouse || launcher.footerMenuOpen)
+        visible: root.clickable && (mouseArea.containsMouse || footerPanel.open)
         x: -Math.round((root.buttonSize - root.width) / 2)
         anchors.verticalCenter: parent.verticalCenter
         width: root.buttonSize

--- a/src/server/src/qml/qml/LauncherWindow.qml
+++ b/src/server/src/qml/qml/LauncherWindow.qml
@@ -196,7 +196,16 @@ Window {
         ActionPanelPopover {
             id: actionPanelPopover
             z: 100
-            alignLeft: launcher.footerMenuOpen
+            controller: actionPanel
+            anchors.fill: parent
+            anchors.bottomMargin: footer.height + 1 + Config.borderWidth
+        }
+
+        ActionPanelPopover {
+            id: footerMenuPopover
+            z: 100
+            controller: footerPanel
+            alignLeft: true
             anchors.fill: parent
             anchors.bottomMargin: footer.height + 1 + Config.borderWidth
         }
@@ -280,7 +289,7 @@ Window {
 
     Shortcut {
         sequence: "Escape"
-        enabled: !launcher.alertModel.visible && !actionPanel.open && !launcher.hasOverlay
+        enabled: !launcher.alertModel.visible && !actionPanel.open && !footerPanel.open && !launcher.hasOverlay
         onActivated: launcher.handleEscape()
     }
 

--- a/src/server/src/qml/qml/LauncherWindow.qml
+++ b/src/server/src/qml/qml/LauncherWindow.qml
@@ -196,6 +196,7 @@ Window {
         ActionPanelPopover {
             id: actionPanelPopover
             z: 100
+            alignLeft: launcher.footerMenuOpen
             anchors.fill: parent
             anchors.bottomMargin: footer.height + 1 + Config.borderWidth
         }

--- a/src/server/src/qml/vicinae-store-view-host.cpp
+++ b/src/server/src/qml/vicinae-store-view-host.cpp
@@ -56,6 +56,12 @@ void VicinaeStoreViewHost::handleFinished() {
                        QStringLiteral("Extensions"));
 }
 
+QString VicinaeStoreViewHost::initialNavigationTitle() const { return QStringLiteral("Extension Store"); }
+
+ImageURL VicinaeStoreViewHost::initialNavigationIcon() const {
+  return ImageURL::builtin("cart").setBackgroundTint(SemanticColor::Accent);
+}
+
 void VicinaeStoreViewHost::refresh() {
   if (auto *cached = m_store->cached()) {
     m_section.setEntries(*cached, context()->services->extensionRegistry(), QStringLiteral("Extensions"));

--- a/src/server/src/qml/vicinae-store-view-host.hpp
+++ b/src/server/src/qml/vicinae-store-view-host.hpp
@@ -3,6 +3,7 @@
 #include "vicinae-store-model.hpp"
 #include "bridge-view.hpp"
 #include "services/extension-store/vicinae-store.hpp"
+#include "ui/image/url.hpp"
 #include <QFutureWatcher>
 
 class VicinaeStoreViewHost : public ViewHostBase {
@@ -20,6 +21,8 @@ public:
   void loadInitialData() override;
   void textChanged(const QString &text) override;
   void onReactivated() override;
+  QString initialNavigationTitle() const override;
+  ImageURL initialNavigationIcon() const override;
 
   QObject *listModel() const { return const_cast<SectionListModel *>(&m_model); }
 

--- a/src/server/src/ui/views/base-view.cpp
+++ b/src/server/src/ui/views/base-view.cpp
@@ -27,11 +27,10 @@ void BaseView::setProxy(BaseView *proxy) {
 }
 
 void BaseView::clearActions() {
-  for (auto *view : m_actionPanelStack) {
-    view->onUnmount();
-    view->deleteLater();
+  if (m_rootPanel) {
+    m_rootPanel->deleteLater();
+    m_rootPanel = nullptr;
   }
-  m_actionPanelStack.clear();
 
   if (m_ctx) { m_ctx->navigation->notifyActionPanelChanged(m_navProxy); }
 }
@@ -43,49 +42,15 @@ void BaseView::setActions(std::unique_ptr<ActionPanelState> actions) {
 }
 
 void BaseView::setActions(ActionPanelView *view) {
-  for (auto *old : m_actionPanelStack) {
-    old->onUnmount();
-    old->deleteLater();
-  }
-  m_actionPanelStack.clear();
+  if (m_rootPanel) { m_rootPanel->deleteLater(); }
 
-  if (view) {
-    view->setParent(this);
-    m_actionPanelStack.push_back(view);
-    view->onMount();
-  }
+  m_rootPanel = view;
+  if (view) { view->setParent(this); }
 
   if (m_ctx) { m_ctx->navigation->notifyActionPanelChanged(m_navProxy); }
 }
 
-ActionPanelView *BaseView::actionPanelRoot() const {
-  return m_actionPanelStack.empty() ? nullptr : m_actionPanelStack.front();
-}
-
-void BaseView::pushActionPanelView(ActionPanelView *view) {
-  if (!view) return;
-  view->setParent(this);
-  m_actionPanelStack.push_back(view);
-  view->onMount();
-}
-
-void BaseView::popActionPanelView() {
-  if (m_actionPanelStack.size() <= 1) return;
-  auto *view = m_actionPanelStack.back();
-  view->onUnmount();
-  view->deleteLater();
-  m_actionPanelStack.pop_back();
-}
-
-void BaseView::clearActionPanelStack() {
-  if (m_actionPanelStack.size() <= 1) return;
-  for (size_t i = m_actionPanelStack.size() - 1; i >= 1; --i) {
-    m_actionPanelStack[i]->onUnmount();
-    m_actionPanelStack[i]->deleteLater();
-  }
-  m_actionPanelStack.resize(1);
-  if (auto *root = actionPanelRoot()) { root->resetState(); }
-}
+ActionPanelView *BaseView::actionPanelRoot() const { return m_rootPanel; }
 
 bool BaseView::supportsSearch() const { return true; }
 

--- a/src/server/src/ui/views/base-view.hpp
+++ b/src/server/src/ui/views/base-view.hpp
@@ -26,10 +26,6 @@ public:
   void clearActions();
 
   ActionPanelView *actionPanelRoot() const;
-  const std::vector<ActionPanelView *> &actionPanelStack() const { return m_actionPanelStack; }
-  void pushActionPanelView(ActionPanelView *view);
-  void popActionPanelView();
-  void clearActionPanelStack();
 
   virtual bool supportsSearch() const;
   virtual bool searchInteractive() const;
@@ -97,5 +93,5 @@ private:
   CommandController *m_cmd = nullptr;
 
   const BaseView *m_navProxy = this;
-  std::vector<ActionPanelView *> m_actionPanelStack;
+  ActionPanelView *m_rootPanel = nullptr;
 };


### PR DESCRIPTION
- Make the bottom-left Vicinae footer logo clickable on the root search view.
- Open the existing action panel from the logo with app-level actions: settings, shortcuts, store, docs, bug report, about, and quit.
- The action panel can now align left for this footer menu while preserving the normal right-aligned Actions button behavior.