### PR TITLE
build(nix): support macOS builds and allow system cmark-gfm / syntax-highlighting

### DIFF
--- a/.github/workflows/cachix.yaml
+++ b/.github/workflows/cachix.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [depot-ubuntu-24.04-16, depot-ubuntu-24.04-arm-16]
+        os: [depot-ubuntu-24.04-16, depot-ubuntu-24.04-arm-16, depot-macos-26]
     steps:
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v25

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,11 +36,19 @@ option(
 option(WAYLAND_LAYER_SHELL "Enable support for the layer shell Wayland protocol" ON)
 option(TYPESCRIPT_EXTENSIONS "Enable support for extensions built with React/Typescript (no browser involved)" ON)
 option(PREFER_STATIC_LIBS "When available, link to a library statically instead of dynamically" OFF)
-option(USE_SYSTEM_CMARK_GFM "Use system cmark-gfm (github's fork of cmark) instead of the vendored copy under vendor/cmark-gfm" ON)
+
+# Default for the USE_SYSTEM_* options below: Linux distros ship these as system
+# packages, macOS does not, so it flips per platform.
+set(USE_SYSTEM_DEFAULT ON)
+if (APPLE)
+	set(USE_SYSTEM_DEFAULT OFF)
+endif()
+
+option(USE_SYSTEM_CMARK_GFM "Use system cmark-gfm (github's fork of cmark) instead of the vendored copy under vendor/cmark-gfm" ${USE_SYSTEM_DEFAULT})
 option(USE_SYSTEM_LAYER_SHELL "Use system qt layer shell instead of building it from source" ON)
-option(USE_SYSTEM_KF6 "Use system KDE syntax highlighting library for markdown code block highlight support" ON)
+option(USE_SYSTEM_KF6 "Use system KDE syntax highlighting library for markdown code block highlight support" ${USE_SYSTEM_DEFAULT})
 option(USE_SYSTEM_GLAZE "Use system glaze instead of fetching it. This is a header only library so only required at build time" OFF)
-option(USE_SYSTEM_QT_KEYCHAIN "Use system qt-keychain instead of building it from source. Note: still depends on system libsecret." ON)
+option(USE_SYSTEM_QT_KEYCHAIN "Use system qt-keychain instead of building it from source. Note: still depends on system libsecret." ${USE_SYSTEM_DEFAULT})
 option(ENABLE_SANITIZERS "Enable ASan + UBSan for debug builds" OFF)
 option(ENABLE_CLANG_TIDY "Run clang-tidy during compilation" OFF)
 option(INSTALL_MODULES_LOAD_CONFIG "Install config files to auto load required kernel modules" ON)
@@ -63,7 +71,7 @@ if (NOT USE_SYSTEM_GLAZE)
 	import_glaze()
 endif()
 
-if (NOT USE_SYSTEM_KF6 OR APPLE)
+if (NOT USE_SYSTEM_KF6)
 	include(KF6)
 	import_kf6()
 endif()
@@ -95,8 +103,6 @@ if (APPLE)
 
 	set(WAYLAND_LAYER_SHELL OFF)
 	set(WLR_DATA_CONTROL OFF)
-	set(USE_SYSTEM_CMARK_GFM OFF)
-	set(USE_SYSTEM_QT_KEYCHAIN OFF)
 endif()
 
 set(VENDOR_DIR ${CMAKE_SOURCE_DIR}/vendor)

--- a/flake.nix
+++ b/flake.nix
@@ -42,19 +42,21 @@
     });
     devShells = forEachPkgs (
       pkgs: let
-        qtEnv = pkgs.qt6.env "qt-custom-${pkgs.qt6.qtbase.version}" [
-          pkgs.qt6.qtdeclarative
-          pkgs.qt6.qtwayland
-          pkgs.qt6.qtsvg
-          pkgs.qt6.qtimageformats
-          pkgs.kdePackages.layer-shell-qt
-        ];
+        inherit (pkgs.stdenv.hostPlatform) isLinux;
+        qtEnv = pkgs.qt6.env "qt-custom-${pkgs.qt6.qtbase.version}" ([
+            pkgs.qt6.qtdeclarative
+            pkgs.qt6.qtsvg
+            pkgs.qt6.qtimageformats
+          ]
+          ++ pkgs.lib.optionals isLinux [
+            pkgs.qt6.qtwayland
+            pkgs.kdePackages.layer-shell-qt
+          ]);
+        package = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
       in {
-        default = pkgs.mkShell {
-          stdenv = pkgs.gcc15Stdenv;
-
+        default = pkgs.mkShell.override {stdenv = package.stdenv;} {
           # automatically pulls nativeBuildInputs + buildInputs
-          inputsFrom = [(pkgs.callPackage ./nix/vicinae.nix {gcc15Stdenv = pkgs.gcc15Stdenv;})];
+          inputsFrom = [package];
 
           packages = with pkgs; [
             ccache
@@ -63,7 +65,7 @@
             clang-tools
           ];
 
-          shellHook = ''
+          shellHook = pkgs.lib.optionalString isLinux ''
             export CC=${pkgs.gcc15}/bin/gcc
             export CXX=${pkgs.gcc15}/bin/g++
             export CMAKE_C_COMPILER=$CC

--- a/nix/vicinae.nix
+++ b/nix/vicinae.nix
@@ -5,15 +5,36 @@
   kdePackages,
   lib,
   libqalculate,
+  llvmPackages_21,
   ninja,
   nodejs,
   npmHooks,
   pkg-config,
   qt6,
+  stdenv,
   gcc15Stdenv,
   wayland,
   glaze,
 }: let
+  inherit (stdenv.hostPlatform) isLinux isDarwin;
+
+  effectiveStdenv =
+    if isLinux
+    then gcc15Stdenv
+    else llvmPackages_21.libcxxStdenv;
+
+  # syntax-highlighting (and its extra-cmake-modules dep) is tagged Linux-only in
+  # nixpkgs but builds fine on macOS; lift the platform tag so we can link the
+  # system library instead of vendoring it. No-op on Linux.
+  addDarwinPlatform = drv:
+    drv.overrideAttrs (old: {
+      meta = old.meta // {platforms = old.meta.platforms ++ lib.platforms.darwin;};
+    });
+  kdeScope = kdePackages.overrideScope (_: prev: {
+    extra-cmake-modules = addDarwinPlatform prev.extra-cmake-modules;
+  });
+  syntax-highlighting = addDarwinPlatform kdeScope.syntax-highlighting;
+
   manifestRaw = builtins.readFile ../manifest.yaml;
   manifestGet = key: let
     m = builtins.match ".*${key}:[[:space:]]*\"([^\"]+)\".*" manifestRaw;
@@ -22,7 +43,7 @@
     then throw "Key ${key} not found in manifest.yaml"
     else builtins.elemAt m 0;
 in
-  gcc15Stdenv.mkDerivation (finalAttrs: {
+  effectiveStdenv.mkDerivation (finalAttrs: {
     pname = "vicinae";
     version = lib.removePrefix "v" (manifestGet "tag");
 
@@ -43,7 +64,10 @@ in
       "VICINAE_GIT_COMMIT_HASH" = manifestGet "short_rev";
       "VICINAE_PROVENANCE" = "nix";
       "INSTALL_NODE_MODULES" = "OFF";
+      "USE_SYSTEM_CMARK_GFM" = "ON";
       "USE_SYSTEM_GLAZE" = "ON";
+      "USE_SYSTEM_KF6" = "ON";
+      "USE_SYSTEM_QT_KEYCHAIN" = "ON";
       "CMAKE_INSTALL_PREFIX" = placeholder "out";
       "CMAKE_INSTALL_DATAROOTDIR" = "share";
       "CMAKE_INSTALL_BINDIR" = "bin";
@@ -61,22 +85,25 @@ in
       qt6.wrapQtAppsHook
     ];
 
-    buildInputs = [
-      cmark-gfm
-      kdePackages.layer-shell-qt
-      kdePackages.qtkeychain
-      kdePackages.qtshadertools
-      kdePackages.syntax-highlighting
-      libqalculate
-      nodejs
-      qt6.qtbase
-      qt6.qtdeclarative
-      qt6.qtimageformats
-      qt6.qtsvg
-      qt6.qtwayland
-      wayland
-      glaze
-    ];
+    buildInputs =
+      [
+        cmark-gfm
+        kdePackages.qtkeychain
+        kdePackages.qtshadertools
+        syntax-highlighting
+        libqalculate
+        nodejs
+        qt6.qtbase
+        qt6.qtdeclarative
+        qt6.qtimageformats
+        qt6.qtsvg
+        glaze
+      ]
+      ++ lib.optionals isLinux [
+        kdePackages.layer-shell-qt
+        qt6.qtwayland
+        wayland
+      ];
 
     postPatch = ''
       local postPatchHooks=()
@@ -85,21 +112,43 @@ in
       npmRoot=src/typescript/extension-manager npmDeps=${finalAttrs.extensionManagerDeps} npmConfigHook
     '';
 
-    qtWrapperArgs = [
-      "--prefix PATH : ${
-        lib.makeBinPath [
-          nodejs
-          (placeholder "out")
-        ]
-      }"
-      "--set VICINAE_INPUT_SERVER_BIN /run/wrappers/bin/vicinae-input-server"
-    ];
+    # On macOS CMake installs only the CLI; assemble a thin .app bundle for the
+    # GUI server. Both binaries go in the bundle so the CLI resolves the server
+    # as a sibling (findServerBinary); $out/bin/vicinae is re-added in postFixup.
+    postInstall = lib.optionalString isDarwin ''
+      app=$out/Applications/Vicinae.app
+      install -Dm755 bin/vicinae-server "$app/Contents/MacOS/Vicinae"
+      install -Dm755 bin/vicinae "$app/Contents/MacOS/vicinae-cli"
+      install -Dm644 Info.plist "$app/Contents/Info.plist"
+      install -Dm644 ../extra/vicinae.icns "$app/Contents/Resources/vicinae.icns"
+      cp -r ../extra/themes "$app/Contents/Resources/themes"
+      rm -f "$out/bin/vicinae"
+    '';
+
+    # Symlink the CLI onto PATH after wrapQtAppsHook runs, so the hook doesn't
+    # double-wrap it and the CLI still resolves from inside the bundle.
+    postFixup = lib.optionalString isDarwin ''
+      ln -s ../Applications/Vicinae.app/Contents/MacOS/vicinae-cli "$out/bin/vicinae"
+    '';
+
+    qtWrapperArgs =
+      [
+        "--prefix PATH : ${
+          lib.makeBinPath [
+            nodejs
+            (placeholder "out")
+          ]
+        }"
+      ]
+      ++ lib.optionals isLinux [
+        "--set VICINAE_INPUT_SERVER_BIN /run/wrappers/bin/vicinae-input-server"
+      ];
 
     meta = {
       description = "A focused launcher for your desktop — native, fast, extensible";
       homepage = "https://github.com/vicinaehq/vicinae";
       license = lib.licenses.gpl3Plus;
-      platforms = lib.platforms.linux;
+      platforms = with lib.platforms; linux ++ darwin;
       mainProgram = "vicinae";
     };
   })

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -6,7 +6,7 @@ set(TARGET vicinae-server)
 find_package(Qt6 REQUIRED COMPONENTS Core Network Svg DBus Concurrent Quick Qml GuiPrivate QuickDialogs2 QuickControls2 ShaderTools)
 find_package(OpenSSL REQUIRED)
 
-if (USE_SYSTEM_KF6 AND NOT APPLE)
+if (USE_SYSTEM_KF6)
 	find_package(KF6SyntaxHighlighting REQUIRED)
 endif()
 


### PR DESCRIPTION
I've been following this project for half a year now, and the recent pace of macOS support has been awesome to watch! I work across both Linux and macOS, so being able to use the same great launcher on every platform makes me really happy. Thank you!

## What this PR does

This PR extends the build definitions so that macOS users on Nix can try Vicinae easily.

In addition, the current `CMakeLists.txt` always fetched `cmark-gfm` and the KDE syntax-highlighting library via `FetchContent` on macOS. This PR lets macOS link against the system libraries the same way Linux already does, so the Nix derivation can provide them instead of vendoring.

If there's a cleaner way to handle any of this (especially the CMake option gating and the `.app` bundle assembly), I'd like to hear it.

## Follow-up

This PR focuses on packaging the build. In a follow-up PR I'm planning to add launchd support to the home-manager module.

Thanks again for developing such a nice piece of software!
