### PR TITLE
fix: icon tinting/masking/fallback and expose fileIcon

### DIFF
--- a/extra/extension-boilerplate/package.json
+++ b/extra/extension-boilerplate/package.json
@@ -32,6 +32,12 @@
 			"mode": "view"
 		},
 		{
+			"name": "icon-transforms",
+			"title": "Icon Transforms",
+			"description": "Apply every transform (tint, mask, fallback) to every icon source type",
+			"mode": "view"
+		},
+		{
 			"name": "controlled-list",
 			"title": "Controlled List",
 			"description": "A list where search is controlled by state",

--- a/extra/extension-boilerplate/src/action-panel-stress.tsx
+++ b/extra/extension-boilerplate/src/action-panel-stress.tsx
@@ -46,7 +46,10 @@ function ReconciliationTest() {
 									title={`Primary — render #${tick}`}
 									icon={Icon.Star}
 									onAction={() =>
-										showToast(Toast.Style.Success, `${item.id} at render ${tick}`)
+										showToast(
+											Toast.Style.Success,
+											`${item.id} at render ${tick}`,
+										)
 									}
 								/>
 								<Action
@@ -215,7 +218,11 @@ function DynamicSubmenuTest() {
 							onOpen={handleSubmenuOpen}
 						>
 							{loadedItems.length === 0 ? (
-								<Action title="Loading..." icon={Icon.Clock} onAction={() => {}} />
+								<Action
+									title="Loading..."
+									icon={Icon.Clock}
+									onAction={() => {}}
+								/>
 							) : (
 								loadedItems.map((item, i) => (
 									<Action
@@ -276,10 +283,7 @@ function LargeActionPanelTest() {
 										title={`${cat} Action ${i + 1}`}
 										icon={Icon.Dot}
 										onAction={() =>
-											showToast(
-												Toast.Style.Success,
-												`${cat} #${i + 1}`,
-											)
+											showToast(Toast.Style.Success, `${cat} #${i + 1}`)
 										}
 									/>
 								))}
@@ -364,9 +368,7 @@ function StressTest() {
 												key={a.title}
 												title={`${a.title} — tick ${tick}`}
 												icon={a.icon}
-												onAction={() =>
-													showToast(Toast.Style.Success, a.title)
-												}
+												onAction={() => showToast(Toast.Style.Success, a.title)}
 											/>
 										))}
 									</ActionPanel.Section>
@@ -386,7 +388,10 @@ function StressTest() {
 									)}
 								</>
 							)}
