### PR TITLE
fix(xdg): handle footclient in inferTermExec

### DIFF
--- a/src/server/src/services/app-service/xdg/xdg-app-database.cpp
+++ b/src/server/src/services/app-service/xdg/xdg-app-database.cpp
@@ -379,7 +379,7 @@ xdgpp::DesktopEntry::TerminalExec XdgAppDatabase::inferTermExec(const XdgApplica
         .hold = "--hold",
     };
   }
-  if (app.program() == "foot") {
+  if (app.program() == "foot" || app.program() == "footclient") {
     return {
         .exec = "-e",
         .appId = "--app-id",


### PR DESCRIPTION
## Problem

When `xdg-terminals.list` points at `footclient.desktop`, the `appId` (and `title`/`workingDirectory`/`hold`) set on a script command is silently dropped.

## Root cause

`XdgAppDatabase::inferTermExec()` matches on `app.program()` (the `Exec=` binary). The `footclient.desktop` shipped with foot has `Exec=footclient`, so `app.program()` returns `"footclient"`, the `"foot"` branch is skipped, and the fallback `{.exec = "-e"}` is used. `launchTerminalCommand()` then omits the corresponding flags because they're absent in the `TerminalExec` mapping.

## Fix

`footclient` accepts the same `--app-id` / `--title` / `--working-directory` / `--hold` flags as `foot`, so reuse the same mapping for both program names.

Fixes #1417