### PR TITLE
fix: always forward return/enter to action panel

### DIFF
--- a/src/server/src/navigation-controller.cpp
+++ b/src/server/src/navigation-controller.cpp
@@ -436,16 +436,6 @@ void NavigationController::executeAction(AbstractAction *action) {
   closeActionPanel();
 }
 
-AbstractAction *NavigationController::findBoundAction(const QKeyEvent *event) const {
-  auto state = topState();
-  if (!state) return nullptr;
-
-  auto *root = state->sender->actionPanelRoot();
-  if (!root) return nullptr;
-
-  return root->findBoundAction(event);
-}
-
 void NavigationController::activateView(const ViewState &state) {
   emit headerVisiblityChanged(state.needsTopBar);
   emit searchVisibilityChanged(state.supportsSearch);

--- a/src/server/src/navigation-controller.hpp
+++ b/src/server/src/navigation-controller.hpp
@@ -164,8 +164,6 @@ public:
   QString navigationTitle(const BaseView *caller = nullptr) const;
   void searchPlaceholderText(const QString &text);
 
-  AbstractAction *findBoundAction(const QKeyEvent *event) const;
-
   void setDialog(DialogContentWidget *dialog);
   void confirmAlert(const QString &title, const QString &description, const std::function<void()> &onConfirm);
 

--- a/src/server/src/qml/action-panel-controller.cpp
+++ b/src/server/src/qml/action-panel-controller.cpp
@@ -2,6 +2,7 @@
 #include "action-panel-model.hpp"
 #include "internal/keyboard/keyboard.hpp"
 #include "navigation-controller.hpp"
+#include "ui/action-pannel/action.hpp"
 #include "ui/action-pannel/action-list-view.hpp"
 #include "ui/action-pannel/action-panel-state.hpp"
 #include "ui/action-pannel/action-panel-view.hpp"
@@ -171,6 +172,22 @@ bool ActionPanelController::tryShortcut(int key, int modifiers) {
   if (!model) return false;
 
   return model->activateByShortcut(key, modifiers);
+}
+
+bool ActionPanelController::activateBoundAction(const QKeyEvent *event) {
+  auto *root = activeRoot();
+  if (!root) return false;
+
+  auto *action = root->findBoundAction(event);
+  if (!action) return false;
+
+  if (auto *submenu = dynamic_cast<SubmenuAction *>(action)) {
+    openSubmenu(submenu);
+  } else {
+    executeAction(action);
+  }
+
+  return true;
 }
 
 bool ActionPanelController::executePrimaryAction() {

--- a/src/server/src/qml/action-panel-controller.hpp
+++ b/src/server/src/qml/action-panel-controller.hpp
@@ -59,7 +59,14 @@ public:
 
   Q_INVOKABLE bool tryShortcut(int key, int modifiers);
 
-  bool executePrimaryAction();
+  /**
+   * Activate the action the key event is bound to, if any: submenus are opened,
+   * regular actions are executed. Enter/return uniformization is handled as part
+   * of the shortcut matching.
+   */
+  bool activateBoundAction(const QKeyEvent *event);
+
+  Q_INVOKABLE bool executePrimaryAction();
   void executeAction(AbstractAction *action);
   void openSubmenu(SubmenuAction *action);
 

--- a/src/server/src/qml/launcher-window.cpp
+++ b/src/server/src/qml/launcher-window.cpp
@@ -3,7 +3,6 @@
 #include "keybind-bridge.hpp"
 #include "view-utils.hpp"
 #include "action-panel-controller.hpp"
-#include "ui/action-pannel/action.hpp"
 #include "ui/image/image-renderer.hpp"
 #include "services/news/news-service.hpp"
 #include "alert-model.hpp"
@@ -334,7 +333,12 @@ bool LauncherWindow::eventFilter(QObject *obj, QEvent *event) {
     if (ke->modifiers().testFlag(Qt::KeypadModifier)) {
       ke->setModifiers(ke->modifiers() & ~Qt::KeypadModifier);
     }
-    if (forwardKey(ke->key(), static_cast<int>(ke->modifiers()))) { return true; }
+    // unmodified keys (return included) belong to the focused component: forwarding
+    // them globally would steal text input or returns meant for local widgets such as
+    // text areas, overlays or the opened action panel.
+    if (ke->modifiers() != Qt::NoModifier && forwardKey(ke->key(), static_cast<int>(ke->modifiers()))) {
+      return true;
+    }
   }
 
   // only works on some compositors.
@@ -433,12 +437,19 @@ void LauncherWindow::forwardSearchText(const QString &text) {
   tryCompaction();
 }
 
-void LauncherWindow::handleReturn() { m_actionPanel->executePrimaryAction(); }
-
 bool LauncherWindow::forwardKey(int key, int modifiers) {
   auto mods = static_cast<Qt::KeyboardModifiers>(modifiers);
+  const bool isReturn = key == Qt::Key_Return || key == Qt::Key_Enter;
+  const bool unmodified = (mods & ~Qt::KeypadModifier) == Qt::NoModifier;
 
-  if (mods == Qt::NoModifier) return false;
+  // unmodified keys are regular text input, except return which the action panel
+  // knows how to handle
+  if (unmodified && !isReturn) return false;
+
+  if (unmodified && m_compacted) {
+    expand();
+    return true;
+  }
 
   switch (key) {
   case Qt::Key_Shift:
@@ -465,15 +476,7 @@ bool LauncherWindow::forwardKey(int key, int modifiers) {
 
   QKeyEvent const event(QEvent::KeyPress, key, mods);
 
-  if (auto *action = m_ctx.navigation->findBoundAction(&event)) {
-    if (auto *submenu = dynamic_cast<SubmenuAction *>(action)) {
-      m_actionPanel->openSubmenu(submenu);
-    } else {
-      m_ctx.navigation->executeAction(action);
-      m_actionPanel->close();
-    }
-    return true;
-  }
+  if (m_actionPanel->activateBoundAction(&event)) return true;
 
   if (Keyboard::Shortcut(Keybind::OpenSettings) == &event) {
     m_ctx.navigation->closeWindow();

--- a/src/server/src/qml/launcher-window.hpp
+++ b/src/server/src/qml/launcher-window.hpp
@@ -89,7 +89,6 @@ public:
 
   Q_INVOKABLE void expand();
   Q_INVOKABLE void forwardSearchText(const QString &text);
-  Q_INVOKABLE void handleReturn();
   Q_INVOKABLE bool forwardKey(int key, int modifiers = 0);
   Q_INVOKABLE void handleEscape();
   Q_INVOKABLE void goBack();

--- a/src/server/src/qml/qml/ActionListPanel.qml
+++ b/src/server/src/qml/qml/ActionListPanel.qml
@@ -278,6 +278,7 @@ Item {
                         (event.modifiers & Qt.ControlModifier) ? root.moveSectionDown() : root.moveDown();
                     }
                     Keys.onReturnPressed: root.activateCurrent()
+                    Keys.onEnterPressed: root.activateCurrent()
                 }
             }
         }

--- a/src/server/src/qml/qml/AliasFormView.qml
+++ b/src/server/src/qml/qml/AliasFormView.qml
@@ -20,7 +20,6 @@ Item {
                 text: root.host.alias
                 hasError: aliasField.error !== ""
                 onTextEdited: root.host.alias = text
-                onAccepted: launcher.handleReturn()
             }
         }
     }

--- a/src/server/src/qml/qml/ArgCompleter.qml
+++ b/src/server/src/qml/qml/ArgCompleter.qml
@@ -132,13 +132,6 @@ RowLayout {
                         Keys.onDownPressed: {
                             commandStack.currentItem.moveDown();
                         }
-                        Keys.onReturnPressed: event => {
-                            if (event.modifiers !== Qt.NoModifier) {
-                                event.accepted = launcher.forwardKey(event.key, event.modifiers);
-                            } else {
-                                launcher.handleReturn();
-                            }
-                        }
                         Keys.onTabPressed: event => {
                             if (argLoader.isLast) {
                                 root.focusSearchInput();
@@ -226,13 +219,6 @@ RowLayout {
                             root.valueChanged(argLoader.index, item.id);
                         }
 
-                        Keys.onReturnPressed: event => {
-                            if (event.modifiers !== Qt.NoModifier) {
-                                event.accepted = launcher.forwardKey(event.key, event.modifiers);
-                            } else {
-                                launcher.handleReturn();
-                            }
-                        }
                         Keys.onTabPressed: event => {
                             if (argLoader.isLast) {
                                 root.focusSearchInput();
@@ -240,6 +226,9 @@ RowLayout {
                             } else {
                                 event.accepted = false;
                             }
+                        }
+                        Keys.onPressed: event => {
+                            event.accepted = launcher.forwardKey(event.key, event.modifiers);
                         }
                     }
                 }

--- a/src/server/src/qml/qml/CreateExtensionFormView.qml
+++ b/src/server/src/qml/qml/CreateExtensionFormView.qml
@@ -21,7 +21,6 @@ Item {
                 placeholder: "Username"
                 hasError: authorField.error !== ""
                 onTextEdited: root.host.author = text
-                onAccepted: launcher.handleReturn()
             }
         }
 
@@ -37,7 +36,6 @@ Item {
                 placeholder: "My Extension"
                 hasError: extTitleField.error !== ""
                 onTextEdited: root.host.title = text
-                onAccepted: launcher.handleReturn()
             }
         }
 
@@ -65,7 +63,6 @@ Item {
                 placeholder: "~/code/vicinae-extensions"
                 hasError: locationField.error !== ""
                 onTextEdited: root.host.location = text
-                onAccepted: launcher.handleReturn()
             }
         }
 
