### PR TITLE
feat: populate environment.launchType with proper value

### DIFF
--- a/extra/extension-boilerplate/src/desktop-notif-interval.ts
+++ b/extra/extension-boilerplate/src/desktop-notif-interval.ts
@@ -1,9 +1,20 @@
-import { Color, Icon, sendDesktopNotification } from "@vicinae/api";
+import {
+	Color,
+	environment,
+	Icon,
+	LaunchType,
+	sendDesktopNotification,
+	showToast,
+} from "@vicinae/api";
 
 export default async function DesktopNotificationInterval() {
-	await sendDesktopNotification({
-		title: "Vicinae Extension Boilerplate Notification",
-		body: "This is the body of the notification, hopefully it displays correctly!",
-		icon: { source: Icon.Cog, tintColor: Color.Red },
-	});
+	if (environment.launchType === LaunchType.Background) {
+		await sendDesktopNotification({
+			title: "Vicinae Extension Boilerplate Notification",
+			body: "This is the body of the notification, hopefully it displays correctly!",
+			icon: { source: Icon.Cog, tintColor: Color.Red },
+		});
+	} else {
+		await showToast({ title: "Manually triggered, sent as a toast!" });
+	}
 }

--- a/figura/manager-extension.fig
+++ b/figura/manager-extension.fig
@@ -12,6 +12,11 @@ enum CommandEnv {
   Production
 };
 
+enum LaunchType {
+  User,
+  Background
+};
+
 struct LaunchEventData {
   extension_name: string;
   command_name: string;
@@ -23,6 +28,7 @@ struct LaunchEventData {
   argumentValues: any;
   is_raycast: bool;
   owner_or_author_name: string;
+  launch_type: LaunchType;
 };
 
 service Lifecycle {

--- a/figura/manager.fig
+++ b/figura/manager.fig
@@ -14,6 +14,11 @@ enum CommandEnv {
   Production
 };
 
+enum LaunchType {
+  User,
+  Background
+};
+
 struct LoadOptions {
   mode: CommandMode;
   env: CommandEnv;
@@ -26,6 +31,7 @@ struct LoadOptions {
   owner_or_author_name: string;
   arguments: any;
   preferences: any;
+  launch_type: LaunchType;
 };
 
 struct LoadResponse {

--- a/src/server/src/extension/extension-command-runtime.cpp
+++ b/src/server/src/extension/extension-command-runtime.cpp
@@ -100,6 +100,12 @@ void ExtensionCommandRuntime::load(const LaunchProps &props) {
                    }) |
                    std::ranges::to<std::unordered_map<std::string, std::string>>();
 
+  if (m_headless) {
+    opts.launch_type = manager::LaunchType::Background;
+  } else {
+    opts.launch_type = manager::LaunchType::User;
+  }
+
   auto watcher = new QFutureWatcher<std::expected<manager::LoadResponse, std::string>>(this);
 
   connect(manager, &ExtensionManager::extensionMessageReceived, this,

--- a/src/typescript/extension-manager/src/index.ts
+++ b/src/typescript/extension-manager/src/index.ts
@@ -89,6 +89,7 @@ class ExtensionManager extends manager.ManagerService {
 				extension_name: load.extension_name,
 				owner_or_author_name: load.owner_or_author_name,
 				command_name: load.command_name,
+				launch_type: load.launch_type,
 			},
 		};
 

--- a/src/typescript/extension-manager/src/worker.tsx
+++ b/src/typescript/extension-manager/src/worker.tsx
@@ -81,7 +81,10 @@ const loadEnviron = (
 		supportPath: data.support_path,
 		assetsPath: data.asset_path,
 		raycastVersion: "1.0.0", // provided for compatibility only, not meaningful
-		launchType: LaunchType.UserInitiated,
+		launchType:
+			data.launch_type === "User"
+				? LaunchType.UserInitiated
+				: LaunchType.Background,
 		extensionName: data.extension_name,
 		ownerOrAuthorName: data.owner_or_author_name,
 		vicinaeVersion: {


### PR DESCRIPTION
Now that we support background execution of no-view commands with the `interval` manifest field, it is useful to be able to differenciate between foreground and background executions.

So far `environment.launchType` was always set to user-initiated, which is no longer valid.