### PR TITLE
feat(extension): add sendDesktopNotification API

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 vendor/** linguist-vendored
+
+# this will probably be moved out of the repo eventually
+extra/extension-boilerplate/** linguist-vendored

--- a/extra/extension-boilerplate/package-lock.json
+++ b/extra/extension-boilerplate/package-lock.json
@@ -7,7 +7,7 @@
 			"name": "template",
 			"license": "MIT",
 			"dependencies": {
-				"@vicinae/api": "file:../../typescript/api"
+				"@vicinae/api": "file:../../src/typescript/api"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.3.2",
@@ -16,9 +16,37 @@
 				"typescript": "^5.9.2"
 			}
 		},
+		"../../src/typescript/api": {
+			"name": "@vicinae/api",
+			"version": "0.0.0",
+			"license": "ISC",
+			"dependencies": {
+				"chokidar": "^4.0.3",
+				"esbuild": "^0.25.2",
+				"react": "^19.0.0",
+				"zod": "^4.0.17"
+			},
+			"bin": {
+				"vici": "dist/bin.js"
+			},
+			"devDependencies": {
+				"@biomejs/biome": "2.3.2",
+				"@types/node": "24.3.0",
+				"@types/react": "19.0.10",
+				"typedoc": "0.28.13",
+				"typedoc-github-theme": "0.3.1",
+				"typedoc-plugin-markdown": "4.8.1",
+				"typescript": "5.9.2"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18",
+				"@types/react": "19.0.10"
+			}
+		},
 		"../../typescript/api": {
 			"name": "@vicinae/api",
 			"version": "0.0.0",
+			"extraneous": true,
 			"license": "ISC",
 			"dependencies": {
 				"@jgoz/esbuild-plugin-typecheck": "^4.0.3",
@@ -242,7 +270,7 @@
 			}
 		},
 		"node_modules/@vicinae/api": {
-			"resolved": "../../typescript/api",
+			"resolved": "../../src/typescript/api",
 			"link": true
 		},
 		"node_modules/csstype": {

--- a/extra/extension-boilerplate/package.json
+++ b/extra/extension-boilerplate/package.json
@@ -90,6 +90,13 @@
 			"title": "Action Panel Stress Test",
 			"description": "Test action panel reconciliation, deep submenus, dynamic content, and filter preservation",
 			"mode": "view"
+		},
+		{
+			"name": "desktop-notif-interval",
+			"title": "Desktop Notification Interval",
+			"description": "Desktop Notification Interval",
+			"mode": "no-view",
+			"interval": "30s"
 		}
 	],
 	"preferences": [],

--- a/extra/extension-boilerplate/package.json
+++ b/extra/extension-boilerplate/package.json
@@ -96,7 +96,8 @@
 			"title": "Desktop Notification Interval",
 			"description": "Desktop Notification Interval",
 			"mode": "no-view",
-			"interval": "30s"
+			"interval": "30s",
+			"disabledByDefault": true
 		}
 	],
 	"preferences": [],

--- a/extra/extension-boilerplate/src/desktop-notif-interval.ts
+++ b/extra/extension-boilerplate/src/desktop-notif-interval.ts
@@ -1,0 +1,9 @@
+import { Color, Icon, sendDesktopNotification } from "@vicinae/api";
+
+export default async function DesktopNotificationInterval() {
+	await sendDesktopNotification({
+		title: "This is the title",
+		body: "This is the body of the notification, hopefully it displays correctly!",
+		icon: { source: Icon.Cog, tintColor: Color.Red },
+	});
+}

--- a/extra/extension-boilerplate/src/desktop-notif-interval.ts
+++ b/extra/extension-boilerplate/src/desktop-notif-interval.ts
@@ -2,7 +2,7 @@ import { Color, Icon, sendDesktopNotification } from "@vicinae/api";
 
 export default async function DesktopNotificationInterval() {
 	await sendDesktopNotification({
-		title: "This is the title",
+		title: "Vicinae Extension Boilerplate Notification",
 		body: "This is the body of the notification, hopefully it displays correctly!",
 		icon: { source: Icon.Cog, tintColor: Color.Red },
 	});

--- a/figura/tsapi.fig
+++ b/figura/tsapi.fig
@@ -95,6 +95,19 @@ struct ConfirmAlertPayload {
   icon?: Image;
 };
 
+enum NotificationUrgency {
+  Low,
+  Normal,
+  High
+};
+
+struct DesktopNotificationPayload {
+  title: string;
+  body: string;
+  icon?: Image;
+  urgency: NotificationUrgency;
+};
+
 service UI {
   fn render(json: string) => void;
   fn showToast(id: string, title: string, message: string, style: ToastStyle) => void;
@@ -111,6 +124,8 @@ service UI {
 
   fn setSearchText(text: string) => void;
   fn getSelectedText() => string;
+
+  fn sendDesktopNotification(data: DesktopNotificationPayload) => void;
 
   event viewPoped();
   event viewPushed();

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -409,6 +409,9 @@ set(SRCS
 	src/services/power-manager/systemd/systemd-power-manager.cpp
 	src/services/power-manager/dummy-power-manager.hpp
 
+	src/services/desktop-notification/freedesktop/freedesktop-notification-client.cpp
+	src/services/desktop-notification/dummy-desktop-notification-client.hpp
+
 	src/services/audio-control/pactl/pactl-audio-control.cpp
 	src/services/audio-control/dummy-audio-control.hpp
 

--- a/src/server/src/extension/services/ui-service.hpp
+++ b/src/server/src/extension/services/ui-service.hpp
@@ -6,10 +6,13 @@
 #include "glaze-qt.hpp"
 #include "navigation-controller.hpp"
 #include "qml/extension-view-host.hpp"
+#include "services/desktop-notification/desktop-notification-client.hpp"
 #include "services/toast/toast-service.hpp"
 #include "ui/alert/alert.hpp"
+#include "ui/image/image-renderer.hpp"
 #include <QClipboard>
 #include <QGuiApplication>
+#include <QTemporaryFile>
 #include <QtConcurrent/QtConcurrent>
 #include <qfuturewatcher.h>
 #include <qlogging.h>
@@ -135,6 +138,47 @@ public:
     return tsapi::Result<std::string>::ok(text.toStdString());
   }
 
+  tsapi::Result<void>::Future sendDesktopNotification(tsapi::DesktopNotificationPayload data) override {
+    QString title = QString::fromStdString(data.title);
+    QString body = QString::fromStdString(data.body);
+    auto urgency = mapNotificationUrgency(data.urgency);
+
+    if (!data.icon) {
+      m_notificationClient.provider()->send({title, body, std::nullopt, urgency});
+      return Void::ok();
+    }
+
+    ImageURL iconUrl = TsapiImage::parse(*data.icon);
+
+    auto promise = std::make_shared<QPromise<Void::Type>>();
+    auto future = promise->future();
+    promise->start();
+
+    auto renderFuture = ImageRendering::renderFirstFrame(iconUrl, QSize(128, 128));
+    auto *watcher = new QFutureWatcher<QImage>(this);
+    connect(watcher, &QFutureWatcherBase::finished, this, [this, watcher, promise, title, body, urgency]() {
+      QImage image = watcher->result();
+      std::optional<QString> iconPath;
+
+      if (!image.isNull()) {
+        auto *tmp = new QTemporaryFile(QDir::tempPath() + "/vicinae-notif-XXXXXX.png", this);
+        if (tmp->open()) {
+          image.save(tmp, "PNG");
+          tmp->close();
+          iconPath = tmp->fileName();
+        }
+      }
+
+      m_notificationClient.provider()->send({title, body, iconPath, urgency});
+      promise->addResult(Void::Type{});
+      promise->finish();
+      watcher->deleteLater();
+    });
+    watcher->setFuture(renderFuture);
+
+    return future;
+  }
+
 private slots:
   void modelCreated() {
     auto models = m_modelWatcher.result();
@@ -186,6 +230,19 @@ private:
     }
   }
 
+  static AbstractDesktopNotificationClient::Urgency
+  mapNotificationUrgency(tsapi::NotificationUrgency urgency) {
+    using Urgency = AbstractDesktopNotificationClient::Urgency;
+    switch (urgency) {
+    case tsapi::NotificationUrgency::Low:
+      return Urgency::Low;
+    case tsapi::NotificationUrgency::High:
+      return Urgency::High;
+    default:
+      return Urgency::Normal;
+    }
+  }
+
   static ToastStyle mapToastStyle(tsapi::ToastStyle style) {
     switch (style) {
     case tsapi::ToastStyle::Success:
@@ -210,4 +267,5 @@ private:
   std::shared_ptr<ExtensionCommand> m_command;
   tsapi::AbstractEventCore *m_eventCore;
   ToastService &m_toast;
+  DesktopNotificationClient m_notificationClient;
 };

--- a/src/server/src/services/desktop-notification/abstract-desktop-notification-client.hpp
+++ b/src/server/src/services/desktop-notification/abstract-desktop-notification-client.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include <QString>
+#include <optional>
+
+class AbstractDesktopNotificationClient {
+public:
+  enum class Urgency { Low, Normal, High };
+
+  struct Notification {
+    QString title;
+    QString body;
+    std::optional<QString> iconPath;
+    Urgency urgency = Urgency::Normal;
+  };
+
+  virtual bool send(const Notification &notification) = 0;
+  virtual ~AbstractDesktopNotificationClient() = default;
+};

--- a/src/server/src/services/desktop-notification/desktop-notification-client.hpp
+++ b/src/server/src/services/desktop-notification/desktop-notification-client.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include "abstract-desktop-notification-client.hpp"
+#include <memory>
+#ifdef Q_OS_LINUX
+#include "freedesktop/freedesktop-notification-client.hpp"
+#else
+#include "dummy-desktop-notification-client.hpp"
+#endif
+
+class DesktopNotificationClient {
+public:
+  AbstractDesktopNotificationClient *provider() const { return m_client.get(); }
+  DesktopNotificationClient() {
+#ifdef Q_OS_LINUX
+    m_client = std::make_unique<FreedesktopNotificationClient>();
+#else
+    m_client = std::make_unique<DummyDesktopNotificationClient>();
+#endif
+  }
+
+private:
+  std::unique_ptr<AbstractDesktopNotificationClient> m_client;
+};

--- a/src/server/src/services/desktop-notification/dummy-desktop-notification-client.hpp
+++ b/src/server/src/services/desktop-notification/dummy-desktop-notification-client.hpp
@@ -1,0 +1,7 @@
+#pragma once
+#include "abstract-desktop-notification-client.hpp"
+
+class DummyDesktopNotificationClient : public AbstractDesktopNotificationClient {
+public:
+  bool send(const Notification &) override { return false; }
+};

--- a/src/server/src/services/desktop-notification/freedesktop/freedesktop-notification-client.cpp
+++ b/src/server/src/services/desktop-notification/freedesktop/freedesktop-notification-client.cpp
@@ -1,0 +1,38 @@
+#include "freedesktop-notification-client.hpp"
+#include <QDBusConnection>
+#include <QDBusInterface>
+#include <QDBusMessage>
+#include <qcontainerfwd.h>
+#include <qlogging.h>
+
+// https://specifications.freedesktop.org/notification/latest/protocol.html
+
+FreedesktopNotificationClient::FreedesktopNotificationClient() {
+  m_iface = std::make_unique<QDBusInterface>(DBUS_SERVICE, DBUS_PATH, DBUS_INTERFACE,
+                                             QDBusConnection::sessionBus());
+}
+
+bool FreedesktopNotificationClient::send(const Notification &n) {
+  if (!m_iface->isValid()) return false;
+
+  QVariantMap hints;
+  hints[QStringLiteral("urgency")] = QVariant::fromValue(mapUrgency(n.urgency));
+
+  QDBusMessage reply =
+      m_iface->call(QStringLiteral("Notify"), QStringLiteral("Vicinae"), uint(0),
+                    n.iconPath.value_or(QString()), n.title, n.body, QStringList(), hints, -1);
+
+  return reply.type() != QDBusMessage::ErrorMessage;
+}
+
+uchar FreedesktopNotificationClient::mapUrgency(Urgency urgency) {
+  switch (urgency) {
+  case Urgency::Low:
+    return 0;
+  case Urgency::Normal:
+    return 1;
+  case Urgency::High:
+    return 2;
+  }
+  return 1;
+}

--- a/src/server/src/services/desktop-notification/freedesktop/freedesktop-notification-client.hpp
+++ b/src/server/src/services/desktop-notification/freedesktop/freedesktop-notification-client.hpp
@@ -1,0 +1,19 @@
+#pragma once
+#include "../abstract-desktop-notification-client.hpp"
+#include <QDBusInterface>
+#include <memory>
+
+class FreedesktopNotificationClient : public AbstractDesktopNotificationClient {
+public:
+  FreedesktopNotificationClient();
+  bool send(const Notification &notification) override;
+
+private:
+  static constexpr const char *DBUS_SERVICE = "org.freedesktop.Notifications";
+  static constexpr const char *DBUS_PATH = "/org/freedesktop/Notifications";
+  static constexpr const char *DBUS_INTERFACE = "org.freedesktop.Notifications";
+
+  static uchar mapUrgency(Urgency urgency);
+
+  std::unique_ptr<QDBusInterface> m_iface;
+};

--- a/src/typescript/api/src/api/proto/api.ts
+++ b/src/typescript/api/src/api/proto/api.ts
@@ -87,6 +87,8 @@ export type PopToRootType = "Default" | "Immediate" | "Suspended";
 
 export type ConfirmAlertActionStyle = "Default" | "Destructive" | "Cancel";
 
+export type NotificationUrgency = "Low" | "Normal" | "High";
+
 export type Application = {
 	id: string;
 	name: string;
@@ -143,6 +145,13 @@ export type ConfirmAlertPayload = {
 	dismissAction: ConfirmAlertAction;
 	rememberUserChoice: boolean;
 	icon?: Image;
+};
+
+export type DesktopNotificationPayload = {
+	title: string;
+	body: string;
+	icon?: Image;
+	urgency: NotificationUrgency;
 };
 
 export type Rect = {
@@ -332,6 +341,10 @@ class UIService {
 
 	getSelectedText(): Promise<string> {
 		return this.transport.request("UI/getSelectedText", {});
+	}
+
+	sendDesktopNotification(data: DesktopNotificationPayload): Promise<void> {
+		return this.transport.request("UI/sendDesktopNotification", { data });
 	}
 
 	viewPoped(handler: () => void): EventSubscription {

--- a/src/typescript/api/src/api/utils.ts
+++ b/src/typescript/api/src/api/utils.ts
@@ -168,7 +168,7 @@ export type DesktopNotificationOptions = {
 	/**
 	 * The content of the notification.
 	 * How much you can fit in there highly depends on the capabilities of the running notification server.
-	 * Similarly, you may be able to use some markup language to further style the content,
+	 * Similarly, your notification server may accept the use of some markup language to further style the content.
 	 */
 	body: string;
 

