### PR TITLE
fix(flake): move extension helpers out of packages output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -38,9 +38,12 @@
 
           [[ "$OLD_EXT_MAN_DEPS_HASH" == "$NEW_EXT_MAN_DEPS_HASH" ]] || { echo -e "\e[31mHash mismatch for extension-manager npm deps, please replace the value in vicinae.nix with '$NEW_EXT_MAN_DEPS_HASH'.\e[0m" >&2; exit 1;}
         '';
+      });
+      lib = forEachPkgs (pkgs: {
         mkVicinaeExtension = pkgs.callPackage ./nix/mkVicinaeExtension.nix { };
         mkRayCastExtension = pkgs.callPackage ./nix/mkRayCastExtension.nix { };
-      }); devShells = forEachPkgs (
+      });
+      devShells = forEachPkgs (
         pkgs:
         let
           qtEnv = pkgs.qt6.env "qt-custom-${pkgs.qt6.qtbase.version}" [


### PR DESCRIPTION
Hit this running `nix flake check` / `nix flake show` against vicinae as an input. The error comes from evaluating the flake's package set, which no downstream toggle can suppress. Claude Opus 4.7 tracked it down for me and the fix has worked since.

`mkVicinaeExtension` and `mkRayCastExtension` sit under `packages.<system>`, but they're functions that build derivations, not derivations. The flake schema requires every `packages.<system>.*` to be an actual derivation, so enumerating the set (`flake show`, `flake check`) blows up with `error: expected a derivation`. On a darwin host it surfaces on the `aarch64-darwin` attrs.

Moved both under `lib.<system>`, where non-derivation outputs belong. The overlay still exposes them unchanged, so nothing breaks for overlay users.