### PR TITLE
fix: anchor native popup windows below their trigger on Wayland

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -936,6 +936,8 @@ set(VICINAE_QML_SOURCES
 	src/qml/markdown/text-selection-controller.hpp
 	src/qml/background-effect-attached.hpp
 	src/qml/background-effect-attached.cpp
+	src/qml/popup-placement-attached.hpp
+	src/qml/popup-placement-attached.cpp
 	src/qml/shortcut-inhibitor-attached.hpp
 	src/qml/shortcut-inhibitor-attached.cpp
 )

--- a/src/server/src/qml/popup-placement-attached.cpp
+++ b/src/server/src/qml/popup-placement-attached.cpp
@@ -67,4 +67,11 @@ void PopupPlacementAttached::apply() {
   m_window->setProperty("_q_waylandPopupAnchor", QVariant::fromValue(anchor));
   m_window->setProperty("_q_waylandPopupGravity", QVariant::fromValue(gravity));
   m_window->setProperty("_q_waylandPopupConstraintAdjustment", SLIDE_X | SLIDE_Y | FLIP_Y);
+
+  // Anchor to the trigger's real rect instead of letting QtWayland guess it
+  // from the (possibly shifted/wider) popup window geometry.
+  if (auto *trigger = parent()->property("parent").value<QQuickItem *>(); trigger && trigger->window()) {
+    const QRect rect = trigger->mapRectToScene(trigger->boundingRect()).toRect();
+    m_window->setProperty("_q_waylandPopupAnchorRect", rect);
+  }
 }

--- a/src/server/src/qml/popup-placement-attached.cpp
+++ b/src/server/src/qml/popup-placement-attached.cpp
@@ -1,0 +1,70 @@
+#include "popup-placement-attached.hpp"
+#include <QQuickItem>
+#include <QQuickWindow>
+#include <QVariant>
+
+namespace {
+// xdg_positioner.constraint_adjustment bits from the xdg-shell protocol
+constexpr uint32_t SLIDE_X = 1;
+constexpr uint32_t SLIDE_Y = 2;
+constexpr uint32_t FLIP_Y = 8;
+} // namespace
+
+PopupPlacementAttached::PopupPlacementAttached(QObject *parent) : QObject(parent) {
+  // contentItem is a deferred property on QQuickPopup, so it may not exist
+  // yet when the attached object is created.
+  connect(parent, SIGNAL(contentItemChanged()), this, SLOT(attachToContentItem()));
+  attachToContentItem();
+}
+
+void PopupPlacementAttached::attachToContentItem() {
+  auto *contentItem = parent()->property("contentItem").value<QQuickItem *>();
+  if (contentItem == m_contentItem) return;
+
+  if (m_contentItem) disconnect(m_contentItem, nullptr, this, nullptr);
+  m_contentItem = contentItem;
+  if (!contentItem) return;
+
+  // The popup's content item is reparented into the transient popup window
+  // right before that window is shown, which is when the placement
+  // properties must already be set.
+  connect(contentItem, &QQuickItem::windowChanged, this, &PopupPlacementAttached::onWindowChanged);
+  onWindowChanged(contentItem->window());
+}
+
+void PopupPlacementAttached::setAlignment(Qt::Alignment value) {
+  if (m_alignment == value) return;
+  m_alignment = value;
+  emit alignmentChanged();
+  apply();
+}
+
+void PopupPlacementAttached::onWindowChanged(QQuickWindow *window) {
+  if (window && window->flags().testFlag(Qt::Popup)) {
+    m_window = window;
+    apply();
+  } else {
+    m_window = nullptr;
+  }
+}
+
+void PopupPlacementAttached::apply() {
+  if (!m_window) return;
+
+  // The anchor is the point on the trigger item the popup attaches to, the
+  // gravity the direction it grows in. No horizontal edge means centered.
+  const Qt::Edge side = m_alignment.testFlag(Qt::AlignTop) ? Qt::TopEdge : Qt::BottomEdge;
+  Qt::Edges anchor = side;
+  Qt::Edges gravity = side;
+  if (m_alignment.testFlag(Qt::AlignLeft)) {
+    anchor |= Qt::LeftEdge;
+    gravity |= Qt::RightEdge;
+  } else if (m_alignment.testFlag(Qt::AlignRight)) {
+    anchor |= Qt::RightEdge;
+    gravity |= Qt::LeftEdge;
+  }
+
+  m_window->setProperty("_q_waylandPopupAnchor", QVariant::fromValue(anchor));
+  m_window->setProperty("_q_waylandPopupGravity", QVariant::fromValue(gravity));
+  m_window->setProperty("_q_waylandPopupConstraintAdjustment", SLIDE_X | SLIDE_Y | FLIP_Y);
+}

