### PR TITLE
Enable local currency conversion in Qalculate backend

### DIFF
--- a/src/server/src/services/calculator-service/qalculate/qalculate-backend.cpp
+++ b/src/server/src/services/calculator-service/qalculate/qalculate-backend.cpp
@@ -170,6 +170,7 @@ bool QalculateBackend::supportsCurrencyConversion() const { return true; }
 
 void QalculateBackend::initializeCalculator() {
   m_evalOpts.auto_post_conversion = POST_CONVERSION_BEST;
+  m_evalOpts.local_currency_conversion = true;
   m_evalOpts.structuring = STRUCTURING_SIMPLIFY;
   m_evalOpts.parse_options.parsing_mode = PARSING_MODE_ADAPTIVE;
   m_evalOpts.parse_options.units_enabled = true;


### PR DESCRIPTION
## What changed

Enable `local_currency_conversion` in the Qalculate backend evaluation options.

## Why

Vicinae already supports explicit currency conversions such as `1500usd to eur`, but bare currency amounts like `1500usd` do not produce the local/default currency conversion that qalc/libqalculate can provide.

With this option enabled, libqalculate can convert bare foreign-currency amounts to the user's local/default currency while preserving explicit target conversions.

## Validation

- `git diff --check`
- Standalone libqalculate probe in `nix develop`:
  - old behavior with `POST_CONVERSION_BEST` and `local_currency_conversion = false`: `$1500`
  - new behavior with `POST_CONVERSION_BEST` and `local_currency_conversion = true`: `EUR 1288.6598`
- Root CMake configure was attempted and reached `libqalculate! calculator backend is enabled`, but could not complete from this sparse checkout because unrelated directories such as `src/lib/*`, `vendor/*`, and `src/typescript` were not checked out.

Fixes #1479.
