### PR TITLE
fix: `Open Location` would open app, instead of the folder containing the app on MacOS

### DIFF
--- a/src/server/src/actions/app/app-actions.cpp
+++ b/src/server/src/actions/app/app-actions.cpp
@@ -8,6 +8,19 @@
 #include "services/toast/toast-service.hpp"
 #include "ui/image/url.hpp"
 
+OpenAppLocationAction::OpenAppLocationAction(const std::shared_ptr<AbstractApplication> &app,
+                                             const std::shared_ptr<AbstractApplication> &opener)
+    : AbstractAction("Open Location", opener->iconUrl()), m_app(app) {}
+
+void OpenAppLocationAction::execute(ApplicationContext *ctx) {
+  if (!ctx->services->appDb()->openLocation(*m_app)) {
+    ctx->services->toastService()->failure("Failed to open app location");
+    return;
+  }
+
+  ctx->navigation->closeWindow();
+}
+
 void OpenInTerminalAction::execute(ApplicationContext *ctx) {
   auto appDb = ctx->services->appDb();
   auto toast = ctx->services->toastService();

--- a/src/server/src/actions/app/app-actions.hpp
+++ b/src/server/src/actions/app/app-actions.hpp
@@ -18,6 +18,17 @@ private:
   bool m_clearSearch = false;
 };
 