-							<ActionPanel.Submenu title={`Submenu (phase ${phase})`} icon={Icon.List}>
+							<ActionPanel.Submenu
+								title={`Submenu (phase ${phase})`}
+								icon={Icon.List}
+							>
 								{actions.map((a) => (
 									<Action
 										key={a.title}

--- a/extra/extension-boilerplate/src/form.tsx
+++ b/extra/extension-boilerplate/src/form.tsx
@@ -185,10 +185,7 @@ export default function FormElements() {
 				id="singleFile"
 				title="(single file)"
 				onChange={(files) =>
-					showToast(
-						Toast.Style.Success,
-						`Selected ${files.length} file(s)`,
-					)
+					showToast(Toast.Style.Success, `Selected ${files.length} file(s)`)
 				}
 			/>
 
@@ -198,10 +195,7 @@ export default function FormElements() {
 				title="(multiple files)"
 				allowMultipleSelection={true}
 				onChange={(files) =>
-					showToast(
-						Toast.Style.Success,
-						`Selected ${files.length} file(s)`,
-					)
+					showToast(Toast.Style.Success, `Selected ${files.length} file(s)`)
 				}
 			/>
 

--- a/extra/extension-boilerplate/src/icon-transforms.tsx
+++ b/extra/extension-boilerplate/src/icon-transforms.tsx
@@ -1,0 +1,137 @@
+import { Color, Icon, Image, List } from "@vicinae/api";
+import { DATA_URI_PNG_BASE64, DATA_URI_SVG_BASE64 } from "./constants";
+
+const HTTP_URL = "https://raycast.com/uploads/avatar.png";
+const ASSET = "transparent_icon.png";
+const THEMED = {
+	light: "https://docs.vicinae.com/vicinae.svg",
+	dark: "https://docs.vicinae.com/vicinae-dark.svg",
+};
+
+const TEXT_FILE = "/etc/hostname";
+const EXECUTABLE = "/usr/bin/ls";
+const DIRECTORY = "/tmp";
+const MISSING_FILE = "/this/path/does/not/exist.zzz";
+
+const OPAQUE_SQUARE = `data:image/svg+xml;utf8,${encodeURIComponent(
+	`<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'><rect width='64' height='64' fill='#a78bfa'/></svg>`,
+)}`;
+
+type Variant = {
+	key: string;
+	title: string;
+	// biome-ignore lint/suspicious/noExplicitAny: ImageLike is a union; this command spreads
+	// arbitrary props on top, which doesn't narrow cleanly without per-case branching.
+	icon: any;
+};
+
+const sources: Variant[] = [
+	{ key: "opaque-square", title: "Opaque square (SVG)", icon: OPAQUE_SQUARE },
+	{ key: "enum", title: "Icon enum", icon: Icon.AppWindowGrid3x3 },
+	{ key: "emoji", title: "Emoji", icon: "🐢" },
+	{ key: "url", title: "URL (HTTP)", icon: HTTP_URL },
+	{ key: "asset", title: "Asset", icon: ASSET },
+	{ key: "datauri-svg", title: "Data URI (SVG)", icon: DATA_URI_SVG_BASE64 },
+	{ key: "datauri-png", title: "Data URI (PNG)", icon: DATA_URI_PNG_BASE64 },
+	{ key: "themed", title: "Themed source", icon: { source: THEMED } },
+	{
+		key: "file-text",
+		title: "File icon (text)",
+		icon: { fileIcon: TEXT_FILE },
+	},
+	{
+		key: "file-exe",
+		title: "File icon (executable)",
+		icon: { fileIcon: EXECUTABLE },
+	},
+	{
+		key: "file-dir",
+		title: "File icon (directory)",
+		icon: { fileIcon: DIRECTORY },
+	},
+];
+
+const withProps = (variant: Variant, extra: Record<string, unknown>) => {
+	const isObj =
+		typeof variant.icon === "object" &&
+		variant.icon !== null &&
+		!Array.isArray(variant.icon);
+	const base = isObj ? variant.icon : { source: variant.icon };
+	return { ...base, ...extra };
+};
+
+const renderRow = (variant: Variant, transform: Record<string, unknown>) => (
+	<List.Item
+		key={variant.key}
+		title={variant.title}
+		icon={withProps(variant, transform)}
+	/>
+);
+
+export default function IconTransforms() {
+	return (
+		<List>
+			<List.Section title="Baseline (no transforms)">
+				{sources.map((v) => (
+					<List.Item key={v.key} title={v.title} icon={v.icon} />
+				))}
+			</List.Section>
+
+			<List.Section title="Mask: Circle">
+				{sources.map((v) => renderRow(v, { mask: Image.Mask.Circle }))}
+			</List.Section>
+
+			<List.Section title="Mask: RoundedRectangle">
+				{sources.map((v) =>
+					renderRow(v, { mask: Image.Mask.RoundedRectangle }),
+				)}
+			</List.Section>
+
+			<List.Section title="Tint: solid (red)">
+				{sources.map((v) => renderRow(v, { tintColor: Color.Red }))}
+			</List.Section>
+
+			<List.Section title="Tint: themed (light=blue, dark=yellow)">
+				{sources.map((v) =>
+					renderRow(v, {
+						tintColor: { light: Color.Blue, dark: Color.Yellow },
+					}),
+				)}
+			</List.Section>
+
+			<List.Section title="Tint + Circle mask (green)">
+				{sources.map((v) =>
+					renderRow(v, {
+						tintColor: Color.Green,
+						mask: Image.Mask.Circle,
+					}),
+				)}
+			</List.Section>
+
+			<List.Section title="Fallback chains">
+				<List.Item
+					title="Bad asset → Icon enum"
+					icon={{ source: "nope.png", fallback: Icon.QuestionMarkCircle }}
+				/>
+				<List.Item
+					title="Bad URL → Asset"
+					icon={{
+						source: "https://example.invalid/nope.png",
+						fallback: ASSET,
+					}}
+				/>
+				<List.Item
+					title="Bad URL → themed"
+					icon={{
+						source: "https://example.invalid/nope.png",
+						fallback: THEMED,
+					}}
+				/>
+				<List.Item
+					title="File icon for missing path"
+					icon={{ fileIcon: MISSING_FILE }}
+				/>
+			</List.Section>
+		</List>
+	);
+}

--- a/extra/extension-boilerplate/src/list.tsx
+++ b/extra/extension-boilerplate/src/list.tsx
@@ -1,4 +1,11 @@
-import { Action, ActionPanel, Icon, List, showToast, Toast } from "@vicinae/api";
+import {
+	Action,
+	ActionPanel,
+	Icon,
+	List,
+	showToast,
+	Toast,
+} from "@vicinae/api";
 
 export default function SimpleList() {
 	return (
@@ -16,15 +23,19 @@ export default function SimpleList() {
 									title="Copy emoji"
 									content={fruit.emoji}
 								/>
-								<Action 
-									title="test toast" 
-									onAction={async () => {
-										const toast = await showToast(Toast.Style.Success, 'title', 'selected successfully');
-										setTimeout(() => toast.hide(), 500);
-									}
-								} />
 								<Action
-									shortcut={{key: 'arrowUp', modifiers: ['shift']}}
+									title="test toast"
+									onAction={async () => {
+										const toast = await showToast(
+											Toast.Style.Success,
+											"title",
+											"selected successfully",
+										);
+										setTimeout(() => toast.hide(), 500);
+									}}
+								/>
+								<Action
+									shortcut={{ key: "arrowUp", modifiers: ["shift"] }}
 									title="Custom action"
 									icon={Icon.Cog}
 									onAction={() =>

--- a/extra/extension-boilerplate/src/nested-form.tsx
+++ b/extra/extension-boilerplate/src/nested-form.tsx
@@ -12,7 +12,9 @@ import {
 
 function SubmitResult({ values }: { values: Record<string, unknown> }) {
 	const json = JSON.stringify(values, null, 2);
-	return <Detail markdown={`# Submitted values\n\n\`\`\`json\n${json}\n\`\`\``} />;
+	return (
+		<Detail markdown={`# Submitted values\n\n\`\`\`json\n${json}\n\`\`\``} />
+	);
 }
 
 function NestedForm({ item }: { item: string }) {

--- a/extra/extension-boilerplate/src/torture.tsx
+++ b/extra/extension-boilerplate/src/torture.tsx
@@ -17,8 +17,17 @@ import { useState, useEffect } from "react";
 // Helpers
 // ---------------------------------------------------------------------------
 
-const COLORS = [Color.Red, Color.Blue, Color.Green, Color.Yellow, Color.Orange, Color.Purple, Color.Magenta];
-const colorAt = (i: number) => COLORS[((i % COLORS.length) + COLORS.length) % COLORS.length];
+const COLORS = [
+	Color.Red,
+	Color.Blue,
+	Color.Green,
+	Color.Yellow,
+	Color.Orange,
+	Color.Purple,
+	Color.Magenta,
+];
+const colorAt = (i: number) =>
+	COLORS[((i % COLORS.length) + COLORS.length) % COLORS.length];
 
 function useTick(ms: number) {
 	const [tick, setTick] = useState(0);
@@ -45,7 +54,9 @@ function ViewTypeSwapper() {
 	const tick = useTick(500);
 
 	const cycle = () =>
-		setKind((prev) => VIEW_ORDER[(VIEW_ORDER.indexOf(prev) + 1) % VIEW_ORDER.length]);
+		setKind(
+			(prev) => VIEW_ORDER[(VIEW_ORDER.indexOf(prev) + 1) % VIEW_ORDER.length],
+		);
 
 	useEffect(() => {
 		if (!autoCycle) return;
@@ -55,7 +66,11 @@ function ViewTypeSwapper() {
 
 	const actions = (
 		<ActionPanel>
-			<Action title="Cycle View Type" icon={Icon.ArrowClockwise} onAction={cycle} />
+			<Action
+				title="Cycle View Type"
+				icon={Icon.ArrowClockwise}
+				onAction={cycle}
+			/>
 			<Action
 				title={autoCycle ? "Stop Auto-Cycle" : "Start Auto-Cycle (2 s)"}
 				icon={Icon.Clock}
@@ -68,7 +83,10 @@ function ViewTypeSwapper() {
 	switch (kind) {
 		case "list":
 			return (
-				<List navigationTitle={`Hot-Swap: List (t${tick})`} searchBarPlaceholder="List mode...">
+				<List
+					navigationTitle={`Hot-Swap: List (t${tick})`}
+					searchBarPlaceholder="List mode..."
+				>
 					<List.Section title="View Type Swapper">
 						<List.Item
 							title="Current: List"
@@ -81,7 +99,9 @@ function ViewTypeSwapper() {
 							<List.Item
 								key={`pad-${i}`}
 								title={`Filler ${i} (tick ${tick})`}
-								accessories={[{ tag: { color: colorAt(tick + i), value: `${tick}` } }]}
+								accessories={[
+									{ tag: { color: colorAt(tick + i), value: `${tick}` } },
+								]}
 								actions={actions}
 							/>
 						))}
@@ -90,7 +110,11 @@ function ViewTypeSwapper() {
 			);
 		case "grid":
 			return (
-				<Grid navigationTitle={`Hot-Swap: Grid (t${tick})`} columns={4} searchBarPlaceholder="Grid mode...">
+				<Grid
+					navigationTitle={`Hot-Swap: Grid (t${tick})`}
+					columns={4}
+					searchBarPlaceholder="Grid mode..."
+				>
 					<Grid.Section title="View Type Swapper">
 						{Array.from({ length: 8 }, (_, i) => (
 							<Grid.Item
@@ -122,9 +146,21 @@ function ViewTypeSwapper() {
 		case "form":
 			return (
 				<Form navigationTitle={`Hot-Swap: Form (t${tick})`} actions={actions}>
-					<Form.Description title="View Type Swapper" text={`Tick ${tick} — press Enter to cycle back to List.`} />
-					<Form.TextField id="f1" title="Auto-updating" value={`Value at tick ${tick}`} />
-					<Form.Checkbox id="c1" title="Toggle" label={`Tick is even: ${tick % 2 === 0}`} value={tick % 2 === 0} />
+					<Form.Description
+						title="View Type Swapper"
+						text={`Tick ${tick} — press Enter to cycle back to List.`}
+					/>
+					<Form.TextField
+						id="f1"
+						title="Auto-updating"
+						value={`Value at tick ${tick}`}
+					/>
+					<Form.Checkbox
+						id="c1"
+						title="Toggle"
+						label={`Tick is even: ${tick % 2 === 0}`}
+						value={tick % 2 === 0}
+					/>
 					<Form.Dropdown id="d1" title="Color" defaultValue="red">
 						{COLORS.map((c) => (
 							<Form.Dropdown.Item key={c} value={c} title={c} />
@@ -157,7 +193,12 @@ function DynamicReactivity() {
 			subtitle: `Phase ${phase}`,
 			accessories: [
 				{ tag: { color: colorAt(tick + i), value: `T${tick}` } },
-				{ text: { color: colorAt(tick + i + 3), value: `#${(tick * (i + 1)) % 100}` } },
+				{
+					text: {
+						color: colorAt(tick + i + 3),
+						value: `#${(tick * (i + 1)) % 100}`,
+					},
+				},
 			] as List.Item.Accessory[],
 		};
 	});
@@ -185,7 +226,11 @@ function DynamicReactivity() {
 						}
 						actions={
 							<ActionPanel>
-								<Action title="Add Item" icon={Icon.Plus} onAction={() => setItemCount((c) => c + 1)} />
+								<Action
+									title="Add Item"
+									icon={Icon.Plus}
+									onAction={() => setItemCount((c) => c + 1)}
+								/>
 								<Action
 									title="Remove Item"
 									icon={Icon.Minus}
@@ -199,7 +244,11 @@ function DynamicReactivity() {
 
 			{tick % 6 < 3 && (
 				<List.Section title={`Bonus Section (appears/disappears)`}>
-					<List.Item title="I come and go" subtitle={`tick ${tick}`} icon={Icon.Eye} />
+					<List.Item
+						title="I come and go"
+						subtitle={`tick ${tick}`}
+						icon={Icon.Eye}
+					/>
 				</List.Section>
 			)}
 		</List>
@@ -241,12 +290,19 @@ function MutatingChild({ label, depth }: { label: string; depth: number }) {
 							<Action
 								title={`Push Deeper (depth ${depth + 1})`}
 								icon={Icon.ArrowRight}
-								onAction={() => push(<MutatingChild label={`Child`} depth={depth + 1} />)}
+								onAction={() =>
+									push(<MutatingChild label={`Child`} depth={depth + 1} />)
+								}
 							/>
 							<Action
 								title="Toast from here"
 								icon={Icon.Bubble}
-								onAction={() => showToast(Toast.Style.Success, `From ${label} D${depth} T${tick}`)}
+								onAction={() =>
+									showToast(
+										Toast.Style.Success,
+										`From ${label} D${depth} T${tick}`,
+									)
+								}
 							/>
 						</ActionPanel>
 					}
@@ -255,7 +311,9 @@ function MutatingChild({ label, depth }: { label: string; depth: number }) {
 					<List.Item
 						key={`f-${i}`}
 						title={`Filler ${i} (t${tick})`}
-						accessories={[{ tag: { color: colorAt(tick + i), value: `D${depth}` } }]}
+						accessories={[
+							{ tag: { color: colorAt(tick + i), value: `D${depth}` } },
+						]}
 					/>
 				))}
 			</List.Section>
@@ -270,7 +328,10 @@ function BackgroundMutation() {
 
 	// swap root view type every 5 seconds
 	useEffect(() => {
-		const id = setInterval(() => setRootKind((v) => (v === "list" ? "grid" : "list")), 5000);
+		const id = setInterval(
+			() => setRootKind((v) => (v === "list" ? "grid" : "list")),
+			5000,
+		);
 		return () => clearInterval(id);
 	}, []);
 
@@ -280,7 +341,11 @@ function BackgroundMutation() {
 
 	const actions = (
 		<ActionPanel>
-			<Action title="Push Mutating Child" icon={Icon.ArrowRight} onAction={pushStack} />
+			<Action
+				title="Push Mutating Child"
+				icon={Icon.ArrowRight}
+				onAction={pushStack}
+			/>
 		</ActionPanel>
 	);
 
@@ -324,7 +389,9 @@ function BackgroundMutation() {
 					<List.Item
 						key={`rl-${i}`}
 						title={`Root filler ${i} (t${tick})`}
-						accessories={[{ tag: { color: colorAt(tick + i + 1), value: `${tick}` } }]}
+						accessories={[
+							{ tag: { color: colorAt(tick + i + 1), value: `${tick}` } },
+						]}
 					/>
 				))}
 			</List.Section>
@@ -348,7 +415,11 @@ function ChaosChild({ depth }: { depth: number }) {
 	// swap view type every 3 s
 	useEffect(() => {
 		const id = setInterval(
-			() => setKind((prev) => VIEW_ORDER[(VIEW_ORDER.indexOf(prev) + 1) % VIEW_ORDER.length]),
+			() =>
+				setKind(
+					(prev) =>
+						VIEW_ORDER[(VIEW_ORDER.indexOf(prev) + 1) % VIEW_ORDER.length],
+				),
 			3000 + depth * 500,
 		);
 		return () => clearInterval(id);
@@ -371,7 +442,10 @@ function ChaosChild({ depth }: { depth: number }) {
 				title="Force Cycle View"
 				icon={Icon.ArrowClockwise}
 				onAction={() =>
-					setKind((prev) => VIEW_ORDER[(VIEW_ORDER.indexOf(prev) + 1) % VIEW_ORDER.length])
+					setKind(
+						(prev) =>
+							VIEW_ORDER[(VIEW_ORDER.indexOf(prev) + 1) % VIEW_ORDER.length],
+					)
 				}
 			/>
 		</ActionPanel>
@@ -382,13 +456,19 @@ function ChaosChild({ depth }: { depth: number }) {
 	switch (kind) {
 		case "list":
 			return (
-				<List navigationTitle={navTitle} searchBarPlaceholder={`Chaos list D${depth} t${tick}`} isLoading={loading}>
+				<List
+					navigationTitle={navTitle}
+					searchBarPlaceholder={`Chaos list D${depth} t${tick}`}
+					isLoading={loading}
+				>
 					<List.Section title={`Chaos D${depth} List (t${tick})`}>
 						{Array.from({ length: 4 }, (_, i) => (
 							<List.Item
 								key={`cl-${i}`}
 								title={`D${depth} Item ${i} [t${tick}]`}
-								accessories={[{ tag: { color: colorAt(tick + i), value: kind } }]}
+								accessories={[
+									{ tag: { color: colorAt(tick + i), value: kind } },
+								]}
 								actions={actions}
 							/>
 						))}
@@ -397,7 +477,12 @@ function ChaosChild({ depth }: { depth: number }) {
 			);
 		case "grid":
 			return (
-				<Grid navigationTitle={navTitle} columns={3} searchBarPlaceholder={`Chaos grid D${depth}`} isLoading={loading}>
+				<Grid
+					navigationTitle={navTitle}
+					columns={3}
+					searchBarPlaceholder={`Chaos grid D${depth}`}
+					isLoading={loading}
+				>
 					<Grid.Section title={`Chaos D${depth} Grid (t${tick})`}>
 						{Array.from({ length: 6 }, (_, i) => (
 							<Grid.Item
@@ -421,8 +506,15 @@ function ChaosChild({ depth }: { depth: number }) {
 		case "form":
 			return (
 				<Form navigationTitle={navTitle} isLoading={loading} actions={actions}>
-					<Form.Description title={`Chaos D${depth}`} text={`Tick ${tick}, swapping in ${3 - (tick % 3)} s`} />
-					<Form.TextField id="chaos" title="Field" value={`D${depth} T${tick}`} />
+					<Form.Description
+						title={`Chaos D${depth}`}
+						text={`Tick ${tick}, swapping in ${3 - (tick % 3)} s`}
+					/>
+					<Form.TextField
+						id="chaos"
+						title="Field"
+						value={`D${depth} T${tick}`}
+					/>
 				</Form>
 			);
 	}
@@ -435,7 +527,11 @@ function CombinedChaos() {
 
 	useEffect(() => {
 		const id = setInterval(
-			() => setKind((prev) => VIEW_ORDER[(VIEW_ORDER.indexOf(prev) + 1) % VIEW_ORDER.length]),
+			() =>
+				setKind(
+					(prev) =>
+						VIEW_ORDER[(VIEW_ORDER.indexOf(prev) + 1) % VIEW_ORDER.length],
+				),
 			4000,
 		);
 		return () => clearInterval(id);
@@ -456,7 +552,11 @@ function CombinedChaos() {
 	switch (kind) {
 		case "list":
 			return (
-				<List navigationTitle={navTitle} searchBarPlaceholder={`Root list chaos t${tick}`} isLoading={tick % 8 < 2}>
+				<List
+					navigationTitle={navTitle}
+					searchBarPlaceholder={`Root list chaos t${tick}`}
+					isLoading={tick % 8 < 2}
+				>
 					<List.Section title={`Chaos Root (t${tick})`}>
 						<List.Item
 							title="Push to start chaos stack"
@@ -469,7 +569,12 @@ function CombinedChaos() {
 			);
 		case "grid":
 			return (
-				<Grid navigationTitle={navTitle} columns={4} searchBarPlaceholder={`Root grid chaos`} isLoading={tick % 8 < 2}>
+				<Grid
+					navigationTitle={navTitle}
+					columns={4}
+					searchBarPlaceholder={`Root grid chaos`}
+					isLoading={tick % 8 < 2}
+				>
 					<Grid.Section title={`Chaos Root Grid (t${tick})`}>
 						{Array.from({ length: 4 }, (_, i) => (
 							<Grid.Item
@@ -492,8 +597,15 @@ function CombinedChaos() {
 			);
 		case "form":
 			return (
-				<Form navigationTitle={navTitle} isLoading={tick % 8 < 2} actions={actions}>
-					<Form.Description title="Chaos Root" text={`Tick ${tick}. Push to start chaos stack.`} />
+				<Form
+					navigationTitle={navTitle}
+					isLoading={tick % 8 < 2}
+					actions={actions}
+				>
+					<Form.Description
+						title="Chaos Root"
+						text={`Tick ${tick}. Push to start chaos stack.`}
+					/>
 				</Form>
 			);
 	}
@@ -505,7 +617,10 @@ function CombinedChaos() {
 
 export default function Torture() {
 	return (
-		<List searchBarPlaceholder="Pick a torture test..." navigationTitle="Torture Tests">
+		<List
+			searchBarPlaceholder="Pick a torture test..."
+			navigationTitle="Torture Tests"
+		>
 			<List.Section title="Edge Case Tests">
 				<List.Item
 					title="View Type Hot-Swap"

--- a/figura/tsapi.fig
+++ b/figura/tsapi.fig
@@ -52,10 +52,11 @@ struct ColorLike {
 };
 
 struct Image {
-  source: ImageSource;
+  source?: ImageSource;
   fallback?: ImageSource;
   mask?: ImageMask;
   tintColor?: ColorLike;
+  fileIcon?: string;
 };
 
 // UI Service

--- a/src/server/src/extend/model-deser.cpp
+++ b/src/server/src/extend/model-deser.cpp
@@ -66,7 +66,7 @@ struct ImageObjectWire {
   std::optional<ImageSourceVariant> source;
   std::optional<ImageSourceVariant> fallback;
   std::optional<ColorLikeWire> tintColor;
-  std::optional<std::string> mask;
+  std::optional<OmniPainter::ImageMaskType> mask;
   std::optional<std::string> fileIcon;
 };
 
@@ -99,7 +99,7 @@ struct GridContentObjWire {
   std::optional<ImageSourceVariant> source;
   std::optional<ImageSourceVariant> fallback;
   std::optional<ColorLikeWire> tintColor;
-  std::optional<std::string> mask;
+  std::optional<OmniPainter::ImageMaskType> mask;
   std::optional<std::string> fileIcon;
 };
 
@@ -110,7 +110,7 @@ struct ImageWrappedObjWire {
   std::optional<ImageSourceVariant> source;
   std::optional<ImageSourceVariant> fallback;
   std::optional<ColorLikeWire> tintColor;
-  std::optional<std::string> mask;
+  std::optional<OmniPainter::ImageMaskType> mask;
   std::optional<std::string> fileIcon;
 };
 
@@ -130,7 +130,7 @@ template <> struct glz::meta<GridInset> {
 template <> struct glz::meta<OmniPainter::ImageMaskType> {
   using enum OmniPainter::ImageMaskType;
   static constexpr auto value =
-      glz::enumerate("circle", CircleMask, "roundedRectangle", RoundedRectangleMask);
+      glz::enumerate("None", NoMask, "Circle", CircleMask, "RoundedRectangle", RoundedRectangleMask);
 };
 
 struct ShortcutObjWire {
@@ -440,7 +440,7 @@ static ImageLikeModel toImageLike(ImageLikeWire v) {
           model.source = toImageSource(std::move(*w.source));
           if (w.fallback) model.fallback = toImageSource(std::move(*w.fallback));
           if (w.tintColor) model.tintColor = toColorLike(std::move(*w.tintColor));
-          if (w.mask) model.mask = OmniPainter::maskForName(toQStr(*w.mask));
+          if (w.mask) model.mask = *w.mask;
           return model;
         }
         if (w.fileIcon) return ExtensionFileIconModel{.file = *w.fileIcon};
@@ -468,7 +468,7 @@ static ImageLikeModel toImageWrapped(ImageWrappedWire v) {
           model.source = toImageSource(std::move(*w.source));
           if (w.fallback) model.fallback = toImageSource(std::move(*w.fallback));
           if (w.tintColor) model.tintColor = toColorLike(std::move(*w.tintColor));
-          if (w.mask) model.mask = OmniPainter::maskForName(toQStr(*w.mask));
+          if (w.mask) model.mask = *w.mask;
           return model;
         }
         if (w.fileIcon) return ExtensionFileIconModel{.file = *w.fileIcon};
@@ -489,7 +489,7 @@ static GridItemViewModel::Content toGridContent(GridContentWire v, std::optional
           model.source = toImageSource(std::move(*w.source));
           if (w.fallback) model.fallback = toImageSource(std::move(*w.fallback));
           if (w.tintColor) model.tintColor = toColorLike(std::move(*w.tintColor));
-          if (w.mask) model.mask = OmniPainter::maskForName(toQStr(*w.mask));
+          if (w.mask) model.mask = *w.mask;
           return model;
         }
         if (w.fileIcon) return ExtensionFileIconModel{.file = *w.fileIcon};

--- a/src/server/src/extension/services/tsapi-image.hpp
+++ b/src/server/src/extension/services/tsapi-image.hpp
@@ -4,6 +4,8 @@
 
 struct TsapiImage {
   static ImageURL parse(const tsapi::Image &image) {
+    if (image.fileIcon) { return ImageURL::fileIcon(*image.fileIcon); }
+
     ExtensionImageModel model;
 
     if (image.tintColor) {
@@ -36,12 +38,14 @@ struct TsapiImage {
       }
     }
 
-    if (image.source.raw) {
-      model.source = QString::fromStdString(*image.source.raw);
-    } else if (image.source.themed) {
-      model.source =
-          ThemedIconSource{.light = QString::fromStdString(image.source.themed->light.value_or("")),
-                           .dark = QString::fromStdString(image.source.themed->dark.value_or(""))};
+    if (image.source) {
+      if (image.source->raw) {
+        model.source = QString::fromStdString(*image.source->raw);
+      } else if (image.source->themed) {
+        model.source =
+            ThemedIconSource{.light = QString::fromStdString(image.source->themed->light.value_or("")),
+                             .dark = QString::fromStdString(image.source->themed->dark.value_or(""))};
+      }
     }
 
     if (image.fallback) {

--- a/src/server/src/qml/async-image-provider.cpp
+++ b/src/server/src/qml/async-image-provider.cpp
@@ -555,10 +555,7 @@ QQuickImageResponse *AsyncImageProvider::requestImageResponse(const QString &id,
   static const QString DEFAULT_FALLBACK =
       QStringLiteral("builtin:") + BuiltinIconService::nameForIcon(BuiltinIconService::unknownIcon());
 
-  if (!parsed.fallback.isEmpty())
-    response->setFallback(parsed.fallback, size);
-  else if (parsed.type != QStringLiteral("builtin"))
-    response->setFallback(DEFAULT_FALLBACK, size);
+  response->setFallback(parsed.fallback.isEmpty() ? DEFAULT_FALLBACK : parsed.fallback, size);
 
   dispatchForId(response, id, size);
   return response;

--- a/src/server/src/qml/async-image-provider.cpp
+++ b/src/server/src/qml/async-image-provider.cpp
@@ -16,6 +16,7 @@
 #include <QImageReader>
 #include <QPainter>
 #include <QQuickTextureFactory>
+#include <QMimeDatabase>
 #include <QSvgRenderer>
 #include <QFutureWatcher>
 #include <QtMath>
@@ -447,6 +448,38 @@ QQuickImageResponse *AsyncImageProvider::requestImageResponse(const QString &id,
         response->finish(std::move(img));
       });
     }
+
+  } else if (parsed.type == QStringLiteral("file-icon")) {
+    QString const path = parsed.name;
+    QColor const explicitFg = parsed.fg;
+    QColor const defaultFg = ThemeService::instance().theme().resolve(SemanticColor::Foreground);
+    QColor const bg = parsed.bg;
+    bool const circle = parsed.circleMask;
+    imageDecodingPool().start([response, path, size, explicitFg, defaultFg, bg, circle]() {
+      if (response->isCancelled()) {
+        response->finish({});
+        return;
+      }
+
+      QMimeDatabase const db;
+      auto const mime = db.mimeTypeForFile(path, QMimeDatabase::MatchDefault);
+
+      QImage img = renderSystemIcon(mime.iconName(), size);
+      if (img.isNull()) img = renderSystemIcon(mime.genericIconName(), size);
+
+      if (img.isNull()) {
+        QString const builtinName = mime.name() == QStringLiteral("inode/directory")
+                                        ? QStringLiteral("folder")
+                                        : QStringLiteral("blank-document");
+        QColor const fg = explicitFg.isValid() ? explicitFg : defaultFg;
+        img = renderBuiltinSvg(builtinName, size, fg, bg);
+      } else if (explicitFg.isValid()) {
+        applyFillColor(img, explicitFg);
+      }
+
+      if (circle && !img.isNull()) applyCircleMask(img);
+      response->finish(std::move(img));
+    });
 
   } else if (parsed.type == QStringLiteral("http")) {
     QString url = parsed.name;

--- a/src/server/src/qml/async-image-provider.cpp
+++ b/src/server/src/qml/async-image-provider.cpp
@@ -274,21 +274,46 @@ static void applyCircleMask(QImage &image) {
   image = masked;
 }
 
-static void applyPostTransforms(QImage &image, const QColor &fg, bool circleMask) {
+static void applyRoundedRectMask(QImage &image) {
+  QImage masked(image.size(), QImage::Format_ARGB32_Premultiplied);
+  masked.fill(Qt::transparent);
+  QPainter painter(&masked);
+  painter.setRenderHint(QPainter::Antialiasing, true);
+  painter.setBrush(Qt::white);
+  painter.setPen(Qt::NoPen);
+  int const side = qMin(masked.width(), masked.height());
+  qreal const radius = side * 0.25;
+  painter.drawRoundedRect(masked.rect(), radius, radius);
+  painter.setCompositionMode(QPainter::CompositionMode_SourceIn);
+  painter.drawImage(0, 0, image);
+  image = masked;
+}
+
+static void applyPostTransforms(QImage &image, const QColor &fg, OmniPainter::ImageMaskType mask) {
   if (image.isNull()) return;
   if (fg.isValid()) applyFillColor(image, fg);
-  if (circleMask) applyCircleMask(image);
+  switch (mask) {
+  case OmniPainter::CircleMask:
+    applyCircleMask(image);
+    break;
+  case OmniPainter::RoundedRectangleMask:
+    applyRoundedRectMask(image);
+    break;
+  case OmniPainter::NoMask:
+    break;
+  }
 }
 
 template <typename Render>
-static void dispatchRender(ViciImageResponse *response, QColor fg, bool circleMask, Render render) {
-  imageDecodingPool().start([response, fg, circleMask, render = std::move(render)]() {
+static void dispatchRender(ViciImageResponse *response, QColor fg, OmniPainter::ImageMaskType mask,
+                           Render render) {
+  imageDecodingPool().start([response, fg, mask, render = std::move(render)]() {
     if (response->isCancelled()) {
       response->finish({});
       return;
     }
     QImage img = render();
-    applyPostTransforms(img, fg, circleMask);
+    applyPostTransforms(img, fg, mask);
     response->finish(std::move(img));
   });
 }
@@ -298,7 +323,7 @@ struct ParsedId {
   QString name;
   QColor fg;
   QColor bg;
-  bool circleMask = false;
+  OmniPainter::ImageMaskType mask = OmniPainter::NoMask;
   QString fallback;
 };
 
@@ -312,8 +337,8 @@ static void parseParams(const QString &str, QChar sep, ParsedId &result) {
       result.fg = QColor(val);
     else if (key == QStringLiteral("bg"))
       result.bg = QColor(val);
-    else if (key == QStringLiteral("mask") && val == QStringLiteral("circle"))
-      result.circleMask = true;
+    else if (key == QStringLiteral("mask"))
+      result.mask = OmniPainter::maskForName(val);
     else if (key == QStringLiteral("fallback"))
       result.fallback = val;
   }
@@ -362,10 +387,10 @@ void ViciImageResponse::tryFallback(QImage &image) {
     QColor const fg =
         fb.fg.isValid() ? fb.fg : ThemeService::instance().theme().resolve(SemanticColor::Foreground);
     image = renderBuiltinSvg(fb.name, m_size, fg, fb.bg);
-    applyPostTransforms(image, QColor(), fb.circleMask);
+    applyPostTransforms(image, QColor(), fb.mask);
   } else if (fb.type == QStringLiteral("system")) {
     image = renderSystemIcon(fb.name, m_size);
-    applyPostTransforms(image, fb.fg, fb.circleMask);
+    applyPostTransforms(image, fb.fg, fb.mask);
   }
 }
 
@@ -387,42 +412,41 @@ QQuickImageResponse *AsyncImageProvider::requestImageResponse(const QString &id,
     response->setFallback(DEFAULT_FALLBACK, size);
 
   QColor const fg = parsed.fg;
-  bool const circle = parsed.circleMask;
+  auto const mask = parsed.mask;
 
   if (parsed.type == QStringLiteral("builtin")) {
     QColor builtinFg = fg;
     if (!builtinFg.isValid()) builtinFg = ThemeService::instance().theme().resolve(SemanticColor::Foreground);
     QColor const bg = parsed.bg;
-    dispatchRender(response, QColor(), circle, [name = parsed.name, size, builtinFg, bg]() {
+    dispatchRender(response, QColor(), mask, [name = parsed.name, size, builtinFg, bg]() {
       return renderBuiltinSvg(name, size, builtinFg, bg);
     });
 
   } else if (parsed.type == QStringLiteral("emoji")) {
-    dispatchRender(response, fg, circle, [name = parsed.name, size]() { return renderEmoji(name, size); });
+    dispatchRender(response, fg, mask, [name = parsed.name, size]() { return renderEmoji(name, size); });
 
   } else if (parsed.type == QStringLiteral("system")) {
-    dispatchRender(response, fg, circle,
-                   [name = parsed.name, size]() { return renderSystemIcon(name, size); });
+    dispatchRender(response, fg, mask, [name = parsed.name, size]() { return renderSystemIcon(name, size); });
 
 #ifdef Q_OS_MACOS
   } else if (parsed.type == QStringLiteral("bundle")) {
-    dispatchRender(response, fg, circle,
+    dispatchRender(response, fg, mask,
                    [path = parsed.name, size]() { return renderMacBundleIcon(path, size); });
 #endif
 
   } else if (parsed.type == QStringLiteral("local")) {
     QString const path = parsed.name;
     if (path.endsWith(QStringLiteral(".svg"), Qt::CaseInsensitive)) {
-      dispatchRender(response, fg, circle, [path, size]() { return renderLocalSvg(path, size); });
+      dispatchRender(response, fg, mask, [path, size]() { return renderLocalSvg(path, size); });
     } else {
-      dispatchRender(response, fg, circle, [path, size]() { return renderLocalRaster(path, size); });
+      dispatchRender(response, fg, mask, [path, size]() { return renderLocalRaster(path, size); });
     }
 
   } else if (parsed.type == QStringLiteral("file-icon")) {
     QString const path = parsed.name;
     QColor const defaultFg = ThemeService::instance().theme().resolve(SemanticColor::Foreground);
     QColor const bg = parsed.bg;
-    dispatchRender(response, QColor(), circle, [path, size, fg, defaultFg, bg]() {
+    dispatchRender(response, QColor(), mask, [path, size, fg, defaultFg, bg]() {
       QMimeDatabase const db;
       auto const mime = db.mimeTypeForFile(path, QMimeDatabase::MatchDefault);
 
@@ -448,14 +472,14 @@ QQuickImageResponse *AsyncImageProvider::requestImageResponse(const QString &id,
       url.insert(5, '/');
     QMetaObject::invokeMethod(
         qApp,
-        [response, url, size, circle, fg, id]() {
+        [response, url, size, mask, fg, id]() {
           if (response->isCancelled()) {
             response->finish({});
             return;
           }
           auto *reply = NetworkFetcher::instance()->fetch(QUrl(url));
           QObject::connect(reply, &FetchReply::finished, qApp,
-                           [response, reply, size, circle, fg, id](const QByteArray &data) {
+                           [response, reply, size, mask, fg, id](const QByteArray &data) {
                              reply->deleteLater();
                              if (response->isCancelled()) {
                                response->finish({});
@@ -465,7 +489,7 @@ QQuickImageResponse *AsyncImageProvider::requestImageResponse(const QString &id,
                                ImageDataCache::instance().storeAnimated(id, data);
                              else
                                ImageDataCache::instance().storeNotAnimated(id);
-                             dispatchRender(response, fg, circle,
+                             dispatchRender(response, fg, mask,
                                             [data, size]() { return decodeImageData(data, size); });
                            });
         },
@@ -474,7 +498,7 @@ QQuickImageResponse *AsyncImageProvider::requestImageResponse(const QString &id,
   } else if (parsed.type == QStringLiteral("favicon")) {
     QMetaObject::invokeMethod(
         qApp,
-        [response, domain = parsed.name, size, fg, circle]() {
+        [response, domain = parsed.name, size, fg, mask]() {
           if (response->isCancelled()) {
             response->finish({});
             return;
@@ -488,12 +512,12 @@ QQuickImageResponse *AsyncImageProvider::requestImageResponse(const QString &id,
           // No parent: watcher must live on main thread, response lives on reader thread
           auto *watcher = new QFutureWatcher<FaviconService::FaviconResponse>;
           QObject::connect(
-              watcher, &QFutureWatcherBase::finished, qApp, [response, watcher, size, fg, circle]() {
+              watcher, &QFutureWatcherBase::finished, qApp, [response, watcher, size, fg, mask]() {
                 auto result = watcher->result();
                 if (!response->isCancelled() && result) {
                   QImage img =
                       result.value().scaled(size, Qt::KeepAspectRatio, Qt::SmoothTransformation).toImage();
-                  applyPostTransforms(img, fg, circle);
+                  applyPostTransforms(img, fg, mask);
                   response->finish(std::move(img));
                 } else {
                   response->finish({});
@@ -506,7 +530,7 @@ QQuickImageResponse *AsyncImageProvider::requestImageResponse(const QString &id,
 
   } else if (parsed.type == QStringLiteral("datauri")) {
     QString const dataStr = parsed.name;
-    dispatchRender(response, fg, circle, [dataStr, size, id]() {
+    dispatchRender(response, fg, mask, [dataStr, size, id]() {
       DataUri const uri(dataStr);
       QByteArray const decoded = uri.decodeContent();
       if (decoded.isEmpty()) return QImage();

--- a/src/server/src/qml/async-image-provider.cpp
+++ b/src/server/src/qml/async-image-provider.cpp
@@ -39,6 +39,9 @@ static QThreadPool &imageDecodingPool() {
   return pool;
 }
 
+class ViciImageResponse;
+static void dispatchForId(ViciImageResponse *response, const QString &id, const QSize &size);
+
 class ViciImageResponse : public QQuickImageResponse {
   Q_OBJECT
 
@@ -72,7 +75,7 @@ public:
       emit finished();
       return;
     }
-    tryFallback(image);
+    if (image.isNull() && tryDispatchFallback()) return;
     image.setDevicePixelRatio(m_dpr);
     m_image = std::move(image);
     emit finished();
@@ -85,14 +88,26 @@ public:
       QTimer::singleShot(0, this, &QQuickImageResponse::finished);
       return;
     }
-    tryFallback(image);
+    if (image.isNull() && !m_fallback.isEmpty()) {
+      QString const fb = m_fallback;
+      m_fallback.clear();
+      QSize const size = m_size;
+      QTimer::singleShot(0, this, [this, fb, size]() { dispatchForId(this, fb, size); });
+      return;
+    }
     image.setDevicePixelRatio(m_dpr);
     m_image = std::move(image);
     QTimer::singleShot(0, this, &QQuickImageResponse::finished);
   }
 
 private:
-  void tryFallback(QImage &image);
+  bool tryDispatchFallback() {
+    if (m_fallback.isEmpty()) return false;
+    QString const fb = m_fallback;
+    m_fallback.clear();
+    dispatchForId(this, fb, m_size);
+    return true;
+  }
 
   QString m_id;
   qreal m_dpr;
@@ -376,41 +391,8 @@ static ParsedId parseId(const QString &id) {
   return result;
 }
 
-void ViciImageResponse::tryFallback(QImage &image) {
-  if (!image.isNull() || m_fallback.isEmpty()) return;
-
-  QString const fallback = m_fallback;
-  m_fallback.clear();
-  auto fb = parseId(fallback);
-
-  if (fb.type == QStringLiteral("builtin")) {
-    QColor const fg =
-        fb.fg.isValid() ? fb.fg : ThemeService::instance().theme().resolve(SemanticColor::Foreground);
-    image = renderBuiltinSvg(fb.name, m_size, fg, fb.bg);
-    applyPostTransforms(image, QColor(), fb.mask);
-  } else if (fb.type == QStringLiteral("system")) {
-    image = renderSystemIcon(fb.name, m_size);
-    applyPostTransforms(image, fb.fg, fb.mask);
-  }
-}
-
-QQuickImageResponse *AsyncImageProvider::requestImageResponse(const QString &id, const QSize &requestedSize) {
-
-  qreal const dpr = qGuiApp->devicePixelRatio();
-  auto *response = new ViciImageResponse(dpr);
-  response->setId(id);
-  QSize const logical = requestedSize.isValid() && !requestedSize.isEmpty() ? requestedSize : QSize(64, 64);
-  QSize const size(qCeil(logical.width() * dpr), qCeil(logical.height() * dpr));
+static void dispatchForId(ViciImageResponse *response, const QString &id, const QSize &size) {
   auto parsed = parseId(id);
-
-  static const QString DEFAULT_FALLBACK =
-      QStringLiteral("builtin:") + BuiltinIconService::nameForIcon(BuiltinIconService::unknownIcon());
-
-  if (!parsed.fallback.isEmpty())
-    response->setFallback(parsed.fallback, size);
-  else if (parsed.type != QStringLiteral("builtin"))
-    response->setFallback(DEFAULT_FALLBACK, size);
-
   QColor const fg = parsed.fg;
   auto const mask = parsed.mask;
 
@@ -560,7 +542,25 @@ QQuickImageResponse *AsyncImageProvider::requestImageResponse(const QString &id,
   } else {
     response->finishDeferred({});
   }
+}
 
+QQuickImageResponse *AsyncImageProvider::requestImageResponse(const QString &id, const QSize &requestedSize) {
+  qreal const dpr = qGuiApp->devicePixelRatio();
+  auto *response = new ViciImageResponse(dpr);
+  response->setId(id);
+  QSize const logical = requestedSize.isValid() && !requestedSize.isEmpty() ? requestedSize : QSize(64, 64);
+  QSize const size(qCeil(logical.width() * dpr), qCeil(logical.height() * dpr));
+  auto const parsed = parseId(id);
+
+  static const QString DEFAULT_FALLBACK =
+      QStringLiteral("builtin:") + BuiltinIconService::nameForIcon(BuiltinIconService::unknownIcon());
+
+  if (!parsed.fallback.isEmpty())
+    response->setFallback(parsed.fallback, size);
+  else if (parsed.type != QStringLiteral("builtin"))
+    response->setFallback(DEFAULT_FALLBACK, size);
+
+  dispatchForId(response, id, size);
   return response;
 }
 

--- a/src/server/src/qml/async-image-provider.cpp
+++ b/src/server/src/qml/async-image-provider.cpp
@@ -274,6 +274,25 @@ static void applyCircleMask(QImage &image) {
   image = masked;
 }
 
+static void applyPostTransforms(QImage &image, const QColor &fg, bool circleMask) {
+  if (image.isNull()) return;
+  if (fg.isValid()) applyFillColor(image, fg);
+  if (circleMask) applyCircleMask(image);
+}
+
+template <typename Render>
+static void dispatchRender(ViciImageResponse *response, QColor fg, bool circleMask, Render render) {
+  imageDecodingPool().start([response, fg, circleMask, render = std::move(render)]() {
+    if (response->isCancelled()) {
+      response->finish({});
+      return;
+    }
+    QImage img = render();
+    applyPostTransforms(img, fg, circleMask);
+    response->finish(std::move(img));
+  });
+}
+
 struct ParsedId {
   QString type;
   QString name;
@@ -343,10 +362,10 @@ void ViciImageResponse::tryFallback(QImage &image) {
     QColor const fg =
         fb.fg.isValid() ? fb.fg : ThemeService::instance().theme().resolve(SemanticColor::Foreground);
     image = renderBuiltinSvg(fb.name, m_size, fg, fb.bg);
-    if (fb.circleMask && !image.isNull()) applyCircleMask(image);
+    applyPostTransforms(image, QColor(), fb.circleMask);
   } else if (fb.type == QStringLiteral("system")) {
     image = renderSystemIcon(fb.name, m_size);
-    if (!image.isNull()) applyFillColor(image, fb.fg);
+    applyPostTransforms(image, fb.fg, fb.circleMask);
   }
 }
 
@@ -367,118 +386,58 @@ QQuickImageResponse *AsyncImageProvider::requestImageResponse(const QString &id,
   else if (parsed.type != QStringLiteral("builtin"))
     response->setFallback(DEFAULT_FALLBACK, size);
 
+  QColor const fg = parsed.fg;
+  bool const circle = parsed.circleMask;
+
   if (parsed.type == QStringLiteral("builtin")) {
-    QColor fg = parsed.fg;
-    if (!fg.isValid()) fg = ThemeService::instance().theme().resolve(SemanticColor::Foreground);
-    bool const circle = parsed.circleMask;
+    QColor builtinFg = fg;
+    if (!builtinFg.isValid()) builtinFg = ThemeService::instance().theme().resolve(SemanticColor::Foreground);
     QColor const bg = parsed.bg;
-    imageDecodingPool().start([response, name = parsed.name, size, fg, bg, circle]() {
-      if (response->isCancelled()) {
-        response->finish({});
-        return;
-      }
-      QImage img = renderBuiltinSvg(name, size, fg, bg);
-      if (circle && !img.isNull()) applyCircleMask(img);
-      response->finish(std::move(img));
+    dispatchRender(response, QColor(), circle, [name = parsed.name, size, builtinFg, bg]() {
+      return renderBuiltinSvg(name, size, builtinFg, bg);
     });
 
   } else if (parsed.type == QStringLiteral("emoji")) {
-    imageDecodingPool().start([response, name = parsed.name, size]() {
-      if (response->isCancelled()) {
-        response->finish({});
-        return;
-      }
-      QImage img = renderEmoji(name, size);
-      response->finish(std::move(img));
-    });
+    dispatchRender(response, fg, circle, [name = parsed.name, size]() { return renderEmoji(name, size); });
 
   } else if (parsed.type == QStringLiteral("system")) {
-    QColor const fg = parsed.fg;
-    imageDecodingPool().start([response, name = parsed.name, size, fg]() {
-      if (response->isCancelled()) {
-        response->finish({});
-        return;
-      }
-      QImage img = renderSystemIcon(name, size);
-      if (!img.isNull()) applyFillColor(img, fg);
-      response->finish(std::move(img));
-    });
+    dispatchRender(response, fg, circle,
+                   [name = parsed.name, size]() { return renderSystemIcon(name, size); });
 
 #ifdef Q_OS_MACOS
   } else if (parsed.type == QStringLiteral("bundle")) {
-    QColor const fg = parsed.fg;
-    bool const circle = parsed.circleMask;
-    imageDecodingPool().start([response, path = parsed.name, size, fg, circle]() {
-      if (response->isCancelled()) {
-        response->finish({});
-        return;
-      }
-      QImage img = renderMacBundleIcon(path, size);
-      if (!img.isNull()) applyFillColor(img, fg);
-      if (circle && !img.isNull()) applyCircleMask(img);
-      response->finish(std::move(img));
-    });
+    dispatchRender(response, fg, circle,
+                   [path = parsed.name, size]() { return renderMacBundleIcon(path, size); });
 #endif
 
   } else if (parsed.type == QStringLiteral("local")) {
     QString const path = parsed.name;
-    bool const circle = parsed.circleMask;
-    QColor const fg = parsed.fg;
-
     if (path.endsWith(QStringLiteral(".svg"), Qt::CaseInsensitive)) {
-      imageDecodingPool().start([response, path, size, circle, fg]() {
-        if (response->isCancelled()) {
-          response->finish({});
-          return;
-        }
-        QImage img = renderLocalSvg(path, size);
-        if (!img.isNull()) applyFillColor(img, fg);
-        if (circle && !img.isNull()) applyCircleMask(img);
-        response->finish(std::move(img));
-      });
+      dispatchRender(response, fg, circle, [path, size]() { return renderLocalSvg(path, size); });
     } else {
-      imageDecodingPool().start([response, path, size, circle, fg]() {
-        if (response->isCancelled()) {
-          response->finish({});
-          return;
-        }
-        QImage img = renderLocalRaster(path, size);
-        if (!img.isNull()) applyFillColor(img, fg);
-        if (circle && !img.isNull()) applyCircleMask(img);
-        response->finish(std::move(img));
-      });
+      dispatchRender(response, fg, circle, [path, size]() { return renderLocalRaster(path, size); });
     }
 
   } else if (parsed.type == QStringLiteral("file-icon")) {
     QString const path = parsed.name;
-    QColor const explicitFg = parsed.fg;
     QColor const defaultFg = ThemeService::instance().theme().resolve(SemanticColor::Foreground);
     QColor const bg = parsed.bg;
-    bool const circle = parsed.circleMask;
-    imageDecodingPool().start([response, path, size, explicitFg, defaultFg, bg, circle]() {
-      if (response->isCancelled()) {
-        response->finish({});
-        return;
-      }
-
+    dispatchRender(response, QColor(), circle, [path, size, fg, defaultFg, bg]() {
       QMimeDatabase const db;
       auto const mime = db.mimeTypeForFile(path, QMimeDatabase::MatchDefault);
 
       QImage img = renderSystemIcon(mime.iconName(), size);
       if (img.isNull()) img = renderSystemIcon(mime.genericIconName(), size);
 
-      if (img.isNull()) {
-        QString const builtinName = mime.name() == QStringLiteral("inode/directory")
-                                        ? QStringLiteral("folder")
-                                        : QStringLiteral("blank-document");
-        QColor const fg = explicitFg.isValid() ? explicitFg : defaultFg;
-        img = renderBuiltinSvg(builtinName, size, fg, bg);
-      } else if (explicitFg.isValid()) {
-        applyFillColor(img, explicitFg);
+      if (!img.isNull()) {
+        if (fg.isValid()) applyFillColor(img, fg);
+        return img;
       }
 
-      if (circle && !img.isNull()) applyCircleMask(img);
-      response->finish(std::move(img));
+      QString const builtinName = mime.name() == QStringLiteral("inode/directory")
+                                      ? QStringLiteral("folder")
+                                      : QStringLiteral("blank-document");
+      return renderBuiltinSvg(builtinName, size, fg.isValid() ? fg : defaultFg, bg);
     });
 
   } else if (parsed.type == QStringLiteral("http")) {
@@ -487,8 +446,6 @@ QQuickImageResponse *AsyncImageProvider::requestImageResponse(const QString &id,
       url.insert(6, '/');
     else if (url.startsWith(QStringLiteral("http:/")) && !url.startsWith(QStringLiteral("http://")))
       url.insert(5, '/');
-    bool const circle = parsed.circleMask;
-    QColor const fg = parsed.fg;
     QMetaObject::invokeMethod(
         qApp,
         [response, url, size, circle, fg, id]() {
@@ -508,16 +465,8 @@ QQuickImageResponse *AsyncImageProvider::requestImageResponse(const QString &id,
                                ImageDataCache::instance().storeAnimated(id, data);
                              else
                                ImageDataCache::instance().storeNotAnimated(id);
-                             imageDecodingPool().start([response, data, size, circle, fg]() {
-                               if (response->isCancelled()) {
-                                 response->finish({});
-                                 return;
-                               }
-                               QImage img = decodeImageData(data, size);
-                               if (!img.isNull()) applyFillColor(img, fg);
-                               if (circle && !img.isNull()) applyCircleMask(img);
-                               response->finish(std::move(img));
-                             });
+                             dispatchRender(response, fg, circle,
+                                            [data, size]() { return decodeImageData(data, size); });
                            });
         },
         Qt::QueuedConnection);
@@ -525,7 +474,7 @@ QQuickImageResponse *AsyncImageProvider::requestImageResponse(const QString &id,
   } else if (parsed.type == QStringLiteral("favicon")) {
     QMetaObject::invokeMethod(
         qApp,
-        [response, domain = parsed.name, size]() {
+        [response, domain = parsed.name, size, fg, circle]() {
           if (response->isCancelled()) {
             response->finish({});
             return;
@@ -538,40 +487,31 @@ QQuickImageResponse *AsyncImageProvider::requestImageResponse(const QString &id,
           auto future = svc->makeRequest(domain);
           // No parent: watcher must live on main thread, response lives on reader thread
           auto *watcher = new QFutureWatcher<FaviconService::FaviconResponse>;
-          QObject::connect(watcher, &QFutureWatcherBase::finished, qApp, [response, watcher, size]() {
-            auto result = watcher->result();
-            if (!response->isCancelled() && result) {
-              QImage img =
-                  result.value().scaled(size, Qt::KeepAspectRatio, Qt::SmoothTransformation).toImage();
-              response->finish(std::move(img));
-            } else {
-              response->finish({});
-            }
-            watcher->deleteLater();
-          });
+          QObject::connect(
+              watcher, &QFutureWatcherBase::finished, qApp, [response, watcher, size, fg, circle]() {
+                auto result = watcher->result();
+                if (!response->isCancelled() && result) {
+                  QImage img =
+                      result.value().scaled(size, Qt::KeepAspectRatio, Qt::SmoothTransformation).toImage();
+                  applyPostTransforms(img, fg, circle);
+                  response->finish(std::move(img));
+                } else {
+                  response->finish({});
+                }
+                watcher->deleteLater();
+              });
           watcher->setFuture(future);
         },
         Qt::QueuedConnection);
 
   } else if (parsed.type == QStringLiteral("datauri")) {
     QString const dataStr = parsed.name;
-    bool const circle = parsed.circleMask;
-    QColor const fg = parsed.fg;
-    imageDecodingPool().start([response, dataStr, size, circle, fg, id]() {
-      if (response->isCancelled()) {
-        response->finish({});
-        return;
-      }
-
+    dispatchRender(response, fg, circle, [dataStr, size, id]() {
       DataUri const uri(dataStr);
       QByteArray const decoded = uri.decodeContent();
-      if (decoded.isEmpty()) {
-        response->finish({});
-        return;
-      }
+      if (decoded.isEmpty()) return QImage();
 
       bool const isSvg = uri.mediaType().contains(QStringLiteral("svg"));
-
       if (!isSvg) {
         if (isGif(decoded))
           ImageDataCache::instance().storeAnimated(id, decoded);
@@ -579,25 +519,18 @@ QQuickImageResponse *AsyncImageProvider::requestImageResponse(const QString &id,
           ImageDataCache::instance().storeNotAnimated(id);
       }
 
-      QImage img;
-      if (isSvg) {
-        QSvgRenderer renderer(decoded);
-        if (renderer.isValid()) {
-          img = QImage(size, QImage::Format_ARGB32_Premultiplied);
-          img.fill(Qt::transparent);
-          QPainter painter(&img);
-          painter.setRenderHint(QPainter::Antialiasing, true);
-          painter.setRenderHint(QPainter::SmoothPixmapTransform, true);
-          renderer.setAspectRatioMode(Qt::KeepAspectRatio);
-          renderer.render(&painter, img.rect());
-        }
-      } else {
-        img = decodeImageData(decoded, size);
-      }
+      if (!isSvg) return decodeImageData(decoded, size);
 
-      if (!img.isNull()) applyFillColor(img, fg);
-      if (circle && !img.isNull()) applyCircleMask(img);
-      response->finish(std::move(img));
+      QSvgRenderer renderer(decoded);
+      if (!renderer.isValid()) return QImage();
+      QImage img(size, QImage::Format_ARGB32_Premultiplied);
+      img.fill(Qt::transparent);
+      QPainter painter(&img);
+      painter.setRenderHint(QPainter::Antialiasing, true);
+      painter.setRenderHint(QPainter::SmoothPixmapTransform, true);
+      renderer.setAspectRatioMode(Qt::KeepAspectRatio);
+      renderer.render(&painter, img.rect());
+      return img;
     });
 
   } else {

--- a/src/server/src/qml/image-url.cpp
+++ b/src/server/src/qml/image-url.cpp
@@ -44,7 +44,10 @@ static QString buildParams(const ImageURL &url, bool builtinFgDefault = false) {
     parts << QStringLiteral("bg=%23") + bg.name(QColor::HexRgb).mid(1);
   }
 
-  if (url.mask() == OmniPainter::CircleMask) parts << QStringLiteral("mask=circle");
+  if (url.mask() == OmniPainter::CircleMask)
+    parts << QStringLiteral("mask=circle");
+  else if (url.mask() == OmniPainter::RoundedRectangleMask)
+    parts << QStringLiteral("mask=roundedRectangle");
 
   if (auto fb = url.fallback()) {
     ImageURL const fbUrl(*fb);
@@ -76,13 +79,13 @@ QString ImageUrl::toSource() const {
     return prefix + QStringLiteral("builtin:") + name + buildParams(m_url, true);
 
   case ImageURLType::System:
-    return prefix + QStringLiteral("system:") + name + buildParams(m_url);
+    return prefix + QStringLiteral("system:") + name;
 
   case ImageURLType::Local:
     return prefix + QStringLiteral("local:") + name + buildParams(m_url);
 
   case ImageURLType::FileIcon:
-    return prefix + QStringLiteral("file-icon:") + name + buildParams(m_url);
+    return prefix + QStringLiteral("file-icon:") + name;
 
   case ImageURLType::MacBundle:
     return prefix + QStringLiteral("bundle:") + name + buildParams(m_url);

--- a/src/server/src/qml/image-url.cpp
+++ b/src/server/src/qml/image-url.cpp
@@ -81,6 +81,9 @@ QString ImageUrl::toSource() const {
   case ImageURLType::Local:
     return prefix + QStringLiteral("local:") + name + buildParams(m_url);
 
+  case ImageURLType::FileIcon:
+    return prefix + QStringLiteral("file-icon:") + name + buildParams(m_url);
+
   case ImageURLType::MacBundle:
     return prefix + QStringLiteral("bundle:") + name + buildParams(m_url);
 

--- a/src/server/src/ui/image/url.cpp
+++ b/src/server/src/ui/image/url.cpp
@@ -6,7 +6,6 @@
 #include "ui/omni-painter/omni-painter.hpp"
 #include "theme/theme-file.hpp"
 #include <qdir.h>
-#include <qmimedatabase.h>
 #include <qstringview.h>
 #include <QIcon>
 #include <qurlquery.h>
@@ -200,6 +199,10 @@ ImageURL::ImageURL(const ImageLikeModel &imageLike) {
       return;
     }
   }
+
+  if (auto fileIcon = std::get_if<ExtensionFileIconModel>(&imageLike)) {
+    *this = ImageURL::fileIcon(fileIcon->file);
+  }
 }
 
 ImageURL ImageURL::builtin(const QString &name) {
@@ -292,13 +295,10 @@ ImageURL ImageURL::rawData(const QByteArray &data, const QString &mimeType) {
 }
 
 ImageURL ImageURL::fileIcon(const fs::path &path) {
-  QMimeDatabase const db;
-  auto mime = db.mimeTypeForFile(path.c_str());
-  if (auto icon = QIcon::fromTheme(mime.iconName()); !icon.isNull()) {
-    return ImageURL::system(mime.iconName());
-  }
-  if (auto icon = QIcon::fromTheme(mime.genericIconName()); !icon.isNull()) {
-    return ImageURL::system(mime.genericIconName());
-  }
-  return ImageURL::builtin(mime.name() == "inode/directory" ? "folder" : "blank-document");
+  ImageURL url;
+
+  url.setType(ImageURLType::FileIcon);
+  url.setName(QString::fromStdString(path.string()));
+
+  return url;
 }

--- a/src/server/src/ui/image/url.hpp
+++ b/src/server/src/ui/image/url.hpp
@@ -21,12 +21,13 @@ enum ImageURLType : std::uint8_t {
   Local,
   Emoji,
   DataURI,
-  MacBundle
+  MacBundle,
+  FileIcon
 };
 
 static std::vector<std::pair<QString, ImageURLType>> iconTypes = {
     {"favicon", Favicon}, {"omnicast", Builtin}, {"system", System},    {"http", Http},
-    {"https", Http},      {"local", Local},      {"bundle", MacBundle},
+    {"https", Http},      {"local", Local},      {"bundle", MacBundle}, {"file-icon", FileIcon},
 };
 
 static std::vector<std::pair<QString, SemanticColor>> colorTints = {

--- a/src/server/src/ui/omni-painter/omni-painter.cpp
+++ b/src/server/src/ui/omni-painter/omni-painter.cpp
@@ -56,12 +56,8 @@ QString OmniPainter::serializeColor(const ColorLike &color) {
 }
 
 OmniPainter::ImageMaskType OmniPainter::maskForName(const QString &name) {
-  if (name == "circle") {
-    return CircleMask;
-  } else if (name == "roundedRectangle") {
-    return RoundedRectangleMask;
-  }
-
+  if (name == "circle") return CircleMask;
+  if (name == "roundedRectangle") return RoundedRectangleMask;
   return NoMask;
 }
 

--- a/src/typescript/api/src/api/image.ts
+++ b/src/typescript/api/src/api/image.ts
@@ -14,16 +14,23 @@ export type Image = {
 };
 
 /**
+ * Renders the system icon associated with the given file path.
  * @category Image
  */
-export type ImageLike = Image.ImageLike; // TODO: FileIcon
+export type FileIcon = { fileIcon: string };
+
+/**
+ * @category Image
+ */
+export type ImageLike = Image.ImageLike;
 
 export type SerializedImageLike =
 	| URL
 	| Image.Asset
 	| Icon
 	| api.Image
-	| Image.ThemedImage;
+	| Image.ThemedImage
+	| FileIcon;
 
 /**
  * @category Image
@@ -34,13 +41,24 @@ export namespace Image {
 	export type Fallback = Source;
 	export type Source = URL | Asset | ThemedSource;
 	export type ThemedImage = { light: URL | Asset; dark: URL | Asset };
-	export type ImageLike = URL | Image.Asset | Icon | Image | Image.ThemedImage;
+	export type ImageLike =
+		| URL
+		| Image.Asset
+		| Icon
+		| Image
+		| Image.ThemedImage
+		| FileIcon;
 
 	export enum Mask {
 		Circle = "circle",
 		RoundedRectangle = "roundedRectangle",
 	}
 }
+
+const isFileIcon = (v: unknown): v is FileIcon =>
+	typeof v === "object" &&
+	v !== null &&
+	typeof (v as FileIcon).fileIcon === "string";
 
 const maskMap: Record<Image.Mask, api.ImageMask> = {
 	[Image.Mask.Circle]: "Circle",
@@ -62,6 +80,10 @@ export const serializeProtoImage = (image: ImageLike): api.Image => {
 
 	if (image instanceof URL || typeof image === "string") {
 		return { source: { raw: image.toString() } };
+	}
+
+	if (isFileIcon(image)) {
+		return { fileIcon: image.fileIcon };
 	}
 
 	const img = image as Image;

--- a/src/typescript/api/src/api/image.ts
+++ b/src/typescript/api/src/api/image.ts
@@ -17,7 +17,7 @@ export type Image = {
  * Renders the system icon associated with the given file path.
  * @category Image
  */
-export type FileIcon = { fileIcon: string };
+type FileIcon = { fileIcon: string };
 
 /**
  * @category Image

--- a/src/typescript/api/src/api/index.ts
+++ b/src/typescript/api/src/api/index.ts
@@ -3,7 +3,7 @@ export * from "./components/index.js";
 export * from "./hooks/index.js";
 export { Color, ColorLike } from "./color.js";
 export * from "./keyboard.js";
-export { ImageLike, Image } from "./image.js";
+export { ImageLike, Image, FileIcon } from "./image.js";
 export * from "./icon.js";
 export * from "./environment.js";
 export * from "./controls.js";

--- a/src/typescript/api/src/api/index.ts
+++ b/src/typescript/api/src/api/index.ts
@@ -3,7 +3,7 @@ export * from "./components/index.js";
 export * from "./hooks/index.js";
 export { Color, ColorLike } from "./color.js";
 export * from "./keyboard.js";
-export { ImageLike, Image, FileIcon } from "./image.js";
+export { ImageLike, Image } from "./image.js";
 export * from "./icon.js";
 export * from "./environment.js";
 export * from "./controls.js";

--- a/src/typescript/api/src/api/proto/api.ts
+++ b/src/typescript/api/src/api/proto/api.ts
@@ -124,10 +124,11 @@ export type ColorLike = {
 };
 
 export type Image = {
-	source: ImageSource;
+	source?: ImageSource;
 	fallback?: ImageSource;
 	mask?: ImageMask;
 	tintColor?: ColorLike;
+	fileIcon?: string;
 };
 
 export type ConfirmAlertAction = {


### PR DESCRIPTION
Extensions can now use `{ fileIcon: '/path/to/file' }` where icons are expected, and it will automatically render the icon for that file type.

This also features a refactor of the image loading part, addressing issues with fallback, icon tinting and masking.