### PR TITLE
feat(root-search): optionally hide empty-state suggestions/favorites

### DIFF
--- a/src/server/src/config/config.hpp
+++ b/src/server/src/config/config.hpp
@@ -181,6 +181,16 @@ template <> struct Partial<TelemetryConfig> {
   std::optional<bool> systemInfo;
 };
 
+struct RootSearch {
+  bool hideSuggestionsWhenEmpty = false;
+  bool hideFavoritesWhenEmpty = false;
+};
+
+template <> struct Partial<RootSearch> {
+  std::optional<bool> hideSuggestionsWhenEmpty;
+  std::optional<bool> hideFavoritesWhenEmpty;
+};
+
 using KeybindMap = std::map<std::string, std::string>;
 
 using ProviderMap = std::map<std::string, ProviderData>;
@@ -214,6 +224,7 @@ struct ConfigValue {
   FontConfig font;
   ThemeConfig theme;
   TelemetryConfig telemetry;
+  RootSearch rootSearch;
 
   WindowConfig launcherWindow;
   Header header;
@@ -265,6 +276,7 @@ template <> struct Partial<ConfigValue> {
   std::optional<Partial<FontConfig>> font;
   std::optional<Partial<ThemeConfig>> theme;
   std::optional<Partial<TelemetryConfig>> telemetry;
+  std::optional<Partial<RootSearch>> rootSearch;
 
   std::optional<Partial<WindowConfig>> launcherWindow;
   std::optional<Partial<Header>> header;

--- a/src/server/src/config/config.hpp
+++ b/src/server/src/config/config.hpp
@@ -101,7 +101,7 @@ template <> struct Partial<WindowCSD> {
 };
 
 struct WindowCompactMode {
-  bool enabled;
+  bool enabled = false;
 };
 
 template <> struct Partial<WindowCompactMode> {

--- a/src/server/src/qml/general-settings-model.cpp
+++ b/src/server/src/qml/general-settings-model.cpp
@@ -99,9 +99,7 @@ void GeneralSettingsModel::setHideSuggestionsWhenEmpty(bool v) {
       {.rootSearch = config::Partial<config::RootSearch>{.hideSuggestionsWhenEmpty = v}});
 }
 
-bool GeneralSettingsModel::hideFavoritesWhenEmpty() const {
-  return cfg().rootSearch.hideFavoritesWhenEmpty;
-}
+bool GeneralSettingsModel::hideFavoritesWhenEmpty() const { return cfg().rootSearch.hideFavoritesWhenEmpty; }
 void GeneralSettingsModel::setHideFavoritesWhenEmpty(bool v) {
   cfgManager().mergeWithUser(
       {.rootSearch = config::Partial<config::RootSearch>{.hideFavoritesWhenEmpty = v}});

--- a/src/server/src/qml/general-settings-model.cpp
+++ b/src/server/src/qml/general-settings-model.cpp
@@ -91,6 +91,22 @@ void GeneralSettingsModel::setFontSize(const QString &v) {
   if (ok) cfgManager().mergeWithUser({.font = config::Partial<config::FontConfig>{.normal{.size = val}}});
 }
 
+bool GeneralSettingsModel::hideSuggestionsWhenEmpty() const {
+  return cfg().rootSearch.hideSuggestionsWhenEmpty;
+}
+void GeneralSettingsModel::setHideSuggestionsWhenEmpty(bool v) {
+  cfgManager().mergeWithUser(
+      {.rootSearch = config::Partial<config::RootSearch>{.hideSuggestionsWhenEmpty = v}});
+}
+
+bool GeneralSettingsModel::hideFavoritesWhenEmpty() const {
+  return cfg().rootSearch.hideFavoritesWhenEmpty;
+}
+void GeneralSettingsModel::setHideFavoritesWhenEmpty(bool v) {
+  cfgManager().mergeWithUser(
+      {.rootSearch = config::Partial<config::RootSearch>{.hideFavoritesWhenEmpty = v}});
+}
+
 static QVariantMap makeDropdownItem(const QString &id, const QString &displayName,
                                     const QString &iconSource = {}) {
   QVariantMap m;

--- a/src/server/src/qml/general-settings-model.hpp
+++ b/src/server/src/qml/general-settings-model.hpp
@@ -33,6 +33,10 @@ class GeneralSettingsModel : public QObject {
   Q_PROPERTY(QVariant currentIconTheme READ currentIconTheme NOTIFY configChanged)
   Q_PROPERTY(QVariant currentFaviconService READ currentFaviconService NOTIFY configChanged)
   Q_PROPERTY(QVariant currentKeybindingScheme READ currentKeybindingScheme NOTIFY configChanged)
+  Q_PROPERTY(bool hideSuggestionsWhenEmpty READ hideSuggestionsWhenEmpty WRITE setHideSuggestionsWhenEmpty
+                 NOTIFY configChanged)
+  Q_PROPERTY(bool hideFavoritesWhenEmpty READ hideFavoritesWhenEmpty WRITE setHideFavoritesWhenEmpty NOTIFY
+                 configChanged)
 
 signals:
   void configChanged();
@@ -64,6 +68,10 @@ public:
   void setInputServerEnabled(bool v);
   QString fontSize() const;
   void setFontSize(const QString &v);
+  bool hideSuggestionsWhenEmpty() const;
+  void setHideSuggestionsWhenEmpty(bool v);
+  bool hideFavoritesWhenEmpty() const;
+  void setHideFavoritesWhenEmpty(bool v);
 
   QVariantList themeItems() const;
   QVariantList fontItems() const;

--- a/src/server/src/qml/launcher-window.cpp
+++ b/src/server/src/qml/launcher-window.cpp
@@ -608,8 +608,7 @@ void LauncherWindow::tryCompaction() {
   const auto &val = m_ctx.services->config()->value();
   const auto &cfg = val.launcherWindow.compactMode;
   const auto &rs = val.rootSearch;
-  const bool atRoot =
-      m_ctx.navigation->searchText().isEmpty() && m_ctx.navigation->viewStackSize() == 1;
+  const bool atRoot = m_ctx.navigation->searchText().isEmpty() && m_ctx.navigation->viewStackSize() == 1;
   const bool noUnreadNews = !m_ctx.services->newsService()->hasUnreadNews();
   const bool noFavoritesToShow =
       rs.hideFavoritesWhenEmpty || m_ctx.services->rootItemManager()->queryFavorites(1).empty();

--- a/src/server/src/qml/launcher-window.cpp
+++ b/src/server/src/qml/launcher-window.cpp
@@ -45,12 +45,20 @@
 #include <malloc.h>
 #endif
 
+namespace {
+LauncherWindow *g_currentLauncherWindow = nullptr;
+}
+
+LauncherWindow *LauncherWindow::current() { return g_currentLauncherWindow; }
+
 LauncherWindow::LauncherWindow(ApplicationContext &ctx, QObject *parent)
     : QObject(parent), m_ctx(ctx), m_actionPanel(new ActionPanelController(ctx, this)),
       m_footerPanel(new ActionPanelController(ctx, this)),
       m_alertModel(new AlertModel(*ctx.navigation, this)), m_configBridge(new ConfigBridge(this)),
       m_imgSource(new ImageSource(this)), m_keybindProxy(new KeybindBridge(this)),
       m_themeBridge(new ThemeBridge(this)) {
+
+  g_currentLauncherWindow = this;
 
 #ifndef Q_OS_MACOS
   // Ensure Wayland app_id / X11 WM_CLASS is "vicinae"
@@ -360,6 +368,10 @@ void LauncherWindow::handleVisibilityChanged(bool visible) {
     m_window->raise();
     m_window->requestActivate();
   } else {
+    if (m_userExpanded) {
+      m_userExpanded = false;
+      emit userExpandedChanged();
+    }
     m_window->hide();
     m_cacheEvictionTimer.start();
   }
@@ -574,6 +586,14 @@ void LauncherWindow::buildFooterMenu() {
 
 void LauncherWindow::expand() { setCompacted(false); }
 
+void LauncherWindow::userExpand() {
+  if (!m_userExpanded) {
+    m_userExpanded = true;
+    emit userExpandedChanged();
+  }
+  tryCompaction();
+}
+
 void LauncherWindow::setCompacted(bool value) {
   if (m_compacted == value) return;
   m_compacted = value;
@@ -581,6 +601,10 @@ void LauncherWindow::setCompacted(bool value) {
 }
 
 void LauncherWindow::tryCompaction() {
+  if (m_userExpanded) {
+    setCompacted(false);
+    return;
+  }
   const auto &val = m_ctx.services->config()->value();
   const auto &cfg = val.launcherWindow.compactMode;
   const auto &rs = val.rootSearch;

--- a/src/server/src/qml/launcher-window.cpp
+++ b/src/server/src/qml/launcher-window.cpp
@@ -6,6 +6,7 @@
 #include "ui/action-pannel/action.hpp"
 #include "ui/image/image-renderer.hpp"
 #include "services/news/news-service.hpp"
+#include "services/root-item-manager/root-item-manager.hpp"
 #include "alert-model.hpp"
 #include "bridge-view.hpp"
 #include "image-source.hpp"
@@ -580,9 +581,16 @@ void LauncherWindow::setCompacted(bool value) {
 }
 
 void LauncherWindow::tryCompaction() {
-  auto &cfg = m_ctx.services->config()->value().launcherWindow.compactMode;
-  setCompacted(!m_ctx.services->newsService()->hasUnreadNews() && cfg.enabled &&
-               m_ctx.navigation->searchText().isEmpty() && m_ctx.navigation->viewStackSize() == 1);
+  const auto &val = m_ctx.services->config()->value();
+  const auto &cfg = val.launcherWindow.compactMode;
+  const auto &rs = val.rootSearch;
+  const bool atRoot =
+      m_ctx.navigation->searchText().isEmpty() && m_ctx.navigation->viewStackSize() == 1;
+  const bool noUnreadNews = !m_ctx.services->newsService()->hasUnreadNews();
+  const bool noFavoritesToShow =
+      rs.hideFavoritesWhenEmpty || m_ctx.services->rootItemManager()->queryFavorites(1).empty();
+  const bool rootListEmpty = rs.hideSuggestionsWhenEmpty && noFavoritesToShow;
+  setCompacted(atRoot && noUnreadNews && (cfg.enabled || rootListEmpty));
 }
 
 bool LauncherWindow::isLayerShellActive() const {

--- a/src/server/src/qml/launcher-window.hpp
+++ b/src/server/src/qml/launcher-window.hpp
@@ -38,6 +38,7 @@ class LauncherWindow : public QObject {
   Q_PROPERTY(bool searchInteractive READ searchInteractive NOTIFY searchInteractiveChanged)
   Q_PROPERTY(bool statusBarVisible READ statusBarVisible NOTIFY statusBarVisibleChanged)
   Q_PROPERTY(bool compacted READ compacted NOTIFY compactedChanged)
+  Q_PROPERTY(bool userExpanded READ userExpanded NOTIFY userExpandedChanged)
   Q_PROPERTY(bool hasCompleter READ hasCompleter NOTIFY completerChanged)
   Q_PROPERTY(bool popOnBackspace READ popOnBackspace)
   Q_PROPERTY(QVariantList completerArgs READ completerArgs NOTIFY completerChanged)
@@ -73,6 +74,7 @@ public:
   bool searchInteractive() const { return m_searchInteractive; }
   bool statusBarVisible() const { return m_statusBarVisible; }
   bool compacted() const { return m_compacted; }
+  bool userExpanded() const { return m_userExpanded; }
   bool hasCompleter() const { return m_hasCompleter; }
   bool popOnBackspace();
   QVariantList completerArgs() const { return m_completerArgs; }
@@ -88,6 +90,9 @@ public:
   static bool canPositionWindow();
 
   Q_INVOKABLE void expand();
+  Q_INVOKABLE void userExpand();
+
+  static LauncherWindow *current();
   Q_INVOKABLE void forwardSearchText(const QString &text);
   Q_INVOKABLE void handleReturn();
   Q_INVOKABLE bool forwardKey(int key, int modifiers = 0);
@@ -101,6 +106,7 @@ public:
 
 signals:
   void compactedChanged();
+  void userExpandedChanged();
   void atRootChanged();
   void showBackButtonChanged();
   void searchPlaceholderChanged();
@@ -150,6 +156,7 @@ private:
   QQmlApplicationEngine m_engine;
   QQuickWindow *m_window = nullptr;
   bool m_compacted = false;
+  bool m_userExpanded = false;
   bool m_atRoot = true;
   bool m_showBackButton = true;
   bool m_isLoading = false;

--- a/src/server/src/qml/qml/Footer.qml
+++ b/src/server/src/qml/qml/Footer.qml
@@ -28,6 +28,19 @@ Item {
         }
 
         FooterButton {
+            id: expandButton
+            visible: launcher.compacted
+            Layout.alignment: Qt.AlignVCenter
+            label: "Expand"
+            shortcutTokens: [
+                {
+                    "text": "↓"
+                }
+            ]
+            onClicked: launcher.userExpand()
+        }
+
+        FooterButton {
             id: primaryButton
             visible: actionPanel.primaryActionTitle !== ""
             Layout.alignment: Qt.AlignVCenter

--- a/src/server/src/qml/qml/GeneralSettingsPage.qml
+++ b/src/server/src/qml/qml/GeneralSettingsPage.qml
@@ -73,8 +73,8 @@ Flickable {
         }
 
         SettingsRow {
-            label: "Hide suggestions when empty"
-            description: "Hide the frecency-ranked Suggestions list shown when the search bar is empty."
+            label: "Hide suggestions"
+            description: "Hide the frecency-ranked Suggestions list when the search bar is empty."
             SettingsToggle {
                 checked: root.model.hideSuggestionsWhenEmpty
                 onToggled: checked => root.model.hideSuggestionsWhenEmpty = checked
@@ -82,8 +82,8 @@ Flickable {
         }
 
         SettingsRow {
-            label: "Hide favorites when empty"
-            description: "Hide the Favorites section shown when the search bar is empty."
+            label: "Hide favorites"
+            description: "Hide the Favorites section when the search bar is empty."
             SettingsToggle {
                 checked: root.model.hideFavoritesWhenEmpty
                 onToggled: checked => root.model.hideFavoritesWhenEmpty = checked

--- a/src/server/src/qml/qml/GeneralSettingsPage.qml
+++ b/src/server/src/qml/qml/GeneralSettingsPage.qml
@@ -77,7 +77,7 @@ Flickable {
             description: "Hide the frecency-ranked Suggestions list shown when the search bar is empty."
             SettingsToggle {
                 checked: root.model.hideSuggestionsWhenEmpty
-                onToggled: (checked) => root.model.hideSuggestionsWhenEmpty = checked
+                onToggled: checked => root.model.hideSuggestionsWhenEmpty = checked
             }
         }
 
@@ -86,7 +86,7 @@ Flickable {
             description: "Hide the Favorites section shown when the search bar is empty."
             SettingsToggle {
                 checked: root.model.hideFavoritesWhenEmpty
-                onToggled: (checked) => root.model.hideFavoritesWhenEmpty = checked
+                onToggled: checked => root.model.hideFavoritesWhenEmpty = checked
             }
         }
 

--- a/src/server/src/qml/qml/GeneralSettingsPage.qml
+++ b/src/server/src/qml/qml/GeneralSettingsPage.qml
@@ -74,7 +74,7 @@ Flickable {
 
         SettingsRow {
             label: "Hide suggestions"
-            description: "Hide the frecency-ranked Suggestions list when the search bar is empty."
+            description: "Hide the frecency-ranked Suggestions list when the search bar is empty, unless expanded."
             SettingsToggle {
                 checked: root.model.hideSuggestionsWhenEmpty
                 onToggled: checked => root.model.hideSuggestionsWhenEmpty = checked
@@ -83,7 +83,7 @@ Flickable {
 
         SettingsRow {
             label: "Hide favorites"
-            description: "Hide the Favorites section when the search bar is empty."
+            description: "Hide the Favorites section when the search bar is empty, unless expanded."
             SettingsToggle {
                 checked: root.model.hideFavoritesWhenEmpty
                 onToggled: checked => root.model.hideFavoritesWhenEmpty = checked

--- a/src/server/src/qml/qml/GeneralSettingsPage.qml
+++ b/src/server/src/qml/qml/GeneralSettingsPage.qml
@@ -73,6 +73,24 @@ Flickable {
         }
 
         SettingsRow {
+            label: "Hide suggestions when empty"
+            description: "Hide the frecency-ranked Suggestions list shown when the search bar is empty."
+            SettingsToggle {
+                checked: root.model.hideSuggestionsWhenEmpty
+                onToggled: (checked) => root.model.hideSuggestionsWhenEmpty = checked
+            }
+        }
+
+        SettingsRow {
+            label: "Hide favorites when empty"
+            description: "Hide the Favorites section shown when the search bar is empty."
+            SettingsToggle {
+                checked: root.model.hideFavoritesWhenEmpty
+                onToggled: (checked) => root.model.hideFavoritesWhenEmpty = checked
+            }
+        }
+
+        SettingsRow {
             label: "Basic usage statistics"
             description: "Send basic system and vicinae installation information on startup to help improve Vicinae."
             showSeparator: false

--- a/src/server/src/qml/qml/LauncherWindow.qml
+++ b/src/server/src/qml/qml/LauncherWindow.qml
@@ -15,7 +15,11 @@ Window {
 
     readonly property int _w: launcher.overrideWidth || Config.windowWidth
     readonly property int _h: launcher.overrideHeight || Config.windowHeight
-    readonly property int _contentH: launcher.compacted ? 60 + 2 * Config.borderWidth : _h
+    // When compacted, the visible frame collapses to "search bar + (optional toolbar)".
+    // The toolbar (Footer) stays visible whenever the status bar is, even when compacted —
+    // so the frame must reserve space for it: 60 search + 1 divider + 40 footer.
+    readonly property int _h_compact: 60 + (launcher.statusBarVisible ? (1 + 40) : 0) + 2 * Config.borderWidth
+    readonly property int _contentH: launcher.compacted ? _h_compact : _h
 
     width: _w + 2 * shadowPadding
     height: _h + 2 * shadowPadding
@@ -30,7 +34,7 @@ Window {
 
     BackgroundEffect.enabled: root.blurEnabled && !root.nativeChrome
     BackgroundEffect.radius: root.cornerRadius
-    BackgroundEffect.region: Qt.rect(shadowPadding, shadowPadding, _w, launcher.compacted ? 60 : _h)
+    BackgroundEffect.region: Qt.rect(shadowPadding, shadowPadding, _w, launcher.compacted ? (_h_compact - 2 * Config.borderWidth) : _h)
 
     Item {
         id: shadowMask
@@ -86,7 +90,7 @@ Window {
         Rectangle {
             visible: launcher.compacted
             width: _w
-            height: 60 + 2 * Config.borderWidth
+            height: _h_compact
             radius: root.cornerRadius
             color: Qt.rgba(Theme.background.r, Theme.background.g, Theme.background.b, Config.windowOpacity)
         }
@@ -94,7 +98,7 @@ Window {
         SourceBlendRect {
             visible: launcher.compacted && !root.nativeChrome
             width: _w
-            height: 60 + 2 * Config.borderWidth
+            height: _h_compact
             radius: root.cornerRadius
             overlay: true
             borderColor: Config.withAlpha(Theme.mainWindowBorder, Config.windowOpacity)
@@ -142,8 +146,13 @@ Window {
         }
 
         ColumnLayout {
-            anchors.fill: parent
-            anchors.margins: Config.borderWidth
+            anchors.top: parent.top
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.topMargin: Config.borderWidth
+            anchors.leftMargin: Config.borderWidth
+            anchors.rightMargin: Config.borderWidth
+            height: _contentH - 2 * Config.borderWidth
             spacing: 0
             visible: !launcher.hasOverlay
 
@@ -165,8 +174,9 @@ Window {
             Item {
                 id: contentArea
                 objectName: "contentArea"
+                visible: !launcher.compacted
                 Layout.fillWidth: true
-                Layout.fillHeight: true
+                Layout.fillHeight: !launcher.compacted
 
                 StackView {
                     id: commandStack
@@ -176,13 +186,13 @@ Window {
             }
 
             ViciDivider {
-                visible: !launcher.compacted && launcher.statusBarVisible
+                visible: launcher.statusBarVisible
                 Layout.fillWidth: true
             }
 
             Footer {
                 id: footer
-                visible: !launcher.compacted && launcher.statusBarVisible
+                visible: launcher.statusBarVisible
                 Layout.fillWidth: true
                 Layout.preferredHeight: visible ? 40 : 0
             }

--- a/src/server/src/qml/qml/SearchBar.qml
+++ b/src/server/src/qml/qml/SearchBar.qml
@@ -198,7 +198,9 @@ Item {
                         return false;
 
                     if (launcher.compacted) {
-                        launcher.expand();
+                        // In partial state only the Down direction expands; other directions are no-ops.
+                        if (nav === 2)
+                            launcher.userExpand();
                         return true;
                     }
 
@@ -218,7 +220,7 @@ Item {
 
                 Keys.onUpPressed: event => {
                     if (launcher.compacted) {
-                        launcher.expand();
+                        event.accepted = true;
                         return;
                     }
 
@@ -233,7 +235,8 @@ Item {
                 }
                 Keys.onDownPressed: event => {
                     if (launcher.compacted) {
-                        launcher.expand();
+                        launcher.userExpand();
+                        event.accepted = true;
                         return;
                     }
 
@@ -248,7 +251,7 @@ Item {
                 }
                 Keys.onLeftPressed: event => {
                     if (launcher.compacted) {
-                        launcher.expand();
+                        event.accepted = true;
                         return;
                     }
 
@@ -262,7 +265,7 @@ Item {
                 }
                 Keys.onRightPressed: event => {
                     if (launcher.compacted) {
-                        launcher.expand();
+                        event.accepted = true;
                         return;
                     }
 
@@ -276,7 +279,6 @@ Item {
                 }
                 Keys.onReturnPressed: event => {
                     if (launcher.compacted) {
-                        launcher.expand();
                         event.accepted = true;
                         return;
                     }

--- a/src/server/src/qml/root-search-model.cpp
+++ b/src/server/src/qml/root-search-model.cpp
@@ -34,6 +34,7 @@ RootSearchModel::RootSearchModel(const ViewScope &scope, QObject *parent)
   connect(m_config, &config::Manager::configChanged, this,
           [this](const config::ConfigValue &next, const config::ConfigValue &) {
             m_fileSearchEnabled = next.searchFilesInRoot;
+            refresh();
           });
 
   connect(m_manager, &RootItemManager::metadataChanged, this, &RootSearchModel::refresh);
@@ -127,11 +128,22 @@ bool RootSearchModel::rerunSearch() {
   m_resultsSource->setQueryEmpty(m_query.empty());
   m_fallbackSource->setQuery(m_query);
 
+  const auto &rs = m_config->value().rootSearch;
+  const bool emptyQuery = m_query.empty();
+  const bool hideSuggestions = emptyQuery && rs.hideSuggestionsWhenEmpty;
+  const bool hideFavorites = emptyQuery && rs.hideFavoritesWhenEmpty;
+
   std::vector<RootItemManager::ScoredItem> scored;
-  if (m_query.empty()) {
-    m_manager->search("", scored, {.includeFavorites = false, .prioritizeAliased = false});
+  if (emptyQuery) {
+    if (!hideSuggestions) {
+      m_manager->search("", scored, {.includeFavorites = false, .prioritizeAliased = false});
+    }
     m_newsSource->setItems(m_newsService->activeItems());
-    m_favoritesSource->setItems(m_manager->queryFavorites());
+    if (hideFavorites) {
+      m_favoritesSource->setItems({});
+    } else {
+      m_favoritesSource->setItems(m_manager->queryFavorites());
+    }
     m_fallbackSource->setItems({});
   } else {
     m_manager->search(text, scored);
@@ -148,7 +160,11 @@ bool RootSearchModel::rerunSearch() {
         .meta = s.meta ? *s.meta : RootItemMetadata{},
     });
   }
-  m_resultsSource->setItems(std::move(results));
+  if (hideSuggestions) {
+    m_resultsSource->setItems({});
+  } else {
+    m_resultsSource->setItems(std::move(results));
+  }
 
   rebuild();
   return false;

--- a/src/server/src/qml/root-search-model.cpp
+++ b/src/server/src/qml/root-search-model.cpp
@@ -1,5 +1,6 @@
 #include "root-search-model.hpp"
 #include "config/config.hpp"
+#include "launcher-window.hpp"
 #include "ui/action-pannel/action-panel-view.hpp"
 #include "ui/views/base-view.hpp"
 #include "service-registry.hpp"
@@ -36,6 +37,10 @@ RootSearchModel::RootSearchModel(const ViewScope &scope, QObject *parent)
             m_fileSearchEnabled = next.searchFilesInRoot;
             refresh();
           });
+
+  if (auto *launcher = LauncherWindow::current()) {
+    connect(launcher, &LauncherWindow::userExpandedChanged, this, &RootSearchModel::refresh);
+  }
 
   connect(m_manager, &RootItemManager::metadataChanged, this, &RootSearchModel::refresh);
   connect(m_manager, &RootItemManager::itemsChanged, this, &RootSearchModel::refresh);
@@ -129,9 +134,11 @@ bool RootSearchModel::rerunSearch() {
   m_fallbackSource->setQuery(m_query);
 
   const auto &rs = m_config->value().rootSearch;
+  const auto *launcher = LauncherWindow::current();
+  const bool userExpanded = launcher && launcher->userExpanded();
   const bool emptyQuery = m_query.empty();
-  const bool hideSuggestions = emptyQuery && rs.hideSuggestionsWhenEmpty;
-  const bool hideFavorites = emptyQuery && rs.hideFavoritesWhenEmpty;
+  const bool hideSuggestions = emptyQuery && rs.hideSuggestionsWhenEmpty && !userExpanded;
+  const bool hideFavorites = emptyQuery && rs.hideFavoritesWhenEmpty && !userExpanded;
 
   std::vector<RootItemManager::ScoredItem> scored;
   if (emptyQuery) {


### PR DESCRIPTION
## Motivation

The launcher's empty state always shows Suggestions and Favorites. I prefer a minimal launcher when nothing has been typed, and I suspect I'm not alone, so this adds two opt-in toggles to make that possible. I've kept this brief on behavioral design choices; happy to discuss them and the alternatives I considered.

## What's added

**Settings → General** gets two new toggles:

- **Hide suggestions** — drops the frecency-ranked Suggestions list when the search bar is empty.
- **Hide favorites** — drops the Favorites section when the search bar is empty.

Both default to `false`. Zero behavior change for existing users.

When both flags hide everything the empty state would show (no suggestions and no favorites/news to fall back on), the window collapses to just the search bar and footer. A footer **Expand** button — and `↓` on the search bar — temporarily restores the full layout for the current visibility cycle without flipping the toggles. Other arrow keys and `Enter` are intentionally no-ops while collapsed.

## Implementation

- New `rootSearch.hideSuggestionsWhenEmpty` / `hideFavoritesWhenEmpty` flags in `config.hpp` with a matching `Partial<RootSearch>` for the user-config patch path. Defaults preserved.
- `RootSearchModel::rerunSearch()` gates the relevant `setItems()` calls on the flags and on a transient `userExpanded` override.
- `LauncherWindow` tracks `userExpanded` (reset on each visibility cycle) and exposes `userExpand()` to the Footer button and the search-bar `Keys.onDownPressed` handler.
- Drive-by: gives `WindowCompactMode::enabled` an explicit `= false` default to match surrounding convention. No runtime change; closes a latent uninitialized-bool path.

## Manual verification

Branch is rebased on `main` (`67290dff`). Verified locally on Linux/Wayland:

- Defaults: visual parity with `main`.
- Each toggle independently / both together → expected sections appear/disappear immediately on toggle.
- Settings persist across restarts (checked `settings.json`).
- Both toggles on + no favorites/news → window collapses; `↓` and footer **Expand** restore full layout; Up/Left/Right/Enter are no-ops while collapsed.
- Typing a query restores the full layout regardless of toggle state.

## Screenshots

<img width="803" height="132" alt="vicinae-collapsed" src="https://github.com/user-attachments/assets/d745149b-fbff-40b5-9dec-c14112017104" />

*Collapsed launcher bar — the new optional default empty-state.*

<br>

<img width="878" height="556" alt="vicinae-settings" src="https://github.com/user-attachments/assets/38ef3e27-75a5-4b70-a5d0-df5473c41dc7" />

*Settings pane, General settings, new toggles.*

<br>

**Happy to add a short screen recording of the Expand interaction on request.**