### PR TITLE
feat(macos): mdutil powered file search

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -591,8 +591,8 @@ endif()
 
 if (APPLE)
 	list(APPEND SRCS
-		src/ui/image/mac-bundle-icon-loader.hpp
-		src/ui/image/mac-bundle-icon-loader.mm
+		src/ui/image/mac-file-icon-loader.hpp
+		src/ui/image/mac-file-icon-loader.mm
 		src/services/app-service/macos/mac-app.hpp
 		src/services/app-service/macos/mac-app.mm
 		src/services/app-service/macos/mac-app-database.hpp
@@ -603,13 +603,16 @@ if (APPLE)
 		src/root-search/macos-settings/macos-settings-root-provider.mm
 		src/services/global-shortcuts/macos-global-shortcut-backend.hpp
 		src/services/global-shortcuts/macos-global-shortcut-backend.cpp
+		src/services/files-service/macos/spotlight-file-indexer.hpp
+		src/services/files-service/macos/spotlight-file-indexer.mm
 	)
 	set_source_files_properties(
-		src/ui/image/mac-bundle-icon-loader.mm
+		src/ui/image/mac-file-icon-loader.mm
 		src/services/app-service/macos/mac-app.mm
 		src/services/app-service/macos/mac-app-database.mm
 		src/services/app-runtime/macos/mac-app-runtime.mm
 		src/root-search/macos-settings/macos-settings-root-provider.mm
+		src/services/files-service/macos/spotlight-file-indexer.mm
 		PROPERTIES COMPILE_OPTIONS "-fobjc-arc")
 else()
 	list(APPEND SRCS
@@ -964,7 +967,7 @@ endif()
 target_include_directories(${TARGET} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src ${CMAKE_CURRENT_SOURCE_DIR}/src/qml ${CMAKE_CURRENT_SOURCE_DIR}/src/qml/markdown)
 target_link_libraries(${TARGET} PRIVATE ${LIBS})
 if(APPLE)
-	target_link_libraries(${TARGET} PRIVATE "-framework AppKit" "-framework UniformTypeIdentifiers" "-framework Carbon")
+	target_link_libraries(${TARGET} PRIVATE "-framework AppKit" "-framework UniformTypeIdentifiers" "-framework Carbon" "-framework CoreServices")
 endif()
 target_compile_features(${TARGET} PUBLIC cxx_std_23)
 

--- a/src/server/src/extensions/file/file-extension.hpp
+++ b/src/server/src/extensions/file/file-extension.hpp
@@ -62,16 +62,21 @@ class FileExtension : public BuiltinCommandRepository {
 
 public:
   void initialized(const QJsonObject &preferences) const override {
+#ifdef Q_OS_LINUX
     auto files = ServiceRegistry::instance()->fileService();
     if (preferences.value("autoIndexing").toBool()) { files->indexer()->start(); }
+#endif
   }
 
   FileExtension() {
     registerCommand<SearchFilesCommand>();
+#ifdef Q_OS_LINUX
     registerCommand<RebuildFileIndexCommand>();
+#endif
   }
 
   std::vector<Preference> preferences() const override {
+#ifdef Q_OS_LINUX
     auto indexing = Preference::makeCheckbox("autoIndexing");
 
     indexing.setTitle("Auto Indexing");
@@ -98,10 +103,14 @@ public:
     watcherPaths.setDefaultValue("");
 
     return {indexing, paths, excludedPaths, watcherPaths};
+#else
+    return {};
+#endif
   }
 
   void preferenceValuesChanged(const QJsonObject &preferences) const override {
-    QStringList searchPaths = preferences.value("paths").toString().split(';', Qt::SkipEmptyParts);
+#ifdef Q_OS_LINUX
     ServiceRegistry::instance()->fileService()->preferenceValuesChanged(preferences);
+#endif
   }
 };

--- a/src/server/src/qml/view-utils.cpp
+++ b/src/server/src/qml/view-utils.cpp
@@ -24,8 +24,7 @@ FilePreviewContent resolveFilePreview(const std::filesystem::path &path, QMimeDa
       result.textContent = QString::fromUtf8(file.read(MAX_DISPLAY));
     }
   } else {
-    result.imageSource = imageSourceFor(
-        ImageURL::system(mime.iconName()).withFallback(ImageURL::system(mime.genericIconName())));
+    result.imageSource = imageSourceFor(ImageURL::fileIcon(path));
   }
 
   return result;

