### PR TITLE
style: proper alpha blending for borders, simplify back button

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -797,6 +797,7 @@ set(VICINAE_QML_FILES
 	src/qml/qml/ViciButton.qml
 	src/qml/qml/ViciImage.qml
 	src/qml/qml/ViciScrollBar.qml
+	src/qml/qml/ViciDivider.qml
 	src/qml/qml/ViciToolTip.qml
 	src/qml/qml/ExtensionView.qml
 	src/qml/qml/MarkdownDetailView.qml

--- a/src/server/src/qml/config-bridge.hpp
+++ b/src/server/src/qml/config-bridge.hpp
@@ -50,6 +50,10 @@ public:
   bool activateOnSingleClick() const { return cfg().activateOnSingleClick; }
   bool blurEnabled() const { return cfg().launcherWindow.blur.enabled; }
 
+  Q_INVOKABLE static QColor withAlpha(const QColor &c, qreal alpha) {
+    return QColor::fromRgbF(c.redF(), c.greenF(), c.blueF(), alpha);
+  }
+
 private:
   static const config::ConfigValue &cfg() { return ServiceRegistry::instance()->config()->value(); }
 };

--- a/src/server/src/qml/qml/ActionPanelPopover.qml
+++ b/src/server/src/qml/qml/ActionPanelPopover.qml
@@ -77,7 +77,7 @@ FocusRestoringScope {
             anchors.fill: parent
             radius: Config.borderRounding
             color: Qt.rgba(Theme.statusBarBackground.r, Theme.statusBarBackground.g, Theme.statusBarBackground.b, 1)
-            border.color: Theme.mainWindowBorder
+            border.color: Config.withAlpha(Theme.mainWindowBorder, Config.windowOpacity)
             border.width: 1
 
             MouseArea {

--- a/src/server/src/qml/qml/AlertDialog.qml
+++ b/src/server/src/qml/qml/AlertDialog.qml
@@ -67,7 +67,7 @@ Popup {
     background: Rectangle {
         radius: 6
         color: Qt.rgba(Theme.secondaryBackground.r, Theme.secondaryBackground.g, Theme.secondaryBackground.b, 0.95)
-        border.color: Theme.divider
+        border.color: Config.withAlpha(Theme.divider, Config.windowOpacity)
         border.width: 1
     }
 

--- a/src/server/src/qml/qml/ArgCompleter.qml
+++ b/src/server/src/qml/qml/ArgCompleter.qml
@@ -82,7 +82,7 @@ RowLayout {
                     radius: 4
                     color: "transparent"
                     border.width: 1
-                    border.color: textDel.showError ? "#e53935" : textField.activeFocus ? Theme.accent : Theme.divider
+                    border.color: Config.withAlpha(textDel.showError ? "#e53935" : textField.activeFocus ? Theme.accent : Theme.divider, Config.windowOpacity)
 
                     function forceActiveFocus() {
                         textField.forceActiveFocus();

--- a/src/server/src/qml/qml/ClipboardHistoryView.qml
+++ b/src/server/src/qml/qml/ClipboardHistoryView.qml
@@ -74,10 +74,8 @@ Item {
             }
         }
 
-        Rectangle {
+        ViciDivider {
             Layout.fillWidth: true
-            implicitHeight: 1
-            color: Theme.divider
         }
 
         GenericListView {

--- a/src/server/src/qml/qml/CompletionPopup.qml
+++ b/src/server/src/qml/qml/CompletionPopup.qml
@@ -91,7 +91,7 @@ Popup {
     background: Rectangle {
         radius: 8
         color: Qt.rgba(Theme.background.r, Theme.background.g, Theme.background.b, 0.95)
-        border.color: Theme.divider
+        border.color: Config.withAlpha(Theme.divider, Config.windowOpacity)
         border.width: 1
     }
 

--- a/src/server/src/qml/qml/DetailPanel.qml
+++ b/src/server/src/qml/qml/DetailPanel.qml
@@ -22,11 +22,9 @@ Item {
             Layout.fillHeight: true
         }
 
-        Rectangle {
+        ViciDivider {
             visible: root._hasMetadata && root.hasContent
             Layout.fillWidth: true
-            implicitHeight: 1
-            color: Theme.divider
         }
 
         MetadataBar {

--- a/src/server/src/qml/qml/ExtensionSettingsPage.qml
+++ b/src/server/src/qml/qml/ExtensionSettingsPage.qml
@@ -92,10 +92,8 @@ Item {
                     implicitHeight: 16
                 }
 
-                Rectangle {
+                ViciDivider {
                     Layout.fillWidth: true
-                    height: 1
-                    color: Theme.divider
                 }
             }
 
@@ -125,10 +123,8 @@ Item {
                     implicitHeight: 16
                 }
 
-                Rectangle {
+                ViciDivider {
                     Layout.fillWidth: true
-                    height: 1
-                    color: Theme.divider
                 }
             }
 
@@ -155,7 +151,7 @@ Item {
                     height: 24
                     radius: 4
                     color: "transparent"
-                    border.color: cmdSearchField.activeFocus ? Theme.inputBorderFocus : Theme.inputBorder
+                    border.color: Config.withAlpha(cmdSearchField.activeFocus ? Theme.inputBorderFocus : Theme.inputBorder, Config.windowOpacity)
                     border.width: 1
 
                     RowLayout {
@@ -300,7 +296,7 @@ Item {
                                 background: Rectangle {
                                     radius: 4
                                     color: "transparent"
-                                    border.color: cmdAliasInput.activeFocus ? Theme.inputBorderFocus : Theme.inputBorder
+                                    border.color: Config.withAlpha(cmdAliasInput.activeFocus ? Theme.inputBorderFocus : Theme.inputBorder, Config.windowOpacity)
                                     border.width: cmdAliasInput.activeFocus || cmdAliasInput.hovered ? 1 : 0
                                 }
 
@@ -320,7 +316,7 @@ Item {
                                 Layout.preferredHeight: 20
                                 radius: 4
                                 color: cmdDelegate.enabled ? Theme.accent : "transparent"
-                                border.color: cmdDelegate.enabled ? Theme.accent : Theme.inputBorder
+                                border.color: Config.withAlpha(cmdDelegate.enabled ? Theme.accent : Theme.inputBorder, Config.windowOpacity)
                                 border.width: 1
 
                                 Text {
@@ -351,14 +347,12 @@ Item {
                             implicitHeight: expandedContent.implicitHeight + 24
                             color: "transparent"
 
-                            Rectangle {
+                            ViciDivider {
                                 anchors.top: parent.top
                                 anchors.left: parent.left
                                 anchors.right: parent.right
                                 anchors.leftMargin: root.sideMargin + 20
                                 anchors.rightMargin: root.sideMargin + 20
-                                height: 1
-                                color: Theme.divider
                             }
 
                             ColumnLayout {
@@ -387,12 +381,9 @@ Item {
                         }
                     }
 
-                    // Row separator
-                    Rectangle {
+                    ViciDivider {
                         visible: cmdDelegate.index < root.extModel.commandModel.count - 1
                         width: parent.width
-                        height: 1
-                        color: Theme.divider
                     }
                 }
             }

--- a/src/server/src/qml/qml/Footer.qml
+++ b/src/server/src/qml/qml/Footer.qml
@@ -40,7 +40,7 @@ Item {
             Layout.alignment: Qt.AlignVCenter
             width: 1
             height: 14
-            color: Theme.divider
+            color: Config.withAlpha(Theme.divider, Config.windowOpacity)
         }
 
         FooterButton {

--- a/src/server/src/qml/qml/FooterToast.qml
+++ b/src/server/src/qml/qml/FooterToast.qml
@@ -35,7 +35,7 @@ RowLayout {
         radius: 6
         color: "transparent"
         border.width: 2
-        border.color: Theme.textMuted
+        border.color: Config.withAlpha(Theme.textMuted, Config.windowOpacity)
 
         Rectangle {
             width: 6

--- a/src/server/src/qml/qml/FormAppSelector.qml
+++ b/src/server/src/qml/qml/FormAppSelector.qml
@@ -65,7 +65,7 @@ ColumnLayout {
             implicitHeight: 32
             radius: 6
             color: "transparent"
-            border.color: Theme.inputBorder
+            border.color: Config.withAlpha(Theme.inputBorder, Config.windowOpacity)
             border.width: 1
 
             RowLayout {

--- a/src/server/src/qml/qml/FormCheckbox.qml
+++ b/src/server/src/qml/qml/FormCheckbox.qml
@@ -42,7 +42,7 @@ Item {
             radius: 4
             Layout.alignment: Qt.AlignVCenter
             color: root.checked ? Theme.accent : "transparent"
-            border.color: root.hasError ? Theme.inputBorderError : root.activeFocus ? Theme.inputBorderFocus : root.checked ? Theme.accent : Theme.inputBorder
+            border.color: Config.withAlpha(root.hasError ? Theme.inputBorderError : root.activeFocus ? Theme.inputBorderFocus : root.checked ? Theme.accent : Theme.inputBorder, Config.windowOpacity)
             border.width: 1
 
             Text {

--- a/src/server/src/qml/qml/FormCompletedTextArea.qml
+++ b/src/server/src/qml/qml/FormCompletedTextArea.qml
@@ -51,7 +51,7 @@ Item {
         anchors.fill: parent
         radius: 8
         color: "transparent"
-        border.color: root.hasError ? Theme.inputBorderError : edit.activeFocus ? Theme.inputBorderFocus : Theme.inputBorder
+        border.color: Config.withAlpha(root.hasError ? Theme.inputBorderError : edit.activeFocus ? Theme.inputBorderFocus : Theme.inputBorder, Config.windowOpacity)
         border.width: 1
 
         MouseArea {

--- a/src/server/src/qml/qml/FormDateInput.qml
+++ b/src/server/src/qml/qml/FormDateInput.qml
@@ -32,7 +32,7 @@ Item {
         anchors.fill: parent
         radius: 8
         color: "transparent"
-        border.color: root.hasError ? Theme.inputBorderError : input.activeFocus ? Theme.inputBorderFocus : Theme.inputBorder
+        border.color: Config.withAlpha(root.hasError ? Theme.inputBorderError : input.activeFocus ? Theme.inputBorderFocus : Theme.inputBorder, Config.windowOpacity)
         border.width: 1
 
         TextInput {

--- a/src/server/src/qml/qml/FormFilePicker.qml
+++ b/src/server/src/qml/qml/FormFilePicker.qml
@@ -116,7 +116,7 @@ FocusScope {
             radius: 8
             opacity: root.readOnly ? 0.5 : 1.0
             color: "transparent"
-            border.color: root.hasError ? Theme.inputBorderError : focusItem.activeFocus ? Theme.inputBorderFocus : Theme.inputBorder
+            border.color: Config.withAlpha(root.hasError ? Theme.inputBorderError : focusItem.activeFocus ? Theme.inputBorderFocus : Theme.inputBorder, Config.windowOpacity)
             border.width: 1
 
             RowLayout {
@@ -178,7 +178,7 @@ FocusScope {
                 implicitHeight: 32
                 radius: 6
                 color: "transparent"
-                border.color: Theme.inputBorder
+                border.color: Config.withAlpha(Theme.inputBorder, Config.windowOpacity)
                 border.width: 1
 
                 RowLayout {

--- a/src/server/src/qml/qml/FormSeparator.qml
+++ b/src/server/src/qml/qml/FormSeparator.qml
@@ -6,5 +6,5 @@ Rectangle {
     Layout.topMargin: 5
     Layout.bottomMargin: 5
     implicitHeight: 1
-    color: Theme.divider
+    color: Config.withAlpha(Theme.divider, Config.windowOpacity)
 }

--- a/src/server/src/qml/qml/FormTextArea.qml
+++ b/src/server/src/qml/qml/FormTextArea.qml
@@ -45,7 +45,7 @@ Item {
         anchors.fill: parent
         radius: 8
         color: "transparent"
-        border.color: root.hasError ? Theme.inputBorderError : edit.activeFocus ? Theme.inputBorderFocus : Theme.inputBorder
+        border.color: Config.withAlpha(root.hasError ? Theme.inputBorderError : edit.activeFocus ? Theme.inputBorderFocus : Theme.inputBorder, Config.windowOpacity)
         border.width: 1
 
         MouseArea {

--- a/src/server/src/qml/qml/FormTextInput.qml
+++ b/src/server/src/qml/qml/FormTextInput.qml
@@ -35,7 +35,7 @@ Item {
         anchors.fill: parent
         radius: 8
         color: "transparent"
-        border.color: root.hasError ? Theme.inputBorderError : input.activeFocus && !root.readOnly ? Theme.inputBorderFocus : Theme.inputBorder
+        border.color: Config.withAlpha(root.hasError ? Theme.inputBorderError : input.activeFocus && !root.readOnly ? Theme.inputBorderFocus : Theme.inputBorder, Config.windowOpacity)
         border.width: 1
         opacity: root.readOnly ? 0.5 : 1.0
 

--- a/src/server/src/qml/qml/GenericListView.qml
+++ b/src/server/src/qml/qml/GenericListView.qml
@@ -191,11 +191,10 @@ Item {
             }
         }
 
-        Rectangle {
+        ViciDivider {
             visible: root._showDetail
+            vertical: true
             Layout.fillHeight: true
-            implicitWidth: 1
-            color: Theme.divider
         }
 
         Loader {

--- a/src/server/src/qml/qml/HorizontalLoadingBar.qml
+++ b/src/server/src/qml/qml/HorizontalLoadingBar.qml
@@ -1,12 +1,15 @@
 import QtQuick
 
-Rectangle {
+Item {
     id: root
     property bool loading: false
     clip: true
-    color: Theme.divider
 
     property bool _active: false
+
+    ViciDivider {
+        anchors.fill: parent
+    }
 
     Rectangle {
         id: bar
@@ -23,7 +26,7 @@ Rectangle {
         property: "x"
         from: -bar.width
         to: root.width
-        duration: (root.width + bar.width) / 10 * 10  // match C++: 10px per 10ms
+        duration: (root.width + bar.width) / 10 * 10
         loops: Animation.Infinite
         running: root._active
     }

--- a/src/server/src/qml/qml/HudWindow.qml
+++ b/src/server/src/qml/qml/HudWindow.qml
@@ -25,7 +25,7 @@ Window {
         height: row.height + 20
         radius: height / 2
         color: Qt.rgba(Theme.background.r, Theme.background.g, Theme.background.b, 0.9)
-        border.color: Theme.divider
+        border.color: Config.withAlpha(Theme.divider, Config.windowOpacity)
         border.width: 1
 
         RowLayout {

--- a/src/server/src/qml/qml/LauncherWindow.qml
+++ b/src/server/src/qml/qml/LauncherWindow.qml
@@ -89,8 +89,16 @@ Window {
             height: 60 + 2 * Config.borderWidth
             radius: root.cornerRadius
             color: Qt.rgba(Theme.background.r, Theme.background.g, Theme.background.b, Config.windowOpacity)
-            border.color: Theme.mainWindowBorder
-            border.width: Config.borderWidth
+        }
+
+        SourceBlendRect {
+            visible: launcher.compacted && !root.nativeChrome
+            width: _w
+            height: 60 + 2 * Config.borderWidth
+            radius: root.cornerRadius
+            overlay: true
+            borderColor: Config.withAlpha(Theme.mainWindowBorder, Config.windowOpacity)
+            borderWidth: Config.borderWidth
         }
 
         Item {
@@ -124,13 +132,13 @@ Window {
             }
         }
 
-        Rectangle {
+        SourceBlendRect {
             visible: !launcher.compacted && !root.nativeChrome
             anchors.fill: parent
             radius: root.cornerRadius
-            color: "transparent"
-            border.color: Theme.mainWindowBorder
-            border.width: Config.borderWidth
+            overlay: true
+            borderColor: Config.withAlpha(Theme.mainWindowBorder, Config.windowOpacity)
+            borderWidth: Config.borderWidth
         }
 
         ColumnLayout {
@@ -167,11 +175,9 @@ Window {
                 }
             }
 
-            Rectangle {
+            ViciDivider {
                 visible: !launcher.compacted && launcher.statusBarVisible
                 Layout.fillWidth: true
-                implicitHeight: 1
-                color: Theme.divider
             }
 
             Footer {

--- a/src/server/src/qml/qml/MarkdownDetailView.qml
+++ b/src/server/src/qml/qml/MarkdownDetailView.qml
@@ -34,11 +34,10 @@ RowLayout {
         contentPadding: 20
     }
 
-    Rectangle {
+    ViciDivider {
         visible: root._hasMarkdown && root._hasMetadata
+        vertical: true
         Layout.fillHeight: true
-        implicitWidth: 1
-        color: Theme.divider
     }
 
     MetadataBar {

--- a/src/server/src/qml/qml/MetadataBar.qml
+++ b/src/server/src/qml/qml/MetadataBar.qml
@@ -237,9 +237,6 @@ Item {
 
     Component {
         id: separatorComponent
-        Rectangle {
-            implicitHeight: 1
-            color: Theme.divider
-        }
+        ViciDivider {}
     }
 }

--- a/src/server/src/qml/qml/SearchBar.qml
+++ b/src/server/src/qml/qml/SearchBar.qml
@@ -17,27 +17,14 @@ Item {
         anchors.rightMargin: 16
         spacing: launcher.hasCompleter ? 4 : 12
 
-        SourceBlendRect {
+        ViciImage {
             id: backButton
             visible: launcher.showBackButton
-            Layout.preferredWidth: 28
-            Layout.preferredHeight: 28
+            Layout.preferredWidth: 22
+            Layout.preferredHeight: 22
             Layout.alignment: Qt.AlignVCenter
-            radius: 6
-            backgroundColor: Qt.rgba(Theme.background.r, Theme.background.g, Theme.background.b, Config.windowOpacity)
-            color: {
-                const base = backHover.hovered ? Theme.listItemHoverBg : Theme.secondaryBackground;
-                return Qt.rgba(base.r, base.g, base.b, Config.windowOpacity);
-            }
-            borderWidth: 1
-            borderColor: Config.withAlpha(Theme.inputBorder, Config.windowOpacity)
-
-            ViciImage {
-                anchors.centerIn: parent
-                source: Img.builtin("chevron-left")
-                width: 14
-                height: 14
-            }
+            source: Img.builtin("chevron-left").withFillColor(Theme.textMuted)
+            opacity: backHover.hovered ? 0.6 : 1.0
 
             HoverHandler {
                 id: backHover
@@ -65,7 +52,7 @@ Item {
                 anchors.fill: parent
                 verticalAlignment: TextInput.AlignVCenter
                 font.family: Theme.fontFamily
-                font.pointSize: Theme.regularFontSize * 1.1
+                font.pointSize: Theme.regularFontSize * 1.15
                 color: Theme.foreground
                 selectionColor: Theme.textSelectionBg
                 selectedTextColor: Theme.textSelectionFg

--- a/src/server/src/qml/qml/SearchBar.qml
+++ b/src/server/src/qml/qml/SearchBar.qml
@@ -30,7 +30,7 @@ Item {
                 return Qt.rgba(base.r, base.g, base.b, Config.windowOpacity);
             }
             borderWidth: 1
-            borderColor: Theme.inputBorder
+            borderColor: Config.withAlpha(Theme.inputBorder, Config.windowOpacity)
 
             ViciImage {
                 anchors.centerIn: parent

--- a/src/server/src/qml/qml/SearchableDropdown.qml
+++ b/src/server/src/qml/qml/SearchableDropdown.qml
@@ -50,7 +50,7 @@ Item {
         height: compact ? 28 : implicitHeight
         radius: compact ? 6 : 8
         color: buttonMouseArea.containsMouse ? Theme.listItemHoverBg : "transparent"
-        border.color: root.hasError ? Theme.inputBorderError : (root.activeFocus || completionPopup.visible ? Theme.inputBorderFocus : (compact ? Theme.divider : Theme.inputBorder))
+        border.color: Config.withAlpha(root.hasError ? Theme.inputBorderError : (root.activeFocus || completionPopup.visible ? Theme.inputBorderFocus : (compact ? Theme.divider : Theme.inputBorder)), Config.windowOpacity)
         border.width: 1
 
         RowLayout {
@@ -106,7 +106,7 @@ Item {
         background: Rectangle {
             radius: 8
             color: Qt.rgba(Theme.background.r, Theme.background.g, Theme.background.b, 0.95)
-            border.color: Theme.divider
+            border.color: Config.withAlpha(Theme.divider, Config.windowOpacity)
             border.width: 1
             BackgroundEffect.enabled: Config.blurEnabled
             BackgroundEffect.radius: 8

--- a/src/server/src/qml/qml/SettingsPreferenceForm.qml
+++ b/src/server/src/qml/qml/SettingsPreferenceForm.qml
@@ -105,7 +105,7 @@ ColumnLayout {
                     iconSource: Img.builtin(field.revealed ? "eye-disabled" : "eye").withFillColor(Theme.textMuted)
                     variant: "ghost"
                     border.width: revealBtn.hovered ? 1 : 0
-                    border.color: Theme.inputBorder
+                    border.color: Config.withAlpha(Theme.inputBorder, Config.windowOpacity)
                     onClicked: field.revealed = !field.revealed
                 }
             }

--- a/src/server/src/qml/qml/SettingsRow.qml
+++ b/src/server/src/qml/qml/SettingsRow.qml
@@ -48,12 +48,10 @@ ColumnLayout {
         }
     }
 
-    Rectangle {
+    ViciDivider {
         visible: root.showSeparator
         Layout.fillWidth: true
         Layout.leftMargin: 20
         Layout.rightMargin: 20
-        height: 1
-        color: Theme.divider
     }
 }

--- a/src/server/src/qml/qml/SettingsSidebar.qml
+++ b/src/server/src/qml/qml/SettingsSidebar.qml
@@ -66,7 +66,7 @@ Item {
                 height: 28
                 radius: 4
                 color: "transparent"
-                border.color: extSearchField.activeFocus ? Theme.inputBorderFocus : Theme.inputBorder
+                border.color: Config.withAlpha(extSearchField.activeFocus ? Theme.inputBorderFocus : Theme.inputBorder, Config.windowOpacity)
                 border.width: 1
 
                 RowLayout {
@@ -127,10 +127,8 @@ Item {
             }
         }
 
-        Rectangle {
+        ViciDivider {
             Layout.fillWidth: true
-            height: 1
-            color: Theme.divider
         }
 
         ListView {
@@ -166,15 +164,13 @@ Item {
                     }
                 }
 
-                Rectangle {
+                ViciDivider {
                     visible: navItem.modelData._kind === "divider"
                     anchors.left: parent.left
                     anchors.right: parent.right
                     anchors.leftMargin: 16
                     anchors.rightMargin: 16
                     anchors.verticalCenter: parent.verticalCenter
-                    height: 1
-                    color: Theme.divider
                 }
 
                 SourceBlendRect {

--- a/src/server/src/qml/qml/SettingsToggle.qml
+++ b/src/server/src/qml/qml/SettingsToggle.qml
@@ -15,7 +15,7 @@ Item {
         radius: 10
         color: root.checked ? Theme.accent : Qt.rgba(Theme.foreground.r, Theme.foreground.g, Theme.foreground.b, 0.2)
         border.width: root.activeFocus ? 1 : 0
-        border.color: Theme.inputBorderFocus
+        border.color: Config.withAlpha(Theme.inputBorderFocus, Config.windowOpacity)
         Behavior on color {
             ColorAnimation {
                 duration: 120

--- a/src/server/src/qml/qml/SettingsWindow.qml
+++ b/src/server/src/qml/qml/SettingsWindow.qml
@@ -60,8 +60,6 @@ Window {
         radius: 10
         Keys.onEscapePressed: settings.close()
         color: Qt.rgba(Theme.background.r, Theme.background.g, Theme.background.b, Config.windowOpacity)
-        border.color: Theme.divider
-        border.width: 1
         clip: true
 
         RowLayout {
@@ -73,10 +71,9 @@ Window {
                 Layout.preferredWidth: 220
             }
 
-            Rectangle {
+            ViciDivider {
+                vertical: true
                 Layout.fillHeight: true
-                width: 1
-                color: Theme.divider
             }
 
             ColumnLayout {
@@ -163,10 +160,8 @@ Window {
                     }
                 }
 
-                Rectangle {
+                ViciDivider {
                     Layout.fillWidth: true
-                    height: 1
-                    color: Theme.divider
                 }
 
                 Loader {
@@ -210,6 +205,14 @@ Window {
                 }
             }
         }
+    }
+
+    SourceBlendRect {
+        anchors.fill: parent
+        radius: 10
+        overlay: true
+        borderColor: Config.withAlpha(Theme.divider, Config.windowOpacity)
+        borderWidth: 1
     }
 
     Component {

--- a/src/server/src/qml/qml/ShortcutRecorderField.qml
+++ b/src/server/src/qml/qml/ShortcutRecorderField.qml
@@ -46,7 +46,7 @@ Popup {
     background: Rectangle {
         radius: 8
         color: Qt.rgba(Theme.secondaryBackground.r, Theme.secondaryBackground.g, Theme.secondaryBackground.b, 0.95)
-        border.color: Theme.divider
+        border.color: Config.withAlpha(Theme.divider, Config.windowOpacity)
         border.width: 1
         BackgroundEffect.enabled: Config.blurEnabled
         BackgroundEffect.radius: 8

--- a/src/server/src/qml/qml/ShortcutsSettingsPage.qml
+++ b/src/server/src/qml/qml/ShortcutsSettingsPage.qml
@@ -91,7 +91,7 @@ Item {
                 height: 24
                 radius: 4
                 color: "transparent"
-                border.color: searchField.activeFocus ? Theme.inputBorderFocus : Theme.inputBorder
+                border.color: Config.withAlpha(searchField.activeFocus ? Theme.inputBorderFocus : Theme.inputBorder, Config.windowOpacity)
                 border.width: 1
 
                 RowLayout {
@@ -139,10 +139,8 @@ Item {
             }
         }
 
-        Rectangle {
+        ViciDivider {
             Layout.fillWidth: true
-            height: 1
-            color: Theme.divider
         }
 
         ListView {
@@ -226,12 +224,10 @@ Item {
                     }
                 }
 
-                Rectangle {
+                ViciDivider {
                     anchors.left: parent.left
                     anchors.right: parent.right
                     anchors.bottom: parent.bottom
-                    height: 1
-                    color: Theme.divider
                 }
             }
         }

--- a/src/server/src/qml/qml/StoreDetailView.qml
+++ b/src/server/src/qml/qml/StoreDetailView.qml
@@ -316,7 +316,7 @@ Item {
                             Rectangle {
                                 anchors.fill: parent
                                 color: "transparent"
-                                border.color: Theme.divider
+                                border.color: Config.withAlpha(Theme.divider, Config.windowOpacity)
                                 border.width: 1
                                 radius: 4
                             }

--- a/src/server/src/qml/qml/StoreListingView.qml
+++ b/src/server/src/qml/qml/StoreListingView.qml
@@ -58,7 +58,6 @@ Item {
                     id: itemDelegate
                     width: delegateLoader.width
                     height: 50
-                    opacity: delegateLoader.compatTier === 2 ? 0.5 : 1.0
                     selected: listView.currentIndex === delegateLoader.index
                     onClicked: listView.currentIndex = delegateLoader.index
                     onActivated: listView.itemActivated(delegateLoader.index)

--- a/src/server/src/qml/qml/ViciButton.qml
+++ b/src/server/src/qml/qml/ViciButton.qml
@@ -39,12 +39,12 @@ Rectangle {
     border.width: root.bordered || root.activeFocus ? 1 : 0
     border.color: {
         if (root.activeFocus)
-            return root.variant === "accent" ? Theme.listItemSelectionFg : Theme.accent;
+            return Config.withAlpha(root.variant === "accent" ? Theme.listItemSelectionFg : Theme.accent, Config.windowOpacity);
         if (!root.bordered)
             return "transparent";
         if (root.variant === "secondary")
-            return Theme.inputBorder;
-        return Theme.divider;
+            return Config.withAlpha(Theme.inputBorder, Config.windowOpacity);
+        return Config.withAlpha(Theme.divider, Config.windowOpacity);
     }
 
     Row {

--- a/src/server/src/qml/qml/ViciDivider.qml
+++ b/src/server/src/qml/qml/ViciDivider.qml
@@ -1,0 +1,8 @@
+import QtQuick
+
+SourceBlendRect {
+    property bool vertical: false
+    implicitWidth: vertical ? 1 : -1
+    implicitHeight: vertical ? -1 : 1
+    color: Config.withAlpha(Theme.divider, Config.windowOpacity)
+}

--- a/src/server/src/qml/qml/ViciToolTip.qml
+++ b/src/server/src/qml/qml/ViciToolTip.qml
@@ -14,7 +14,7 @@ ToolTip {
 
     background: Rectangle {
         color: Qt.rgba(Theme.secondaryBackground.r, Theme.secondaryBackground.g, Theme.secondaryBackground.b, 0.95)
-        border.color: Theme.divider
+        border.color: Config.withAlpha(Theme.divider, Config.windowOpacity)
         border.width: 1
         radius: 4
         BackgroundEffect.enabled: Config.blurEnabled

--- a/src/server/src/qml/qml/markdown/MarkdownView.qml
+++ b/src/server/src/qml/qml/markdown/MarkdownView.qml
@@ -248,7 +248,7 @@ Item {
                 anchors.fill: parent
                 radius: Config.borderRounding
                 color: Qt.rgba(Theme.statusBarBackground.r, Theme.statusBarBackground.g, Theme.statusBarBackground.b, 1)
-                border.color: Theme.mainWindowBorder
+                border.color: Config.withAlpha(Theme.mainWindowBorder, Config.windowOpacity)
                 border.width: 1
             }
         }

--- a/src/server/src/qml/qml/markdown/MdCodeBlock.qml
+++ b/src/server/src/qml/qml/markdown/MdCodeBlock.qml
@@ -20,7 +20,7 @@ Rectangle {
     radius: 6
     color: Qt.rgba(Theme.secondaryBackground.r, Theme.secondaryBackground.g, Theme.secondaryBackground.b, Theme.surfaceOpacity)
     border.width: 1
-    border.color: Theme.divider
+    border.color: Config.withAlpha(Theme.divider, Config.windowOpacity)
 
     ColumnLayout {
         id: col

--- a/src/server/src/qml/qml/markdown/MdTable.qml
+++ b/src/server/src/qml/qml/markdown/MdTable.qml
@@ -20,7 +20,7 @@ Rectangle {
     implicitHeight: tableCol.implicitHeight
     color: "transparent"
     border.width: 1
-    border.color: Theme.divider
+    border.color: Config.withAlpha(Theme.divider, Config.windowOpacity)
     radius: 4
     clip: true
 


### PR DESCRIPTION
Most borders drawn against the main window will now be drawn with the corresponding opacity and, where possible, blend directly with the compositor's background instead of the window background.

![Uploading image.png…]()
