### PR TITLE
feat(settings): add GUI toggle for compact mode

### DIFF
--- a/src/server/src/qml/general-settings-model.cpp
+++ b/src/server/src/qml/general-settings-model.cpp
@@ -65,6 +65,12 @@ void GeneralSettingsModel::setClientSideDecorations(bool v) {
            .clientSideDecorations = config::Partial<config::WindowCSD>{.enabled = v}}});
 }
 
+bool GeneralSettingsModel::compactMode() const { return cfg().launcherWindow.compactMode.enabled; }
+void GeneralSettingsModel::setCompactMode(bool v) {
+  cfgManager().mergeWithUser({.launcherWindow = config::Partial<config::WindowConfig>{
+                                  .compactMode = config::Partial<config::WindowCompactMode>{.enabled = v}}});
+}
+
 bool GeneralSettingsModel::inputServerEnabled() const { return cfg().inputServer.enabled; }
 
 void GeneralSettingsModel::setInputServerEnabled(bool v) {

--- a/src/server/src/qml/general-settings-model.hpp
+++ b/src/server/src/qml/general-settings-model.hpp
@@ -19,6 +19,7 @@ class GeneralSettingsModel : public QObject {
       bool telemetrySystemInfo READ telemetrySystemInfo WRITE setTelemetrySystemInfo NOTIFY configChanged)
   Q_PROPERTY(bool clientSideDecorations READ clientSideDecorations WRITE setClientSideDecorations NOTIFY
                  configChanged)
+  Q_PROPERTY(bool compactMode READ compactMode WRITE setCompactMode NOTIFY configChanged)
   Q_PROPERTY(QString windowOpacity READ windowOpacity WRITE setWindowOpacity NOTIFY configChanged)
   Q_PROPERTY(
       bool nativeTextRendering READ nativeTextRendering WRITE setNativeTextRendering NOTIFY configChanged)
@@ -56,6 +57,8 @@ public:
   void setTelemetrySystemInfo(bool v);
   bool clientSideDecorations() const;
   void setClientSideDecorations(bool v);
+  bool compactMode() const;
+  void setCompactMode(bool v);
   QString windowOpacity() const;
   void setWindowOpacity(const QString &v);
   bool nativeTextRendering() const;

--- a/src/server/src/qml/qml/GeneralSettingsPage.qml
+++ b/src/server/src/qml/qml/GeneralSettingsPage.qml
@@ -73,6 +73,15 @@ Flickable {
         }
 
         SettingsRow {
+            label: "Compact mode"
+            description: "Show only the search bar at root; expand when a query is entered."
+            SettingsToggle {
+                checked: root.model.compactMode
+                onToggled: root.model.compactMode = checked
+            }
+        }
+
+        SettingsRow {
             label: "Basic usage statistics"
             description: "Send basic system and vicinae installation information on startup to help improve Vicinae."
             showSeparator: false


### PR DESCRIPTION
## Summary

Surfaces `launcher_window.compact_mode.enabled` as a single toggle on Settings → General. The wiring already existed end-to-end via `tryCompaction()` and the config-file watcher; this is GUI exposure only — no behavioral change. Thanks for the go-ahead this morning.

Pattern mirrors `clientSideDecorations`: `Q_PROPERTY` + getter/setter on `GeneralSettingsModel`, plus one `SettingsRow` in `GeneralSettingsPage.qml` placed after "Pop to root on close."

The in-app description is intentionally brief and omits the layer-shell caveat, to match the cadence of the surrounding rows. Happy to add it inline, or open a follow-up docs PR if you'd rather surface that warning somewhere users will find it — your call.

A user who manually set `compact_mode.enabled: true` will see the GUI toggle reflect that state, can flip it via the toggle, and the change will persist back to their `settings.json` without disturbing their other settings. 

## Testing

Tested locally in an isolated XDG sandbox: GUI toggle and direct `settings.json` edits both hot-apply via the existing `configChanged` signal, no restart needed. `clang-format` / `clang-tidy` clean on touched files. 

## Screenshot

<img width="868" height="551" alt="vicinae-settings-feat-compact-mode-gui-toggle" src="https://github.com/user-attachments/assets/d18ff973-4408-49ca-a359-7bdbefa713dc" />