@@ -81,7 +78,6 @@ Item {
                 placeholder: "My Wonderful Command"
                 hasError: cmdTitleField.error !== ""
                 onTextEdited: root.host.commandTitle = text
-                onAccepted: launcher.handleReturn()
             }
         }
 
@@ -95,7 +91,6 @@ Item {
                 placeholder: "An helpful subtitle"
                 hasError: subtitleField.error !== ""
                 onTextEdited: root.host.commandSubtitle = text
-                onAccepted: launcher.handleReturn()
             }
         }
 

--- a/src/server/src/qml/qml/Footer.qml
+++ b/src/server/src/qml/qml/Footer.qml
@@ -34,7 +34,7 @@ Item {
             label: actionPanel.primaryActionTitle
             shortcutTokens: actionPanel.primaryActionShortcutTokens
             highlighted: true
-            onClicked: launcher.handleReturn()
+            onClicked: actionPanel.executePrimaryAction()
         }
 
         Rectangle {

--- a/src/server/src/qml/qml/SearchBar.qml
+++ b/src/server/src/qml/qml/SearchBar.qml
@@ -274,18 +274,6 @@ Item {
                         event.accepted = launcher.forwardKey(event.key, event.modifiers);
                     }
                 }
-                Keys.onReturnPressed: event => {
-                    if (launcher.compacted) {
-                        launcher.expand();
-                        event.accepted = true;
-                        return;
-                    }
-                    if (event.modifiers !== Qt.NoModifier) {
-                        event.accepted = launcher.forwardKey(event.key, event.modifiers);
-                    } else {
-                        launcher.handleReturn();
-                    }
-                }
                 Keys.onBacktabPressed: event => {
                     event.accepted = false;
                 }