--- a/src/server/src/services/files-service/file-service.cpp
+++ b/src/server/src/services/files-service/file-service.cpp
@@ -2,8 +2,10 @@
 #include "services/files-service/abstract-file-indexer.hpp"
 #include <qlogging.h>
 #include "file-service.hpp"
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX)
 #include "file-indexer/file-indexer.hpp"
+#elif defined(Q_OS_MACOS)
+#include "macos/spotlight-file-indexer.hpp"
 #else
 #include "dummy-file-indexer.hpp"
 #endif
@@ -64,8 +66,10 @@ void FileService::preferenceValuesChanged(const QJsonObject &preferences) {
 }
 
 FileService::FileService(OmniDatabase &db) : m_db(db) {
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX)
   m_indexer = std::make_unique<FileIndexer>();
+#elif defined(Q_OS_MACOS)
+  m_indexer = std::make_unique<SpotlightFileIndexer>();
 #else
   m_indexer = std::make_unique<DummyFileIndexer>();
 #endif

--- a/src/server/src/services/files-service/macos/spotlight-file-indexer.hpp
+++ b/src/server/src/services/files-service/macos/spotlight-file-indexer.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include "services/files-service/abstract-file-indexer.hpp"
+
+/**
+ * macOS file indexer backed by Spotlight. Spotlight owns the index, so there is
+ * nothing to start, rebuild or configure: only querying is implemented. Spotlight
+ * acts as a candidate generator (substring match on the file name) and results are
+ * re-ranked with the same fuzzy matcher used by the Linux indexer.
+ */
+class SpotlightFileIndexer : public AbstractFileIndexer {
+public:
+  void start() override {}
+  void rebuildIndex() override {}
+  void preferenceValuesChanged(const QJsonObject &) override {}
+
+  QFuture<std::vector<IndexerFileResult>> queryAsync(std::string_view query,
+                                                     const QueryParams &params = {}) override;
+};

