### PR TITLE
feat: make root search view a proper view

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -454,6 +454,8 @@ set(SRCS
 	src/qml/keybind-bridge.hpp
 	src/qml/launcher-window.hpp
 	src/qml/launcher-window.cpp
+	src/qml/root-view-host.hpp
+	src/qml/root-view-host.cpp
 	src/qml/root-search-model.hpp
 	src/qml/root-search-model.cpp
 	src/qml/root-search-sources.hpp

--- a/src/server/src/cli/server.cpp
+++ b/src/server/src/cli/server.cpp
@@ -358,9 +358,9 @@ int startServer(const ServerLaunchOptions &launchOpts) {
 
   configChanged(cfgService->value(), {});
 
-  ctx.navigation->launch(std::make_shared<RootCommand>());
-
   LauncherWindow const qmlWindow(ctx);
+
+  ctx.navigation->launch(std::make_shared<RootCommand>());
 
   if (launchOpts.open) {
     ctx.navigation->showWindow();

--- a/src/server/src/qml/launcher-window.cpp
+++ b/src/server/src/qml/launcher-window.cpp
@@ -10,7 +10,6 @@
 #include "bridge-view.hpp"
 #include "image-source.hpp"
 #include "image-url.hpp"
-#include "root-search-model.hpp"
 #include "config-bridge.hpp"
 #include "theme-bridge.hpp"
 #include "navigation-controller.hpp"
@@ -57,15 +56,12 @@ LauncherWindow::LauncherWindow(ApplicationContext &ctx, QObject *parent)
   QGuiApplication::setDesktopFileName(QStringLiteral("vicinae"));
 #endif
 
-  m_searchModel = new RootSearchModel(ViewScope(&ctx, ctx.navigation->topState()->sender), this);
-
   qRegisterMetaType<ImageUrl>("ImageUrl");
 
   m_engine.addImageProvider(QStringLiteral("vicinae"), new AsyncImageProvider());
 
   auto *rootCtx = m_engine.rootContext();
   rootCtx->setContextProperty(QStringLiteral("Nav"), ctx.navigation.get());
-  rootCtx->setContextProperty(QStringLiteral("searchModel"), m_searchModel);
   rootCtx->setContextProperty(QStringLiteral("Theme"), m_themeBridge);
   rootCtx->setContextProperty(QStringLiteral("Config"), m_configBridge);
   rootCtx->setContextProperty(QStringLiteral("Img"), m_imgSource);
@@ -382,39 +378,23 @@ void LauncherWindow::handleCurrentViewChanged() {
   m_viewWasPopped = false;
   m_viewWasReplaced = false;
 
-  if (nav->viewStackSize() == 1) {
-    disconnect(m_searchAccessoryConnection);
-    if (!m_searchAccessoryUrl.isEmpty()) {
-      m_searchAccessoryUrl.clear();
-      emit searchAccessoryChanged();
-    }
-    if (m_commandViewHost) {
-      m_commandViewHost = nullptr;
-      emit commandViewHostChanged();
-    }
-    if (!m_isRootSearch) {
-      m_isRootSearch = true;
-      emit isRootSearchChanged();
-    }
-    if (!m_showBackButton) {
-      m_showBackButton = true;
-      emit showBackButtonChanged();
-    }
-    if (m_overrideWidth != 0 || m_overrideHeight != 0) {
-      m_overrideWidth = 0;
-      m_overrideHeight = 0;
-      emit windowSizeOverrideChanged();
-    }
-    emit commandStackCleared();
-    tryCompaction();
-    return;
-  }
-
   auto *state = nav->topState();
   if (!state || !state->sender) return;
 
   auto *bridge = dynamic_cast<ViewHostBase *>(state->sender);
   if (!bridge) return;
+
+  bool const isRoot = nav->viewStackSize() == 1;
+  if (m_atRoot != isRoot) {
+    m_atRoot = isRoot;
+    emit atRootChanged();
+  }
+
+  if (m_overrideWidth != 0 || m_overrideHeight != 0) {
+    m_overrideWidth = 0;
+    m_overrideHeight = 0;
+    emit windowSizeOverrideChanged();
+  }
 
   disconnect(m_searchAccessoryConnection);
   m_searchAccessoryConnection =
@@ -446,11 +426,6 @@ void LauncherWindow::handleCurrentViewChanged() {
   } else {
     bridge->onReactivated();
   }
-
-  if (m_isRootSearch) {
-    m_isRootSearch = false;
-    emit isRootSearchChanged();
-  }
   tryCompaction();
 }
 
@@ -459,13 +434,7 @@ void LauncherWindow::forwardSearchText(const QString &text) {
   tryCompaction();
 }
 
-void LauncherWindow::handleReturn() {
-  if (!m_isRootSearch) {
-    m_actionPanel->executePrimaryAction();
-  } else {
-    m_searchModel->activateSelected();
-  }
-}
+void LauncherWindow::handleReturn() { m_actionPanel->executePrimaryAction(); }
 
 bool LauncherWindow::forwardKey(int key, int modifiers) {
   auto mods = static_cast<Qt::KeyboardModifiers>(modifiers);
@@ -536,8 +505,6 @@ void LauncherWindow::popToRoot() {
 }
 
 bool LauncherWindow::popOnBackspace() { return m_ctx.services->config()->value().popOnBackspace; }
-
-bool LauncherWindow::tryAliasFastTrack() { return m_searchModel->tryAliasFastTrack(); }
 
 int LauncherWindow::matchNavigationKey(int key, int modifiers) {
   return KeyBindingService::matchNavigation(key, modifiers, m_ctx.services->config()->value().keybinding);

--- a/src/server/src/qml/launcher-window.hpp
+++ b/src/server/src/qml/launcher-window.hpp
@@ -13,7 +13,6 @@ class ConfigBridge;
 class HudBridge;
 class ImageSource;
 class KeybindBridge;
-class RootSearchModel;
 class ThemeBridge;
 class ViewHostBase;
 class QQuickWindow;
@@ -22,7 +21,7 @@ class DialogContentWidget;
 
 class LauncherWindow : public QObject {
   Q_OBJECT
-  Q_PROPERTY(bool isRootSearch READ isRootSearch NOTIFY isRootSearchChanged)
+  Q_PROPERTY(bool atRoot READ atRoot NOTIFY atRootChanged)
   Q_PROPERTY(bool showBackButton READ showBackButton NOTIFY showBackButtonChanged)
   Q_PROPERTY(QString searchPlaceholder READ searchPlaceholder NOTIFY searchPlaceholderChanged)
   Q_PROPERTY(QUrl searchAccessoryUrl READ searchAccessoryUrl NOTIFY searchAccessoryChanged)
@@ -55,7 +54,7 @@ class LauncherWindow : public QObject {
 public:
   explicit LauncherWindow(ApplicationContext &ctx, QObject *parent = nullptr);
 
-  bool isRootSearch() const { return m_isRootSearch; }
+  bool atRoot() const { return m_atRoot; }
   bool showBackButton() const { return m_showBackButton; }
   QString searchPlaceholder() const { return m_searchPlaceholder; }
   QUrl searchAccessoryUrl() const { return m_searchAccessoryUrl; }
@@ -93,7 +92,6 @@ public:
   Q_INVOKABLE void handleEscape();
   Q_INVOKABLE void goBack();
   Q_INVOKABLE void popToRoot();
-  Q_INVOKABLE bool tryAliasFastTrack();
   Q_INVOKABLE int matchNavigationKey(int key, int modifiers);
   Q_INVOKABLE void setCompleterValue(int index, const QString &value);
   Q_INVOKABLE QRect cursorScreenGeometry() const;
@@ -101,7 +99,7 @@ public:
 
 signals:
   void compactedChanged();
-  void isRootSearchChanged();
+  void atRootChanged();
   void showBackButtonChanged();
   void searchPlaceholderChanged();
   void searchAccessoryChanged();
@@ -111,7 +109,6 @@ signals:
   void commandViewPushed(const QUrl &componentUrl, const QVariantMap &properties);
   void commandViewReplaced(const QUrl &componentUrl, const QVariantMap &properties);
   void commandViewPopped();
-  void commandStackCleared();
   void navigationStatusChanged();
   void toastActiveChanged();
   void toastChanged();
@@ -149,10 +146,9 @@ private:
   ThemeBridge *m_themeBridge;
 
   QQmlApplicationEngine m_engine;
-  RootSearchModel *m_searchModel;
   QQuickWindow *m_window = nullptr;
   bool m_compacted = false;
-  bool m_isRootSearch = true;
+  bool m_atRoot = true;
   bool m_showBackButton = true;
   bool m_isLoading = false;
   bool m_searchVisible = true;

--- a/src/server/src/qml/qml/ClipboardFilterAccessory.qml
+++ b/src/server/src/qml/qml/ClipboardFilterAccessory.qml
@@ -20,7 +20,7 @@ SearchableDropdown {
     currentItem: {
         var idx = launcher.commandViewHost ? launcher.commandViewHost.currentKindFilter : 0;
         return {
-            id: idx.toString(),
+            id: idx?.toString() ?? 'unknown',
             displayName: _options[idx]
         };
     }

--- a/src/server/src/qml/qml/ClipboardHistoryView.qml
+++ b/src/server/src/qml/qml/ClipboardHistoryView.qml
@@ -7,16 +7,19 @@ Item {
     required property var host
 
     function moveUp() {
-        listView.moveUp();
+        return listView.moveUp();
     }
+
     function moveDown() {
-        listView.moveDown();
+        return listView.moveDown();
     }
+
     function moveSectionUp() {
-        listView.moveSectionUp();
+        return listView.moveSectionUp();
     }
+
     function moveSectionDown() {
-        listView.moveSectionDown();
+        return listView.moveSectionDown();
     }
 
     ColumnLayout {

--- a/src/server/src/qml/qml/Footer.qml
+++ b/src/server/src/qml/qml/Footer.qml
@@ -14,7 +14,7 @@ Item {
 
             FooterNavStatus {
                 visible: !launcher.toastActive
-                clickable: launcher.isRootSearch
+                clickable: launcher.atRoot
                 anchors.verticalCenter: parent.verticalCenter
                 onClicked: launcher.openFooterMenu()
             }
@@ -28,14 +28,10 @@ Item {
 
         FooterButton {
             id: primaryButton
-            visible: {
-                if (!launcher.isRootSearch)
-                    return actionPanel.primaryActionTitle !== "";
-                return searchModel.primaryActionTitle !== "";
-            }
+            visible: actionPanel.primaryActionTitle !== ""
             Layout.alignment: Qt.AlignVCenter
-            label: !launcher.isRootSearch ? actionPanel.primaryActionTitle : searchModel.primaryActionTitle
-            shortcutTokens: !launcher.isRootSearch ? actionPanel.primaryActionShortcutTokens : searchModel.primaryActionShortcutTokens
+            label: actionPanel.primaryActionTitle
+            shortcutTokens: actionPanel.primaryActionShortcutTokens
             onClicked: launcher.handleReturn()
         }
 

--- a/src/server/src/qml/qml/LauncherWindow.qml
+++ b/src/server/src/qml/qml/LauncherWindow.qml
@@ -164,7 +164,6 @@ Window {
                     id: commandStack
                     anchors.fill: parent
                     visible: !launcher.compacted
-                    initialItem: RootSearchList {}
                 }
             }
 
@@ -249,10 +248,6 @@ Window {
         function onCommandViewPopped() {
             if (commandStack.depth > 1)
                 commandStack.pop(StackView.Immediate);
-        }
-        function onCommandStackCleared() {
-            if (commandStack.depth > 1)
-                commandStack.pop(null, StackView.Immediate);
         }
         function onOverlayChanged() {
             if (launcher.hasOverlay) {

--- a/src/server/src/qml/qml/RootSearchList.qml
+++ b/src/server/src/qml/qml/RootSearchList.qml
@@ -3,10 +3,11 @@ import QtQuick.Controls
 
 GenericListView {
     id: searchListView
-    model: searchModel
-    listModel: searchModel
+    required property var cmdModel
+    model: cmdModel
+    listModel: cmdModel
     autoWireModel: true
-    selectFirstOnReset: searchModel.selectFirstOnReset
+    selectFirstOnReset: cmdModel.selectFirstOnReset
 
     delegate: Loader {
         id: delegateLoader

--- a/src/server/src/qml/qml/SearchBar.qml
+++ b/src/server/src/qml/qml/SearchBar.qml
@@ -19,7 +19,7 @@ Item {
 
         SourceBlendRect {
             id: backButton
-            visible: !launcher.isRootSearch && launcher.showBackButton
+            visible: launcher.showBackButton
             Layout.preferredWidth: 28
             Layout.preferredHeight: 28
             Layout.alignment: Qt.AlignVCenter
@@ -126,8 +126,6 @@ Item {
                 function _syncSearchText() {
                     const value = Config.considerPreedit ? searchInput.displayText : searchInput.text;
                     launcher.forwardSearchText(value);
-                    if (launcher.isRootSearch)
-                        searchModel.setFilter(value);
                 }
 
                 function _handleEmacsEditing(event) {
@@ -309,13 +307,11 @@ Item {
                         event.accepted = true;
                     } else if (_handleNavigation(event)) {
                         event.accepted = true;
-                    } else if (event.key === Qt.Key_Backspace && searchInput.text === "" && !event.isAutoRepeat && !launcher.isRootSearch && launcher.showBackButton && launcher.popOnBackspace) {
+                    } else if (event.key === Qt.Key_Backspace && searchInput.text === "" && !event.isAutoRepeat && launcher.showBackButton && launcher.popOnBackspace) {
                         launcher.goBack();
                         event.accepted = true;
-                    } else if (event.key === Qt.Key_Space && launcher.isRootSearch && event.modifiers === Qt.NoModifier) {
-                        if (launcher.tryAliasFastTrack()) {
-                            event.accepted = true;
-                        }
+                    } else if (event.key === Qt.Key_Space && event.modifiers === Qt.NoModifier && launcher.commandViewHost?.tryAliasFastTrack()) {
+                        event.accepted = true;
                     } else if (launcher.forwardKey(event.key, event.modifiers)) {
                         if (launcher.compacted)
                             launcher.expand();
@@ -378,12 +374,8 @@ Item {
                 searchInput.forceActiveFocus();
         }
         function onSearchTextUpdated(text) {
-            if (searchInput.text !== text) {
+            if (searchInput.text !== text)
                 searchInput.text = text;
-                if (launcher.isRootSearch) {
-                    searchModel.setFilter(text);
-                }
-            }
         }
         function onViewNavigatedBack() {
             root.focusInput();

--- a/src/server/src/qml/qml/SearchableDropdown.qml
+++ b/src/server/src/qml/qml/SearchableDropdown.qml
@@ -68,7 +68,7 @@ Item {
             }
 
             Text {
-                text: root.currentItem ? root.currentItem.displayName : root.placeholder
+                text: root.currentItem?.displayName ?? root.placeholder ?? ""
                 color: !compact && !root.currentItem ? Theme.textPlaceholder : Theme.foreground
                 font.pointSize: compact ? Theme.smallerFontSize : Theme.regularFontSize
                 elide: Text.ElideRight

--- a/src/server/src/qml/root-search-model.cpp
+++ b/src/server/src/qml/root-search-model.cpp
@@ -163,7 +163,7 @@ void RootSearchModel::setSelectedIndex(int index) {
   if (!dataItemAt(index, sourceIdx, itemIdx)) {
     if (!oldId.isEmpty()) scope().destroyCurrentCompletion();
     m_lastCompleterItemId.clear();
-    emit primaryActionChanged();
+
     return;
   }
 
@@ -191,8 +191,6 @@ void RootSearchModel::setSelectedIndex(int index) {
 
     if (!createdCompleter) scope().destroyCurrentCompletion();
   }
-
-  emit primaryActionChanged();
 }
 
 bool RootSearchModel::tryAliasFastTrack() {
@@ -215,37 +213,6 @@ bool RootSearchModel::tryAliasFastTrack() {
 
   activateSelected();
   return true;
-}
-
-QString RootSearchModel::primaryActionTitle() const {
-  auto *state = scope().topState();
-  if (!state) return {};
-  auto *root = state->sender->actionPanelRoot();
-  if (!root) return {};
-  auto *action = root->primaryAction();
-  return action ? action->title() : QString();
-}
-
-QString RootSearchModel::primaryActionIcon() const {
-  auto *state = scope().topState();
-  if (!state) return {};
-  auto *root = state->sender->actionPanelRoot();
-  if (!root) return {};
-  auto *action = root->primaryAction();
-  if (!action) return {};
-  auto icon = action->icon();
-  return icon ? qml::imageSourceFor(*icon) : QString();
-}
-
-QVariantList RootSearchModel::primaryActionShortcutTokens() const {
-  auto *state = scope().topState();
-  if (!state) return {};
-  auto *root = state->sender->actionPanelRoot();
-  if (!root) return {};
-  auto *action = root->primaryAction();
-  if (!action) return {};
-  auto shortcut = action->shortcut().value_or(Keyboard::Shortcut::enter());
-  return shortcut.toDisplayTokens();
 }
 
 void RootSearchModel::startCalculator() {

--- a/src/server/src/qml/root-search-model.hpp
+++ b/src/server/src/qml/root-search-model.hpp
@@ -17,13 +17,6 @@ class Manager;
 
 class RootSearchModel : public SectionListModel {
   Q_OBJECT
-  Q_PROPERTY(QString primaryActionTitle READ primaryActionTitle NOTIFY primaryActionChanged)
-  Q_PROPERTY(QString primaryActionIcon READ primaryActionIcon NOTIFY primaryActionChanged)
-  Q_PROPERTY(
-      QVariantList primaryActionShortcutTokens READ primaryActionShortcutTokens NOTIFY primaryActionChanged)
-
-signals:
-  void primaryActionChanged();
 
 public:
   using CalculatorWatcher = QFutureWatcher<AbstractCalculatorBackend::ComputeResult>;
@@ -34,10 +27,6 @@ public:
   Q_INVOKABLE void setFilter(const QString &text);
   void setSelectedIndex(int index) override;
   Q_INVOKABLE bool tryAliasFastTrack();
-
-  QString primaryActionTitle() const;
-  QString primaryActionIcon() const;
-  QVariantList primaryActionShortcutTokens() const;
 
 private:
   void refresh();

--- a/src/server/src/qml/root-view-host.cpp
+++ b/src/server/src/qml/root-view-host.cpp
@@ -1,0 +1,45 @@
+#include "root-view-host.hpp"
+#include "root-search-model.hpp"
+#include "section-source.hpp"
+#include "view-scope.hpp"
+
+void RootViewHost::initialize() {
+  BaseView::initialize();
+  m_model = new RootSearchModel(ViewScope(context(), this), this);
+
+  connect(m_model, &SectionListModel::itemSelected, this, [this](SectionSource *source, int itemIdx) {
+    if (auto panel = source->actionPanel(itemIdx))
+      setActions(std::move(panel));
+    else
+      clearActions();
+  });
+
+  connect(m_model, &SectionListModel::selectionCleared, this, [this]() { clearActions(); });
+
+  m_model->setFilter({});
+}
+
+QUrl RootViewHost::qmlComponentUrl() const { return QUrl(QStringLiteral("qrc:/Vicinae/RootSearchList.qml")); }
+
+QVariantMap RootViewHost::qmlProperties() {
+  return {{QStringLiteral("cmdModel"), QVariant::fromValue(static_cast<QObject *>(m_model))}};
+}
+
+void RootViewHost::textChanged(const QString &text) {
+  if (m_model) m_model->setFilter(text);
+}
+
+void RootViewHost::onReactivated() {
+  if (m_model) m_model->refreshActionPanel();
+}
+
+void RootViewHost::beforePop() {
+  if (m_model) m_model->beforePop();
+}
+
+QObject *RootViewHost::listModel() const { return m_model; }
+
+bool RootViewHost::tryAliasFastTrack() {
+  if (!m_model) return false;
+  return m_model->tryAliasFastTrack();
+}

--- a/src/server/src/qml/root-view-host.hpp
+++ b/src/server/src/qml/root-view-host.hpp
@@ -1,11 +1,26 @@
 #pragma once
 #include "bridge-view.hpp"
 
-/// Minimal view host for the root navigation frame.
-/// The actual root search UI is provided by RootSearchModel inside the QML launcher.
-/// This host only exists so that the navigation stack has a valid BaseView at the bottom.
+class RootSearchModel;
+
 class RootViewHost : public ViewHostBase {
+  Q_OBJECT
+  Q_PROPERTY(QObject *listModel READ listModel CONSTANT)
+
 public:
-  QUrl qmlComponentUrl() const override { return {}; }
+  QUrl qmlComponentUrl() const override;
+  QVariantMap qmlProperties() override;
   QString initialSearchPlaceholderText() const override { return QStringLiteral("Search for anything..."); }
+  bool showBackButton() const override { return false; }
+
+  void initialize() override;
+  void textChanged(const QString &text) override;
+  void onReactivated() override;
+  void beforePop() override;
+
+  QObject *listModel() const;
+  Q_INVOKABLE bool tryAliasFastTrack();
+
+private:
+  RootSearchModel *m_model = nullptr;
 };


### PR DESCRIPTION
for historical reasons we used to consider the root search view as a special kind of view directly tied to the launcher window. It didn't make much sense so this PR fixes that. It's now a view like any other, automatically pushed as the first view and not popable.