### PR TITLE
feat: add ext-hotkey implementation and change to sync API

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -693,6 +693,8 @@ if (UNIX AND NOT APPLE)
 	wayland_generate_protocol("ext-data-control-v1")
 	wayland_generate_protocol("kde-blur")
 	wayland_generate_protocol("ext-background-effect-v1")
+	wayland_generate_protocol("keyboard-shortcuts-inhibit-unstable-v1")
+	wayland_generate_protocol("ext-hotkey-v1")
 
 	list(APPEND LIBS xkbcommon)
 
@@ -704,8 +706,12 @@ if (UNIX AND NOT APPLE)
 		src/internal/wayland/seat.cpp
 		src/services/background-effect/ext-background-effect-v1-manager.cpp
 		src/services/background-effect/kde-background-effect-manager.cpp
+		src/services/shortcut-inhibit/wayland-shortcut-inhibit-manager.cpp
 		src/services/clipboard/data-control/data-control-clipboard-server.hpp
 		src/services/clipboard/data-control/data-control-clipboard-server.cpp
+
+		src/services/global-shortcuts/ext-hotkey-global-shortcut-backend.hpp
+		src/services/global-shortcuts/ext-hotkey-global-shortcut-backend.cpp
 
 		src/services/files-service/file-indexer/file-indexer.hpp
 		src/services/files-service/file-indexer/file-indexer.cpp
@@ -915,6 +921,8 @@ set(VICINAE_QML_SOURCES
 	src/qml/markdown/text-selection-controller.hpp
 	src/qml/background-effect-attached.hpp
 	src/qml/background-effect-attached.cpp
+	src/qml/shortcut-inhibitor-attached.hpp
+	src/qml/shortcut-inhibitor-attached.cpp
 )
 
 if(APPLE)

--- a/src/server/src/internal/wayland/globals.cpp
+++ b/src/server/src/internal/wayland/globals.cpp
@@ -1,5 +1,7 @@
 #include "globals.hpp"
 #include "ext-background-effect-v1-client-protocol.h"
+#include "ext-hotkey-v1-client-protocol.h"
+#include "keyboard-shortcuts-inhibit-unstable-v1-client-protocol.h"
 #include <QGuiApplication>
 
 namespace Wayland {
@@ -24,6 +26,16 @@ void Globals::handleGlobal(void *data, struct wl_registry *registry, uint32_t na
   else if (strcmp(interface, ext_background_effect_manager_v1_interface.name) == 0) {
     self->m_backgroundEffect = static_cast<decltype(self->m_backgroundEffect)>(
         wl_registry_bind(registry, name, &ext_background_effect_manager_v1_interface, version));
+  }
+
+  else if (strcmp(interface, ext_hotkey_manager_v1_interface.name) == 0) {
+    self->m_hotkey = static_cast<decltype(self->m_hotkey)>(
+        wl_registry_bind(registry, name, &ext_hotkey_manager_v1_interface, version));
+  }
+
+  else if (strcmp(interface, zwp_keyboard_shortcuts_inhibit_manager_v1_interface.name) == 0) {
+    self->m_shortcutInhibit = static_cast<decltype(self->m_shortcutInhibit)>(
+        wl_registry_bind(registry, name, &zwp_keyboard_shortcuts_inhibit_manager_v1_interface, version));
   }
 }
 // NOLINTEND(cppcoreguidelines-pro-type-static-cast-downcast)

--- a/src/server/src/internal/wayland/globals.hpp
+++ b/src/server/src/internal/wayland/globals.hpp
@@ -3,6 +3,8 @@
 #include "ext-data-control-v1-client-protocol.h"
 #include "kde-blur-client-protocol.h"
 #include "ext-background-effect-v1-client-protocol.h"
+#include "ext-hotkey-v1-client-protocol.h"
+#include "keyboard-shortcuts-inhibit-unstable-v1-client-protocol.h"
 #include <wayland-client.h>
 
 namespace Wayland {
@@ -12,6 +14,8 @@ public:
   static auto kwinBlur() { return instance().m_kwinBlur; }
   static auto *extBackgroundEffectManager() { return instance().m_backgroundEffect; }
   static ext_data_control_manager_v1 *dataControlManager();
+  static ext_hotkey_manager_v1 *hotkey() { return instance().m_hotkey; }
+  static zwp_keyboard_shortcuts_inhibit_manager_v1 *shortcutInhibit() { return instance().m_shortcutInhibit; }
 
 private:
   static Globals &instance();
@@ -27,5 +31,7 @@ private:
   ext_data_control_manager_v1 *m_dataControlManager = nullptr;
   org_kde_kwin_blur_manager *m_kwinBlur = nullptr;
   ext_background_effect_manager_v1 *m_backgroundEffect = nullptr;
+  ext_hotkey_manager_v1 *m_hotkey = nullptr;
+  zwp_keyboard_shortcuts_inhibit_manager_v1 *m_shortcutInhibit = nullptr;
 };
 } // namespace Wayland

--- a/src/server/src/qml/global-shortcut-bridge.hpp
+++ b/src/server/src/qml/global-shortcut-bridge.hpp
@@ -22,9 +22,16 @@ public:
     if (auto *service = ServiceRegistry::instance()->globalShortcuts()) { service->setCapturing(capturing); }
   }
 
-  Q_INVOKABLE QString validate(int key, int modifiers, const QString &excludeId) const {
+  Q_INVOKABLE QString validate(int key, int modifiers, const QString &excludeId) {
     Keyboard::Shortcut const shortcut(static_cast<Qt::Key>(key),
                                       static_cast<Qt::KeyboardModifiers>(modifiers));
-    return shortcut_conflict::validate(shortcut, excludeId);
+
+    if (auto error = shortcut_conflict::validate(shortcut, excludeId); !error.isEmpty()) { return error; }
+
+    if (auto *service = ServiceRegistry::instance()->globalShortcuts()) {
+      if (auto denied = service->probeBind(shortcut)) { return *denied; }
+    }
+
+    return {};
   }
 };

