### PR TITLE
fix: show window on compact/inline script command

### DIFF
--- a/src/server/src/navigation-controller.cpp
+++ b/src/server/src/navigation-controller.cpp
@@ -589,8 +589,6 @@ bool NavigationController::activateEntrypoint(const EntrypointId &id,
 
   popToRoot({.clearSearch = false});
 
-  if (!initialOpenState) { setInstantDismiss(); }
-
   // FIXME: we need a unified interface for this
   if (auto *ext = dynamic_cast<const CommandRootItem *>(entrypoint)) {
     launch(ext->command(), options.arguments);
@@ -609,7 +607,8 @@ bool NavigationController::activateEntrypoint(const EntrypointId &id,
 
   auto *active = activeCommand();
 
-  if (!isRootSearch() && active && active->isView() && !initialOpenState) {
+  if (!isRootSearch() && !initialOpenState) {
+    setInstantDismiss();
     setBackButtonVisibility(false);
     showWindow();
   }

--- a/src/server/src/script/script-actions.cpp
+++ b/src/server/src/script/script-actions.cpp
@@ -86,8 +86,10 @@ void ScriptExecutorAction::execute(ApplicationContext *ctx) {
             } else {
               toastService->setToast(line, style);
             }
-            ctx->navigation->setSearchText(title);
-            ctx->navigation->showWindow();
+            if (!ctx->navigation->isWindowOpened()) {
+              ctx->navigation->setSearchText(title);
+              ctx->navigation->showWindow();
+            }
           });
       break;
     case Mode::Terminal: {
@@ -127,8 +129,10 @@ void ScriptExecutorAction::execute(ApplicationContext *ctx) {
 
                        ctx->services->scriptDb()->metadata()->saveRun(id, line.toStdString());
                        emit ctx->services->rootItemManager()->subtitleChanged();
-                       ctx->navigation->setSearchText(title);
-                       ctx->navigation->showWindow();
+                       if (!ctx->navigation->isWindowOpened()) {
+                         ctx->navigation->setSearchText(title);
+                         ctx->navigation->showWindow();
+                       }
                      });
       break;
     default:

--- a/src/server/src/script/script-actions.cpp
+++ b/src/server/src/script/script-actions.cpp
@@ -9,6 +9,7 @@
 #include "services/toast/toast-service.hpp"
 #include "navigation-controller.hpp"
 #include "qml/script-executor-view-host.hpp"
+#include "utils.hpp"
 
 ScriptExecutorAction::ScriptExecutorAction(const std::shared_ptr<ScriptCommandFile> &file,
                                            std::optional<script_command::OutputMode> mode)
@@ -45,19 +46,17 @@ void ScriptExecutorAction::executeOneLine(const ScriptCommandFile &script, const
 // activated we can automatically cancel any pending script execution. The current architecture does not
 // allow this, so this will have to do for now.
 void ScriptExecutorAction::execute(ApplicationContext *ctx) {
-  const auto error = m_file->reload();
-
-  if (error) {
+  if (const auto error = m_file->reload()) {
     ctx->services->toastService()->failure(QString("Failed to parse script: %1").arg(error->c_str()));
     return;
   }
+
+  using Mode = script_command::OutputMode;
 
   const bool needsConfirm = m_file->data().needsConfirmation;
   const auto outputMode = m_outputModeOverride.value_or(m_file->data().mode);
   const auto runScript = [script = m_file, ctx, outputMode]() {
     const auto args = ctx->navigation->unnamedCompletionValues();
-
-    using Mode = script_command::OutputMode;
 
     switch (outputMode) {
     case Mode::Full:
@@ -76,16 +75,20 @@ void ScriptExecutorAction::execute(ApplicationContext *ctx) {
       });
       break;
     case Mode::Compact:
-      executeOneLine(*script, args, [ctx](bool ok, const QString &line) {
-        const auto toastService = ctx->services->toastService();
-        ToastStyle const style = ok ? ToastStyle::Success : ToastStyle::Danger;
+      executeOneLine(
+          *script, args,
+          [ctx, title = QString::fromStdString(script->data().title)](bool ok, const QString &line) {
+            const auto toastService = ctx->services->toastService();
+            ToastStyle const style = ok ? ToastStyle::Success : ToastStyle::Danger;
 
-        if (line.isEmpty()) {
-          toastService->setToast(ok ? "Script executed" : "Script execution failed", style);
-        } else {
-          toastService->setToast(line, style);
-        }
-      });
+            if (line.isEmpty()) {
+              toastService->setToast(ok ? "Script executed" : "Script execution failed", style);
+            } else {
+              toastService->setToast(line, style);
+            }
+            ctx->navigation->setSearchText(title);
+            ctx->navigation->showWindow();
+          });
       break;
     case Mode::Terminal: {
       LaunchTerminalCommandOptions termOpts{.hold = true};
@@ -113,15 +116,20 @@ void ScriptExecutorAction::execute(ApplicationContext *ctx) {
       break;
     }
     case Mode::Inline:
-      executeOneLine(*script, args, [id = std::string(script->id()), ctx](bool ok, const QString &line) {
-        if (!ok) {
-          ctx->services->toastService()->failure(line.isEmpty() ? "Script exited with error code" : line);
-          return;
-        }
+      executeOneLine(*script, args,
+                     [id = script->id(), title = QString::fromStdString(script->data().title),
+                      ctx](bool ok, const QString &line) {
+                       if (!ok) {
+                         ctx->services->toastService()->failure(
+                             line.isEmpty() ? "Script exited with error code" : line);
+                         return;
+                       }
 
-        ctx->services->scriptDb()->metadata()->saveRun(id, line.toStdString());
-        emit ctx->services->rootItemManager()->subtitleChanged();
-      });
+                       ctx->services->scriptDb()->metadata()->saveRun(id, line.toStdString());
+                       emit ctx->services->rootItemManager()->subtitleChanged();
+                       ctx->navigation->setSearchText(title);
+                       ctx->navigation->showWindow();
+                     });
       break;
     default:
       qWarning() << "script command has invalid mode" << static_cast<int>(outputMode);


### PR DESCRIPTION
Compact and inline script command modes need the vicinae window to be open in order for them to be useful.

This forces the window to open if it isn't (e.g if triggering the script from a deeplink or global shortcut).

We also try to select the script inside the root search so that inline mode works correctly.