### PR TITLE
feat: (force)quit active apps

### DIFF
--- a/src/server/src/actions/app/app-actions.cpp
+++ b/src/server/src/actions/app/app-actions.cpp
@@ -63,7 +63,6 @@ OpenRawProgramAction::OpenRawProgramAction(const std::vector<QString> &args) : m
 QuitAppAction::QuitAppAction(const std::shared_ptr<AbstractApplication> &app)
     : AbstractAction("Quit Application", BuiltinIcon::XMarkCircle), m_app(app) {
   setAutoClose();
-  setShortcut(QString("ctrl+q"));
 }
 
 void QuitAppAction::execute(ApplicationContext *ctx) {

--- a/src/server/src/actions/app/app-actions.cpp
+++ b/src/server/src/actions/app/app-actions.cpp
@@ -3,8 +3,10 @@
 #include "service-registry.hpp"
 #include "services/app-service/abstract-app-db.hpp"
 #include "ui/action-pannel/action.hpp"
+#include "services/app-runtime/app-runtime.hpp"
 #include "services/app-service/app-service.hpp"
 #include "services/toast/toast-service.hpp"
+#include "ui/image/url.hpp"
 
 void OpenInTerminalAction::execute(ApplicationContext *ctx) {
   auto appDb = ctx->services->appDb();
@@ -57,6 +59,39 @@ void OpenRawProgramAction::execute(ApplicationContext *ctx) {
 }
 
 OpenRawProgramAction::OpenRawProgramAction(const std::vector<QString> &args) : m_args(args) {}
+
+QuitAppAction::QuitAppAction(const std::shared_ptr<AbstractApplication> &app)
+    : AbstractAction("Quit Application", BuiltinIcon::XMarkCircle), m_app(app) {
+  setAutoClose();
+  setShortcut(QString("ctrl+q"));
+}
+
+void QuitAppAction::execute(ApplicationContext *ctx) {
+  auto toast = ctx->services->toastService();
+
+  if (!ctx->services->appRuntime()->quit(*m_app)) {
+    toast->failure(QString("Failed to quit %1").arg(m_app->displayName()));
+    return;
+  }
+
+  ctx->navigation->showHud(QString("Quit %1").arg(m_app->displayName()));
+}
+
+ForceQuitAppAction::ForceQuitAppAction(const std::shared_ptr<AbstractApplication> &app)
+    : AbstractAction("Force Quit Application", BuiltinIcon::XMarkCircle), m_app(app) {
+  setAutoClose();
+}
+
+void ForceQuitAppAction::execute(ApplicationContext *ctx) {
+  auto toast = ctx->services->toastService();
+
+  if (!ctx->services->appRuntime()->forceQuit(*m_app)) {
+    toast->failure(QString("Failed to force quit %1").arg(m_app->displayName()));
+    return;
+  }
+
+  ctx->navigation->showHud(QString("Force quit %1").arg(m_app->displayName()));
+}
 
 void OpenInBrowserAction::execute(ApplicationContext *ctx) {
   const auto toast = ctx->services->toastService();

--- a/src/server/src/actions/app/app-actions.hpp
+++ b/src/server/src/actions/app/app-actions.hpp
@@ -57,6 +57,26 @@ private:
   bool m_clearSearch = false;
 };
 
+class QuitAppAction : public AbstractAction {
+public:
+  QuitAppAction(const std::shared_ptr<AbstractApplication> &app);
+
+  void execute(ApplicationContext *ctx) override;
+
+private:
+  std::shared_ptr<AbstractApplication> m_app;
+};
+
+class ForceQuitAppAction : public AbstractAction {
+public:
+  ForceQuitAppAction(const std::shared_ptr<AbstractApplication> &app);
+
+  void execute(ApplicationContext *ctx) override;
+
+private:
+  std::shared_ptr<AbstractApplication> m_app;
+};
+
 class OpenInBrowserAction : public AbstractAction {
 public:
   OpenInBrowserAction(QUrl url, const QString &title = "Open in browser") : m_url(url), m_title(title) {}

--- a/src/server/src/qml/macos-chrome-attached.hpp
+++ b/src/server/src/qml/macos-chrome-attached.hpp
@@ -161,3 +161,4 @@ public:
 
 void macosSetAccessoryActivationPolicy();
 void macosActivateApp();
+void macosReleaseMenuShortcuts();

--- a/src/server/src/qml/macos-chrome-attached.mm
+++ b/src/server/src/qml/macos-chrome-attached.mm
@@ -487,6 +487,27 @@ void macosSetAccessoryActivationPolicy() {
 
 void macosActivateApp() { [NSApp activateIgnoringOtherApps:YES]; }
 
+static void macosClearMenuShortcuts(NSMenu *menu) {
+  if (!menu) return;
+  NSMenu *servicesMenu = [NSApp servicesMenu];
+  for (NSMenuItem *topItem in menu.itemArray) {
+    NSMenu *submenu = topItem.submenu;
+    if (!submenu) continue;
+    for (NSMenuItem *item in submenu.itemArray) {
+      if (item.submenu == servicesMenu) continue;
+      item.keyEquivalent = @"";
+      item.keyEquivalentModifierMask = 0;
+    }
+  }
+}
+
+void macosReleaseMenuShortcuts() {
+  macosClearMenuShortcuts([NSApp mainMenu]);
+  dispatch_async(dispatch_get_main_queue(), ^{
+    macosClearMenuShortcuts([NSApp mainMenu]);
+  });
+}
+
 void MacOSPanelAttached::beginShow(qreal yFraction) {
   if (!m_window) return;
   m_window->setOpacity(0.0);

--- a/src/server/src/qml/switch-windows-model.cpp
+++ b/src/server/src/qml/switch-windows-model.cpp
@@ -1,4 +1,5 @@
 #include "switch-windows-model.hpp"
+#include "actions/app/app-actions.hpp"
 #include "actions/wm/window-actions.hpp"
 
 QString SwitchWindowsSection::displayTitle(const WindowEntry &e) const { return e.window->title(); }
@@ -35,6 +36,12 @@ std::unique_ptr<ActionPanelState> SwitchWindowsSection::buildActionPanel(const W
   auto closeAction = new CloseWindowAction(e.window);
   closeAction->setShortcut(Keyboard::Shortcut(Qt::Key_Q, Qt::ControlModifier));
   section->addAction(closeAction);
+
+  if (e.app) {
+    auto appSection = panel->createSection();
+    appSection->addAction(new QuitAppAction(e.app));
+    appSection->addAction(new ForceQuitAppAction(e.app));
+  }
 
   return panel;
 }

--- a/src/server/src/root-search/apps/app-root-provider.cpp
+++ b/src/server/src/root-search/apps/app-root-provider.cpp
@@ -65,6 +65,7 @@ std::unique_ptr<ActionPanelState> AppRootItem::newActionPanel(ApplicationContext
 
   auto mainSection = panel->createSection();
   auto utils = panel->createSection();
+  auto lifecycleSection = panel->createSection();
   auto itemSection = panel->createSection();
   auto appActions = m_app->actions();
 
@@ -110,6 +111,11 @@ std::unique_ptr<ActionPanelState> AppRootItem::newActionPanel(ApplicationContext
 
   utils->addAction(copyId);
   utils->addAction(copyLocation);
+
+  if (ctx->services->appRuntime()->isRunning(*m_app)) {
+    lifecycleSection->addAction(new QuitAppAction(m_app));
+    lifecycleSection->addAction(new ForceQuitAppAction(m_app));
+  }
 
   for (const auto &action : RootSearchActionGenerator::generateActions(*this, metadata)) {
     itemSection->addAction(action);

--- a/src/server/src/root-search/apps/app-root-provider.cpp
+++ b/src/server/src/root-search/apps/app-root-provider.cpp
@@ -113,7 +113,9 @@ std::unique_ptr<ActionPanelState> AppRootItem::newActionPanel(ApplicationContext
   utils->addAction(copyLocation);
 
   if (ctx->services->appRuntime()->isRunning(*m_app)) {
-    lifecycleSection->addAction(new QuitAppAction(m_app));
+    auto quit = new QuitAppAction(m_app);
+    quit->setShortcut(QString("ctrl+q"));
+    lifecycleSection->addAction(quit);
     lifecycleSection->addAction(new ForceQuitAppAction(m_app));
   }
 

--- a/src/server/src/server.cpp
+++ b/src/server/src/server.cpp
@@ -127,6 +127,7 @@ int startServer(const ServerLaunchOptions &launchOpts) {
 
 #ifdef Q_OS_MACOS
   macosSetAccessoryActivationPolicy();
+  macosReleaseMenuShortcuts();
 #endif
 
   auto m_config = launchOpts.config.empty() ? Omnicast::configDir() / "settings.json"

--- a/src/server/src/services/app-runtime/abstract-app-runtime.hpp
+++ b/src/server/src/services/app-runtime/abstract-app-runtime.hpp
@@ -13,6 +13,8 @@ public:
   virtual bool isRunning(const AbstractApplication &app) const = 0;
   virtual std::shared_ptr<AbstractApplication> frontmostApp() const = 0;
   virtual bool activate(const AbstractApplication &app) const = 0;
+  virtual bool quit(const AbstractApplication &app) const = 0;
+  virtual bool forceQuit(const AbstractApplication &app) const = 0;
 
 signals:
   void runningAppsChanged();

--- a/src/server/src/services/app-runtime/app-runtime.cpp
+++ b/src/server/src/services/app-runtime/app-runtime.cpp
@@ -18,6 +18,10 @@ std::shared_ptr<AbstractApplication> AppRuntime::frontmostApp() const { return m
 
 bool AppRuntime::activate(const AbstractApplication &app) const { return m_provider->activate(app); }
 
+bool AppRuntime::quit(const AbstractApplication &app) const { return m_provider->quit(app); }
+
+bool AppRuntime::forceQuit(const AbstractApplication &app) const { return m_provider->forceQuit(app); }
+
 std::unique_ptr<AbstractAppRuntime> AppRuntime::createProvider(WindowManager &wm, AppService &appService) {
 #ifdef Q_OS_MACOS
   (void)wm;

--- a/src/server/src/services/app-runtime/app-runtime.hpp
+++ b/src/server/src/services/app-runtime/app-runtime.hpp
@@ -21,6 +21,8 @@ public:
   bool isRunning(const AbstractApplication &app) const;
   std::shared_ptr<AbstractApplication> frontmostApp() const;
   bool activate(const AbstractApplication &app) const;
+  bool quit(const AbstractApplication &app) const;
+  bool forceQuit(const AbstractApplication &app) const;
 
 private:
   static std::unique_ptr<AbstractAppRuntime> createProvider(WindowManager &wm, AppService &appService);

--- a/src/server/src/services/app-runtime/linux/linux-app-runtime.cpp
+++ b/src/server/src/services/app-runtime/linux/linux-app-runtime.cpp
@@ -1,6 +1,8 @@
 #include "linux-app-runtime.hpp"
 #include "services/app-service/app-service.hpp"
 #include "services/window-manager/window-manager.hpp"
+#include <csignal>
+#include <unordered_set>
 
 LinuxAppRuntime::LinuxAppRuntime(WindowManager &wm, AppService &appService)
     : m_wm(wm), m_appService(appService) {
@@ -23,4 +25,37 @@ bool LinuxAppRuntime::activate(const AbstractApplication &app) const {
   if (wins.empty()) return false;
   m_wm.provider()->focusWindowSync(*wins.front());
   return true;
+}
+
+bool LinuxAppRuntime::quit(const AbstractApplication &app) const {
+  bool closed = false;
+  for (const auto &win : m_wm.findAppWindows(app)) {
+    if (m_wm.provider()->closeWindow(*win)) closed = true;
+  }
+  return closed;
+}
+
+bool LinuxAppRuntime::forceQuit(const AbstractApplication &app) const {
+  auto wins = m_wm.findAppWindows(app);
+
+  std::unordered_set<int> pids;
+  AbstractWindowManager::WindowList pidless;
+  pidless.reserve(wins.size());
+
+  for (const auto &win : wins) {
+    if (auto pid = win->pid(); pid && *pid > 0) {
+      pids.emplace(*pid);
+    } else {
+      pidless.emplace_back(win);
+    }
+  }
+
+  bool acted = false;
+  for (int pid : pids) {
+    if (::kill(pid, SIGKILL) == 0) acted = true;
+  }
+  for (const auto &win : pidless) {
+    if (m_wm.provider()->closeWindow(*win)) acted = true;
+  }
+  return acted;
 }

--- a/src/server/src/services/app-runtime/linux/linux-app-runtime.hpp
+++ b/src/server/src/services/app-runtime/linux/linux-app-runtime.hpp
@@ -13,6 +13,8 @@ public:
   bool isRunning(const AbstractApplication &app) const override;
   std::shared_ptr<AbstractApplication> frontmostApp() const override;
   bool activate(const AbstractApplication &app) const override;
+  bool quit(const AbstractApplication &app) const override;
+  bool forceQuit(const AbstractApplication &app) const override;
 
 private:
   WindowManager &m_wm;

--- a/src/server/src/services/app-runtime/macos/mac-app-runtime.hpp
+++ b/src/server/src/services/app-runtime/macos/mac-app-runtime.hpp
@@ -20,6 +20,8 @@ public:
   bool isRunning(const AbstractApplication &app) const override;
   std::shared_ptr<AbstractApplication> frontmostApp() const override;
   bool activate(const AbstractApplication &app) const override;
+  bool quit(const AbstractApplication &app) const override;
+  bool forceQuit(const AbstractApplication &app) const override;
 
   // Invoked by the observer when a workspace notification arrives.
   void onRunningAppsChanged();

--- a/src/server/src/services/app-runtime/macos/mac-app-runtime.mm
+++ b/src/server/src/services/app-runtime/macos/mac-app-runtime.mm
@@ -96,6 +96,34 @@ bool MacAppRuntime::activate(const AbstractApplication &app) const {
   }
 }
 
+bool MacAppRuntime::quit(const AbstractApplication &app) const {
+  @autoreleasepool {
+    NSString *bundleId = app.id().toNSString();
+    if (bundleId.length == 0) return false;
+    NSArray<NSRunningApplication *> *matches =
+        [NSRunningApplication runningApplicationsWithBundleIdentifier:bundleId];
+    bool requested = false;
+    for (NSRunningApplication *a in matches) {
+      if ([a terminate]) requested = true;
+    }
+    return requested;
+  }
+}
+
+bool MacAppRuntime::forceQuit(const AbstractApplication &app) const {
+  @autoreleasepool {
+    NSString *bundleId = app.id().toNSString();
+    if (bundleId.length == 0) return false;
+    NSArray<NSRunningApplication *> *matches =
+        [NSRunningApplication runningApplicationsWithBundleIdentifier:bundleId];
+    bool killed = false;
+    for (NSRunningApplication *a in matches) {
+      if ([a forceTerminate]) killed = true;
+    }
+    return killed;
+  }
+}
+
 std::shared_ptr<AbstractApplication> MacAppRuntime::frontmostApp() const {
   QString bundleId;
   @autoreleasepool {

--- a/src/server/src/services/window-manager/hyprland/hypr-window.cpp
+++ b/src/server/src/services/window-manager/hyprland/hypr-window.cpp
@@ -5,6 +5,7 @@ HyprlandWindow::HyprlandWindow(const QJsonObject &json) {
   m_title = json.value("title").toString();
   m_wmClass = json.value("class").toString();
   m_workspaceId = json.value("workspace").toObject().value("id").toInt();
+  m_pid = json.value("pid").toInt();
 
   auto at = json.value("at").toArray();
   auto size = json.value("size").toArray();

--- a/src/server/src/services/window-manager/hyprland/hyprland.hpp
+++ b/src/server/src/services/window-manager/hyprland/hyprland.hpp
@@ -20,7 +20,10 @@
 class HyprlandWindow : public AbstractWindowManager::AbstractWindow {
 public:
   QString id() const override { return m_id; }
-  std::optional<int> pid() const override { return m_pid; }
+  std::optional<int> pid() const override {
+    if (m_pid <= 0) return std::nullopt;
+    return m_pid;
+  }
   QString title() const override { return m_title; }
   QString wmClass() const override { return m_wmClass; }
   std::optional<AbstractWindowManager::WindowBounds> bounds() const override { return m_bounds; }
@@ -34,7 +37,7 @@ private:
   QString m_title;
   QString m_wmClass;
   int m_workspaceId;
-  int m_pid;
+  int m_pid = 0;
   AbstractWindowManager::WindowBounds m_bounds;
 };
 

--- a/src/server/src/services/window-manager/wayland/wayland.hpp
+++ b/src/server/src/services/window-manager/wayland/wayland.hpp
@@ -6,7 +6,10 @@ class WaylandWindowManager;
 class WaylandWindow : public AbstractWindowManager::AbstractWindow {
 public:
   QString id() const override { return m_id; }
-  std::optional<int> pid() const override { return m_pid; }
+  std::optional<int> pid() const override {
+    if (m_pid <= 0) return std::nullopt;
+    return m_pid;
+  }
   QString title() const override { return m_title; }
   QString wmClass() const override { return m_wmClass; }
 


### PR DESCRIPTION
Add action to quit and force quit an active app from the root search
On macOS it terminates (or force terminates) the target app
On linux it attempts to close all the windows that are linked to the app

on macOS this required removing the default menu items to close/hide apps, otherwise command+q was being swallowed by it and quitted the app.