--- a/src/typescript/api/src/api/utils.ts
+++ b/src/typescript/api/src/api/utils.ts
@@ -159,6 +159,33 @@ export const showInFileBrowser = async (
 	);
 };
 
+export type DesktopNotificationOptions = {
+	/**
+	 * The title of the notification, usually shown at the very top.
+	 */
+	title: string;
+
+	/**
+	 * The content of the notification.
+	 * How much you can fit in there highly depends on the capabilities of the running notification server.
+	 * Similarly, you may be able to use some markup language to further style the content,
+	 */
+	body: string;
+
+	/**
+	 * Icon used to represent the notification, usually positionned on the left.
+	 */
+	icon?: ImageLike;
+
+	/**
+	 * Urgency level associated with the notification.
+	 */
+	urgency?: NotificationUrgency;
+};
+
+/**
+ * @category System
+ */
 export const sendDesktopNotification = (payload: {
 	title: string;
 	body: string;

--- a/src/typescript/api/src/api/utils.ts
+++ b/src/typescript/api/src/api/utils.ts
@@ -1,8 +1,13 @@
 import type { PathLike } from "node:fs";
 import { rm } from "node:fs/promises";
 import { WindowManagement } from "./window-management";
-import type { Application } from "./proto/api";
+import type {
+	Application,
+	DesktopNotificationPayload,
+	NotificationUrgency,
+} from "./proto/api";
 import { getClient } from "./client";
+import { ImageLike, serializeProtoImage } from "./image";
 
 /**
   @ignore - we should probably move this to raycast compat, I don't think we want that.
@@ -153,5 +158,18 @@ export const showInFileBrowser = async (
 		options.select ?? true,
 	);
 };
+
+export const sendDesktopNotification = (payload: {
+	title: string;
+	body: string;
+	icon?: ImageLike;
+	urgency?: NotificationUrgency;
+}) =>
+	getClient().UI.sendDesktopNotification({
+		title: payload.title,
+		body: payload.body,
+		icon: payload.icon ? serializeProtoImage(payload.icon) : undefined,
+		urgency: payload.urgency ?? "Normal",
+	});
 
 export type { Application } from "./proto/api";


### PR DESCRIPTION
Extensions can now send proper desktop notifications.
Mostly useful for no-view commands running at a given interval.