--- a/src/server/src/services/files-service/macos/spotlight-file-indexer.mm
+++ b/src/server/src/services/files-service/macos/spotlight-file-indexer.mm
@@ -1,0 +1,154 @@
+#include "spotlight-file-indexer.hpp"
+#include "fuzzy/fzf.hpp"
+#include <CoreServices/CoreServices.h>
+#include <QtConcurrent/QtConcurrentRun>
+#include <algorithm>
+#include <climits>
+#include <ranges>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr int MIN_CANDIDATE_LIMIT = 250;
+constexpr int CANDIDATE_LIMIT_MULTIPLIER = 20;
+
+int candidateLimitFor(const Pagination &pagination) {
+  int const total = std::max(0, pagination.offset) + std::max(0, pagination.limit);
+
+  if (total == 0) { return 0; }
+
+  return std::max(MIN_CANDIDATE_LIMIT, total * CANDIDATE_LIMIT_MULTIPLIER);
+}
+
+/**
+ * Builds a Spotlight predicate matching each whitespace-separated term as a
+ * case/diacritic-insensitive substring of the file name. This purposely mirrors
+ * the Linux FTS5 prefix matching: it is only a candidate generator, the real
+ * ranking is done afterwards by the fuzzy matcher.
+ */
+std::string buildPredicate(std::string_view query) {
+  std::string predicate;
+
+  for (size_t i = 0; i < query.size();) {
+    while (i < query.size() && query[i] == ' ') {
+      ++i;
+    }
+
+    size_t const start = i;
+
+    while (i < query.size() && query[i] != ' ') {
+      ++i;
+    }
+
+    if (i == start) { break; }
+
+    std::string_view const word = query.substr(start, i - start);
+    std::string escaped;
+
+    escaped.reserve(word.size());
+
+    for (char c : word) {
+      if (c == '"' || c == '\\' || c == '*') { escaped.push_back('\\'); }
+      escaped.push_back(c);
+    }
+
+    if (!predicate.empty()) { predicate += " || "; }
+    predicate += "kMDItemFSName == \"*" + escaped + "*\"cd";
+  }
+
+  return predicate;
+}
+
+std::vector<IndexerFileResult> runQuery(const std::string &query,
+                                        const AbstractFileIndexer::QueryParams &params) {
+  std::vector<IndexerFileResult> results;
+  int const candidateLimit = candidateLimitFor(params.pagination);
+
+  if (candidateLimit == 0) { return results; }
+
+  std::string const predicate = buildPredicate(query);
+
+  if (predicate.empty()) { return results; }
+
+  CFStringRef queryString =
+      CFStringCreateWithCString(kCFAllocatorDefault, predicate.c_str(), kCFStringEncodingUTF8);
+
+  if (!queryString) { return results; }
+
+  MDQueryRef mdQuery = MDQueryCreate(kCFAllocatorDefault, queryString, nullptr, nullptr);
+  CFRelease(queryString);
+
+  if (!mdQuery) { return results; }
+
+  MDQuerySetMaxCount(mdQuery, candidateLimit);
+
+  if (!MDQueryExecute(mdQuery, kMDQuerySynchronous)) {
+    CFRelease(mdQuery);
+    return results;
+  }
+
+  struct Scored {
+    std::filesystem::path path;
+    int score = 0;
+  };
+
+  CFIndex const count = MDQueryGetResultCount(mdQuery);
+  const auto &matcher = fzf::threadLocalMatcher();
+  std::vector<Scored> scored;
+
+  scored.reserve(count);
+
+  for (CFIndex i = 0; i < count; ++i) {
+    auto item = (MDItemRef)MDQueryGetResultAtIndex(mdQuery, i);
+
+    if (!item) { continue; }
+
+    auto pathRef = (CFStringRef)MDItemCopyAttribute(item, kMDItemPath);
+
+    if (!pathRef) { continue; }
+
+    char buf[PATH_MAX];
+
+    if (CFStringGetCString(pathRef, buf, sizeof(buf), kCFStringEncodingUTF8)) {
+      std::filesystem::path path(buf);
+      int const fuzzyScore = matcher.fuzzy_match_v2_score_query(path.filename().string(), query);
+
+      if (fuzzyScore > 0) { scored.emplace_back(Scored{.path = std::move(path), .score = fuzzyScore}); }
+    }
+
+    CFRelease(pathRef);
+  }
+
+  CFRelease(mdQuery);
+
+  std::ranges::stable_sort(scored, [](const Scored &a, const Scored &b) {
+    if (a.score != b.score) { return a.score > b.score; }
+    return a.path < b.path;
+  });
+
+  int const offset = std::max(0, params.pagination.offset);
+  int const limit = std::max(0, params.pagination.limit);
+  size_t const begin = std::min(static_cast<size_t>(offset), scored.size());
+  size_t const end = std::min(begin + static_cast<size_t>(limit), scored.size());
+
+  results.reserve(end - begin);
+
+  for (size_t i = begin; i < end; ++i) {
+    results.emplace_back(
+        IndexerFileResult{.path = std::move(scored[i].path), .rank = static_cast<double>(scored[i].score)});
+  }
+
+  return results;
+}
+
+} // namespace
+
+QFuture<std::vector<IndexerFileResult>> SpotlightFileIndexer::queryAsync(std::string_view query,
+                                                                         const QueryParams &params) {
+  return QtConcurrent::run([params, q = std::string(query)]() {
+    @autoreleasepool {
+      return runQuery(q, params);
+    }
+  });
+}

--- a/src/server/src/ui/image/image-renderer.cpp
+++ b/src/server/src/ui/image/image-renderer.cpp
@@ -7,6 +7,9 @@
 #include "theme/theme-file.hpp"
 #include "ui/image/contrast-helper.hpp"
 #include "ui/image/url.hpp"
+#ifdef Q_OS_MACOS
+#include "ui/image/mac-file-icon-loader.hpp"
+#endif
 #include <QBuffer>
 #include <QCoreApplication>
 #include <QFutureWatcher>
