### PR TITLE
fix: allow focusing all form fields using tab on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ heaptrack*
 /tmp
 
 /internal-docs
+
+
+.worktrees

--- a/src/server/src/server.cpp
+++ b/src/server/src/server.cpp
@@ -119,6 +119,10 @@ int startServer(const ServerLaunchOptions &launchOpts) {
   QGuiApplication::setApplicationName("vicinae");
   QQuickWindow::setTextRenderType(QQuickWindow::NativeTextRendering);
 
+  // macOS defaults to cycling Tab focus between text controls only, skipping form fields whose root
+  // is a plain Item delegating focus inward.
+  QGuiApplication::styleHints()->setTabFocusBehavior(Qt::TabFocusAllControls);
+
 #ifdef Q_OS_MACOS
   macosSetAccessoryActivationPolicy();
 #endif


### PR DESCRIPTION
Tweak macOS specific behavior so that all focusable form fields can be focused using the tab key. 