--- a/src/server/src/qml/qml/ShortcutRecorderField.qml
+++ b/src/server/src/qml/qml/ShortcutRecorderField.qml
@@ -21,13 +21,24 @@ Popup {
     property string _statusText: "Recording..."
     property color _statusColor: Theme.foreground
 
+    property bool _justClosed: false
+
     Timer {
         id: closeTimer
         interval: 2000
         onTriggered: recorder.close()
     }
 
-    function show(targetItem) {
+    Timer {
+        id: reopenGuard
+        interval: 300
+        onTriggered: recorder._justClosed = false
+    }
+
+    function show(targetItem, below) {
+        if (_justClosed)
+            return false;
+
         _currentShortcutTokens = [];
         _statusText = "Recording...";
         _statusColor = Theme.foreground;
@@ -35,13 +46,18 @@ Popup {
 
         var pos = targetItem.mapToItem(recorder.parent, 0, 0);
         recorder.x = pos.x + targetItem.width / 2 - recorder.width / 2;
-        recorder.y = pos.y - recorder.height - 10;
+        recorder.y = below ? pos.y + targetItem.height + 10 : pos.y - recorder.height - 10;
         recorder.open();
+        return true;
     }
 
     onOpened: {
         GlobalShortcuts.setCapturing(true);
         keyReceiver.forceActiveFocus();
+    }
+    onAboutToHide: {
+        _justClosed = true;
+        reopenGuard.restart();
     }
     onClosed: GlobalShortcuts.setCapturing(false)
     onActiveFocusChanged: if (!activeFocus && opened)
@@ -60,6 +76,8 @@ Popup {
 
     contentItem: FocusScope {
         focus: true
+
+        ShortcutInhibitor.enabled: recorder.opened
 
         Keys.onPressed: event => {
             event.accepted = true;

--- a/src/server/src/qml/qml/ShortcutsSettingsPage.qml
+++ b/src/server/src/qml/qml/ShortcutsSettingsPage.qml
@@ -7,62 +7,19 @@ Item {
     readonly property var model: settings.keybindModel
 
     property int _recordingRow: -1
-    property var _recordingTokens: []
-    property string _recordingStatus: ""
-    property color _recordingStatusColor: Theme.textMuted
 
-    function _startRecording(row) {
-        _recordingRow = row;
-        _recordingTokens = [];
-        _recordingStatus = "Press a shortcut...";
-        _recordingStatusColor = Theme.textMuted;
-        root.forceActiveFocus();
+    ShortcutRecorderField {
+        id: recorder
+        shortcutDisplayProvider: (key, mods) => root.model.shortcutDisplayTokens(key, mods)
+        validateShortcut: (key, mods) => root.model.validateShortcut(root._recordingRow, key, mods)
+        onShortcutCaptured: (key, modifiers) => root.model.setShortcut(root._recordingRow, key, modifiers)
     }
 
-    function _cancelRecording() {
-        _recordingRow = -1;
-        _recordingTokens = [];
-        _recordingStatus = "";
-    }
-
-    onActiveFocusChanged: {
-        if (!activeFocus && _recordingRow >= 0)
-            _cancelRecording();
-    }
-
-    Keys.onPressed: event => {
-        if (root._recordingRow < 0)
-            return;
-        event.accepted = true;
-
-        const key = event.key;
-        const mods = event.modifiers;
-
-        const isModKey = key === Qt.Key_Shift || key === Qt.Key_Control || key === Qt.Key_Alt || key === Qt.Key_Meta;
-        const isCloseKey = key === Qt.Key_Escape || key === Qt.Key_Backspace;
-
-        if (!isModKey && isCloseKey && mods === Qt.NoModifier) {
-            root._cancelRecording();
-            return;
+    Connections {
+        target: recorder
+        function onClosed() {
+            root._recordingRow = -1;
         }
-
-        root._recordingTokens = root.model.shortcutDisplayTokens(key, mods);
-
-        if (isModKey) {
-            root._recordingStatus = "Press a key...";
-            root._recordingStatusColor = Theme.textMuted;
-            return;
-        }
-
-        const error = root.model.validateShortcut(root._recordingRow, key, mods);
-        if (error !== "") {
-            root._recordingStatus = error;
-            root._recordingStatusColor = Theme.danger;
-            return;
-        }
-
-        root.model.setShortcut(root._recordingRow, key, mods);
-        root._cancelRecording();
     }
 
     ColumnLayout {
@@ -178,7 +135,10 @@ Item {
                 }
                 MouseArea {
                     anchors.fill: parent
-                    onClicked: root._startRecording(rowItem.index)
+                    onClicked: {
+                        if (recorder.show(rowItem, true))
+                            root._recordingRow = rowItem.index;
+                    }
                 }
 
                 RowLayout {
@@ -205,15 +165,8 @@ Item {
                     }
 
                     ShortcutBadge {
-                        visible: rowItem.isRecording ? root._recordingTokens.length > 0 : rowItem.shortcutTokens.length > 0
-                        tokens: rowItem.isRecording ? root._recordingTokens : rowItem.shortcutTokens
-                    }
-
-                    Text {
-                        visible: rowItem.isRecording
-                        text: root._recordingStatus
-                        color: root._recordingStatusColor
-                        font.pointSize: Theme.smallerFontSize
+                        visible: rowItem.shortcutTokens.length > 0
+                        tokens: rowItem.shortcutTokens
                     }
 
                     Text {

--- a/src/server/src/qml/shortcut-inhibitor-attached.cpp
+++ b/src/server/src/qml/shortcut-inhibitor-attached.cpp
@@ -1,0 +1,88 @@
+#include "shortcut-inhibitor-attached.hpp"
+#include <QQuickItem>
+#include <QQuickWindow>
+#include <qevent.h>
+
+ShortcutInhibitorAttached::ShortcutInhibitorAttached(QObject *parent) : QObject(parent) {
+  m_window = qobject_cast<QWindow *>(parent);
+  if (m_window) {
+    trackWindow(m_window);
+    return;
+  }
+
+  m_item = qobject_cast<QQuickItem *>(parent);
+  if (m_item) {
+    connect(m_item, &QQuickItem::windowChanged, this, &ShortcutInhibitorAttached::onWindowChanged);
+    if (m_item->window()) onWindowChanged(m_item->window());
+  }
+}
+
+void ShortcutInhibitorAttached::setEnabled(bool value) {
+  if (m_enabled == value) return;
+  m_enabled = value;
+  emit enabledChanged();
+  apply();
+}
+
+void ShortcutInhibitorAttached::trackWindow(QWindow *window) {
+  m_window = window;
+  if (!m_window) return;
+  m_window->installEventFilter(this);
+}
+
+void ShortcutInhibitorAttached::onWindowChanged(QQuickWindow *window) {
+  if (m_window) {
+    m_window->removeEventFilter(this);
+    if (auto *mgr = ShortcutInhibitor::manager(); mgr && m_inhibited) { mgr->release(m_inhibited); }
+    m_inhibited = nullptr;
+    m_window = nullptr;
+    m_surfaceReady = false;
+  }
+
+  if (window) {
+    trackWindow(window);
+    apply();
+  }
+}
+
+QWindow *ShortcutInhibitorAttached::targetWindow() const {
+  QWindow *win = m_window;
+  while (win && win->transientParent()) {
+    win = win->transientParent();
+  }
+  return win;
+}
+
+void ShortcutInhibitorAttached::apply() {
+  auto *mgr = ShortcutInhibitor::manager();
+  QWindow *target = targetWindow();
+
+  if (!m_window || !mgr || !mgr->isSupported()) return;
+
+  if (!m_surfaceReady) {
+    if (!m_window->handle()) return;
+    m_surfaceReady = true;
+  }
+
+  if (m_inhibited && (!m_enabled || m_inhibited != target)) {
+    mgr->release(m_inhibited);
+    m_inhibited = nullptr;
+  }
+
+  if (m_enabled && target && target->handle() && !m_inhibited) {
+    if (mgr->inhibit(target)) { m_inhibited = target; }
+  }
+}
+
+bool ShortcutInhibitorAttached::eventFilter(QObject *obj, QEvent *event) {
+  if (obj == m_window && event->type() == QEvent::PlatformSurface) {
+    auto *se = static_cast<QPlatformSurfaceEvent *>(event); // NOLINT
+    if (se->surfaceEventType() == QPlatformSurfaceEvent::SurfaceCreated) {
+      m_surfaceReady = true;
+      apply();
+    } else if (se->surfaceEventType() == QPlatformSurfaceEvent::SurfaceAboutToBeDestroyed) {
+      m_surfaceReady = false;
+    }
+  }
+  return QObject::eventFilter(obj, event);
+}

--- a/src/server/src/qml/shortcut-inhibitor-attached.hpp
+++ b/src/server/src/qml/shortcut-inhibitor-attached.hpp
@@ -1,0 +1,54 @@
+#pragma once
+#include <QObject>
+#include <QWindow>
+#include <qqmlregistration.h>
+#include "services/shortcut-inhibit/shortcut-inhibit-manager.hpp"
+
+class QQuickItem;
+class QQuickWindow;
+
+class ShortcutInhibitorAttached : public QObject {
+  Q_OBJECT
+  Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged)
+
+public:
+  explicit ShortcutInhibitorAttached(QObject *parent);
+
+  bool enabled() const { return m_enabled; }
+  void setEnabled(bool value);
+
+signals:
+  void enabledChanged();
+
+private:
+  void apply();
+  void trackWindow(QWindow *window);
+  void onWindowChanged(QQuickWindow *window);
+  bool eventFilter(QObject *obj, QEvent *event) override;
+
+  QWindow *targetWindow() const;
+
+  QQuickItem *m_item = nullptr;
+  QWindow *m_window = nullptr;
+  QWindow *m_inhibited = nullptr;
+  bool m_enabled = false;
+  bool m_surfaceReady = false;
+};
+
+class ShortcutInhibitor : public QObject {
+  Q_OBJECT
+  QML_NAMED_ELEMENT(ShortcutInhibitor)
+  QML_UNCREATABLE("")
+  QML_ATTACHED(ShortcutInhibitorAttached)
+
+public:
+  static ShortcutInhibitorAttached *qmlAttachedProperties(QObject *object) {
+    return new ShortcutInhibitorAttached(object);
+  }
+
+  static void setManager(ShortcutInhibitManager *mgr) { s_manager = mgr; }
+  static ShortcutInhibitManager *manager() { return s_manager; }
+
+private:
+  static inline ShortcutInhibitManager *s_manager = nullptr;
+};

--- a/src/server/src/server.cpp
+++ b/src/server/src/server.cpp
@@ -25,6 +25,8 @@
 #include "service-registry.hpp"
 #include "services/background-effect/background-effect-manager.hpp"
 #include "qml/background-effect-attached.hpp"
+#include "services/shortcut-inhibit/shortcut-inhibit-manager.hpp"
+#include "qml/shortcut-inhibitor-attached.hpp"
 #include "services/file-chooser/file-chooser-service.hpp"
 #include "services/browser-extension-service.hpp"
 #include "services/calculator-service/calculator-service.hpp"
@@ -153,9 +155,9 @@ int startServer(const ServerLaunchOptions &launchOpts) {
                                                        std::move(platformPaste));
     auto fontService = std::make_unique<FontService>();
     auto configService = std::make_unique<config::Manager>(m_config);
-    auto globalShortcutService =
-        std::make_unique<GlobalShortcutService>(*configService, createGlobalShortcutBackend());
     auto rootItemManager = std::make_unique<RootItemManager>(*configService, *localStorage);
+    auto globalShortcutService = std::make_unique<GlobalShortcutService>(*configService, *rootItemManager,
+                                                                         createGlobalShortcutBackend());
     auto shortcutService =
         std::make_unique<ShortcutService>(Omnicast::dataDir() / "shortcuts" / "shortcuts.json", omniDb.get());
     auto toastService = std::make_unique<ToastService>();
@@ -214,6 +216,8 @@ int startServer(const ServerLaunchOptions &launchOpts) {
     registry->setBrowserExtension(std::make_unique<BrowserExtensionService>());
     registry->setBackgroundEffectManager(std::make_unique<BackgroundEffectManager>());
     BackgroundEffect::setManager(registry->backgroundEffectManager());
+    registry->setShortcutInhibitManager(std::make_unique<ShortcutInhibitManager>());
+    ShortcutInhibitor::setManager(registry->shortcutInhibitManager());
     registry->setFileChooserService(std::make_unique<FileChooserService>());
     registry->setNewsService(std::make_unique<NewsService>(*registry->config()));
     registry->setTelemetry(std::make_unique<TelemetryService>(*registry->config()));

--- a/src/server/src/service-registry.cpp
+++ b/src/server/src/service-registry.cpp
@@ -8,6 +8,7 @@
 #include "omni-database.hpp"
 #include "services/app-service/app-service.hpp"
 #include "services/background-effect/background-effect-manager.hpp"
+#include "services/shortcut-inhibit/shortcut-inhibit-manager.hpp"
 #include "services/browser-extension-service.hpp"
 #include "services/power-manager/power-manager.hpp"
 #include "services/script-command/script-command-service.hpp"
@@ -74,6 +75,10 @@ NewsService *ServiceRegistry::newsService() const { return m_newsService.get(); 
 
 BackgroundEffectManager *ServiceRegistry::backgroundEffectManager() const {
   return m_backgroundEffectManager.get();
+}
+
+ShortcutInhibitManager *ServiceRegistry::shortcutInhibitManager() const {
+  return m_shortcutInhibitManager.get();
 }
 
 TelemetryService *ServiceRegistry::telemetry() const { return m_telemetry.get(); }
@@ -172,6 +177,10 @@ void ServiceRegistry::setNewsService(std::unique_ptr<NewsService> service) {
 
 void ServiceRegistry::setBackgroundEffectManager(std::unique_ptr<BackgroundEffectManager> service) {
   m_backgroundEffectManager = std::move(service);
+}
+
+void ServiceRegistry::setShortcutInhibitManager(std::unique_ptr<ShortcutInhibitManager> service) {
+  m_shortcutInhibitManager = std::move(service);
 }
 
 void ServiceRegistry::setTelemetry(std::unique_ptr<TelemetryService> telemetry) {

--- a/src/server/src/service-registry.hpp
+++ b/src/server/src/service-registry.hpp
@@ -30,6 +30,7 @@ class LinuxInputServer;
 class SnippetService;
 class BrowserExtensionService;
 class BackgroundEffectManager;
+class ShortcutInhibitManager;
 class FileChooserService;
 class NewsService;
 class PasteService;
@@ -76,6 +77,7 @@ public:
   FileChooserService *fileChooserService() const;
   NewsService *newsService() const;
   BackgroundEffectManager *backgroundEffectManager() const;
+  ShortcutInhibitManager *shortcutInhibitManager() const;
   TelemetryService *telemetry() const;
   AudioControlService *audioControl() const;
   AppRuntime *appRuntime() const;
@@ -112,6 +114,7 @@ public:
   void setFileChooserService(std::unique_ptr<FileChooserService> service);
   void setNewsService(std::unique_ptr<NewsService> service);
   void setBackgroundEffectManager(std::unique_ptr<BackgroundEffectManager> manager);
+  void setShortcutInhibitManager(std::unique_ptr<ShortcutInhibitManager> manager);
   void setTelemetry(std::unique_ptr<TelemetryService> telemetry);
   void setAudioControl(std::unique_ptr<AudioControlService> service);
   void setAppRuntime(std::unique_ptr<AppRuntime> service);
@@ -148,6 +151,7 @@ private:
   std::unique_ptr<FileChooserService> m_fileChooserService;
   std::unique_ptr<NewsService> m_newsService;
   std::unique_ptr<BackgroundEffectManager> m_backgroundEffectManager;
+  std::unique_ptr<ShortcutInhibitManager> m_shortcutInhibitManager;
   std::unique_ptr<TelemetryService> m_telemetry;
   std::unique_ptr<AudioControlService> m_audioControl;
   std::unique_ptr<AppRuntime> m_appRuntime;

--- a/src/server/src/services/global-shortcuts/abstract-global-shortcut-backend.hpp
+++ b/src/server/src/services/global-shortcuts/abstract-global-shortcut-backend.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <expected>
 #include <optional>
 #include <QObject>
 #include "keyboard/keyboard.hpp"
@@ -6,15 +7,7 @@
 struct GlobalShortcutRequest {
   QString id;
   Keyboard::Shortcut trigger;
-};
-
-enum class GlobalShortcutStatus { Bound, Unbound, Failed };
-
-struct GlobalShortcutInfo {
-  QString id;
-  GlobalShortcutStatus status = GlobalShortcutStatus::Unbound;
-  Keyboard::Shortcut trigger;
-  QString error;
+  QString description;
 };
 
 /**
@@ -25,7 +18,6 @@ class AbstractGlobalShortcutBackend : public QObject {
 
 signals:
   void shortcutActivated(const QString &id, quint64 timestamp);
-  void shortcutsChanged();
   void ready();
 
 public:
@@ -37,19 +29,11 @@ public:
   /// callers (and the UI) can tell when global shortcuts are unsupported in the current environment.
   virtual bool isSupported() const { return true; }
 
-  /// Whether this backend is suitable in the current environment. Make it as specific as possible.
-  virtual bool isActivatable() const = 0;
-
-  /// If several backends are activatable, the highest priority one is selected.
-  virtual int activationPriority() const { return 1; }
-
   /// Begin setup, `ready` should be emitted once done.
   virtual bool start() = 0;
 
-  virtual void bindShortcut(const GlobalShortcutRequest &request) = 0;
+  /// Synchronously bind the shortcut, or return a human-readable reason if the platform rejected it.
+  virtual std::expected<void, QString> bindShortcut(const GlobalShortcutRequest &request) = 0;
   virtual void unbindShortcut(const QString &id) = 0;
   virtual void unbindAll() = 0;
-
-  /// Current cached state for a shortcut. Never blocks; reads the backend's local view.
-  virtual std::optional<GlobalShortcutInfo> shortcut(const QString &id) const = 0;
 };

--- a/src/server/src/services/global-shortcuts/dummy-global-shortcut-backend.hpp
+++ b/src/server/src/services/global-shortcuts/dummy-global-shortcut-backend.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#include <limits>
 #include "services/global-shortcuts/abstract-global-shortcut-backend.hpp"
+#include <expected>
 
 /**
  * Fallback used when no real backend is activatable. Accepts binds but never fires.
@@ -11,12 +11,11 @@ class DummyGlobalShortcutBackend : public AbstractGlobalShortcutBackend {
 public:
   QString id() const override { return "dummy"; }
   bool isSupported() const override { return false; }
-  bool isActivatable() const override { return true; }
-  int activationPriority() const override { return std::numeric_limits<int>::min(); }
 
   bool start() override { return true; }
-  void bindShortcut(const GlobalShortcutRequest &) override {}
+  std::expected<void, QString> bindShortcut(const GlobalShortcutRequest &) override {
+    return std::unexpected(QStringLiteral("global shortcuts are not supported in this environment"));
+  }
   void unbindShortcut(const QString &) override {}
   void unbindAll() override {}
-  std::optional<GlobalShortcutInfo> shortcut(const QString &) const override { return std::nullopt; }
 };

--- a/src/server/src/services/global-shortcuts/ext-hotkey-global-shortcut-backend.cpp
+++ b/src/server/src/services/global-shortcuts/ext-hotkey-global-shortcut-backend.cpp
@@ -1,0 +1,143 @@
+#include "ext-hotkey-global-shortcut-backend.hpp"
+#include "ext-hotkey-v1-client-protocol.h"
+#include "services/global-shortcuts/abstract-global-shortcut-backend.hpp"
+#include "services/global-shortcuts/xkb-keysym.hpp"
+#include "wayland/globals.hpp"
+#include <algorithm>
+#include <cstdint>
+#include <qguiapplication.h>
+#include <qlogging.h>
+#include <qnamespace.h>
+#include <qobject.h>
+#include <vector>
+#include <wayland-client-core.h>
+
+namespace {
+std::uint32_t fromQtMods(Qt::KeyboardModifiers mods) {
+  std::uint32_t m = 0;
+  if (mods.testFlag(Qt::KeyboardModifier::ControlModifier)) m |= EXT_HOTKEY_MANAGER_V1_MODIFIERS_CTRL;
+  if (mods.testFlag(Qt::KeyboardModifier::AltModifier)) m |= EXT_HOTKEY_MANAGER_V1_MODIFIERS_ALT;
+  if (mods.testFlag(Qt::KeyboardModifier::MetaModifier)) m |= EXT_HOTKEY_MANAGER_V1_MODIFIERS_SUPER;
+  if (mods.testFlag(Qt::KeyboardModifier::ShiftModifier)) m |= EXT_HOTKEY_MANAGER_V1_MODIFIERS_SHIFT;
+
+  return m;
+}
+
+void wlRoundtrip() {
+  auto dp = qApp->nativeInterface<QNativeInterface::QWaylandApplication>()->display();
+  wl_display_roundtrip(dp);
+}
+} // namespace
+
+ExtHotkeyGlobalShortcutBackend::~ExtHotkeyGlobalShortcutBackend() { unbindAll(); }
+
+QString ExtHotkeyGlobalShortcutBackend::id() const { return "ext-hotkey"; }
+
+bool ExtHotkeyGlobalShortcutBackend::start() {
+  emit ready();
+  return true;
+}
+
+std::expected<void, QString>
+ExtHotkeyGlobalShortcutBackend::bindShortcut(const GlobalShortcutRequest &request) {
+  auto manager = Wayland::Globals::hotkey();
+  auto keysym = global_shortcuts::xkbKeysymForQtKey(request.trigger.key());
+
+  if (!keysym) {
+    qWarning() << "no xkb keysym matching qt key code" << request.trigger.key();
+    return std::unexpected(QStringLiteral("Unsupported trigger key"));
+  }
+
+  auto description = request.description.toUtf8();
+  auto handle = ext_hotkey_manager_v1_bind(manager, keysym.value(), fromQtMods(request.trigger.mods()),
+                                           nullptr, "vicinae", description.constData());
+
+  ext_hotkey_v1_add_listener(handle, &listener, this);
+  m_binds.emplace_back(HotkeyInfo{.handle = handle, .id = request.id});
+
+  m_pendingBind = handle;
+  m_pendingDeny.reset();
+  wlRoundtrip();
+  m_pendingBind = nullptr;
+
+  if (m_pendingDeny) {
+    dropHotkey(handle);
+    return std::unexpected(std::move(*m_pendingDeny));
+  }
+
+  if (!findHotkey(handle)) { return std::unexpected(QStringLiteral("Hotkey binding was lost")); }
+
+  return {};
+}
+
+void ExtHotkeyGlobalShortcutBackend::unbindShortcut(const QString &id) {
+  if (auto it = std::ranges::find_if(m_binds, [&](auto &&b) { return b.id == id; }); it != m_binds.end()) {
+    ext_hotkey_v1_destroy(it->handle);
+    m_binds.erase(it);
+  }
+
+  wlRoundtrip();
+}
+
+void ExtHotkeyGlobalShortcutBackend::unbindAll() {
+  for (const auto &bind : m_binds) {
+    ext_hotkey_v1_destroy(bind.handle);
+  }
+  m_binds.clear();
+  wlRoundtrip();
+}
+
+ExtHotkeyGlobalShortcutBackend::HotkeyInfo *
+ExtHotkeyGlobalShortcutBackend::findHotkey(ext_hotkey_v1 *hotkey) {
+  if (auto it = std::ranges::find_if(m_binds, [&](auto &&b) { return b.handle == hotkey; });
+      it != m_binds.end()) {
+    return &*it;
+  }
+  return nullptr;
+}
+
+void ExtHotkeyGlobalShortcutBackend::dropHotkey(ext_hotkey_v1 *hotkey) {
+  if (auto it = std::ranges::find_if(m_binds, [&](auto &&b) { return b.handle == hotkey; });
+      it != m_binds.end()) {
+    ext_hotkey_v1_destroy(it->handle);
+    m_binds.erase(it);
+  }
+}
+
+void ExtHotkeyGlobalShortcutBackend::denied(void *data, ext_hotkey_v1 *hotkey, uint32_t reason,
+                                            const char *msg) {
+  auto self = static_cast<ExtHotkeyGlobalShortcutBackend *>(data);
+
+  if (hotkey == self->m_pendingBind) {
+    self->m_pendingDeny = *msg ? QString::fromUtf8(msg)
+                               : QStringLiteral("Compositor denied the bind. Try another key "
+                                                "combination.");
+    return;
+  }
+
+  self->dropHotkey(hotkey);
+}
+
+void ExtHotkeyGlobalShortcutBackend::revoked(void *data, ext_hotkey_v1 *hotkey, uint32_t reason,
+                                             const char *msg) {
+  auto self = static_cast<ExtHotkeyGlobalShortcutBackend *>(data);
+  self->dropHotkey(hotkey);
+}
+
+void ExtHotkeyGlobalShortcutBackend::bound(void *data, ext_hotkey_v1 *hotkey) {
+  auto self = static_cast<ExtHotkeyGlobalShortcutBackend *>(data);
+
+  if (!self->findHotkey(hotkey)) { qWarning() << "ext-hotkey: bound event for an untracked hotkey"; }
+}
+
+void ExtHotkeyGlobalShortcutBackend::pressed(void *data, struct ext_hotkey_v1 *hotkey, uint32_t serial,
+                                             uint32_t time) {
+  auto self = static_cast<ExtHotkeyGlobalShortcutBackend *>(data);
+
+  if (auto bind = self->findHotkey(hotkey)) { emit self->shortcutActivated(bind->id, time); }
+}
+
+void ExtHotkeyGlobalShortcutBackend::released(void *data, struct ext_hotkey_v1 *hotkey, uint32_t serial,
+                                              uint32_t time) {
+  // no-op, we don't care about release
+}

--- a/src/server/src/services/global-shortcuts/ext-hotkey-global-shortcut-backend.hpp
+++ b/src/server/src/services/global-shortcuts/ext-hotkey-global-shortcut-backend.hpp
@@ -1,0 +1,45 @@
+#pragma once
+#include "ext-hotkey-v1-client-protocol.h"
+#include "services/global-shortcuts/abstract-global-shortcut-backend.hpp"
+#include <cstdint>
+#include <expected>
+#include <optional>
+#include <qtmetamacros.h>
+
+class ExtHotkeyGlobalShortcutBackend : public AbstractGlobalShortcutBackend {
+public:
+  ~ExtHotkeyGlobalShortcutBackend() override;
+
+  QString id() const override;
+  bool start() override;
+
+  std::expected<void, QString> bindShortcut(const GlobalShortcutRequest &request) override;
+  void unbindShortcut(const QString &id) override;
+  void unbindAll() override;
+  bool isSupported() const override { return true; }
+
+private:
+  struct HotkeyInfo {
+    ext_hotkey_v1 *handle;
+    QString id;
+  };
+
+  static void bound(void *data, ext_hotkey_v1 *hotkey);
+
+  static void denied(void *data, ext_hotkey_v1 *hotkey, uint32_t reason, const char *msg);
+
+  static void revoked(void *data, ext_hotkey_v1 *hotkey, uint32_t reason, const char *msg);
+
+  static void pressed(void *data, struct ext_hotkey_v1 *ext_hotkey_v1, uint32_t serial, uint32_t time);
+
+  static void released(void *data, struct ext_hotkey_v1 *ext_hotkey_v1, uint32_t serial, uint32_t time);
+
+  static constexpr const ext_hotkey_v1_listener listener = {bound, denied, revoked, pressed, released};
+
+  HotkeyInfo *findHotkey(ext_hotkey_v1 *hotkey);
+  void dropHotkey(ext_hotkey_v1 *hotkey);
+
+  std::vector<HotkeyInfo> m_binds;
+  ext_hotkey_v1 *m_pendingBind = nullptr;
+  std::optional<QString> m_pendingDeny;
+};

--- a/src/server/src/services/global-shortcuts/global-shortcut-backend-factory.cpp
+++ b/src/server/src/services/global-shortcuts/global-shortcut-backend-factory.cpp
@@ -1,5 +1,8 @@
 #include "services/global-shortcuts/global-shortcut-backend-factory.hpp"
 #include "services/global-shortcuts/dummy-global-shortcut-backend.hpp"
+#include "services/global-shortcuts/ext-hotkey-global-shortcut-backend.hpp"
+#include "wayland/globals.hpp"
+#include <memory>
 
 #ifdef Q_OS_MACOS
 #include "services/global-shortcuts/macos-global-shortcut-backend.hpp"
@@ -9,7 +12,8 @@ std::unique_ptr<AbstractGlobalShortcutBackend> createGlobalShortcutBackend() {
   // TODO: X11 (XGrabKey) / Windows backends.
 #ifdef Q_OS_MACOS
   return std::make_unique<MacOSGlobalShortcutBackend>();
-#else
-  return std::make_unique<DummyGlobalShortcutBackend>();
+#elifdef Q_OS_LINUX
+  if (Wayland::Globals::hotkey()) { return std::make_unique<ExtHotkeyGlobalShortcutBackend>(); }
 #endif
+  return std::make_unique<DummyGlobalShortcutBackend>();
 }

--- a/src/server/src/services/global-shortcuts/global-shortcut-service.cpp
+++ b/src/server/src/services/global-shortcuts/global-shortcut-service.cpp
@@ -1,13 +1,12 @@
 #include "services/global-shortcuts/global-shortcut-service.hpp"
 #include "common/types.hpp"
 #include "config/config.hpp"
-#include "service-registry.hpp"
 #include "services/root-item-manager/root-item-manager.hpp"
 #include <utility>
 
-GlobalShortcutService::GlobalShortcutService(config::Manager &config,
+GlobalShortcutService::GlobalShortcutService(config::Manager &config, RootItemManager &rootItemManager,
                                              std::unique_ptr<AbstractGlobalShortcutBackend> backend)
-    : m_config(config), m_backend(std::move(backend)) {
+    : m_config(config), m_rootItemManager(rootItemManager), m_backend(std::move(backend)) {
   connect(m_backend.get(), &AbstractGlobalShortcutBackend::shortcutActivated, this,
           &GlobalShortcutService::onActivated);
   connect(m_backend.get(), &AbstractGlobalShortcutBackend::ready, this, &GlobalShortcutService::reconcile);
@@ -32,15 +31,17 @@ void GlobalShortcutService::setCapturing(bool capturing) {
 
 void GlobalShortcutService::reconcile() {
   if (m_capturing) { return; }
+  if (!isSupported()) { return; }
 
   const config::ConfigValue &cfg = m_config.value();
 
-  std::unordered_map<QString, std::pair<QString, Action>> desired;
+  std::unordered_map<QString, Desired> desired;
 
   if (cfg.globalShortcuts.toggle && !cfg.globalShortcuts.toggle->empty()) {
-    desired.emplace(
-        QString::fromUtf8(TOGGLE_ID),
-        std::pair{QString::fromStdString(*cfg.globalShortcuts.toggle), Action{ToggleLauncherWindow{}}});
+    desired.emplace(QString::fromUtf8(TOGGLE_ID),
+                    Desired{.trigger = QString::fromStdString(*cfg.globalShortcuts.toggle),
+                            .description = QStringLiteral("Toggle Vicinae"),
+                            .action = ToggleLauncherWindow{}});
   }
 
   for (const auto &[provider, providerData] : cfg.providers) {
@@ -49,14 +50,15 @@ void GlobalShortcutService::reconcile() {
       if (item.enabled.has_value() && !*item.enabled) { continue; }
 
       EntrypointId eid{provider, entrypoint};
-      desired.emplace(QString::fromStdString(eid),
-                      std::pair{QString::fromStdString(*item.shortcut), Action{RunCommand{eid}}});
+      desired.emplace(QString::fromStdString(eid), Desired{.trigger = QString::fromStdString(*item.shortcut),
+                                                           .description = describeCommand(eid),
+                                                           .action = RunCommand{eid}});
     }
   }
 
   for (auto it = m_appliedTriggers.begin(); it != m_appliedTriggers.end();) {
     auto desiredIt = desired.find(it->first);
-    if (desiredIt == desired.end() || desiredIt->second.first != it->second) {
+    if (desiredIt == desired.end() || desiredIt->second.trigger != it->second) {
       m_backend->unbindShortcut(it->first);
       m_actions.erase(it->first);
       it = m_appliedTriggers.erase(it);
@@ -66,28 +68,41 @@ void GlobalShortcutService::reconcile() {
   }
 
   for (const auto &[id, entry] : desired) {
-    const auto &[trigger, action] = entry;
-    if (auto it = m_appliedTriggers.find(id); it != m_appliedTriggers.end() && it->second == trigger) {
+    if (auto it = m_appliedTriggers.find(id); it != m_appliedTriggers.end() && it->second == entry.trigger) {
       continue;
     }
 
-    auto shortcut = Keyboard::Shortcut::fromString(trigger);
+    auto shortcut = Keyboard::Shortcut::fromString(entry.trigger);
 
     if (!shortcut.isValid()) { continue; }
 
-    m_backend->bindShortcut({.id = id, .trigger = shortcut});
-    m_appliedTriggers[id] = trigger;
+    auto bound = m_backend->bindShortcut({.id = id, .trigger = shortcut, .description = entry.description});
+    m_appliedTriggers[id] = entry.trigger;
 
-    // TODO: assumes a synchronous backend. An async backend won't have a Bound status yet here;
-    // drive m_actions off the backend's shortcutsChanged signal instead.
-    auto info = m_backend->shortcut(id);
-
-    if (info && info->status == GlobalShortcutStatus::Bound) {
-      m_actions[id] = action;
+    if (bound) {
+      m_actions[id] = entry.action;
     } else {
       m_actions.erase(id);
+      qWarning() << "Failed to bind global shortcut" << id << "(" << entry.trigger << "):" << bound.error();
     }
   }
+}
+
+std::optional<QString> GlobalShortcutService::probeBind(const Keyboard::Shortcut &shortcut) {
+  if (!isSupported() || !m_capturing) { return std::nullopt; }
+
+  const QString probeId = QStringLiteral("@probe");
+  auto bound =
+      m_backend->bindShortcut({.id = probeId, .trigger = shortcut, .description = QStringLiteral("Vicinae")});
+  m_backend->unbindShortcut(probeId);
+
+  if (!bound) { return bound.error(); }
+  return std::nullopt;
+}
+
+QString GlobalShortcutService::describeCommand(const EntrypointId &id) const {
+  if (auto meta = m_rootItemManager.itemMetadata(id); meta.item) { return meta.item->title(); }
+  return QString::fromStdString(id);
 }
 
 void GlobalShortcutService::onActivated(const QString &id, quint64 timestamp) {
@@ -119,9 +134,7 @@ std::optional<QString> GlobalShortcutService::findConflict(const Keyboard::Short
       EntrypointId eid{provider, entrypoint};
       if (QString::fromStdString(eid) == excludeId || !matches(*item.shortcut)) { continue; }
 
-      if (auto *manager = ServiceRegistry::instance()->rootItemManager()) {
-        if (auto meta = manager->itemMetadata(eid); meta.item) { return meta.item->title(); }
-      }
+      if (auto meta = m_rootItemManager.itemMetadata(eid); meta.item) { return meta.item->title(); }
       return QStringLiteral("another command");
     }
   }

--- a/src/server/src/services/global-shortcuts/global-shortcut-service.hpp
+++ b/src/server/src/services/global-shortcuts/global-shortcut-service.hpp
@@ -9,6 +9,8 @@ namespace config {
 class Manager;
 }
 
+class RootItemManager;
+
 /**
  * Projects the global shortcuts declared in the config onto the provided backend, and dispatches
  * activations to actions. Config is the single source of truth: there is no separate storage.
@@ -27,7 +29,8 @@ public:
   // Non-command global shortcuts are prefixed with '@' to avoid colliding with entrypoint ids.
   static constexpr const char *TOGGLE_ID = "@toggle-launcher";
 
-  GlobalShortcutService(config::Manager &config, std::unique_ptr<AbstractGlobalShortcutBackend> backend);
+  GlobalShortcutService(config::Manager &config, RootItemManager &rootItemManager,
+                        std::unique_ptr<AbstractGlobalShortcutBackend> backend);
 
   AbstractGlobalShortcutBackend *backend() const { return m_backend.get(); }
   bool isSupported() const { return m_backend && m_backend->isSupported(); }
@@ -35,6 +38,8 @@ public:
   // Display name of the global shortcut already using `shortcut` (excluding `excludeId`), or nullopt.
   // Always nullopt when the backend is unsupported (inert shortcuts can't actually conflict).
   std::optional<QString> findConflict(const Keyboard::Shortcut &shortcut, const QString &excludeId) const;
+
+  std::optional<QString> probeBind(const Keyboard::Shortcut &shortcut);
 
   // Suspends all global binds while the in-app recorder captures (so it doesn't hijack the keystroke),
   // then rebinds from config on release.
@@ -49,10 +54,18 @@ private:
 
   using Action = std::variant<RunCommand, ToggleLauncherWindow>;
 
+  struct Desired {
+    QString trigger;
+    QString description;
+    Action action;
+  };
+
   void reconcile();
   void onActivated(const QString &id, quint64 timestamp);
+  QString describeCommand(const EntrypointId &id) const;
 
   config::Manager &m_config;
+  RootItemManager &m_rootItemManager;
   std::unique_ptr<AbstractGlobalShortcutBackend> m_backend;
   std::unordered_map<QString, Action> m_actions;
   std::unordered_map<QString, QString> m_appliedTriggers;

--- a/src/server/src/services/global-shortcuts/macos-global-shortcut-backend.cpp
+++ b/src/server/src/services/global-shortcuts/macos-global-shortcut-backend.cpp
@@ -209,19 +209,11 @@ bool MacOSGlobalShortcutBackend::start() {
   return true;
 }
 
-void MacOSGlobalShortcutBackend::bindShortcut(const GlobalShortcutRequest &request) {
+std::expected<void, QString> MacOSGlobalShortcutBackend::bindShortcut(const GlobalShortcutRequest &request) {
   unbindShortcut(request.id);
 
-  GlobalShortcutInfo info{.id = request.id, .trigger = request.trigger};
   const auto keyCode = macVirtualKeyForQtKey(request.trigger.key());
-
-  if (!keyCode) {
-    info.status = GlobalShortcutStatus::Failed;
-    info.error = QStringLiteral("unsupported or invalid trigger");
-    m_bindings.emplace(request.id, Binding{.info = info});
-    emit shortcutsChanged();
-    return;
-  }
+  if (!keyCode) { return std::unexpected(QStringLiteral("unsupported or invalid trigger")); }
 
   const uint32_t carbonId = m_nextCarbonId++;
   const EventHotKeyID hotKeyId{.signature = HOT_KEY_SIGNATURE, .id = carbonId};
@@ -230,17 +222,12 @@ void MacOSGlobalShortcutBackend::bindShortcut(const GlobalShortcutRequest &reque
                                               GetApplicationEventTarget(), 0, &ref);
 
   if (status != noErr || !ref) {
-    info.status = GlobalShortcutStatus::Failed;
-    info.error = QStringLiteral("RegisterEventHotKey failed (%1)").arg(status);
-    m_bindings.emplace(request.id, Binding{.info = info});
-    emit shortcutsChanged();
-    return;
+    return std::unexpected(QStringLiteral("RegisterEventHotKey failed (%1)").arg(status));
   }
 
-  info.status = GlobalShortcutStatus::Bound;
-  m_bindings.emplace(request.id, Binding{.info = info, .ref = ref, .carbonId = carbonId});
+  m_bindings.emplace(request.id, Binding{.ref = ref, .carbonId = carbonId});
   m_idByCarbonId.emplace(carbonId, request.id);
-  emit shortcutsChanged();
+  return {};
 }
 
 void MacOSGlobalShortcutBackend::unbindShortcut(const QString &id) {
@@ -253,7 +240,6 @@ void MacOSGlobalShortcutBackend::unbindShortcut(const QString &id) {
   }
 
   m_bindings.erase(it);
-  emit shortcutsChanged();
 }
 
 void MacOSGlobalShortcutBackend::unbindAll() {
@@ -262,12 +248,6 @@ void MacOSGlobalShortcutBackend::unbindAll() {
   }
   m_bindings.clear();
   m_idByCarbonId.clear();
-  emit shortcutsChanged();
-}
-
-std::optional<GlobalShortcutInfo> MacOSGlobalShortcutBackend::shortcut(const QString &id) const {
-  if (const auto it = m_bindings.find(id); it != m_bindings.end()) { return it->second.info; }
-  return std::nullopt;
 }
 
 void MacOSGlobalShortcutBackend::handleHotKey(uint32_t carbonId, quint64 timestamp) {

--- a/src/server/src/services/global-shortcuts/macos-global-shortcut-backend.hpp
+++ b/src/server/src/services/global-shortcuts/macos-global-shortcut-backend.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include <cstdint>
-#include <optional>
+#include <expected>
 #include <unordered_map>
 #include "services/global-shortcuts/abstract-global-shortcut-backend.hpp"
 
@@ -14,20 +14,16 @@ public:
   ~MacOSGlobalShortcutBackend() override;
 
   QString id() const override { return "carbon"; }
-  bool isActivatable() const override { return true; }
-  int activationPriority() const override { return 100; }
 
   bool start() override;
-  void bindShortcut(const GlobalShortcutRequest &request) override;
+  std::expected<void, QString> bindShortcut(const GlobalShortcutRequest &request) override;
   void unbindShortcut(const QString &id) override;
   void unbindAll() override;
-  std::optional<GlobalShortcutInfo> shortcut(const QString &id) const override;
 
   void handleHotKey(uint32_t carbonId, quint64 timestamp);
 
 private:
   struct Binding {
-    GlobalShortcutInfo info;
     void *ref = nullptr; // EventHotKeyRef
     uint32_t carbonId = 0;
   };

--- a/src/server/src/services/shortcut-inhibit/abstract-shortcut-inhibit-manager.hpp
+++ b/src/server/src/services/shortcut-inhibit/abstract-shortcut-inhibit-manager.hpp
@@ -1,0 +1,19 @@
+#pragma once
+#include <qobject.h>
+#include <qwindow.h>
+
+class AbstractShortcutInhibitManager : public QObject {
+public:
+  virtual ~AbstractShortcutInhibitManager() = default;
+
+  virtual bool isSupported() const = 0;
+  virtual bool inhibit(QWindow *win) = 0;
+  virtual bool release(QWindow *win) = 0;
+};
+
+class DummyShortcutInhibitManager : public AbstractShortcutInhibitManager {
+public:
+  bool isSupported() const override { return false; }
+  bool inhibit(QWindow *) override { return false; }
+  bool release(QWindow *) override { return false; }
+};

--- a/src/server/src/services/shortcut-inhibit/shortcut-inhibit-manager.hpp
+++ b/src/server/src/services/shortcut-inhibit/shortcut-inhibit-manager.hpp
@@ -1,0 +1,30 @@
+#pragma once
+#include <memory>
+#include <qwindow.h>
+#include "common/types.hpp"
+#include "services/shortcut-inhibit/abstract-shortcut-inhibit-manager.hpp"
+#ifdef Q_OS_LINUX
+#include "internal/wayland/globals.hpp"
+#include "services/shortcut-inhibit/wayland-shortcut-inhibit-manager.hpp"
+#endif
+
+class ShortcutInhibitManager : NonCopyable {
+public:
+  ShortcutInhibitManager() : m_manager(createManager()) {}
+
+  bool isSupported() const { return m_manager->isSupported(); }
+  bool inhibit(QWindow *win) { return m_manager->inhibit(win); }
+  bool release(QWindow *win) { return m_manager->release(win); }
+
+private:
+  static std::unique_ptr<AbstractShortcutInhibitManager> createManager() {
+#ifdef Q_OS_LINUX
+    if (auto *manager = Wayland::Globals::shortcutInhibit()) {
+      return std::make_unique<WaylandShortcutInhibitManager>(manager);
+    }
+#endif
+    return std::make_unique<DummyShortcutInhibitManager>();
+  }
+
+  std::unique_ptr<AbstractShortcutInhibitManager> m_manager;
+};

--- a/src/server/src/services/shortcut-inhibit/wayland-shortcut-inhibit-manager.cpp
+++ b/src/server/src/services/shortcut-inhibit/wayland-shortcut-inhibit-manager.cpp
@@ -1,0 +1,63 @@
+#include "wayland-shortcut-inhibit-manager.hpp"
+#include <QGuiApplication>
+#include <qevent.h>
+#include <qlogging.h>
+#include "qt-wayland-utils.hpp"
+
+WaylandShortcutInhibitManager::WaylandShortcutInhibitManager(
+    zwp_keyboard_shortcuts_inhibit_manager_v1 *manager)
+    : m_manager(manager) {}
+
+WaylandShortcutInhibitManager::~WaylandShortcutInhibitManager() {
+  for (auto &[win, inhibitor] : m_inhibitors) {
+    zwp_keyboard_shortcuts_inhibitor_v1_destroy(inhibitor);
+  }
+}
+
+bool WaylandShortcutInhibitManager::inhibit(QWindow *win) {
+  if (m_inhibitors.contains(win)) { return true; }
+
+  auto *surface = QtWaylandUtils::getWindowSurface(win);
+
+  if (!surface) {
+    qWarning() << "Failed to get wl_surface for window" << win;
+    return false;
+  }
+
+  auto *seat = qApp->nativeInterface<QNativeInterface::QWaylandApplication>()->seat();
+  auto *inhibitor = zwp_keyboard_shortcuts_inhibit_manager_v1_inhibit_shortcuts(m_manager, surface, seat);
+
+  if (!inhibitor) { return false; }
+
+  win->installEventFilter(this);
+  m_inhibitors[win] = inhibitor;
+
+  return true;
+}
+
+bool WaylandShortcutInhibitManager::release(QWindow *win) {
+  auto it = m_inhibitors.find(win);
+
+  if (it == m_inhibitors.end()) { return false; }
+
+  win->removeEventFilter(this);
+  zwp_keyboard_shortcuts_inhibitor_v1_destroy(it->second);
+  m_inhibitors.erase(it);
+
+  return true;
+}
+
+bool WaylandShortcutInhibitManager::eventFilter(QObject *sender, QEvent *event) {
+  if (event->type() == QEvent::PlatformSurface) {
+    auto *surfaceEvent = static_cast<QPlatformSurfaceEvent *>(event); // NOLINT
+
+    if (surfaceEvent->surfaceEventType() == QPlatformSurfaceEvent::SurfaceAboutToBeDestroyed) {
+      if (auto it = m_inhibitors.find(qobject_cast<QWindow *>(sender)); it != m_inhibitors.end()) {
+        zwp_keyboard_shortcuts_inhibitor_v1_destroy(it->second);
+        m_inhibitors.erase(it);
+      }
+    }
+  }
+
+  return QObject::eventFilter(sender, event);
+}

--- a/src/server/src/services/shortcut-inhibit/wayland-shortcut-inhibit-manager.hpp
+++ b/src/server/src/services/shortcut-inhibit/wayland-shortcut-inhibit-manager.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#include <qwindow.h>
+#include <unordered_map>
+#include "keyboard-shortcuts-inhibit-unstable-v1-client-protocol.h"
+#include "services/shortcut-inhibit/abstract-shortcut-inhibit-manager.hpp"
+
+class WaylandShortcutInhibitManager : public AbstractShortcutInhibitManager {
+public:
+  explicit WaylandShortcutInhibitManager(zwp_keyboard_shortcuts_inhibit_manager_v1 *manager);
+  ~WaylandShortcutInhibitManager() override;
+
+  bool isSupported() const override { return true; }
+  bool inhibit(QWindow *win) override;
+  bool release(QWindow *win) override;
+
+protected:
+  bool eventFilter(QObject *sender, QEvent *event) override;
+
+private:
+  zwp_keyboard_shortcuts_inhibit_manager_v1 *m_manager = nullptr;
+  std::unordered_map<QWindow *, zwp_keyboard_shortcuts_inhibitor_v1 *> m_inhibitors;
+};

--- a/src/wayland-protocols/ext-hotkey-v1.xml
+++ b/src/wayland-protocols/ext-hotkey-v1.xml
@@ -1,0 +1,306 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="ext_hotkey_v1">
+  <copyright>
+    Copyright © 2026 Aurelien Brabant
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="client-managed global hotkeys">
+    This protocol lets a client choose, and freely reconfigure, its own
+    global hotkeys: it requests a specific key combination and the compositor
+    accepts it or rejects it with a reason. The compositor remains the eventual
+    arbiter (it may deny a request, revoke a binding at any time, or apply
+    whatever policy it likes), but within that the application manages its own
+    bindings, including changing them at runtime (for example from its own
+    settings UI), with no out-of-band user configuration, no persisted compositor
+    state, and no per-change confirmation dialog.
+
+    This is the same model native applications already use on Windows
+    (RegisterHotKey), macOS (RegisterEventHotKey), and X11 (XGrabKey). A
+    cross-platform application or UI toolkit can therefore map its existing
+    global-hotkey API directly onto this protocol, so supporting Wayland becomes a
+    port rather than a redesign. That is the key difference from the
+    org.freedesktop.portal GlobalShortcuts interface and compositor protocols such
+    as hyprland-global-shortcuts-v1, which register an anonymous action and let
+    the user choose its trigger out-of-band (with the binding outliving the
+    client); here the client owns the trigger and the compositor arbitrates.
+    It is unrelated to keyboard-shortcuts-inhibit, which lets a focused client
+    suppress the compositor's own shortcuts.
+
+    A hotkey is a key combination that fires regardless of which surface holds
+    keyboard focus.
+
+    Whether a combination is exclusive is compositor policy. A compositor MAY
+    treat combinations as exclusive and reject a clashing request with
+    "already_bound", or MAY grant the same combination to more than one binding
+    (each bound hotkey then receives the events), as some platforms do. Clients
+    must cope with either.
+
+    It is intentionally a thin mechanism. It does NOT define which combinations
+    are acceptable: that is policy and belongs to the compositor, expressed
+    through the accept/deny channel. It does NOT persist hotkeys: a binding lives
+    only as long as its ext_hotkey_v1 object and the client connection; there is
+    no configure or storage step, a binding never outlives the client that created
+    it, and reconfiguring is simply destroying a hotkey and binding the new
+    combination.
+
+    Warning! The protocol described in this file is currently in the testing
+    phase. Backward incompatible changes may be added together with the
+    corresponding interface version bump. Backward compatible changes are added
+    by bumping the interface version.
+
+    Security considerations:
+
+    A global hotkey lets an unfocused client observe that a specific key
+    combination was pressed. Compositors are the security boundary and SHOULD
+    apply policy when deciding whether to accept a request. In particular,
+    implementations SHOULD reject combinations that do not include at least one
+    non-latching modifier among Ctrl, Alt or Super, unless the trigger is a
+    function key, because unmodified (and Shift-only) keys carry ordinary text
+    entry and grabbing them turns this protocol into a keylogger.
+
+    The protocol's one hard guarantee is containment: a compositor MUST NOT
+    deliver events for a combination the client did not successfully bind, and
+    never forwards the raw key stream, so a client learns nothing about input it
+    did not explicitly, and successfully, bind. Beyond that, a compositor MAY
+    apply any further policy it sees fit (for example prompting the user,
+    restricting which clients may bind, or limiting how many bindings a client may
+    hold) and MAY revoke a binding at any time via the "revoked" event, including
+    under user control.
+
+    These are recommendations, not wire requirements: a combination the
+    compositor disallows is simply reported through the "denied" event with the
+    "not_permitted" reason, so applications can rely on a uniform rejection path
+    regardless of each compositor's policy.
+  </description>
+
+  <interface name="ext_hotkey_manager_v1" version="1">
+    <description summary="global hotkey factory">
+      This interface is the entry point of the protocol. It is used to request
+      global hotkeys.
+    </description>
+
+    <enum name="modifiers" bitfield="true">
+      <description summary="modifier keys required by a hotkey">
+        A bitmask of the modifiers that must be held for the hotkey to fire.
+
+        These are fixed, keymap-independent semantic bits naming the standard
+        modifiers, suitable for expressing a binding, unlike wl_keyboard.modifiers,
+        which carries opaque, keymap-derived masks for runtime state. A compositor
+        matches each bit against the corresponding modifier in its keyboard state
+        as the keymap defines it; for the xkb_v1 keymap format that is shift ->
+        XKB_MOD_NAME_SHIFT, ctrl -> XKB_MOD_NAME_CTRL, alt -> XKB_MOD_NAME_ALT
+        ("Mod1"), super -> XKB_MOD_NAME_LOGO ("Mod4").
+
+        Lock modifiers (Caps Lock, Num Lock) are never part of a binding and are
+        ignored when matching.
+      </description>
+      <entry name="shift" value="1" summary="the Shift modifier"/>
+      <entry name="ctrl" value="2" summary="the Control modifier"/>
+      <entry name="alt" value="4" summary="the Alt modifier"/>
+      <entry name="super" value="8" summary="the Super/Logo modifier"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        Destroy the manager object. Hotkey objects created through this manager
+        are unaffected and remain valid; their bindings persist until they are
+        themselves destroyed or the client disconnects.
+      </description>
+    </request>
+
+    <request name="bind">
+      <description summary="request a global hotkey">
+        Request that the given key combination be bound as a global hotkey.
+
+        The keysym identifies the trigger key using the keysym numbering shared
+        with the keymap delivered over wl_keyboard (for the xkb_v1 keymap format,
+        an XKB_KEY_* value), taken in its unshifted form. A compositor SHOULD match
+        it against any of the user's layout groups, so a binding keeps firing after
+        the user switches layout group. This is one deliberately specified rule,
+        not a universal one: other platforms differ (macOS matches a physical
+        keycode, X11 re-grabs per layout, Windows tracks the active layout's key),
+        and no rule serves a layout that never produces the keysym; the single
+        documented rule is chosen for predictability across compositors.
+
+        The request creates an ext_hotkey_v1 object immediately, but the binding
+        is not active yet. The compositor replies asynchronously with either the
+        "bound" event (the hotkey is now active) or the "denied" event (the
+        request was rejected, with a reason).
+
+        seat is the wl_seat whose keyboard should trigger the hotkey, or null to
+        request it on all of the client's seats. Most clients pass null; seat is
+        provided for completeness on multi-seat systems.
+
+        app_id identifies the requesting application, for use in the compositor's
+        policy and any user-facing audit UI. It is advisory and may be spoofed;
+        a compositor that needs a trustworthy identity SHOULD obtain it through
+        the security-context mechanism rather than relying on this string.
+
+        description is a human-readable, localized description of what the hotkey
+        does (e.g. "Toggle the launcher"), for display in compositor UI.
+      </description>
+      <arg name="id" type="new_id" interface="ext_hotkey_v1"
+           summary="the new hotkey object"/>
+      <arg name="keysym" type="uint" summary="keysym of the trigger key (see description)"/>
+      <arg name="modifiers" type="uint" enum="modifiers"
+           summary="bitmask of required modifiers"/>
+      <arg name="seat" type="object" interface="wl_seat" allow-null="true"
+           summary="target seat, or null for all of the client's seats"/>
+      <arg name="app_id" type="string" summary="advisory application identifier"/>
+      <arg name="description" type="string"
+           summary="human-readable action description"/>
+    </request>
+  </interface>
+
+  <interface name="ext_hotkey_v1" version="1">
+    <description summary="a single global hotkey">
+      Represents one requested global hotkey. Its binding is ephemeral: it is
+      released when this object is destroyed or when the client disconnects, and
+      it is never written to any persistent store.
+
+      After bind, exactly one of "bound" or "denied" is sent. While the hotkey is
+      bound, "pressed" and "released" are sent as the combination is activated.
+      The compositor may send "revoked" at any time after "bound" to indicate the
+      binding is no longer active (for example because the user removed it, or a
+      higher-priority binding took the combination).
+    </description>
+
+    <enum name="deny_reason">
+      <description summary="why a bind request was denied">
+        Carried by the "denied" event. This is a reason code, not a fatal
+        protocol error: the object remains valid and the client should destroy
+        it (or try a different combination).
+      </description>
+      <entry name="already_bound" value="0"
+             summary="already held by another hotkey the compositor treats as exclusive. The compositor is not obligated to give this level of detail and can just give not_permitted as the general 'deny' reason."/>
+      <entry name="not_permitted" value="1"
+             summary="the combination is disallowed by compositor policy"/>
+      <entry name="invalid" value="2"
+             summary="the keysym or combination is not a valid trigger"/>
+    </enum>
+
+    <enum name="revoke_reason">
+      <description summary="why a previously bound hotkey was withdrawn">
+        Carried by the "revoked" event. This is a reason code, not a fatal
+        protocol error: the object remains valid and the client should destroy
+        it.
+
+        The distinction is actionable: on "superseded" the combination may
+        become available again, so a client may reasonably re-request it later;
+        on "removed" the withdrawal is a deliberate user or compositor decision,
+        so a client MUST NOT silently re-request the same combination. A client
+        that receives a value it does not recognise (a future addition) MUST
+        treat it conservatively as "removed" and not auto-rebind.
+      </description>
+      <entry name="removed" value="0"
+             summary="withdrawn by the user or compositor; do not auto-rebind"/>
+      <entry name="superseded" value="1"
+             summary="a higher-priority binding took the combination; it may become available again"/>
+      <entry name="not_permitted" value="2"
+             summary="the combination is no longer allowed by compositor policy"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="release the hotkey">
+        Release the binding and destroy the object. The combination becomes
+        available again immediately. It is valid to destroy the object before
+        receiving "bound" or "denied", which cancels the pending request.
+      </description>
+    </request>
+
+    <event name="bound">
+      <description summary="the hotkey is now active">
+        The requested combination was accepted and is now active. "pressed" and
+        "released" events may follow.
+      </description>
+    </event>
+
+    <event name="denied">
+      <description summary="the request was rejected">
+        The requested combination was not bound. No input events will be sent.
+        The client should destroy this object; it may then create a new request
+        with a different combination.
+
+        message is an optional, advisory, human-readable explanation in the
+        compositor's locale, intended for verbatim display in client UI (for
+        example a "change shortcut" settings screen). It may be empty, and a
+        compositor is never required to provide it. Clients MUST NOT parse it or
+        rely on its contents in any way; all programmatic behavior keys off
+        reason. A client with nowhere to show it simply ignores it.
+      </description>
+      <arg name="reason" type="uint" enum="deny_reason" summary="why it was rejected"/>
+      <arg name="message" type="string"
+           summary="optional human-readable detail for display (may be empty)"/>
+    </event>
+
+    <event name="revoked">
+      <description summary="a previously active hotkey was withdrawn">
+        A binding that was previously "bound" is no longer active. No further
+        input events will be sent for it. The client should destroy this object;
+        it may request the combination again later.
+
+        message is an optional, advisory, human-readable explanation in the
+        compositor's locale, intended for verbatim display in client UI. It may
+        be empty, and a compositor is never required to provide it. Clients MUST
+        NOT parse it or rely on its contents in any way; all programmatic
+        behavior keys off reason. A client with nowhere to show it simply
+        ignores it.
+      </description>
+      <arg name="reason" type="uint" enum="revoke_reason" summary="why it was withdrawn"/>
+      <arg name="message" type="string"
+           summary="optional human-readable detail for display (may be empty)"/>
+    </event>
+
+    <event name="pressed">
+      <description summary="the hotkey combination was pressed">
+        The bound combination was activated.
+
+        serial is a compositor-issued input serial that counts as a recent user
+        interaction, so the client can act on the hotkey even though the
+        triggering key press is not otherwise delivered to it (the compositor
+        consumes it). In particular, a client may pass this serial to
+        xdg_activation_token_v1.set_serial in order to raise or focus a surface in
+        response to the hotkey; a compositor SHOULD honor activation carried by
+        this serial, since the hotkey is itself a deliberate user action. The
+        serial is drawn from the same space as other input event serials.
+
+        time is the event timestamp, with the same millisecond clock as wl_pointer
+        and wl_keyboard input events; it is useful for ordering and for measuring
+        press-to-release duration.
+      </description>
+      <arg name="serial" type="uint" summary="input serial for the activation (e.g. xdg-activation)"/>
+      <arg name="time" type="uint" summary="timestamp in milliseconds"/>
+    </event>
+
+    <event name="released">
+      <description summary="the hotkey combination was released">
+        The trigger key of a previously pressed combination was released. This
+        enables press-and-hold uses (e.g. push-to-talk); clients that only act
+        on activation may ignore it.
+
+        serial and time have the same meaning as in the "pressed" event.
+      </description>
+      <arg name="serial" type="uint" summary="input serial for the activation (e.g. xdg-activation)"/>
+      <arg name="time" type="uint" summary="timestamp in milliseconds"/>
+    </event>
+  </interface>
+</protocol>

--- a/src/wayland-protocols/keyboard-shortcuts-inhibit-unstable-v1.xml
+++ b/src/wayland-protocols/keyboard-shortcuts-inhibit-unstable-v1.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="keyboard_shortcuts_inhibit_unstable_v1">
+
+  <copyright>
+    Copyright © 2017 Red Hat Inc.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="Protocol for inhibiting the compositor keyboard shortcuts">
+    This protocol specifies a way for a client to request the compositor
+    to ignore its own keyboard shortcuts for a given seat, so that all
+    key events from that seat get forwarded to a surface.
+
+    Warning! The protocol described in this file is experimental and
+    backward incompatible changes may be made. Backward compatible
+    changes may be added together with the corresponding interface
+    version bump.
+    Backward incompatible changes are done by bumping the version
+    number in the protocol and interface names and resetting the
+    interface version. Once the protocol is to be declared stable,
+    the 'z' prefix and the version number in the protocol and
+    interface names are removed and the interface version number is
+    reset.
+  </description>
+
+  <interface name="zwp_keyboard_shortcuts_inhibit_manager_v1" version="1">
+    <description summary="context object for keyboard grab_manager">
+      A global interface used for inhibiting the compositor keyboard shortcuts.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the keyboard shortcuts inhibitor object">
+	Destroy the keyboard shortcuts inhibitor manager.
+      </description>
+    </request>
+
+    <request name="inhibit_shortcuts">
+      <description summary="create a new keyboard shortcuts inhibitor object">
+	Create a new keyboard shortcuts inhibitor object associated with
+	the given surface for the given seat.
+
+	If shortcuts are already inhibited for the specified seat and surface,
+	a protocol error "already_inhibited" is raised by the compositor.
+      </description>
+      <arg name="id" type="new_id" interface="zwp_keyboard_shortcuts_inhibitor_v1"/>
+      <arg name="surface" type="object" interface="wl_surface"
+	   summary="the surface that inhibits the keyboard shortcuts behavior"/>
+      <arg name="seat" type="object" interface="wl_seat"
+	   summary="the wl_seat for which keyboard shortcuts should be disabled"/>
+    </request>
+
+    <enum name="error">
+      <entry name="already_inhibited"
+	     value="0"
+	     summary="the shortcuts are already inhibited for this surface"/>
+    </enum>
+  </interface>
+
+  <interface name="zwp_keyboard_shortcuts_inhibitor_v1" version="1">
+    <description summary="context object for keyboard shortcuts inhibitor">
+      A keyboard shortcuts inhibitor instructs the compositor to ignore
+      its own keyboard shortcuts when the associated surface has keyboard
+      focus. As a result, when the surface has keyboard focus on the given
+      seat, it will receive all key events originating from the specified
+      seat, even those which would normally be caught by the compositor for
+      its own shortcuts.
+
+      The Wayland compositor is however under no obligation to disable
+      all of its shortcuts, and may keep some special key combo for its own
+      use, including but not limited to one allowing the user to forcibly
+      restore normal keyboard events routing in the case of an unwilling
+      client. The compositor may also use the same key combo to reactivate
+      an existing shortcut inhibitor that was previously deactivated on
+      user request.
+
+      When the compositor restores its own keyboard shortcuts, an
+      "inactive" event is emitted to notify the client that the keyboard
+      shortcuts inhibitor is not effectively active for the surface and
+      seat any more, and the client should not expect to receive all
+      keyboard events.
+
+      When the keyboard shortcuts inhibitor is inactive, the client has
+      no way to forcibly reactivate the keyboard shortcuts inhibitor.
+
+      The user can chose to re-enable a previously deactivated keyboard
+      shortcuts inhibitor using any mechanism the compositor may offer,
+      in which case the compositor will send an "active" event to notify
+      the client.
+
+      If the surface is destroyed, unmapped, or loses the seat's keyboard
+      focus, the keyboard shortcuts inhibitor becomes irrelevant and the
+      compositor will restore its own keyboard shortcuts but no "inactive"
+      event is emitted in this case.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the keyboard shortcuts inhibitor object">
+	Remove the keyboard shortcuts inhibitor from the associated wl_surface.
+      </description>
+    </request>
+
+    <event name="active">
+      <description summary="shortcuts are inhibited">
+	This event indicates that the shortcut inhibitor is active.
+
+	The compositor sends this event every time compositor shortcuts
+	are inhibited on behalf of the surface. When active, the client
+	may receive input events normally reserved by the compositor
+	(see zwp_keyboard_shortcuts_inhibitor_v1).
+
+	This occurs typically when the initial request "inhibit_shortcuts"
+	first becomes active or when the user instructs the compositor to
+	re-enable and existing shortcuts inhibitor using any mechanism
+	offered by the compositor.
+      </description>
+    </event>
+
+    <event name="inactive">
+      <description summary="shortcuts are restored">
+	This event indicates that the shortcuts inhibitor is inactive,
+	normal shortcuts processing is restored by the compositor.
+       </description>
+    </event>
+  </interface>
+</protocol>


### PR DESCRIPTION
Implement my [ext-hotkey](https://github.com/vicinaehq/vicinae-wayland-protocols/tree/main/staging/ext-hotkey) protocol.

First working implementation is already available in my [niri fork](https://github.com/aurelleb/niri).