### PR TITLE
fix(root-item-manager): guard erase when unfavoriting an item not present in the list

### DIFF
--- a/src/server/src/services/root-item-manager/root-item-manager.cpp
+++ b/src/server/src/services/root-item-manager/root-item-manager.cpp
@@ -420,7 +420,9 @@ bool RootItemManager::setItemAsFavorite(const EntrypointId &itemId, bool value) 
   if (value) {
     favorites.insert(favorites.begin(), id);
   } else {
-    favorites.erase(std::ranges::find(favorites, id));
+    auto it = std::ranges::find(favorites, id);
+    if (it == favorites.end()) { return false; }
+    favorites.erase(it);
   }
 
   m_cfg.mergeWithUser({.favorites = favorites});


### PR DESCRIPTION
### Summary

`RootItemManager::setItemAsFavorite` calls `vector::erase` on the iterator returned by `std::ranges::find` without checking against `end()`. When the `EntrypointId` is not present in the favorites list, this is undefined behavior.

### How it was found

Caught by AddressSanitizer (heap-buffer-overflow at `src/server/src/services/root-item-manager/root-item-manager.cpp:423`) while testing an unrelated branch. Triggered by invoking "Remove from Favorites" on an item that was not actually in the persisted favorites list at the moment of the call.

### Fix

Check the iterator before erasing; return `false` early if there is nothing to remove. No behavior change for the well-formed paths.

### Testing

`make debug` builds cleanly. The original ASan repro was non-deterministic, so I have not added a regression test. I'd be happy to look at adding one if you'd like (would need a small refactor to make the config injectable).

<details><summary>Original ASan trace (truncated)</summary>

```
==146274==ERROR: AddressSanitizer: heap-buffer-overflow
    #28 ActionPanelModel::activate(int) src/server/src/qml/action-panel-model.cpp:187
    ...
SUMMARY: AddressSanitizer: heap-buffer-overflow
  src/server/src/services/root-item-manager/root-item-manager.cpp:423
  in RootItemManager::setItemAsFavorite(EntrypointId const&, bool)
```

</details>