### PR TITLE
fix: input server failing to start on NixOS

### DIFF
--- a/nix/vicinae.nix
+++ b/nix/vicinae.nix
@@ -66,7 +66,7 @@ gcc15Stdenv.mkDerivation (finalAttrs: {
     cmark-gfm
     kdePackages.layer-shell-qt
     kdePackages.qtkeychain
-	kdePackages.qtshadertools
+    kdePackages.qtshadertools
     kdePackages.syntax-highlighting
     libqalculate
     nodejs
@@ -85,6 +85,11 @@ gcc15Stdenv.mkDerivation (finalAttrs: {
     npmRoot=src/typescript/extension-manager npmDeps=${finalAttrs.extensionManagerDeps} npmConfigHook
   '';
 
+  postFixup = ''
+    wrapProgram "$out/bin/vicinae" \
+      --set VICINAE_INPUT_SERVER_BIN "$out/libexec/vicinae/vicinae-input-server"
+  '';
+
   qtWrapperArgs = [
     "--prefix PATH : ${
       lib.makeBinPath [
@@ -92,7 +97,6 @@ gcc15Stdenv.mkDerivation (finalAttrs: {
         (placeholder "out")
       ]
     }"
-    "--set VICINAE_INPUT_SERVER_BIN /run/wrappers/bin/vicinae-input-server"
   ];
 
   meta = {


### PR DESCRIPTION
Hello. I noticed I couldn't choose to paste the clipboard content as the clipboard history default action.
After investigating the issue I found out the input server failed to start every time because `VICINAE_INPUT_SERVER_BIN` was set to `/run/wrappers/bin/vicinae-input-server`, which can't be found because it's located in the nix store.
It now points to the executable in the nix store, and it seems to work just perfect now

I encountered this problem and solved it while being on nixpkgs unstable 26.11

Errors found via `journalctl`:
`[V] 2026-06-06T09:54:57 error - input server process error occured "Child process set up failed: execve: No such file or directory" `
`[V] 2026-06-06T09:54:57 error - Failed to start input server QProcess::FailedToStart`