### PR TITLE
feat: add drag-and-drop support to SearchFilesView

### DIFF
--- a/src/server/src/qml/qml/CommandListView.qml
+++ b/src/server/src/qml/qml/CommandListView.qml
@@ -25,6 +25,14 @@ GenericListView {
         required property string subtitle
         required property string iconSource
         required property var itemAccessory
+        required property string filePath
+        required property string fileUrl
+
+        Component.onCompleted: {
+            if (!isSection && filePath !== "") {
+                console.log("[DRAG] CommandListView delegate: title=" + title + " filePath=" + filePath + " fileUrl=" + fileUrl)
+            }
+        }
 
         sourceComponent: isSection ? sectionComponent : itemComponent
 
@@ -49,6 +57,8 @@ GenericListView {
                 selected: commandListView.currentIndex === delegateLoader.index
                 onClicked: commandListView.currentIndex = delegateLoader.index
                 onActivated: commandListView.itemActivated(delegateLoader.index)
+                filePath: delegateLoader.filePath
+                fileUrl: delegateLoader.fileUrl
             }
         }
     }

--- a/src/server/src/qml/qml/CommandListView.qml
+++ b/src/server/src/qml/qml/CommandListView.qml
@@ -30,7 +30,7 @@ GenericListView {
 
         Component.onCompleted: {
             if (!isSection && filePath !== "") {
-                console.log("[DRAG] CommandListView delegate: title=" + title + " filePath=" + filePath + " fileUrl=" + fileUrl)
+                console.debug("[DRAG] CommandListView delegate: title=" + title + " filePath=" + filePath + " fileUrl=" + fileUrl)
             }
         }
 

--- a/src/server/src/qml/qml/ListItemDelegate.qml
+++ b/src/server/src/qml/qml/ListItemDelegate.qml
@@ -13,6 +13,32 @@ SelectableDelegate {
     required property bool itemIsActive
     property var itemAccessory: []
     property string itemAccessoryColor: ""
+    property string filePath: ""
+    property string fileUrl: ""
+
+    readonly property bool _isDraggable: root.filePath !== ""
+
+    Component.onCompleted: {
+        if (_isDraggable) {
+            console.log("[DRAG] ListItemDelegate created: filePath=" + root.filePath + " fileUrl=" + root.fileUrl)
+        }
+    }
+
+    Drag.dragType: root._isDraggable ? Drag.Automatic : Drag.None
+    Drag.active: root._isDraggable ? dragHandler.active : false
+    Drag.mimeData: root._isDraggable ? ({
+        "text/uri-list": root.fileUrl,
+        "text/plain": root.filePath
+    }) : ({})
+    Drag.supportedActions: Qt.CopyAction
+
+    DragHandler {
+        id: dragHandler
+        enabled: root._isDraggable
+        onActiveChanged: {
+            if (active) console.log("[DRAG] DragHandler ACTIVATED! filePath=" + root.filePath)
+        }
+    }
 
     RowLayout {
         anchors.fill: parent

--- a/src/server/src/qml/qml/ListItemDelegate.qml
+++ b/src/server/src/qml/qml/ListItemDelegate.qml
@@ -20,7 +20,7 @@ SelectableDelegate {
 
     Component.onCompleted: {
         if (_isDraggable) {
-            console.log("[DRAG] ListItemDelegate created: filePath=" + root.filePath + " fileUrl=" + root.fileUrl)
+            console.debug("[DRAG] ListItemDelegate created: filePath=" + root.filePath + " fileUrl=" + root.fileUrl)
         }
     }
 
@@ -36,7 +36,7 @@ SelectableDelegate {
         id: dragHandler
         enabled: root._isDraggable
         onActiveChanged: {
-            if (active) console.log("[DRAG] DragHandler ACTIVATED! filePath=" + root.filePath)
+            if (active) console.debug("[DRAG] DragHandler ACTIVATED! filePath=" + root.filePath)
         }
     }
 

--- a/src/server/src/qml/search-files-model.cpp
+++ b/src/server/src/qml/search-files-model.cpp
@@ -3,6 +3,8 @@
 #include "utils/file-list-item.hpp"
 #include "service-registry.hpp"
 #include "utils/utils.hpp"
+#include <QDebug>
+#include <QUrl>
 
 void SearchFilesSection::setFiles(std::vector<std::filesystem::path> files, const QString &sectionName) {
   m_files = std::move(files);
@@ -26,4 +28,41 @@ QString SearchFilesSection::itemIconSource(int i) const {
 
 std::unique_ptr<ActionPanelState> SearchFilesSection::actionPanel(int i) const {
   return FileActions::actionPanel(m_files.at(i), scope().services()->appDb());
+}
+
+QVariant SearchFilesSection::customData(int i, int role) const {
+  if (std::cmp_greater_equal(i, m_files.size())) return {};
+  static int dbgCount = 0;
+  switch (role) {
+  case SectionListModel::FilePath: {
+    auto val = QString::fromStdString(m_files[i].string());
+    if (dbgCount++ < 3) qWarning() << "[DRAG] customData FilePathRole i=" << i << "val=" << val;
+    return val;
+  }
+  case SectionListModel::FileUrl: {
+    auto val = QUrl::fromLocalFile(QString::fromStdString(m_files[i].string())).toString();
+    if (dbgCount++ < 3) qWarning() << "[DRAG] customData FileUrlRole i=" << i << "val=" << val;
+    return val;
+  }
+  default:
+    return {};
+  }
+}
+
+QHash<int, QByteArray> SearchFilesSection::customRoleNames() const {
+  static int callCount = 0;
+  if (callCount++ == 0) {
+    qWarning() << "[DRAG] SearchFilesSection::customRoleNames() called, roles:" << SectionListModel::FilePath << SectionListModel::FileUrl;
+  }
+  return {
+      {SectionListModel::FilePath, "filePath"},
+      {SectionListModel::FileUrl, "fileUrl"},
+  };
+}
+
+QHash<int, QVariant> SearchFilesSection::customRoleDefaults() const {
+  return {
+      {SectionListModel::FilePath, QString()},
+      {SectionListModel::FileUrl, QString()},
+  };
 }

--- a/src/server/src/qml/search-files-model.cpp
+++ b/src/server/src/qml/search-files-model.cpp
@@ -36,12 +36,12 @@ QVariant SearchFilesSection::customData(int i, int role) const {
   switch (role) {
   case SectionListModel::FilePath: {
     auto val = QString::fromStdString(m_files[i].string());
-    if (dbgCount++ < 3) qWarning() << "[DRAG] customData FilePathRole i=" << i << "val=" << val;
+    if (dbgCount++ < 3) qDebug() << "[DRAG] customData FilePathRole i=" << i << "val=" << val;
     return val;
   }
   case SectionListModel::FileUrl: {
     auto val = QUrl::fromLocalFile(QString::fromStdString(m_files[i].string())).toString();
-    if (dbgCount++ < 3) qWarning() << "[DRAG] customData FileUrlRole i=" << i << "val=" << val;
+    if (dbgCount++ < 3) qDebug() << "[DRAG] customData FileUrlRole i=" << i << "val=" << val;
     return val;
   }
   default:
@@ -52,7 +52,7 @@ QVariant SearchFilesSection::customData(int i, int role) const {
 QHash<int, QByteArray> SearchFilesSection::customRoleNames() const {
   static int callCount = 0;
   if (callCount++ == 0) {
-    qWarning() << "[DRAG] SearchFilesSection::customRoleNames() called, roles:" << SectionListModel::FilePath << SectionListModel::FileUrl;
+    qDebug() << "[DRAG] SearchFilesSection::customRoleNames() called, roles:" << SectionListModel::FilePath << SectionListModel::FileUrl;
   }
   return {
       {SectionListModel::FilePath, "filePath"},

--- a/src/server/src/qml/search-files-model.cpp
+++ b/src/server/src/qml/search-files-model.cpp
@@ -52,7 +52,8 @@ QVariant SearchFilesSection::customData(int i, int role) const {
 QHash<int, QByteArray> SearchFilesSection::customRoleNames() const {
   static int callCount = 0;
   if (callCount++ == 0) {
-    qDebug() << "[DRAG] SearchFilesSection::customRoleNames() called, roles:" << SectionListModel::FilePath << SectionListModel::FileUrl;
+    qDebug() << "[DRAG] SearchFilesSection::customRoleNames() called, roles:" << SectionListModel::FilePath
+             << SectionListModel::FileUrl;
   }
   return {
       {SectionListModel::FilePath, "filePath"},

--- a/src/server/src/qml/search-files-model.hpp
+++ b/src/server/src/qml/search-files-model.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "section-source.hpp"
+#include "section-list-model.hpp"
 #include <filesystem>
 #include <functional>
 
@@ -21,6 +21,10 @@ public:
   }
 
   QString itemId(int i) const override;
+
+  QVariant customData(int i, int role) const override;
+  QHash<int, QByteArray> customRoleNames() const override;
+  QHash<int, QVariant> customRoleDefaults() const override;
 
 protected:
   QString itemTitle(int i) const override;

--- a/src/server/src/qml/section-list-model.cpp
+++ b/src/server/src/qml/section-list-model.cpp
@@ -80,6 +80,9 @@ QVariant SectionListModel::data(const QModelIndex &index, int role) const {
       return QString();
     case Accessory:
       return {};
+    case FilePath:
+    case FileUrl:
+      return QString();
     default: {
       auto it = m_customRoleDefaults.find(role);
       return it != m_customRoleDefaults.end() ? it.value() : QVariant{};
@@ -118,7 +121,8 @@ QHash<int, QByteArray> SectionListModel::roleNames() const {
       {IsSection, "isSection"},     {IsSelectable, "isSelectable"},
       {SectionName, "sectionName"}, {Title, "title"},
       {Subtitle, "subtitle"},       {IconSource, "iconSource"},
-      {Accessory, "itemAccessory"},
+      {Accessory, "itemAccessory"}, {FilePath, "filePath"},
+      {FileUrl, "fileUrl"},
   };
   for (auto *source : m_sources)
     roles.insert(source->customRoleNames());

--- a/src/server/src/qml/section-list-model.hpp
+++ b/src/server/src/qml/section-list-model.hpp
@@ -28,6 +28,8 @@ public:
     Subtitle,
     IconSource,
     Accessory,
+    FilePath,
+    FileUrl,
   };
 
   explicit SectionListModel(QObject *parent = nullptr);


### PR DESCRIPTION
Closes #199 

Disclaimer: vibe-assisted

Expose filePath and fileUrl model roles via SectionListModel enum so file results in the dedicated search view can be dragged to other applications. Uses DragHandler + Drag.Automatic with text/uri-list MIME type for external file drag-and-drop.