### PR TITLE
nix module: rename from `services.vicinae` -> `programs.vicinae`

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -4,7 +4,7 @@ self: {
   lib,
   ...
 }: let
-  cfg = config.services.vicinae;
+  cfg = config.programs.vicinae;
 
   inherit (pkgs.stdenv.hostPlatform) system;
   vicinaePkg = self.packages.${system}.default;
@@ -12,7 +12,31 @@ self: {
   jsonFormat = pkgs.formats.json {};
   tomlFormat = pkgs.formats.toml {};
 in {
-  options.services.vicinae = {
+  disabledModules = ["programs/vicinae"];
+
+  # backwards compatibility: services.vicinae -> programs.vicinae
+  imports = lib.flatten [
+    (
+      map (x: lib.mkRenamedOptionModule ["services" "vicinae" x] ["programs" "vicinae" x]) [
+        "enable"
+        "package"
+        "enableFirefoxIntegration"
+        "extensions"
+        "themes"
+        "settingOverrides"
+        "settings"
+      ]
+    )
+    (
+      map (x: lib.mkRenamedOptionModule ["services" "vicinae" "systemd" x] ["programs" "vicinae" "systemd" x]) [
+        "enable"
+        "autoStart"
+        "target"
+      ]
+    )
+  ];
+
+  options.programs.vicinae = {
     enable = lib.mkEnableOption "vicinae launcher daemon";
 
     package = lib.mkOption {


### PR DESCRIPTION
This change brings our home-manager module in-line with the [upstream home-manager module](https://github.com/nix-community/home-manager/blob/979bfee6e1a7996fc395270d54c9b59e88762494/modules/programs/vicinae/default.nix) and fixes some compatibility issues, e.g. with [catppuccin-nix](https://github.com/catppuccin/nix/blob/e98afe2dfd950bda4e6a8ef32bb563ec2f04505a/modules/home-manager/vicinae.nix#L15), where `programs.vicinae` is expected. Additionally, we now clobber the `programs.vicinae` (`programs/vicinae`) module from home-manager, so ours can override it. `services.vicinae` is now an "alias" of `programs.vicinae`, and usage of `services.vicinae` will result in evaluation warnings suggesting migrating to `programs.vicinae`.

Documentation PR: [docs#57](https://github.com/vicinaehq/docs/pull/57)