### PR TITLE
Add pin/bring actions to switch-windows view and app sea…

### DIFF
--- a/src/server/src/actions/wm/window-actions.hpp
+++ b/src/server/src/actions/wm/window-actions.hpp
@@ -9,7 +9,7 @@ class FocusWindowAction : public AbstractAction {
 
   void execute(ApplicationContext *ctx) override {
     auto wm = ctx->services->windowManager();
-    wm->provider()->focusWindowSync(*m_window.get());
+    wm->provider()->focusWindowSync(*m_window);
   }
 
 public:
@@ -24,7 +24,7 @@ class CloseWindowAction : public AbstractAction {
 
   void execute(ApplicationContext *ctx) override {
     auto wm = ctx->services->windowManager();
-    wm->provider()->closeWindow(*m_window.get());
+    wm->provider()->closeWindow(*m_window);
   }
 
 public:
@@ -40,7 +40,7 @@ class PinWindowAction : public AbstractAction {
   void execute(ApplicationContext *ctx) override {
     auto provider = ctx->services->windowManager()->provider();
     bool currentlySticky = m_window->sticky();
-    provider->setSticky(*m_window.get(), !currentlySticky);
+    provider->setSticky(*m_window, !currentlySticky);
   }
 
 public:
@@ -57,7 +57,7 @@ class BringToWorkspaceAction : public AbstractAction {
     auto provider = ctx->services->windowManager()->provider();
     auto activeWs = provider->getActiveWorkspace();
     if (!activeWs) return;
-    provider->moveToWorkspace(*m_window.get(), activeWs->id());
+    provider->moveToWorkspace(*m_window, activeWs->id());
   }
 
 public:

--- a/src/server/src/actions/wm/window-actions.hpp
+++ b/src/server/src/actions/wm/window-actions.hpp
@@ -33,3 +33,36 @@ public:
     setStyle(AbstractAction::Style::Danger);
   }
 };
+
+class PinWindowAction : public AbstractAction {
+  std::shared_ptr<AbstractWindowManager::AbstractWindow> m_window;
+
+  void execute(ApplicationContext *ctx) override {
+    auto provider = ctx->services->windowManager()->provider();
+    bool currentlySticky = m_window->sticky();
+    provider->setSticky(*m_window.get(), !currentlySticky);
+  }
+
+public:
+  PinWindowAction(const std::shared_ptr<AbstractWindowManager::AbstractWindow> &window)
+      : AbstractAction(window->sticky() ? "Unpin from all workspaces" : "Pin to all workspaces",
+                       ImageURL::builtin(window->sticky() ? "pin-disabled" : "pin")),
+        m_window(window) {}
+};
+
+class BringToWorkspaceAction : public AbstractAction {
+  std::shared_ptr<AbstractWindowManager::AbstractWindow> m_window;
+
+  void execute(ApplicationContext *ctx) override {
+    auto provider = ctx->services->windowManager()->provider();
+    auto activeWs = provider->getActiveWorkspace();
+    if (!activeWs) return;
+    provider->moveToWorkspace(*m_window.get(), activeWs->id());
+  }
+
+public:
+  BringToWorkspaceAction(const std::shared_ptr<AbstractWindowManager::AbstractWindow> &window)
+      : AbstractAction("Bring to current workspace", ImageURL::builtin("move")), m_window(window) {
+    setAutoClose();
+  }
+};

--- a/src/server/src/qml/switch-windows-model.cpp
+++ b/src/server/src/qml/switch-windows-model.cpp
@@ -1,6 +1,5 @@
 #include "switch-windows-model.hpp"
 #include "actions/wm/window-actions.hpp"
-#include "navigation-controller.hpp"
 
 QString SwitchWindowsSection::displayTitle(const WindowEntry &e) const { return e.window->title(); }
 
@@ -25,7 +24,7 @@ std::unique_ptr<ActionPanelState> SwitchWindowsSection::buildActionPanel(const W
   auto section = panel->createSection("Window Actions");
   section->addAction(new FocusWindowAction(e.window));
 
-  if (scope().services()->windowManager()->id() == "x11") {
+  if (scope().services()->windowManager()->provider()->id() == "x11") {
     auto pinAction = new PinWindowAction(e.window);
     section->addAction(pinAction);
 

--- a/src/server/src/qml/switch-windows-model.cpp
+++ b/src/server/src/qml/switch-windows-model.cpp
@@ -25,11 +25,13 @@ std::unique_ptr<ActionPanelState> SwitchWindowsSection::buildActionPanel(const W
   auto section = panel->createSection("Window Actions");
   section->addAction(new FocusWindowAction(e.window));
 
-  auto pinAction = new PinWindowAction(e.window);
-  section->addAction(pinAction);
+  if (scope().services()->windowManager()->id() == "x11") {
+    auto pinAction = new PinWindowAction(e.window);
+    section->addAction(pinAction);
 
-  auto bringAction = new BringToWorkspaceAction(e.window);
-  section->addAction(bringAction);
+    auto bringAction = new BringToWorkspaceAction(e.window);
+    section->addAction(bringAction);
+  }
 
   auto closeAction = new CloseWindowAction(e.window);
   closeAction->setShortcut(Keyboard::Shortcut(Qt::Key_Q, Qt::ControlModifier));

--- a/src/server/src/qml/switch-windows-model.cpp
+++ b/src/server/src/qml/switch-windows-model.cpp
@@ -25,6 +25,12 @@ std::unique_ptr<ActionPanelState> SwitchWindowsSection::buildActionPanel(const W
   auto section = panel->createSection("Window Actions");
   section->addAction(new FocusWindowAction(e.window));
 
+  auto pinAction = new PinWindowAction(e.window);
+  section->addAction(pinAction);
+
+  auto bringAction = new BringToWorkspaceAction(e.window);
+  section->addAction(bringAction);
+
   auto closeAction = new CloseWindowAction(e.window);
   closeAction->setShortcut(Keyboard::Shortcut(Qt::Key_Q, Qt::ControlModifier));
   section->addAction(closeAction);

--- a/src/server/src/root-search/apps/app-root-provider.cpp
+++ b/src/server/src/root-search/apps/app-root-provider.cpp
@@ -83,13 +83,9 @@ std::unique_ptr<ActionPanelState> AppRootItem::newActionPanel(ApplicationContext
       mainSection->addAction(focus);
     }
 
-    if (preferences.value("showPin").toBool(true)) {
+    if (ctx->services->windowManager()->id() == "x11") {
       mainSection->addAction(new PinWindowAction(activeWindows.front()));
-    }
-    if (preferences.value("showBring").toBool(true)) {
       mainSection->addAction(new BringToWorkspaceAction(activeWindows.front()));
-    }
-    if (preferences.value("showClose").toBool(true)) {
       mainSection->addAction(new CloseWindowAction(activeWindows.front()));
     }
   } else {

--- a/src/server/src/root-search/apps/app-root-provider.cpp
+++ b/src/server/src/root-search/apps/app-root-provider.cpp
@@ -82,6 +82,16 @@ std::unique_ptr<ActionPanelState> AppRootItem::newActionPanel(ApplicationContext
       mainSection->addAction(new DefaultActionWrapper(uniqueId(), open));
       mainSection->addAction(focus);
     }
+
+    if (preferences.value("showPin").toBool(true)) {
+      mainSection->addAction(new PinWindowAction(activeWindows.front()));
+    }
+    if (preferences.value("showBring").toBool(true)) {
+      mainSection->addAction(new BringToWorkspaceAction(activeWindows.front()));
+    }
+    if (preferences.value("showClose").toBool(true)) {
+      mainSection->addAction(new CloseWindowAction(activeWindows.front()));
+    }
   } else {
     mainSection->addAction(new DefaultActionWrapper(uniqueId(), open));
   }

--- a/src/server/src/root-search/apps/app-root-provider.cpp
+++ b/src/server/src/root-search/apps/app-root-provider.cpp
@@ -83,7 +83,7 @@ std::unique_ptr<ActionPanelState> AppRootItem::newActionPanel(ApplicationContext
       mainSection->addAction(focus);
     }
 
-    if (ctx->services->windowManager()->id() == "x11") {
+    if (ctx->services->windowManager()->provider()->id() == "x11") {
       mainSection->addAction(new PinWindowAction(activeWindows.front()));
       mainSection->addAction(new BringToWorkspaceAction(activeWindows.front()));
       mainSection->addAction(new CloseWindowAction(activeWindows.front()));

--- a/src/server/src/services/app-service/xdg/xdg-app-database.cpp
+++ b/src/server/src/services/app-service/xdg/xdg-app-database.cpp
@@ -550,19 +550,7 @@ PreferenceList XdgAppDatabase::preferences() const {
   paths.setReadOnly(true);
   paths.setDefaultValue(defaultPaths);
 
-  auto showPin = Preference::makeCheckbox("showPin", "Show Pin to workspace");
-  showPin.setDefaultValue(true);
-  showPin.setDescription("Show the Pin/Unpin window action in the app action panel.");
-
-  auto showBring = Preference::makeCheckbox("showBring", "Show Bring to workspace");
-  showBring.setDefaultValue(true);
-  showBring.setDescription("Show the Bring to current workspace action in the app action panel.");
-
-  auto showClose = Preference::makeCheckbox("showClose", "Show Close window");
-  showClose.setDefaultValue(true);
-  showClose.setDescription("Show the Close window action in the app action panel.");
-
-  return {defaultAction, launchPrefix, paths, showPin, showBring, showClose};
+  return {defaultAction, launchPrefix, paths};
 }
 
 void XdgAppDatabase::applyPreferences(const QJsonObject &preferences) {

--- a/src/server/src/services/app-service/xdg/xdg-app-database.cpp
+++ b/src/server/src/services/app-service/xdg/xdg-app-database.cpp
@@ -550,7 +550,19 @@ PreferenceList XdgAppDatabase::preferences() const {
   paths.setReadOnly(true);
   paths.setDefaultValue(defaultPaths);
 
-  return {defaultAction, launchPrefix, paths};
+  auto showPin = Preference::makeCheckbox("showPin", "Show Pin to workspace");
+  showPin.setDefaultValue(true);
+  showPin.setDescription("Show the Pin/Unpin window action in the app action panel.");
+
+  auto showBring = Preference::makeCheckbox("showBring", "Show Bring to workspace");
+  showBring.setDefaultValue(true);
+  showBring.setDescription("Show the Bring to current workspace action in the app action panel.");
+
+  auto showClose = Preference::makeCheckbox("showClose", "Show Close window");
+  showClose.setDefaultValue(true);
+  showClose.setDescription("Show the Close window action in the app action panel.");
+
+  return {defaultAction, launchPrefix, paths, showPin, showBring, showClose};
 }
 
 void XdgAppDatabase::applyPreferences(const QJsonObject &preferences) {

--- a/src/server/src/services/window-manager/abstract-window-manager.hpp
+++ b/src/server/src/services/window-manager/abstract-window-manager.hpp
@@ -72,6 +72,7 @@ public:
 
     virtual bool canClose() const { return true; }
     virtual bool canFullScreen() const { return true; }
+    virtual bool sticky() const { return false; }
   };
 
   class AbstractWorkspace {
@@ -181,6 +182,12 @@ public:
    * This is a common operation that should be supported by all window managers.
    */
   virtual bool closeWindow(const AbstractWindow &window) const { return false; }
+
+  virtual bool setSticky(const AbstractWindow &window, bool sticky) const { return false; }
+
+  virtual bool moveToWorkspace(const AbstractWindow &window, const QString &workspaceId) const {
+    return false;
+  }
 
   /**
    * To make sure the window manager IPC link is healthy.

--- a/src/server/src/services/window-manager/x11/x11-window-manager.cpp
+++ b/src/server/src/services/window-manager/x11/x11-window-manager.cpp
@@ -461,6 +461,71 @@ std::shared_ptr<AbstractWindowManager::AbstractWorkspace> X11WindowManager::getA
   return std::make_shared<X11Workspace>(*current, name);
 }
 
+bool X11WindowManager::setSticky(const AbstractWindow &window, bool sticky) const {
+  auto *conn = getConnection();
+  auto root = getRootWindow();
+  if (!conn || root == XCB_WINDOW_NONE) return false;
+
+  const auto &x11_window = static_cast<const X11Window &>(window);  // NOLINT(cppcoreguidelines-pro-type-static-cast-downcast)
+  xcb_window_t const win = x11_window.windowId();
+
+  xcb_atom_t const net_wm_state = internAtom("_NET_WM_STATE");
+  xcb_atom_t const net_wm_state_sticky = internAtom("_NET_WM_STATE_STICKY");
+
+  if (net_wm_state == XCB_ATOM_NONE || net_wm_state_sticky == XCB_ATOM_NONE) return false;
+
+  xcb_client_message_event_t event;
+  memset(&event, 0, sizeof(event));
+  event.response_type = XCB_CLIENT_MESSAGE;
+  event.window = win;
+  event.format = 32;
+  event.type = net_wm_state;
+  event.data.data32[0] = sticky ? 1 : 0;
+  event.data.data32[1] = net_wm_state_sticky;
+  event.data.data32[2] = 0;
+
+  xcb_send_event(conn, 0, root,
+                 XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT | XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY,
+                 reinterpret_cast<const char *>(&event));
+  xcb_flush(conn);
+
+  emit const_cast<X11WindowManager *>(this)->windowsChanged();
+  return true;
+}
+
+bool X11WindowManager::moveToWorkspace(const AbstractWindow &window, const QString &workspaceId) const {
+  auto *conn = getConnection();
+  auto root = getRootWindow();
+  if (!conn || root == XCB_WINDOW_NONE) return false;
+
+  const auto &x11_window = static_cast<const X11Window &>(window);  // NOLINT(cppcoreguidelines-pro-type-static-cast-downcast)
+  xcb_window_t const win = x11_window.windowId();
+
+  bool ok = false;
+  uint32_t const desktop = workspaceId.toUInt(&ok);
+  if (!ok) return false;
+
+  xcb_atom_t const net_wm_desktop = internAtom("_NET_WM_DESKTOP");
+  if (net_wm_desktop == XCB_ATOM_NONE) return false;
+
+  xcb_client_message_event_t event;
+  memset(&event, 0, sizeof(event));
+  event.response_type = XCB_CLIENT_MESSAGE;
+  event.window = win;
+  event.format = 32;
+  event.type = net_wm_desktop;
+  event.data.data32[0] = desktop;
+  event.data.data32[1] = 2;
+
+  xcb_send_event(conn, 0, root,
+                 XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT | XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY,
+                 reinterpret_cast<const char *>(&event));
+  xcb_flush(conn);
+
+  emit const_cast<X11WindowManager *>(this)->windowsChanged();
+  return true;
+}
+
 bool X11WindowManager::ping() const {
   auto *conn = getConnection();
   if (!conn) { return false; }

--- a/src/server/src/services/window-manager/x11/x11-window-manager.cpp
+++ b/src/server/src/services/window-manager/x11/x11-window-manager.cpp
@@ -466,7 +466,8 @@ bool X11WindowManager::setSticky(const AbstractWindow &window, bool sticky) cons
   auto root = getRootWindow();
   if (!conn || root == XCB_WINDOW_NONE) return false;
 
-  const auto &x11_window = static_cast<const X11Window &>(window);  // NOLINT(cppcoreguidelines-pro-type-static-cast-downcast)
+  const auto &x11_window =
+      static_cast<const X11Window &>(window); // NOLINT(cppcoreguidelines-pro-type-static-cast-downcast)
   xcb_window_t const win = x11_window.windowId();
 
   xcb_atom_t const net_wm_state = internAtom("_NET_WM_STATE");
@@ -484,8 +485,7 @@ bool X11WindowManager::setSticky(const AbstractWindow &window, bool sticky) cons
   event.data.data32[1] = net_wm_state_sticky;
   event.data.data32[2] = 0;
 
-  xcb_send_event(conn, 0, root,
-                 XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT | XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY,
+  xcb_send_event(conn, 0, root, XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT | XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY,
                  reinterpret_cast<const char *>(&event));
   xcb_flush(conn);
 
@@ -498,7 +498,8 @@ bool X11WindowManager::moveToWorkspace(const AbstractWindow &window, const QStri
   auto root = getRootWindow();
   if (!conn || root == XCB_WINDOW_NONE) return false;
 
-  const auto &x11_window = static_cast<const X11Window &>(window);  // NOLINT(cppcoreguidelines-pro-type-static-cast-downcast)
+  const auto &x11_window =
+      static_cast<const X11Window &>(window); // NOLINT(cppcoreguidelines-pro-type-static-cast-downcast)
   xcb_window_t const win = x11_window.windowId();
 
   bool ok = false;
@@ -517,8 +518,7 @@ bool X11WindowManager::moveToWorkspace(const AbstractWindow &window, const QStri
   event.data.data32[0] = desktop;
   event.data.data32[1] = 2;
 
-  xcb_send_event(conn, 0, root,
-                 XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT | XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY,
+  xcb_send_event(conn, 0, root, XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT | XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY,
                  reinterpret_cast<const char *>(&event));
   xcb_flush(conn);
 

--- a/src/server/src/services/window-manager/x11/x11-window-manager.hpp
+++ b/src/server/src/services/window-manager/x11/x11-window-manager.hpp
@@ -32,6 +32,8 @@ public:
   bool supportsFocusTracking() const override { return true; }
   void focusWindowSync(const AbstractWindow &window) const override;
   bool closeWindow(const AbstractWindow &window) const override;
+  bool setSticky(const AbstractWindow &window, bool sticky) const override;
+  bool moveToWorkspace(const AbstractWindow &window, const QString &workspaceId) const override;
 
   bool hasWorkspaces() const override;
   WorkspaceList listWorkspaces() const override;

--- a/src/server/src/services/window-manager/x11/x11-window.cpp
+++ b/src/server/src/services/window-manager/x11/x11-window.cpp
@@ -67,6 +67,7 @@ void X11Window::queryProperties(xcb_connection_t *connection) {
   m_workspace = queryWorkspace(connection);
   m_bounds = queryBounds(connection);
   m_canClose = queryCanClose(connection);
+  m_sticky = querySticky(connection);
 }
 
 QString X11Window::queryTitle(xcb_connection_t *connection) {
@@ -150,4 +151,13 @@ bool X11Window::queryCanClose(xcb_connection_t *connection) {
   if (wm_protocols == XCB_ATOM_NONE || wm_delete_window == XCB_ATOM_NONE) { return false; }
 
   return hasAtomInList(connection, m_window, wm_protocols, wm_delete_window);
+}
+
+bool X11Window::querySticky(xcb_connection_t *connection) {
+  xcb_atom_t const net_wm_state = internAtom(connection, "_NET_WM_STATE");
+  xcb_atom_t const net_wm_state_sticky = internAtom(connection, "_NET_WM_STATE_STICKY");
+
+  if (net_wm_state == XCB_ATOM_NONE || net_wm_state_sticky == XCB_ATOM_NONE) return false;
+
+  return hasAtomInList(connection, m_window, net_wm_state, net_wm_state_sticky);
 }

--- a/src/server/src/services/window-manager/x11/x11-window.hpp
+++ b/src/server/src/services/window-manager/x11/x11-window.hpp
@@ -25,6 +25,7 @@ public:
   std::optional<QString> workspace() const override { return m_workspace; }
   std::optional<AbstractWindowManager::WindowBounds> bounds() const override { return m_bounds; }
   bool canClose() const override { return m_canClose; }
+  bool sticky() const override { return m_sticky; }
 
   /**
    * Get the underlying X11 window ID
@@ -67,6 +68,8 @@ private:
    */
   bool queryCanClose(xcb_connection_t *connection);
 
+  bool querySticky(xcb_connection_t *connection);
+
   xcb_window_t m_window;
   QString m_id;
   QString m_title;
@@ -75,4 +78,5 @@ private:
   std::optional<QString> m_workspace;
   std::optional<AbstractWindowManager::WindowBounds> m_bounds;
   bool m_canClose;
+  bool m_sticky = false;
 };


### PR DESCRIPTION
…rch action panel (only for X11)

Fixes #1477. Do check the discussion therein.

 - Adds {pin, bring to} workspace actions to X11 only
 - Uses standard xcb events
 - Semi-vibe-coded using a mix of opencode go models