### PR TITLE
nix: format and use the wrapper for config instead of systemd var

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,3 @@
-{
-  pkgs ? import <nixpkgs> { },
-}:
-{
-  vicinae = pkgs.callPackage ./nix/vicinae.nix { };
+{pkgs ? import <nixpkgs> {}}: {
+  vicinae = pkgs.callPackage ./nix/vicinae.nix {};
 }

--- a/flake.nix
+++ b/flake.nix
@@ -7,88 +7,83 @@
   };
 
   nixConfig = {
-    extra-substituters = [ "https://vicinae.cachix.org" ];
-    extra-trusted-public-keys = [ "vicinae.cachix.org-1:1kDrfienkGHPYbkpNj1mWTr7Fm1+zcenzgTizIcI3oc=" ];
+    extra-substituters = ["https://vicinae.cachix.org"];
+    extra-trusted-public-keys = ["vicinae.cachix.org-1:1kDrfienkGHPYbkpNj1mWTr7Fm1+zcenzgTizIcI3oc="];
   };
 
-  outputs =
-    {
-      self,
-      nixpkgs,
-      systems,
-    }:
-    let
-      inherit (nixpkgs) lib;
-      forEachPkgs = f: lib.genAttrs (import systems) (system: f nixpkgs.legacyPackages.${system});
-    in
-    {
-      packages = forEachPkgs (pkgs: {
-        default = pkgs.callPackage ./nix/vicinae.nix { gcc15Stdenv = pkgs.gcc15Stdenv; };
-        nix-update-script = pkgs.writeShellScriptBin "nix-update-script" ''
-          OLD_API_DEPS_HASH=$(${pkgs.lib.getExe pkgs.nix} eval --raw .#packages.x86_64-linux.default.apiDeps.hash)
-          OLD_EXT_MAN_DEPS_HASH=$(${pkgs.lib.getExe pkgs.nix} eval --raw .#packages.x86_64-linux.default.extensionManagerDeps.hash)
+  outputs = {
+    self,
+    nixpkgs,
+    systems,
+  }: let
+    inherit (nixpkgs) lib;
+    forEachPkgs = f: lib.genAttrs (import systems) (system: f nixpkgs.legacyPackages.${system});
+  in {
+    packages = forEachPkgs (pkgs: {
+      default = pkgs.callPackage ./nix/vicinae.nix {gcc15Stdenv = pkgs.gcc15Stdenv;};
+      nix-update-script = pkgs.writeShellScriptBin "nix-update-script" ''
+        OLD_API_DEPS_HASH=$(${pkgs.lib.getExe pkgs.nix} eval --raw .#packages.x86_64-linux.default.apiDeps.hash)
+        OLD_EXT_MAN_DEPS_HASH=$(${pkgs.lib.getExe pkgs.nix} eval --raw .#packages.x86_64-linux.default.extensionManagerDeps.hash)
 
-          cd src/typescript/api
-          NEW_API_DEPS_HASH=$(${pkgs.lib.getExe pkgs.prefetch-npm-deps} package-lock.json)
-          cd ../extension-manager
-          NEW_EXT_MAN_DEPS_HASH=$(${pkgs.lib.getExe pkgs.prefetch-npm-deps} package-lock.json)
-          cd ..
+        cd src/typescript/api
+        NEW_API_DEPS_HASH=$(${pkgs.lib.getExe pkgs.prefetch-npm-deps} package-lock.json)
+        cd ../extension-manager
+        NEW_EXT_MAN_DEPS_HASH=$(${pkgs.lib.getExe pkgs.prefetch-npm-deps} package-lock.json)
+        cd ..
 
-          [[ "$OLD_API_DEPS_HASH" == "$NEW_API_DEPS_HASH" ]] || { echo -e "\e[31mHash mismatch for API npm deps, please replace the value in vicinae.nix with '$NEW_API_DEPS_HASH'.\e[0m" >&2; exit 1;}
+        [[ "$OLD_API_DEPS_HASH" == "$NEW_API_DEPS_HASH" ]] || { echo -e "\e[31mHash mismatch for API npm deps, please replace the value in vicinae.nix with '$NEW_API_DEPS_HASH'.\e[0m" >&2; exit 1;}
 
-          [[ "$OLD_EXT_MAN_DEPS_HASH" == "$NEW_EXT_MAN_DEPS_HASH" ]] || { echo -e "\e[31mHash mismatch for extension-manager npm deps, please replace the value in vicinae.nix with '$NEW_EXT_MAN_DEPS_HASH'.\e[0m" >&2; exit 1;}
-        '';
-      });
-      lib = forEachPkgs (pkgs: {
-        mkVicinaeExtension = pkgs.callPackage ./nix/mkVicinaeExtension.nix { };
-        mkRayCastExtension = pkgs.callPackage ./nix/mkRayCastExtension.nix { };
-      });
-      devShells = forEachPkgs (
-        pkgs:
-        let
-          qtEnv = pkgs.qt6.env "qt-custom-${pkgs.qt6.qtbase.version}" [
-            pkgs.qt6.qtdeclarative
-            pkgs.qt6.qtwayland
-            pkgs.qt6.qtsvg
+        [[ "$OLD_EXT_MAN_DEPS_HASH" == "$NEW_EXT_MAN_DEPS_HASH" ]] || { echo -e "\e[31mHash mismatch for extension-manager npm deps, please replace the value in vicinae.nix with '$NEW_EXT_MAN_DEPS_HASH'.\e[0m" >&2; exit 1;}
+      '';
+    });
+    lib = forEachPkgs (pkgs: {
+      mkVicinaeExtension = pkgs.callPackage ./nix/mkVicinaeExtension.nix {};
+      mkRayCastExtension = pkgs.callPackage ./nix/mkRayCastExtension.nix {};
+    });
+    devShells = forEachPkgs (
+      pkgs: let
+        qtEnv = pkgs.qt6.env "qt-custom-${pkgs.qt6.qtbase.version}" [
+          pkgs.qt6.qtdeclarative
+          pkgs.qt6.qtwayland
+          pkgs.qt6.qtsvg
+        ];
+      in {
+        default = pkgs.mkShell {
+          stdenv = pkgs.gcc15Stdenv;
+
+          # automatically pulls nativeBuildInputs + buildInputs
+          inputsFrom = [(pkgs.callPackage ./nix/vicinae.nix {gcc15Stdenv = pkgs.gcc15Stdenv;})];
+
+          packages = with pkgs; [
+            ccache
+            catch2_3
+            qtEnv
+            clang-tools
           ];
-        in
-        {
-          default = pkgs.mkShell {
-            stdenv = pkgs.gcc15Stdenv;
 
-            # automatically pulls nativeBuildInputs + buildInputs
-            inputsFrom = [ (pkgs.callPackage ./nix/vicinae.nix { gcc15Stdenv = pkgs.gcc15Stdenv; }) ];
-
-            packages = with pkgs; [
-              ccache
-              catch2_3
-              qtEnv
-              clang-tools
-            ];
-
-            shellHook = ''
-              export CC=${pkgs.gcc15}/bin/gcc
-              export CXX=${pkgs.gcc15}/bin/g++
-              export CMAKE_C_COMPILER=$CC
-              export CMAKE_CXX_COMPILER=$CXX
-            '';
-          };
-        }
-      );
-      overlays.default = final: prev: {
-        vicinae = final.callPackage ./nix/vicinae.nix { };
-        mkVicinaeExtension = prev.callPackage ./nix/mkVicinaeExtension.nix { };
-        mkRayCastExtension = prev.callPackage ./nix/mkRayCastExtension.nix { };
-      };
-      homeManagerModules.default = import ./nix/module.nix self;
-
-      nixosModules.default = { pkgs, ... }: {
-        security.wrappers.vicinae-input-server = {
-          source = "${self.packages.${pkgs.stdenv.hostPlatform.system}.default}/libexec/vicinae/vicinae-input-server";
-          capabilities = "cap_dac_override+ep";
-          owner = "root";
-          group = "root";
+          shellHook = ''
+            export CC=${pkgs.gcc15}/bin/gcc
+            export CXX=${pkgs.gcc15}/bin/g++
+            export CMAKE_C_COMPILER=$CC
+            export CMAKE_CXX_COMPILER=$CXX
+          '';
         };
+      }
+    );
+    overlays.default = final: prev: {
+      vicinae = final.callPackage ./nix/vicinae.nix {};
+      mkVicinaeExtension = prev.callPackage ./nix/mkVicinaeExtension.nix {};
+      mkRayCastExtension = prev.callPackage ./nix/mkRayCastExtension.nix {};
+    };
+    homeManagerModules.default = import ./nix/module.nix self;
+
+    nixosModules.default = {pkgs, ...}: {
+      security.wrappers.vicinae-input-server = {
+        source = "${self.packages.${pkgs.stdenv.hostPlatform.system}.default}/libexec/vicinae/vicinae-input-server";
+        capabilities = "cap_dac_override+ep";
+        owner = "root";
+        group = "root";
       };
     };
+  };
 }

--- a/nix/mkRayCastExtension.nix
+++ b/nix/mkRayCastExtension.nix
@@ -7,47 +7,43 @@
 lib.extendMkDerivation {
   constructDrv = buildNpmPackage;
 
-  extendDrvArgs =
-    finalAttrs:
-    {
-      name,
-      hash ? null,
-      sha256 ? null,
-      ...
-    }@attrs:
-    {
-      inherit name;
-      src =
-        attrs.src or (
-          fetchFromGitHub {
-            owner = "raycast";
-            repo = "extensions";
-            rev = attrs.rev or (throw "mkRayCastExtension: `rev` is required when src isn't suplied");
-            hash =
-              if hash != null then
-                hash
-              else if sha256 != null then
-                sha256
-              else
-                throw "mkRayCastExtension: `hash` or `sha256` is required";
-            sparseCheckout = [
-              "/extensions/${name}"
-            ];
-          }
-          + "/extensions/${name}"
-        );
+  extendDrvArgs = finalAttrs: {
+    name,
+    hash ? null,
+    sha256 ? null,
+    ...
+  } @ attrs: {
+    inherit name;
+    src =
+      attrs.src or (
+        fetchFromGitHub {
+          owner = "raycast";
+          repo = "extensions";
+          rev = attrs.rev or (throw "mkRayCastExtension: `rev` is required when src isn't suplied");
+          hash =
+            if hash != null
+            then hash
+            else if sha256 != null
+            then sha256
+            else throw "mkRayCastExtension: `hash` or `sha256` is required";
+          sparseCheckout = [
+            "/extensions/${name}"
+          ];
+        }
+        + "/extensions/${name}"
+      );
 
-      npmDeps = attrs.npmDeps or (importNpmLock { npmRoot = finalAttrs.src; });
-      npmConfigHook = attrs.npmConfigHook or importNpmLock.npmConfigHook;
+    npmDeps = attrs.npmDeps or (importNpmLock {npmRoot = finalAttrs.src;});
+    npmConfigHook = attrs.npmConfigHook or importNpmLock.npmConfigHook;
 
-      installPhase =
-        attrs.installPhase or ''
-          runHook preInstall
+    installPhase =
+      attrs.installPhase or ''
+        runHook preInstall
 
-          mkdir -p $out
-          cp -r /build/.config/raycast/extensions/${name}/* $out/
+        mkdir -p $out
+        cp -r /build/.config/raycast/extensions/${name}/* $out/
 
-          runHook postInstall
-        '';
-    };
+        runHook postInstall
+      '';
+  };
 }

--- a/nix/mkVicinaeExtension.nix
+++ b/nix/mkVicinaeExtension.nix
@@ -6,19 +6,16 @@
 lib.extendMkDerivation {
   constructDrv = buildNpmPackage;
 
-  extendDrvArgs =
-    _:
-    {
-      version ? lib.warn "mkVicinaeExtension: not including version is deprecated" "0",
-      src,
-      ...
-    }@attrs:
-    {
-      inherit version;
-      npmDeps = attrs.npmDeps or (importNpmLock { npmRoot = src; });
-      npmConfigHook = attrs.npmConfigHook or importNpmLock.npmConfigHook;
-      # NOTE: using buildPhase because $out doesn't work with npmBuildFlags
-      buildPhase = attrs.buildPhase or "npm run build -- --out=$out";
-      dontNpmInstall = attrs.dontNpmInstall or true;
-    };
+  extendDrvArgs = _: {
+    version ? lib.warn "mkVicinaeExtension: not including version is deprecated" "0",
+    src,
+    ...
+  } @ attrs: {
+    inherit version;
+    npmDeps = attrs.npmDeps or (importNpmLock {npmRoot = src;});
+    npmConfigHook = attrs.npmConfigHook or importNpmLock.npmConfigHook;
+    # NOTE: using buildPhase because $out doesn't work with npmBuildFlags
+    buildPhase = attrs.buildPhase or "npm run build -- --out=$out";
+    dontNpmInstall = attrs.dontNpmInstall or true;
+  };
 }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -175,74 +175,69 @@ in {
     };
   };
 
-  config = lib.mkIf cfg.enable {
-    home.packages = [cfg.package];
+  config = let
+    finalPackage = cfg.package.override {
+      inherit (cfg) settings settingOverrides;
+    };
+  in
+    lib.mkIf cfg.enable {
+      home.packages = [finalPackage];
 
-    xdg = let
-      themeFiles =
-        lib.mapAttrs' (
-          name: theme:
-            lib.nameValuePair "vicinae/themes/${name}.toml" {
-              source = tomlFormat.generate "vicinae-${name}-theme" theme;
-            }
-        )
-        cfg.themes;
-    in {
-      configFile = {
-        "vicinae/nix.json" = lib.mkIf (cfg.settings != {}) {
-          source = jsonFormat.generate "vicinae-settings" cfg.settings;
+      xdg = let
+        themeFiles =
+          lib.mapAttrs' (
+            name: theme:
+              lib.nameValuePair "vicinae/themes/${name}.toml" {
+                source = tomlFormat.generate "vicinae-${name}-theme" theme;
+              }
+          )
+          cfg.themes;
+      in {
+        configFile = {};
+
+        dataFile =
+          builtins.listToAttrs (
+            builtins.map (item: {
+              name = "vicinae/extensions/${item.name}";
+              value.source = item;
+            })
+            cfg.extensions
+          )
+          // themeFiles;
+      };
+
+      systemd.user.services.vicinae = lib.mkIf (cfg.systemd.enable) {
+        Unit = {
+          Description = "Vicinae server daemon";
+          Documentation = ["https://docs.vicinae.com"];
+          After = [cfg.systemd.target];
+          PartOf = [cfg.systemd.target];
+        };
+        Service = {
+          Environment =
+            lib.mapAttrsToList (
+              key: val: let
+                valueStr =
+                  if lib.isBool val
+                  then
+                    (
+                      if val
+                      then "1"
+                      else "0"
+                    )
+                  else toString val;
+              in "${key}=${valueStr}"
+            )
+            cfg.systemd.environment;
+          Type = "simple";
+          ExecStart = "${lib.getExe' finalPackage "vicinae"} server";
+          Restart = "always";
+          RestartSec = 5;
+          KillMode = "process";
+        };
+        Install = lib.mkIf cfg.systemd.autoStart {
+          WantedBy = [cfg.systemd.target];
         };
       };
-
-      dataFile =
-        builtins.listToAttrs (
-          builtins.map (item: {
-            name = "vicinae/extensions/${item.name}";
-            value.source = item;
-          })
-          cfg.extensions
-        )
-        // themeFiles;
     };
-
-    systemd.user.services.vicinae = lib.mkIf (cfg.systemd.enable) {
-      Unit = {
-        Description = "Vicinae server daemon";
-        Documentation = ["https://docs.vicinae.com"];
-        After = [cfg.systemd.target];
-        PartOf = [cfg.systemd.target];
-      };
-      Service = {
-        Environment =
-          lib.mapAttrsToList (
-            key: val: let
-              valueStr =
-                if lib.isBool val
-                then
-                  (
-                    if val
-                    then "1"
-                    else "0"
-                  )
-                else toString val;
-            in "${key}=${valueStr}"
-          )
-          cfg.systemd.environment
-          ++ [
-            (lib.mkIf (cfg.settings != {}) ''VICINAE_OVERRIDES="${config.xdg.configHome}/vicinae/nix.json"'')
-            (lib.mkIf (
-              cfg.settingOverrides != []
-            ) ''VICINAE_OVERRIDES="${lib.concatStringsSep ":" cfg.settingOverrides}"'')
-          ];
-        Type = "simple";
-        ExecStart = "${lib.getExe' cfg.package "vicinae"} server";
-        Restart = "always";
-        RestartSec = 5;
-        KillMode = "process";
-      };
-      Install = lib.mkIf cfg.systemd.autoStart {
-        WantedBy = [cfg.systemd.target];
-      };
-    };
-  };
 }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,21 +1,17 @@
-self:
-{
+self: {
   config,
   pkgs,
   lib,
   ...
-}:
-let
+}: let
   cfg = config.services.vicinae;
 
   inherit (pkgs.stdenv.hostPlatform) system;
   vicinaePkg = self.packages.${system}.default;
 
-  jsonFormat = pkgs.formats.json { };
-  tomlFormat = pkgs.formats.toml { };
-in
-{
-
+  jsonFormat = pkgs.formats.json {};
+  tomlFormat = pkgs.formats.toml {};
+in {
   options.services.vicinae = {
     enable = lib.mkEnableOption "vicinae launcher daemon";
 
@@ -36,18 +32,16 @@ in
       };
 
       environment = lib.mkOption {
-        type =
-          with lib.types;
-          let
-            valueType = attrsOf (oneOf [
-              str
-              int
-              float
-              bool
-            ]);
-          in
+        type = with lib.types; let
+          valueType = attrsOf (oneOf [
+            str
+            int
+            float
+            bool
+          ]);
+        in
           valueType;
-        default = { };
+        default = {};
         description = "Environment variables for the vicinae daemon. See <https://docs.vicinae.com/launcher-window#wayland-layer-shell>";
         example = lib.literalExpression ''
           {
@@ -69,7 +63,7 @@ in
 
     extensions = lib.mkOption {
       type = lib.types.listOf lib.types.package;
-      default = [ ];
+      default = [];
       description = ''
         List of Vicinae extensions to install.
         You can use the `mkVicinaeExtension` function from the overlay to create extensions.
@@ -78,7 +72,7 @@ in
 
     themes = lib.mkOption {
       inherit (tomlFormat) type;
-      default = { };
+      default = {};
       description = ''
         Theme settings to add to the themes folder in `~/.config/vicinae/themes`. See <https://docs.vicinae.com/theming/getting-started> for supported values.
 
@@ -86,53 +80,55 @@ in
       '';
       example =
         lib.literalExpression # nix
-          ''
-            {
-              catppuccin-mocha = {
-                meta = {
-                  version = 1;
-                  name = "Catppuccin Mocha";
-                  description = "Cozy feeling with color-rich accents";
-                  variant = "dark";
-                  icon = "icons/catppuccin-mocha.png";
-                  inherits = "vicinae-dark";
-                };
+        
+        ''
+          {
+            catppuccin-mocha = {
+              meta = {
+                version = 1;
+                name = "Catppuccin Mocha";
+                description = "Cozy feeling with color-rich accents";
+                variant = "dark";
+                icon = "icons/catppuccin-mocha.png";
+                inherits = "vicinae-dark";
+              };
 
-                colors = {
-                  core = {
-                    background = "#1E1E2E";
-                    foreground = "#CDD6F4";
-                    secondary_background = "#181825";
-                    border = "#313244";
-                    accent = "#89B4FA";
-                  };
-                  accents = {
-                    blue = "#89B4FA";
-                    green = "#A6E3A1";
-                    magenta = "#F5C2E7";
-                    orange = "#FAB387";
-                    purple = "#CBA6F7";
-                    red = "#F38BA8";
-                    yellow = "#F9E2AF";
-                    cyan = "#94E2D5";
-                  };
+              colors = {
+                core = {
+                  background = "#1E1E2E";
+                  foreground = "#CDD6F4";
+                  secondary_background = "#181825";
+                  border = "#313244";
+                  accent = "#89B4FA";
+                };
+                accents = {
+                  blue = "#89B4FA";
+                  green = "#A6E3A1";
+                  magenta = "#F5C2E7";
+                  orange = "#FAB387";
+                  purple = "#CBA6F7";
+                  red = "#F38BA8";
+                  yellow = "#F9E2AF";
+                  cyan = "#94E2D5";
                 };
               };
-            }
-          '';
+            };
+          }
+        '';
     };
 
     settingOverrides = lib.mkOption {
       type = lib.types.listOf lib.types.path;
-      default = [ ];
+      default = [];
       example =
         lib.literalExpression # nix
-          ''
-            [
-              ${config.xdg.configHome}/vicinae/override.json
-              /run/secrets/vicinae-secrets.json
-            ]
-          '';
+        
+        ''
+          [
+            ${config.xdg.configHome}/vicinae/override.json
+            /run/secrets/vicinae-secrets.json
+          ]
+        '';
       description = ''
         Allows you to specify additional JSON files that will be merged with the imperative settings and take precedence.
       '';
@@ -140,7 +136,7 @@ in
 
     settings = lib.mkOption {
       inherit (jsonFormat) type;
-      default = { };
+      default = {};
       description = ''
         Settings written as JSON to `~/.config/vicinae/nix.json`.
         This is will override any settings from the default settings.json.
@@ -180,54 +176,62 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = [cfg.package];
 
-    xdg =
-      let
-        themeFiles = lib.mapAttrs' (
+    xdg = let
+      themeFiles =
+        lib.mapAttrs' (
           name: theme:
-          lib.nameValuePair "vicinae/themes/${name}.toml" {
-            source = tomlFormat.generate "vicinae-${name}-theme" theme;
-          }
-        ) cfg.themes;
-      in
-      {
-        configFile = {
-          "vicinae/nix.json" = lib.mkIf (cfg.settings != { }) {
-            source = jsonFormat.generate "vicinae-settings" cfg.settings;
-          };
+            lib.nameValuePair "vicinae/themes/${name}.toml" {
+              source = tomlFormat.generate "vicinae-${name}-theme" theme;
+            }
+        )
+        cfg.themes;
+    in {
+      configFile = {
+        "vicinae/nix.json" = lib.mkIf (cfg.settings != {}) {
+          source = jsonFormat.generate "vicinae-settings" cfg.settings;
         };
-
-        dataFile =
-          builtins.listToAttrs (
-            builtins.map (item: {
-              name = "vicinae/extensions/${item.name}";
-              value.source = item;
-            }) cfg.extensions
-          )
-          // themeFiles;
       };
+
+      dataFile =
+        builtins.listToAttrs (
+          builtins.map (item: {
+            name = "vicinae/extensions/${item.name}";
+            value.source = item;
+          })
+          cfg.extensions
+        )
+        // themeFiles;
+    };
 
     systemd.user.services.vicinae = lib.mkIf (cfg.systemd.enable) {
       Unit = {
         Description = "Vicinae server daemon";
-        Documentation = [ "https://docs.vicinae.com" ];
-        After = [ cfg.systemd.target ];
-        PartOf = [ cfg.systemd.target ];
+        Documentation = ["https://docs.vicinae.com"];
+        After = [cfg.systemd.target];
+        PartOf = [cfg.systemd.target];
       };
       Service = {
         Environment =
           lib.mapAttrsToList (
-            key: val:
-            let
-              valueStr = if lib.isBool val then (if val then "1" else "0") else toString val;
-            in
-            "${key}=${valueStr}"
-          ) cfg.systemd.environment
+            key: val: let
+              valueStr =
+                if lib.isBool val
+                then
+                  (
+                    if val
+                    then "1"
+                    else "0"
+                  )
+                else toString val;
+            in "${key}=${valueStr}"
+          )
+          cfg.systemd.environment
           ++ [
-            (lib.mkIf (cfg.settings != { }) ''VICINAE_OVERRIDES="${config.xdg.configHome}/vicinae/nix.json"'')
+            (lib.mkIf (cfg.settings != {}) ''VICINAE_OVERRIDES="${config.xdg.configHome}/vicinae/nix.json"'')
             (lib.mkIf (
-              cfg.settingOverrides != [ ]
+              cfg.settingOverrides != []
             ) ''VICINAE_OVERRIDES="${lib.concatStringsSep ":" cfg.settingOverrides}"'')
           ];
         Type = "simple";
@@ -237,9 +241,8 @@ in
         KillMode = "process";
       };
       Install = lib.mkIf cfg.systemd.autoStart {
-        WantedBy = [ cfg.systemd.target ];
+        WantedBy = [cfg.systemd.target];
       };
     };
-
   };
 }

--- a/nix/vicinae.nix
+++ b/nix/vicinae.nix
@@ -13,93 +13,92 @@
   gcc15Stdenv,
   wayland,
   glaze,
-}:
-let
+}: let
   manifestRaw = builtins.readFile ../manifest.yaml;
-  manifestGet =
-    key:
-    let
-      m = builtins.match ".*${key}:[[:space:]]*\"([^\"]+)\".*" manifestRaw;
-    in
-    if m == null then throw "Key ${key} not found in manifest.yaml" else builtins.elemAt m 0;
+  manifestGet = key: let
+    m = builtins.match ".*${key}:[[:space:]]*\"([^\"]+)\".*" manifestRaw;
+  in
+    if m == null
+    then throw "Key ${key} not found in manifest.yaml"
+    else builtins.elemAt m 0;
 in
-gcc15Stdenv.mkDerivation (finalAttrs: {
-  pname = "vicinae";
-  version = lib.removePrefix "v" (manifestGet "tag");
+  gcc15Stdenv.mkDerivation (finalAttrs: {
+    pname = "vicinae";
+    version = lib.removePrefix "v" (manifestGet "tag");
 
-  src = ../.;
+    src = ../.;
 
-  apiDeps = fetchNpmDeps {
-    src = "${finalAttrs.src}/src/typescript/api";
-    hash = "sha256-Ki/l3PiBY3R0Bzd6leqx2OxA7c+jckjr+YD4GHHaSqI=";
-  };
+    apiDeps = fetchNpmDeps {
+      src = "${finalAttrs.src}/src/typescript/api";
+      hash = "sha256-Ki/l3PiBY3R0Bzd6leqx2OxA7c+jckjr+YD4GHHaSqI=";
+    };
 
-  extensionManagerDeps = fetchNpmDeps {
-    src = "${finalAttrs.src}/src/typescript/extension-manager";
-    hash = "sha256-6Kz7I8cGm1lnGPOI/gju3t5/imnbBFlDEKzWar5O770=";
-  };
+    extensionManagerDeps = fetchNpmDeps {
+      src = "${finalAttrs.src}/src/typescript/extension-manager";
+      hash = "sha256-6Kz7I8cGm1lnGPOI/gju3t5/imnbBFlDEKzWar5O770=";
+    };
 
-  cmakeFlags = lib.mapAttrsToList lib.cmakeFeature {
-    "VICINAE_GIT_TAG" = "v${finalAttrs.version}";
-    "VICINAE_GIT_COMMIT_HASH" = manifestGet "short_rev";
-    "VICINAE_PROVENANCE" = "nix";
-    "INSTALL_NODE_MODULES" = "OFF";
-    "USE_SYSTEM_GLAZE" = "ON";
-    "CMAKE_INSTALL_PREFIX" = placeholder "out";
-    "CMAKE_INSTALL_DATAROOTDIR" = "share";
-    "CMAKE_INSTALL_BINDIR" = "bin";
-    "CMAKE_INSTALL_LIBDIR" = "lib";
-    "INSTALL_BROWSER_NATIVE_HOST" = "OFF";
-  };
+    cmakeFlags = lib.mapAttrsToList lib.cmakeFeature {
+      "VICINAE_GIT_TAG" = "v${finalAttrs.version}";
+      "VICINAE_GIT_COMMIT_HASH" = manifestGet "short_rev";
+      "VICINAE_PROVENANCE" = "nix";
+      "INSTALL_NODE_MODULES" = "OFF";
+      "USE_SYSTEM_GLAZE" = "ON";
+      "CMAKE_INSTALL_PREFIX" = placeholder "out";
+      "CMAKE_INSTALL_DATAROOTDIR" = "share";
+      "CMAKE_INSTALL_BINDIR" = "bin";
+      "CMAKE_INSTALL_LIBDIR" = "lib";
+      "INSTALL_BROWSER_NATIVE_HOST" = "OFF";
+    };
 
-  strictDeps = true;
+    strictDeps = true;
 
-  nativeBuildInputs = [
-    cmake
-    ninja
-    nodejs
-    pkg-config
-    qt6.wrapQtAppsHook
-  ];
+    nativeBuildInputs = [
+      cmake
+      ninja
+      nodejs
+      pkg-config
+      qt6.wrapQtAppsHook
+    ];
 
-  buildInputs = [
-    cmark-gfm
-    kdePackages.layer-shell-qt
-    kdePackages.qtkeychain
-	kdePackages.qtshadertools
-    kdePackages.syntax-highlighting
-    libqalculate
-    nodejs
-    qt6.qtbase
-    qt6.qtdeclarative
-    qt6.qtsvg
-    qt6.qtwayland
-    wayland
-    glaze
-  ];
+    buildInputs = [
+      cmark-gfm
+      kdePackages.layer-shell-qt
+      kdePackages.qtkeychain
+      kdePackages.qtshadertools
+      kdePackages.syntax-highlighting
+      libqalculate
+      nodejs
+      qt6.qtbase
+      qt6.qtdeclarative
+      qt6.qtsvg
+      qt6.qtwayland
+      wayland
+      glaze
+    ];
 
-  postPatch = ''
-    local postPatchHooks=()
-    source ${npmHooks.npmConfigHook}/nix-support/setup-hook
-    npmRoot=src/typescript/api npmDeps=${finalAttrs.apiDeps} npmConfigHook
-    npmRoot=src/typescript/extension-manager npmDeps=${finalAttrs.extensionManagerDeps} npmConfigHook
-  '';
+    postPatch = ''
+      local postPatchHooks=()
+      source ${npmHooks.npmConfigHook}/nix-support/setup-hook
+      npmRoot=src/typescript/api npmDeps=${finalAttrs.apiDeps} npmConfigHook
+      npmRoot=src/typescript/extension-manager npmDeps=${finalAttrs.extensionManagerDeps} npmConfigHook
+    '';
 
-  qtWrapperArgs = [
-    "--prefix PATH : ${
-      lib.makeBinPath [
-        nodejs
-        (placeholder "out")
-      ]
-    }"
-    "--set VICINAE_INPUT_SERVER_BIN /run/wrappers/bin/vicinae-input-server"
-  ];
+    qtWrapperArgs = [
+      "--prefix PATH : ${
+        lib.makeBinPath [
+          nodejs
+          (placeholder "out")
+        ]
+      }"
+      "--set VICINAE_INPUT_SERVER_BIN /run/wrappers/bin/vicinae-input-server"
+    ];
 
-  meta = {
-    description = "A focused launcher for your desktop — native, fast, extensible";
-    homepage = "https://github.com/vicinaehq/vicinae";
-    license = lib.licenses.gpl3Plus;
-    platforms = lib.platforms.linux;
-    mainProgram = "vicinae";
-  };
-})
+    meta = {
+      description = "A focused launcher for your desktop — native, fast, extensible";
+      homepage = "https://github.com/vicinaehq/vicinae";
+      license = lib.licenses.gpl3Plus;
+      platforms = lib.platforms.linux;
+      mainProgram = "vicinae";
+    };
+  })

--- a/nix/vicinae.nix
+++ b/nix/vicinae.nix
@@ -13,6 +13,9 @@
   gcc15Stdenv,
   wayland,
   glaze,
+  formats,
+  settings ? {},
+  settingOverrides ? [],
 }: let
   manifestRaw = builtins.readFile ../manifest.yaml;
   manifestGet = key: let
@@ -84,15 +87,18 @@ in
       npmRoot=src/typescript/extension-manager npmDeps=${finalAttrs.extensionManagerDeps} npmConfigHook
     '';
 
-    qtWrapperArgs = [
-      "--prefix PATH : ${
-        lib.makeBinPath [
-          nodejs
-          (placeholder "out")
-        ]
-      }"
-      "--set VICINAE_INPUT_SERVER_BIN /run/wrappers/bin/vicinae-input-server"
-    ];
+    qtWrapperArgs =
+      [
+        "--prefix PATH : ${
+          lib.makeBinPath [
+            nodejs
+            (placeholder "out")
+          ]
+        }"
+        "--set VICINAE_INPUT_SERVER_BIN /run/wrappers/bin/vicinae-input-server"
+      ]
+      ++ lib.optional (settings != {}) "--set VICINAE_OVERRIDES ${toString ((formats.json {}).generate "vicinae-settings.json" settings)}"
+      ++ lib.optional (settingOverrides != []) "--set VICINAE_OVERRIDES ${lib.concatStringsSep ":" settingOverrides}";
 
     meta = {
       description = "A focused launcher for your desktop — native, fast, extensible";


### PR DESCRIPTION
this pr switches how config is being applied from being applied using an env var thats being set inside of the systemd service to being set into our already existing wrapper.

# benefits: 

previously a user starting vicinae using its actual binary (e.x: `vicinae server`) would not have their nix config applied at all.

right now, whether the user launches it using `vicinae server` or using systemd, it would launch with the user's config just fine.

# note

when reviewing the pr just review the 2nd commit (37046444cdda2c2f0b6aa0658e15d60e08647224), the first one is just a format using [alejandra](https://github.com/kamadorueda/alejandra)