### PR TITLE
 feat: pass proper app id to CLI apps

### DIFF
--- a/src/server/src/services/app-service/xdg/xdg-app-database.cpp
+++ b/src/server/src/services/app-service/xdg/xdg-app-database.cpp
@@ -1,5 +1,6 @@
 #include "xdg-app-database.hpp"
 #include "environment.hpp"
+#include "services/app-service/abstract-app-db.hpp"
 #include "services/app-service/xdg/xdg-app.hpp"
 #include "utils.hpp"
 #include "xdgpp/desktop-entry/entry.hpp"
@@ -474,7 +475,18 @@ bool XdgAppDatabase::launch(const AbstractApplication &app, const std::vector<QS
     return launch(*opener, {*url});
   }
 
-  if (xdgApp.isTerminalApp()) return launchTerminalCommand(xdgApp.parseExec(args), {});
+  if (xdgApp.isTerminalApp()) {
+    auto wd = xdgApp.data().workingDirectory().transform(QString::fromStdString);
+    // we pass a proper appId if the terminal allows it (according to xdg-terminal-exec spec)
+    // so that we can identify the terminal app from its own wm class and not the one of the terminal
+    // emulator. We don't alter title because it is usually dynamic and useful
+    auto opts = LaunchTerminalCommandOptions{
+        .appId = xdgApp.windowClass().value_or(xdgApp.id()),
+        .workingDirectory = std::move(wd),
+    };
+
+    return launchTerminalCommand(xdgApp.parseExec(args), std::move(opts));
+  }
 
   auto exec = xdgApp.parseExec(args, m_launchPrefix);
 


### PR DESCRIPTION
This way we can map a terminal window to the actual application it's hosting, and mark it as active from the root search and have the proper icon/metadata when enumerating windows.

<img width="993" height="196" alt="image" src="https://github.com/user-attachments/assets/6265bb4c-f4c7-4e1e-9cf0-e60bc12be66f" />