@@ -150,6 +153,12 @@ static void applyFillColor(QImage &image, const QColor &fg) {
 }
 
 QImage renderFileIcon(const QString &path, const QSize &size, const QColor &fg, const QColor &bg) {
+#ifdef Q_OS_MACOS
+  if (!fg.isValid()) {
+    if (QImage native = renderMacFileIcon(path, size); !native.isNull()) { return native; }
+  }
+#endif
+
   QMimeDatabase const db;
   auto const mime = db.mimeTypeForFile(path, QMimeDatabase::MatchDefault);
 

--- a/src/server/src/ui/image/image-stream.cpp
+++ b/src/server/src/ui/image/image-stream.cpp
@@ -5,7 +5,7 @@
 #include "theme.hpp"
 #include "theme/theme-file.hpp"
 #ifdef Q_OS_MACOS
-#include "ui/image/mac-bundle-icon-loader.hpp"
+#include "ui/image/mac-file-icon-loader.hpp"
 #endif
 #include <QBuffer>
 #include <QCache>
@@ -178,7 +178,7 @@ void ImageStream::startStatic() {
     break;
 #ifdef Q_OS_MACOS
   case ImageURLType::MacBundle:
-    runInPool([name, size = m_size]() { return renderMacBundleIcon(name, size); }, m_fg);
+    runInPool([name, size = m_size]() { return renderMacFileIcon(name, size); }, m_fg);
     break;
 #endif
   case ImageURLType::FileIcon:

--- a/src/server/src/ui/image/mac-bundle-icon-loader.hpp
+++ b/src/server/src/ui/image/mac-bundle-icon-loader.hpp
@@ -1,6 +1,0 @@
-#pragma once
-#include <QImage>
-#include <QSize>
-#include <QString>
-
-QImage renderMacBundleIcon(const QString &bundlePath, const QSize &size);

--- a/src/server/src/ui/image/mac-file-icon-loader.hpp
+++ b/src/server/src/ui/image/mac-file-icon-loader.hpp
@@ -1,0 +1,6 @@
+#pragma once
+#include <QImage>
+#include <QSize>
+#include <QString>
+
+QImage renderMacFileIcon(const QString &path, const QSize &size);

--- a/src/server/src/ui/image/mac-file-icon-loader.mm
+++ b/src/server/src/ui/image/mac-file-icon-loader.mm
@@ -1,12 +1,12 @@
-#include "mac-bundle-icon-loader.hpp"
+#include "mac-file-icon-loader.hpp"
 
 #import <AppKit/AppKit.h>
 
-QImage renderMacBundleIcon(const QString &bundlePath, const QSize &size) {
-  if (bundlePath.isEmpty() || !size.isValid() || size.isEmpty()) return {};
+QImage renderMacFileIcon(const QString &path, const QSize &size) {
+  if (path.isEmpty() || !size.isValid() || size.isEmpty()) return {};
 
   @autoreleasepool {
-    NSString *nsPath = [NSString stringWithUTF8String:bundlePath.toUtf8().constData()];
+    NSString *nsPath = [NSString stringWithUTF8String:path.toUtf8().constData()];
     if (!nsPath) return {};
 
     NSImage *icon = [[NSWorkspace sharedWorkspace] iconForFile:nsPath];
@@ -32,12 +32,19 @@ QImage renderMacBundleIcon(const QString &bundlePath, const QSize &size) {
     NSGraphicsContext *ctx = [NSGraphicsContext graphicsContextWithBitmapImageRep:target];
     if (!ctx) return {};
 
+    // file icons are always square: if the size is not a square, we center the icon
+    // in it and make sure we preserve the correct aspect ratio.
+    NSInteger const side = MIN(width, height);
+    NSRect const drawRect = NSMakeRect((width - side) / 2.0, (height - side) / 2.0, side, side);
+
     [NSGraphicsContext saveGraphicsState];
     [NSGraphicsContext setCurrentContext:ctx];
     [ctx setImageInterpolation:NSImageInterpolationHigh];
-    [icon drawInRect:NSMakeRect(0, 0, width, height)
+    [[NSColor clearColor] setFill];
+    NSRectFillUsingOperation(NSMakeRect(0, 0, width, height), NSCompositingOperationCopy);
+    [icon drawInRect:drawRect
             fromRect:NSZeroRect
-           operation:NSCompositingOperationCopy
+           operation:NSCompositingOperationSourceOver
             fraction:1.0
       respectFlipped:YES
                hints:nil];


### PR DESCRIPTION
Implements file search using mdutil (spotlight). File search will not work if the user explicitly disabled mdutil. For now we don't have plans to support alternative file search backends on macOS.