### PR TITLE
fix: Highlight footer actions button when menu is open

### DIFF
--- a/src/server/src/qml/qml/Footer.qml
+++ b/src/server/src/qml/qml/Footer.qml
@@ -42,7 +42,7 @@ Item {
             Layout.alignment: Qt.AlignVCenter
             width: 1
             height: 12
-            opacity: primaryButton.hovered || actionsButton.hovered ? 0 : 0.35
+            opacity: primaryButton.hovered || actionsButton.hovered || actionsButton.backgrounded ? 0 : 0.35
             color: Config.withAlpha(Theme.textMuted, Config.windowOpacity)
 
             Behavior on opacity {
@@ -60,6 +60,7 @@ Item {
             label: "Actions"
             shortcutTokens: Keybinds.toggleActionPanelTokens
             highlighted: actionPanel.open
+            backgrounded: actionPanel.open
             onClicked: actionPanel.toggle()
         }
     }

--- a/src/server/src/qml/qml/FooterButton.qml
+++ b/src/server/src/qml/qml/FooterButton.qml
@@ -6,6 +6,7 @@ Item {
     required property string label
     required property var shortcutTokens
     property bool highlighted: false
+    property bool backgrounded: false
 
     signal clicked
 
@@ -18,7 +19,7 @@ Item {
 
     Rectangle {
         anchors.fill: parent
-        visible: root.hovered
+        visible: root.hovered || root.backgrounded
         radius: 6
         color: Theme.listItemHoverBg
     }


### PR DESCRIPTION
- Shows the footer Actions button background while the menu is open.
- Keeps the divider hidden in that open state.