### PR TITLE
nix module: add missing systemd option in option renames

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -31,6 +31,7 @@ in {
       map (x: lib.mkRenamedOptionModule ["services" "vicinae" "systemd" x] ["programs" "vicinae" "systemd" x]) [
         "enable"
         "autoStart"
+        "environment"
         "target"
       ]
     )


### PR DESCRIPTION
This just adds `environment` to the `systemd` portion of the `services.vicinae` -> `programs.vicinae` option renames. Missed this in my original pull request, sorry about that.

Fixes #1550.