--- a/src/server/src/qml/popup-placement-attached.hpp
+++ b/src/server/src/qml/popup-placement-attached.hpp
@@ -1,0 +1,67 @@
+#pragma once
+#include <QObject>
+#include <QPointer>
+#include <QWindow>
+#include <qqmlregistration.h>
+
+class QQuickItem;
+class QQuickWindow;
+
+/**
+ * Fixes native popup window (`popupType: Popup.Window`) placement on Wayland.
+ *
+ * QtWayland positions native popups exclusively through an xdg_positioner;
+ * the popup's QML x/y are never part of it. Qt anchors the positioner to the
+ * popup's parent item rect, but only its own ComboBox/Menu/ToolTip types set
+ * the extended window type that selects below-the-control anchoring. A plain
+ * `Popup` keeps the default top-right anchor and opens at the right edge of
+ * its parent item (see QWaylandXdgSurface::createPositioner in Qt sources).
+ *
+ * This attached type opts a popup into the same compositor-side placement Qt
+ * uses for ComboBox: anchored to the parent item, sliding to stay on screen
+ * and flipping to the other side when there is no room. It uses the
+ * "_q_waylandPopup*" override properties QtWayland reads when the popup
+ * surface is created. On non-Wayland platforms the properties are ignored
+ * and the regular QML x/y positioning applies.
+ *
+ * `alignment` combines a vertical flag (Qt.AlignBottom opens below the
+ * parent item, Qt.AlignTop above; below is the default) with a horizontal
+ * flag (Qt.AlignLeft, Qt.AlignHCenter, Qt.AlignRight) describing which
+ * edges of popup and parent item line up.
+ */
+class PopupPlacementAttached : public QObject {
+  Q_OBJECT
+  Q_PROPERTY(Qt::Alignment alignment READ alignment WRITE setAlignment NOTIFY alignmentChanged)
+
+public:
+  explicit PopupPlacementAttached(QObject *parent);
+
+  Qt::Alignment alignment() const { return m_alignment; }
+  void setAlignment(Qt::Alignment value);
+
+signals:
+  void alignmentChanged();
+
+private slots:
+  void attachToContentItem();
+
+private:
+  void onWindowChanged(QQuickWindow *window);
+  void apply();
+
+  QPointer<QQuickItem> m_contentItem;
+  QPointer<QWindow> m_window;
+  Qt::Alignment m_alignment = Qt::AlignLeft;
+};
+
+class PopupPlacement : public QObject {
+  Q_OBJECT
+  QML_NAMED_ELEMENT(PopupPlacement)
+  QML_UNCREATABLE("")
+  QML_ATTACHED(PopupPlacementAttached)
+
+public:
+  static PopupPlacementAttached *qmlAttachedProperties(QObject *object) {
+    return new PopupPlacementAttached(object);
+  }
+};

--- a/src/server/src/qml/qml/SearchableDropdown.qml
+++ b/src/server/src/qml/qml/SearchableDropdown.qml
@@ -32,6 +32,10 @@ Item {
         completionPopup.open();
     }
 
+    function popupX() {
+        return Math.min(0, triggerButton.width - completionPopup.width);
+    }
+
     Keys.onReturnPressed: {
         if (!completionPopup.visible)
             open();
@@ -96,7 +100,10 @@ Item {
         id: completionPopup
         parent: triggerButton
         popupType: Popup.Window
-        x: compact ? triggerButton.width - width : 0
+        // On Wayland the compositor places the native popup window from the
+        // PopupPlacement anchor; x/y only apply on other platforms.
+        PopupPlacement.alignment: root.compact ? Qt.AlignRight : Qt.AlignLeft
+        x: root.popupX()
         y: triggerButton.height + 4
         width: Math.max(compact ? 200 : 250, root.width)
         focus: true

--- a/src/server/src/qml/qml/ShortcutRecorderField.qml
+++ b/src/server/src/qml/qml/ShortcutRecorderField.qml
@@ -15,7 +15,10 @@ Popup {
     focus: true
     closePolicy: Popup.CloseOnPressOutside
     popupType: Popup.Window
+    PopupPlacement.alignment: Qt.AlignHCenter | (recorder._below ? Qt.AlignBottom : Qt.AlignTop)
     padding: 10
+
+    property bool _below: false
 
     property var _currentShortcutTokens: []
     property string _statusText: "Recording..."
@@ -44,9 +47,12 @@ Popup {
         _statusColor = Theme.foreground;
         closeTimer.stop();
 
-        var pos = targetItem.mapToItem(recorder.parent, 0, 0);
-        recorder.x = pos.x + targetItem.width / 2 - recorder.width / 2;
-        recorder.y = below ? pos.y + targetItem.height + 10 : pos.y - recorder.height - 10;
+        // Parent to the trigger so the native popup anchors to it; x/y only
+        // apply on non-Wayland platforms.
+        recorder._below = !!below;
+        recorder.parent = targetItem;
+        recorder.x = targetItem.width / 2 - recorder.width / 2;
+        recorder.y = below ? targetItem.height + 10 : -recorder.height - 10;
         recorder.open();
         return true;
     }

--- a/src/server/src/qml/qml/ViciToolTip.qml
+++ b/src/server/src/qml/qml/ViciToolTip.qml
@@ -5,6 +5,9 @@ ToolTip {
     id: root
     delay: 500
     popupType: Popup.Window
+    // Centered above the hovered item; Qt's native ToolTip placement would
+    // put it at the item's bottom-right corner instead.
+    PopupPlacement.alignment: Qt.AlignHCenter | Qt.AlignTop
 
     contentItem: Text {
         text: root.text


### PR DESCRIPTION
QtWayland positions Popup.Window popups exclusively through an xdg_positioner - the QML x/y are never part of it, and a plain Popup gets the default top-right anchor on its trigger rect instead of the below-the-control anchoring Qt's own ComboBox/Menu/ToolTip opt into. 

This adds a PopupPlacement attached type that sets the positioner override properties QtWayland reads at popup-surface creation, and applies it to the three native popups (searchable dropdowns, tooltips, shortcut recorder). No compositor detection; native popups and their blur/shadow are preserved.