+class OpenAppLocationAction : public AbstractAction {
+public:
+  OpenAppLocationAction(const std::shared_ptr<AbstractApplication> &app,
+                        const std::shared_ptr<AbstractApplication> &opener);
+
+  void execute(ApplicationContext *ctx) override;
+
+private:
+  std::shared_ptr<AbstractApplication> m_app;
+};
+
 class OpenInTerminalAction : public AbstractAction {
 public:
   void setClearSearch(bool value) { m_clearSearch = value; }

--- a/src/server/src/qml/browse-apps-model.cpp
+++ b/src/server/src/qml/browse-apps-model.cpp
@@ -24,7 +24,6 @@ QVariantList BrowseAppsSection::displayAccessories(const AppPtr &app) const {
 
 std::unique_ptr<ActionPanelState> BrowseAppsSection::buildActionPanel(const AppPtr &app) const {
   auto panel = std::make_unique<ListActionPanelState>();
-  auto appDb = scope().services()->appDb();
 
   panel->setTitle(app->displayName());
 
@@ -45,11 +44,22 @@ std::unique_ptr<ActionPanelState> BrowseAppsSection::buildActionPanel(const AppP
     mainSection->addAction(action);
   }
 
-  if (auto opener = appDb->findDefaultOpener(app->path().c_str())) {
+#ifdef Q_OS_MACOS
+  if (!app->path().empty()) {
+    auto *openLocation = new StaticAction("Open Location", ImageURL::builtin("folder"),
+                                          [path = app->path()](ApplicationContext *ctx) {
+                                            ctx->services->appDb()->showInFileBrowser(path, true);
+                                          });
+    openLocation->setShortcut(Keybind::OpenAction);
+    utils->addAction(openLocation);
+  }
+#else
+  if (auto opener = scope().services()->appDb()->findDefaultOpener(app->path().c_str())) {
     auto *openLocation = new OpenAppAction(opener, "Open Location", {app->path().c_str()});
     openLocation->setShortcut(Keybind::OpenAction);
     utils->addAction(openLocation);
   }
+#endif
 
   auto *copyId = new CopyToClipboardAction(Clipboard::Text(app->id()), "Copy App ID");
   utils->addAction(copyId);

--- a/src/server/src/qml/browse-apps-model.cpp
+++ b/src/server/src/qml/browse-apps-model.cpp
@@ -45,22 +45,11 @@ std::unique_ptr<ActionPanelState> BrowseAppsSection::buildActionPanel(const AppP
     mainSection->addAction(action);
   }
 
-#ifdef Q_OS_MACOS
-  if (!app->path().empty()) {
-    auto *openLocation = new StaticAction("Open Location", ImageURL::builtin("folder"),
-                                          [path = app->path()](ApplicationContext *ctx) {
-                                            ctx->services->appDb()->showInFileBrowser(path, true);
-                                          });
+  if (auto opener = appDb->provider()->locationOpener(*app)) {
+    auto *openLocation = new OpenAppLocationAction(app, opener);
     openLocation->setShortcut(Keybind::OpenAction);
     utils->addAction(openLocation);
   }
-#else
-  if (auto opener = appDb->findDefaultOpener(app->path().c_str())) {
-    auto *openLocation = new OpenAppAction(opener, "Open Location", {app->path().c_str()});
-    openLocation->setShortcut(Keybind::OpenAction);
-    utils->addAction(openLocation);
-  }
-#endif
 
   auto *copyId = new CopyToClipboardAction(Clipboard::Text(app->id()), "Copy App ID");
   utils->addAction(copyId);

--- a/src/server/src/qml/browse-apps-model.cpp
+++ b/src/server/src/qml/browse-apps-model.cpp
@@ -24,6 +24,7 @@ QVariantList BrowseAppsSection::displayAccessories(const AppPtr &app) const {
 
 std::unique_ptr<ActionPanelState> BrowseAppsSection::buildActionPanel(const AppPtr &app) const {
   auto panel = std::make_unique<ListActionPanelState>();
+  auto appDb = scope().services()->appDb();
 
   panel->setTitle(app->displayName());
 
@@ -54,7 +55,7 @@ std::unique_ptr<ActionPanelState> BrowseAppsSection::buildActionPanel(const AppP
     utils->addAction(openLocation);
   }
 #else
-  if (auto opener = scope().services()->appDb()->findDefaultOpener(app->path().c_str())) {
+  if (auto opener = appDb->findDefaultOpener(app->path().c_str())) {
     auto *openLocation = new OpenAppAction(opener, "Open Location", {app->path().c_str()});
     openLocation->setShortcut(Keybind::OpenAction);
     utils->addAction(openLocation);

--- a/src/server/src/root-search/apps/app-root-provider.cpp
+++ b/src/server/src/root-search/apps/app-root-provider.cpp
@@ -104,12 +104,7 @@ std::unique_ptr<ActionPanelState> AppRootItem::newActionPanel(ApplicationContext
   }
 
   if (auto opener = appDb->provider()->locationOpener(*m_app)) {
-    auto openLocation =
-        new StaticAction("Open Location", opener->iconUrl(), [app = m_app](ApplicationContext *ctx) {
-          ctx->services->appDb()->openLocation(*app);
-          ctx->navigation->closeWindow();
-        });
-
+    auto openLocation = new OpenAppLocationAction(m_app, opener);
     openLocation->setShortcut(Keybind::OpenAction);
     utils->addAction(openLocation);
   }

--- a/src/server/src/root-search/apps/app-root-provider.cpp
+++ b/src/server/src/root-search/apps/app-root-provider.cpp
@@ -56,7 +56,6 @@ ImageURL AppRootItem::iconUrl() const { return m_app->iconUrl(); }
 std::unique_ptr<ActionPanelState> AppRootItem::newActionPanel(ApplicationContext *ctx,
                                                               const RootItemMetadata &metadata) const {
   auto panel = std::make_unique<ListActionPanelState>();
-  auto appDb = ctx->services->appDb();
   auto open = new OpenAppAction(m_app, "Open Application", {});
   auto copyId = new CopyToClipboardAction(Clipboard::Text(m_app->id()), "Copy App ID");
   auto copyLocation = new CopyToClipboardAction(Clipboard::Text(m_app->path().c_str()), "Copy App Location");
@@ -103,11 +102,22 @@ std::unique_ptr<ActionPanelState> AppRootItem::newActionPanel(ApplicationContext
     mainSection->addAction(openAction);
   }
 
-  if (auto opener = appDb->findDefaultOpener(m_app->path().c_str())) {
+#ifdef Q_OS_MACOS
+  if (!m_app->path().empty()) {
+    auto openLocation = new StaticAction("Open Location", ImageURL::builtin("folder"),
+                                         [path = m_app->path()](ApplicationContext *ctx) {
+                                           ctx->services->appDb()->showInFileBrowser(path, true);
+                                         });
+    openLocation->setShortcut(Keybind::OpenAction);
+    utils->addAction(openLocation);
+  }
+#else
+  if (auto opener = ctx->services->appDb()->findDefaultOpener(m_app->path().c_str())) {
     auto openLocation = new OpenAppAction(opener, "Open Location", {m_app->path().c_str()});
     openLocation->setShortcut(Keybind::OpenAction);
     utils->addAction(openLocation);
   }
+#endif
 
   utils->addAction(copyId);
   utils->addAction(copyLocation);

--- a/src/server/src/root-search/apps/app-root-provider.cpp
+++ b/src/server/src/root-search/apps/app-root-provider.cpp
@@ -103,22 +103,16 @@ std::unique_ptr<ActionPanelState> AppRootItem::newActionPanel(ApplicationContext
     mainSection->addAction(openAction);
   }
 
-#ifdef Q_OS_MACOS
-  if (!m_app->path().empty()) {
-    auto openLocation = new StaticAction("Open Location", ImageURL::builtin("folder"),
-                                         [path = m_app->path()](ApplicationContext *ctx) {
-                                           ctx->services->appDb()->showInFileBrowser(path, true);
-                                         });
+  if (auto opener = appDb->provider()->locationOpener(*m_app)) {
+    auto openLocation =
+        new StaticAction("Open Location", opener->iconUrl(), [app = m_app](ApplicationContext *ctx) {
+          ctx->services->appDb()->openLocation(*app);
+          ctx->navigation->closeWindow();
+        });
+
     openLocation->setShortcut(Keybind::OpenAction);
     utils->addAction(openLocation);
   }
-#else
-  if (auto opener = appDb->findDefaultOpener(m_app->path().c_str())) {
-    auto openLocation = new OpenAppAction(opener, "Open Location", {m_app->path().c_str()});
-    openLocation->setShortcut(Keybind::OpenAction);
-    utils->addAction(openLocation);
-  }
-#endif
 
   utils->addAction(copyId);
   utils->addAction(copyLocation);

--- a/src/server/src/root-search/apps/app-root-provider.cpp
+++ b/src/server/src/root-search/apps/app-root-provider.cpp
@@ -56,6 +56,7 @@ ImageURL AppRootItem::iconUrl() const { return m_app->iconUrl(); }
 std::unique_ptr<ActionPanelState> AppRootItem::newActionPanel(ApplicationContext *ctx,
                                                               const RootItemMetadata &metadata) const {
   auto panel = std::make_unique<ListActionPanelState>();
+  auto appDb = ctx->services->appDb();
   auto open = new OpenAppAction(m_app, "Open Application", {});
   auto copyId = new CopyToClipboardAction(Clipboard::Text(m_app->id()), "Copy App ID");
   auto copyLocation = new CopyToClipboardAction(Clipboard::Text(m_app->path().c_str()), "Copy App Location");
@@ -112,7 +113,7 @@ std::unique_ptr<ActionPanelState> AppRootItem::newActionPanel(ApplicationContext
     utils->addAction(openLocation);
   }
 #else
-  if (auto opener = ctx->services->appDb()->findDefaultOpener(m_app->path().c_str())) {
+  if (auto opener = appDb->findDefaultOpener(m_app->path().c_str())) {
     auto openLocation = new OpenAppAction(opener, "Open Location", {m_app->path().c_str()});
     openLocation->setShortcut(Keybind::OpenAction);
     utils->addAction(openLocation);

--- a/src/server/src/services/app-service/abstract-app-db.hpp
+++ b/src/server/src/services/app-service/abstract-app-db.hpp
@@ -198,6 +198,19 @@ public:
   virtual AppPtr terminalEmulator() const = 0;
 
   /**
+   * Open the location where the app is installed at.
+   * What this does highly depends on how applications are defined on the target platform.
+   * On linux this would open the .desktop file, on macOS open the app bundle directory...
+   */
+  virtual bool openLocation(const AbstractApplication &app) const = 0;
+
+  /**
+   * Application used to open the `app` at its installed location.
+   * If this return null, it means that calling `openLocation` will likely return `false`.
+   */
+  virtual AppPtr locationOpener(const AbstractApplication &app) const = 0;
+
+  /**
    * Open the system file browser for the provided path.
    * If `select` is true, implementations should try to reveal/select the item and
    * gracefully fall back to opening the containing folder when that is not supported.

--- a/src/server/src/services/app-service/app-service.cpp
+++ b/src/server/src/services/app-service/app-service.cpp
@@ -117,6 +117,8 @@ bool AppService::showInFileBrowser(const std::filesystem::path &path, bool selec
   return m_provider->showInFileBrowser(path, select);
 }
 
+bool AppService::openLocation(const AbstractApplication &app) const { return m_provider->openLocation(app); }
+
 void AppService::handleDirectoryChanged(const QString &path) {
   (void)path;
   m_rescanDebounce->start();

--- a/src/server/src/services/app-service/app-service.hpp
+++ b/src/server/src/services/app-service/app-service.hpp
@@ -77,6 +77,7 @@ public:
   std::shared_ptr<AbstractApplication> findDefaultOpener(const QString &target) const;
   void setAdditionalSearchPaths(const std::vector<std::filesystem::path> &paths);
   bool showInFileBrowser(const std::filesystem::path &path, bool select) const;
+  bool openLocation(const AbstractApplication &app) const;
 
   bool openTarget(const QString &target) const;
   bool openTarget(const QUrl &target) const;

--- a/src/server/src/services/app-service/macos/mac-app-database.hpp
+++ b/src/server/src/services/app-service/macos/mac-app-database.hpp
@@ -27,6 +27,8 @@ public:
   AppPtr webBrowser() const override;
   AppPtr terminalEmulator() const override;
   bool showInFileBrowser(const std::filesystem::path &path, bool select) const override;
+  bool openLocation(const AbstractApplication &app) const override;
+  AppPtr locationOpener(const AbstractApplication &app) const override;
 
 private:
   std::vector<std::shared_ptr<MacApplication>> m_apps;

--- a/src/server/src/services/app-service/macos/mac-app-database.mm
+++ b/src/server/src/services/app-service/macos/mac-app-database.mm
@@ -1,4 +1,5 @@
 #include "mac-app-database.hpp"
+#include "services/app-service/abstract-app-db.hpp"
 
 #import <AppKit/AppKit.h>
 #import <Foundation/Foundation.h>
@@ -394,3 +395,10 @@ bool MacAppDatabase::showInFileBrowser(const fs::path &path, bool select) const 
   return true;
 }
 
+bool MacAppDatabase::openLocation(const AbstractApplication &app) const {
+  return showInFileBrowser(app.path(), true);
+}
+
+AbstractAppDatabase::AppPtr MacAppDatabase::locationOpener(const AbstractApplication &app) const {
+  return fileBrowser();
+}

--- a/src/server/src/services/app-service/xdg/xdg-app-database.cpp
+++ b/src/server/src/services/app-service/xdg/xdg-app-database.cpp
@@ -284,6 +284,19 @@ bool XdgAppDatabase::showInFileBrowser(const fs::path &path, bool select) const 
   return launch(*browser, {target->c_str()});
 }
 
+bool XdgAppDatabase::openLocation(const AbstractApplication &app) const {
+  auto path = QString::fromStdString(app.path());
+  const auto opener = findDefaultOpener(path);
+
+  if (!opener) return false;
+
+  return launch(*opener, {std::move(path)});
+}
+
+AppPtr XdgAppDatabase::locationOpener(const AbstractApplication &app) const {
+  return findDefaultOpener(QString::fromStdString(app.path()));
+}
+
 std::vector<fs::path> XdgAppDatabase::defaultSearchPaths() const { return xdgpp::appDirs(); }
 
 AppPtr XdgAppDatabase::findById(const QString &id) const {

--- a/src/server/src/services/app-service/xdg/xdg-app-database.hpp
+++ b/src/server/src/services/app-service/xdg/xdg-app-database.hpp
@@ -33,6 +33,8 @@ public:
   AppPtr genericTextEditor() const override;
   AppPtr webBrowser() const override;
   bool showInFileBrowser(const std::filesystem::path &path, bool select) const override;
+  bool openLocation(const AbstractApplication &app) const override;
+  AppPtr locationOpener(const AbstractApplication &app) const override;
 
   XdgAppDatabase();
 


### PR DESCRIPTION
On MacOS selecting `Open Location` from the actions menu would open the app, instead of opening the folder containing the app, this change fixes that.