--- a/src/server/src/qml/qml/ShortcutFormView.qml
+++ b/src/server/src/qml/qml/ShortcutFormView.qml
@@ -17,7 +17,6 @@ Item {
                 text: root.host.name
                 placeholder: "Shortcut Name"
                 onTextEdited: root.host.name = text
-                onAccepted: launcher.handleReturn()
             }
         }
 
@@ -35,7 +34,6 @@ Item {
                 hasError: urlField.error !== ""
 
                 onTextEdited: root.host.link = text
-                onAccepted: launcher.handleReturn()
 
                 onEditingChanged: {
                     if (!editing)

--- a/src/server/src/qml/qml/SnippetFormView.qml
+++ b/src/server/src/qml/qml/SnippetFormView.qml
@@ -20,7 +20,6 @@ Item {
                 placeholder: "Euro symbol"
                 hasError: titleField.error !== ""
                 onTextEdited: root.host.name = text
-                onAccepted: launcher.handleReturn()
             }
         }
 
@@ -54,7 +53,6 @@ Item {
                 hasError: keywordField.error !== ""
                 readOnly: !root.host.serverRunning
                 onTextEdited: root.host.keyword = text
-                onAccepted: launcher.handleReturn()
             }
         }
 

--- a/src/server/src/qml/raycast-store-detail-host.cpp
+++ b/src/server/src/qml/raycast-store-detail-host.cpp
@@ -208,7 +208,7 @@ void RaycastStoreDetailHost::openUrl(const QString &url) {
 QString RaycastStoreDetailHost::initialNavigationTitle() const { return QStringLiteral("Extension Store"); }
 
 void RaycastStoreDetailHost::createActions() {
-  auto panel = std::make_unique<FormActionPanelState>();
+  auto panel = std::make_unique<ListActionPanelState>();
   auto main = panel->createSection();
 
   if (!m_isInstalled) {

--- a/src/server/src/qml/root-search-sources.cpp
+++ b/src/server/src/qml/root-search-sources.cpp
@@ -104,7 +104,7 @@ QHash<int, QVariant> RootLinkSection::customRoleDefaults() const { return root_s
 
 std::unique_ptr<ActionPanelState> RootLinkSection::actionPanel(int) const {
   if (!m_link) return nullptr;
-  auto panel = std::make_unique<ActionPanelState>();
+  auto panel = std::make_unique<ListActionPanelState>();
   auto *section = panel->createSection();
   auto *open =
       new OpenAppAction(m_link->app, QString("Open in %1").arg(m_link->app->displayName()), {m_link->url});

--- a/src/server/src/qml/store-intro-view-host.cpp
+++ b/src/server/src/qml/store-intro-view-host.cpp
@@ -22,7 +22,7 @@ QVariantMap StoreIntroViewHost::qmlProperties() {
 void StoreIntroViewHost::initialize() {
   BaseView::initialize();
 
-  auto panel = std::make_unique<ActionPanelState>();
+  auto panel = std::make_unique<ListActionPanelState>();
   auto section = panel->createSection();
   auto action = new StaticAction(m_actionLabel, m_icon, m_continueAction);
   action->setPrimary(true);

--- a/src/server/src/qml/vicinae-store-detail-host.cpp
+++ b/src/server/src/qml/vicinae-store-detail-host.cpp
@@ -142,7 +142,7 @@ void VicinaeStoreDetailHost::openUrl(const QString &url) {
 QString VicinaeStoreDetailHost::initialNavigationTitle() const { return QStringLiteral("Extension Store"); }
 
 void VicinaeStoreDetailHost::createActions() {
-  auto panel = std::make_unique<FormActionPanelState>();
+  auto panel = std::make_unique<ListActionPanelState>();
   auto main = panel->createSection();
 
   if (!m_isInstalled) {

--- a/src/server/src/root-search/shortcuts/shortcut-root-provider.cpp
+++ b/src/server/src/root-search/shortcuts/shortcut-root-provider.cpp
@@ -47,7 +47,7 @@ std::unique_ptr<ActionPanelState> RootShortcutItem::newActionPanel(ApplicationCo
 
 std::unique_ptr<ActionPanelState>
 RootShortcutItem::fallbackActionPanel(ApplicationContext *ctx, const RootItemMetadata &metadata) const {
-  auto panel = std::make_unique<ActionPanelState>();
+  auto panel = std::make_unique<ListActionPanelState>();
   auto main = panel->createSection();
 
   auto open = new OpenShortcutFromSearchText(m_link);

--- a/src/server/src/services/news/news-service.cpp
+++ b/src/server/src/services/news/news-service.cpp
@@ -102,7 +102,7 @@ std::vector<NewsItem> NewsService::allItems() {
       .icon = ImageURL{BuiltinIcon::Megaphone}.setBackgroundTint(SemanticColor::Yellow),
       .actionFactory =
           [](ApplicationContext *) {
-            auto panel = std::make_unique<ActionPanelState>();
+            auto panel = std::make_unique<ListActionPanelState>();
             auto *section = panel->createSection();
 
             auto *openDocs = new OpenInBrowserAction(QUrl(Omnicast::DOC_TELEMETRY_URL), "Learn more");

--- a/src/server/src/ui/action-pannel/action.hpp
+++ b/src/server/src/ui/action-pannel/action.hpp
@@ -47,9 +47,9 @@ public:
   }
 
   bool isBoundTo(const QKeyEvent *event) {
+    // numpad enter is uniformized with the regular return key
     if (event->key() == Qt::Key_Enter) {
-      qDebug() << "remapping numpad enter to return";
-      return isBoundTo(Keyboard::Shortcut(Qt::Key_Return, event->modifiers() ^= Qt::KeypadModifier));
+      return isBoundTo(Keyboard::Shortcut(Qt::Key_Return, event->modifiers()));
     }
 
     return isBoundTo(Keyboard::Shortcut(event));

--- a/src/server/src/utils/file-list-item.hpp
+++ b/src/server/src/utils/file-list-item.hpp
@@ -40,7 +40,7 @@ private:
 
 inline std::unique_ptr<ActionPanelState> actionPanel(const std::filesystem::path &path, AppService *appDb) {
   QMimeDatabase mimeDb;
-  auto panel = std::make_unique<ActionPanelState>();
+  auto panel = std::make_unique<ListActionPanelState>();
   auto section = panel->createSection();
   auto mime = mimeDb.mimeTypeForFile(path.c_str());
   auto openers = appDb->findCuratedOpeners(mime.name());


### PR DESCRIPTION
This started as a simple fix for #1503 which broke (again)

I realized we have no business hard coding the `handleReturn` behavior and that we should simply submit `return/enter` to the action panel so that actions that are properly bound to that get activated.

This also fixes another issue where some form views were accepting enter as a way to submit the form while the action was showing `shift+return`.

fixes #1503 