### PR TITLE
feat: Sort order settings

### DIFF
--- a/src/server/src/actions/files/file-actions.hpp
+++ b/src/server/src/actions/files/file-actions.hpp
@@ -7,7 +7,9 @@ class OpenFileAction : public OpenAppAction {
 public:
   void execute(ApplicationContext *ctx) override {
     auto files = ctx->services->fileService();
+    auto query = ctx->navigation->searchText().toStdString();
 
+    files->saveQuerySelection(query, m_path);
     OpenAppAction::execute(ctx);
     files->saveAccess(m_path);
   }
@@ -25,7 +27,9 @@ class OpenFileInAppAction : public OpenAppAction {
 public:
   void execute(ApplicationContext *ctx) override {
     auto files = ctx->services->fileService();
+    auto query = ctx->navigation->searchText().toStdString();
 
+    files->saveQuerySelection(query, m_path);
     OpenAppAction::execute(ctx);
     files->saveAccess(m_path);
   }

--- a/src/server/src/actions/root-search/root-search-actions.cpp
+++ b/src/server/src/actions/root-search/root-search-actions.cpp
@@ -82,8 +82,9 @@ ToggleItemAsFavorite::ToggleItemAsFavorite(const EntrypointId &id, bool currentV
 
 void DefaultActionWrapper::execute(ApplicationContext *ctx) {
   auto manager = ctx->services->rootItemManager();
+  auto searchText = ctx->navigation->searchText();
 
-  if (manager->registerVisit(m_id)) {
+  if (manager->registerVisit(m_id, searchText.toStdString())) {
   } else {
     qWarning() << "Failed to register root item visit";
   }

--- a/src/server/src/config/config.hpp
+++ b/src/server/src/config/config.hpp
@@ -222,6 +222,8 @@ struct ConfigValue {
   std::string schema = SCHEMA;
   std::vector<std::string> imports;
   bool searchFilesInRoot = false;
+  bool rollingKnowledge = false;
+  bool keywordLatching = false;
   bool closeOnFocusLoss = false;
   bool considerPreedit = false;
   bool popToRootOnClose = false;
@@ -284,6 +286,8 @@ template <> struct Partial<ConfigValue> {
   std::optional<std::string> keybinding;
   std::optional<int> pixmapCacheMb;
   std::optional<bool> searchFilesInRoot;
+  std::optional<bool> rollingKnowledge;
+  std::optional<bool> keywordLatching;
   std::optional<Partial<InputServer>> inputServer;
   std::optional<Partial<GlobalShortcuts>> globalShortcuts;
 

--- a/src/server/src/extensions/file/file-extension.hpp
+++ b/src/server/src/extensions/file/file-extension.hpp
@@ -62,9 +62,7 @@ class FileExtension : public BuiltinCommandRepository {
 
 public:
   void initialized(const QJsonObject &preferences) const override {
-#ifdef Q_OS_LINUX
     ServiceRegistry::instance()->fileService()->preferenceValuesChanged(preferences);
-#endif
   }
 
   FileExtension() {
@@ -76,7 +74,14 @@ public:
   }
 
   std::vector<Preference> preferences() const override {
-#ifdef Q_OS_LINUX
+    auto defaultOrdering = Preference::makeCheckbox("defaultOrdering");
+    defaultOrdering.setTitle("Default file ordering");
+    defaultOrdering.setDescription(
+      "Prefer files you recently used, then fall back to file modification time when Vicinae does not have "
+      "stronger file usage knowledge.");
+    defaultOrdering.setDefaultValue(false);
+
+  #ifdef Q_OS_LINUX
     auto indexing = Preference::makeCheckbox("autoIndexing");
 
     indexing.setTitle("Enabled");
@@ -95,15 +100,13 @@ public:
     excludedPaths.setDescription("Directories to exclude from file indexing");
     excludedPaths.setDefaultValue(QJsonArray{});
 
-    return {indexing, paths, excludedPaths};
+    return {defaultOrdering, indexing, paths, excludedPaths};
 #else
-    return {};
+    return {defaultOrdering};
 #endif
   }
 
   void preferenceValuesChanged(const QJsonObject &preferences) const override {
-#ifdef Q_OS_LINUX
     ServiceRegistry::instance()->fileService()->preferenceValuesChanged(preferences);
-#endif
   }
 };

--- a/src/server/src/qml/general-settings-model.cpp
+++ b/src/server/src/qml/general-settings-model.cpp
@@ -28,6 +28,16 @@ void GeneralSettingsModel::setSearchFilesInRoot(bool v) {
   cfgManager().mergeWithUser({.searchFilesInRoot = v});
 }
 
+bool GeneralSettingsModel::rollingKnowledge() const { return cfg().rollingKnowledge; }
+void GeneralSettingsModel::setRollingKnowledge(bool v) {
+  cfgManager().mergeWithUser({.rollingKnowledge = v});
+}
+
+bool GeneralSettingsModel::keywordLatching() const { return cfg().keywordLatching; }
+void GeneralSettingsModel::setKeywordLatching(bool v) {
+  cfgManager().mergeWithUser({.keywordLatching = v});
+}
+
 bool GeneralSettingsModel::closeOnFocusLoss() const { return cfg().closeOnFocusLoss; }
 void GeneralSettingsModel::setCloseOnFocusLoss(bool v) {
   cfgManager().mergeWithUser({.closeOnFocusLoss = v});

--- a/src/server/src/qml/general-settings-model.hpp
+++ b/src/server/src/qml/general-settings-model.hpp
@@ -8,6 +8,8 @@ class GeneralSettingsModel : public QObject {
   Q_OBJECT
 
   Q_PROPERTY(bool searchFilesInRoot READ searchFilesInRoot WRITE setSearchFilesInRoot NOTIFY configChanged)
+  Q_PROPERTY(bool rollingKnowledge READ rollingKnowledge WRITE setRollingKnowledge NOTIFY configChanged)
+  Q_PROPERTY(bool keywordLatching READ keywordLatching WRITE setKeywordLatching NOTIFY configChanged)
   Q_PROPERTY(bool inputServerEnabled READ inputServerEnabled WRITE setInputServerEnabled NOTIFY configChanged)
   Q_PROPERTY(bool closeOnFocusLoss READ closeOnFocusLoss WRITE setCloseOnFocusLoss NOTIFY configChanged)
   Q_PROPERTY(bool closeOnEscape READ closeOnEscape WRITE setCloseOnEscape NOTIFY configChanged)
@@ -51,6 +53,10 @@ public:
 
   bool searchFilesInRoot() const;
   void setSearchFilesInRoot(bool v);
+  bool rollingKnowledge() const;
+  void setRollingKnowledge(bool v);
+  bool keywordLatching() const;
+  void setKeywordLatching(bool v);
   bool closeOnFocusLoss() const;
   void setCloseOnFocusLoss(bool v);
   bool closeOnEscape() const;

--- a/src/server/src/qml/qml/AdvancedSettingsPage.qml
+++ b/src/server/src/qml/qml/AdvancedSettingsPage.qml
@@ -85,6 +85,24 @@ Flickable {
             }
 
             SettingsRow {
+                label: "Rolling knowledge"
+                description: "Remember selections over the last 4 weeks and use them to bias default result ordering."
+                SettingsToggle {
+                    checked: root.model.rollingKnowledge
+                    onToggled: root.model.rollingKnowledge = checked
+                }
+            }
+
+            SettingsRow {
+                label: "Keyword latching"
+                description: "Learn the exact query string you typed and promote the item you select for that query."
+                SettingsToggle {
+                    checked: root.model.keywordLatching
+                    onToggled: root.model.keywordLatching = checked
+                }
+            }
+
+            SettingsRow {
                 label: "Favicon Fetching"
                 description: "The favicon provider used to load favicons where needed. Select 'None' to turn off favicon loading."
                 showSeparator: false

--- a/src/server/src/services/files-service/file-service.cpp
+++ b/src/server/src/services/files-service/file-service.cpp
@@ -2,6 +2,7 @@
 #include "services/files-service/abstract-file-indexer.hpp"
 #include "vicinae.hpp"
 #include <algorithm>
+#include <chrono>
 #include <glaze/core/reflect.hpp>
 #include <glaze/json/read.hpp>
 #include <glaze/json/write.hpp>
@@ -19,12 +20,19 @@
 namespace fs = std::filesystem;
 
 constexpr auto RECENT_FILES_NAME = "recent-files.json";
+constexpr auto QUERY_SELECTIONS_NAME = "file-query-selections.json";
 
 AbstractFileIndexer *FileService::indexer() const { return m_indexer.get(); }
 
 QFuture<std::vector<IndexerFileResult>> FileService::queryAsync(std::string_view query,
                                                                 const IndexerQueryParams &params) {
-  return m_indexer->queryAsync(query, params);
+  auto defaultOrdering = m_defaultOrderingEnabled;
+  std::string queryText{query};
+  return m_indexer->queryAsync(query, params).then(
+      [this, defaultOrdering, queryText = std::move(queryText)](std::vector<IndexerFileResult> results) {
+        if (defaultOrdering) { sortFilesIfRequested(results, queryText); }
+    return results;
+  });
 }
 
 void FileService::rebuildIndex() { m_indexer->rebuildIndex(); }
@@ -47,6 +55,28 @@ void FileService::saveAccess(const fs::path &path) {
   if (m_recentFiles.size() > MAX_RECENT_FILES) { m_recentFiles.resize(MAX_RECENT_FILES); }
 
   if (!saveRecentFiles()) { qWarning() << "Failed to save recent file access for" << path.c_str(); }
+}
+
+void FileService::saveQuerySelection(std::string_view query, const fs::path &path) {
+  if (query.empty()) return;
+
+  auto pathString = path.string();
+  auto now = static_cast<std::uint64_t>(QDateTime::currentSecsSinceEpoch());
+  auto it = std::ranges::find_if(m_querySelections, [&](const auto &selection) {
+    return selection.query == query && selection.path == pathString;
+  });
+
+  if (it == m_querySelections.end()) {
+    m_querySelections.emplace_back(QuerySelection{.query = std::string{query},
+                                                  .path = std::move(pathString),
+                                                  .selectedAt = now});
+  } else {
+    it->selectedAt = now;
+  }
+
+  std::ranges::sort(m_querySelections, [](const auto &a, const auto &b) { return a.selectedAt > b.selectedAt; });
+  if (m_querySelections.size() > MAX_QUERY_SELECTIONS) { m_querySelections.resize(MAX_QUERY_SELECTIONS); }
+  if (!saveQuerySelections()) { qWarning() << "Failed to save file query selections for" << path.c_str(); }
 }
 
 bool FileService::clearRecentlyAccessed() {
@@ -85,6 +115,41 @@ bool FileService::saveRecentFiles() {
   if (const auto error =
           glz::write_file_json(m_recentFiles, m_recentFilesPath.c_str(), m_recentFilesBuffer)) {
     qWarning() << "Failed to save recent files state at" << m_recentFilesPath.c_str()
+               << glz::format_error(error).c_str();
+    return false;
+  }
+
+  return true;
+}
+
+void FileService::loadQuerySelections() {
+  if (!fs::is_regular_file(m_querySelectionsPath)) {
+    fs::create_directories(m_querySelectionsPath.parent_path());
+    if (!saveQuerySelections()) {
+      qWarning() << "Unable to create file query selections state at" << m_querySelectionsPath.c_str();
+    }
+  }
+
+  if (const auto error = glz::read_file_json(m_querySelections, m_querySelectionsPath.c_str(),
+                                             m_querySelectionsBuffer)) {
+    qWarning() << "Failed to read file query selections state at" << m_querySelectionsPath.c_str()
+               << glz::format_error(error).c_str();
+    m_querySelections.clear();
+  }
+
+  std::ranges::sort(m_querySelections, [](const auto &a, const auto &b) { return a.selectedAt > b.selectedAt; });
+  if (m_querySelections.size() > MAX_QUERY_SELECTIONS) {
+    m_querySelections.resize(MAX_QUERY_SELECTIONS);
+    saveQuerySelections();
+  }
+}
+
+bool FileService::saveQuerySelections() {
+  fs::create_directories(m_querySelectionsPath.parent_path());
+
+  if (const auto error = glz::write_file_json(m_querySelections, m_querySelectionsPath.c_str(),
+                                              m_querySelectionsBuffer)) {
+    qWarning() << "Failed to save file query selections state at" << m_querySelectionsPath.c_str()
                << glz::format_error(error).c_str();
     return false;
   }
@@ -138,15 +203,70 @@ bool FileService::recentFileMoreRecent(const SerializedRecentFile &a, const Seri
   return a.lastAccessedAt > b.lastAccessedAt;
 }
 
+std::optional<std::uint64_t> FileService::fileModifiedAt(const std::filesystem::path &path) {
+  std::error_code ec;
+  auto const fileTime = std::filesystem::last_write_time(path, ec);
+  if (ec) return std::nullopt;
+
+  using namespace std::chrono;
+  auto const nowSystem = system_clock::now();
+  auto const nowFile = std::filesystem::file_time_type::clock::now();
+  auto const adjusted = time_point_cast<system_clock::duration>(fileTime - nowFile + nowSystem);
+  return static_cast<std::uint64_t>(duration_cast<seconds>(adjusted.time_since_epoch()).count());
+}
+
+std::optional<std::uint64_t> FileService::recentUsageAt(const std::filesystem::path &path) const {
+  auto const pathString = path.string();
+  auto it = std::ranges::find_if(m_recentFiles, [&](const auto &file) { return file.path == pathString; });
+  if (it == m_recentFiles.end()) return std::nullopt;
+  return it->lastAccessedAt;
+}
+
+std::optional<std::uint64_t> FileService::queryUsageAt(std::string_view query,
+                                                       const std::filesystem::path &path) const {
+  if (query.empty()) return std::nullopt;
+
+  auto const pathString = path.string();
+  auto it = std::ranges::find_if(m_querySelections, [&](const auto &selection) {
+    return selection.query == query && selection.path == pathString;
+  });
+  if (it == m_querySelections.end()) return std::nullopt;
+  return it->selectedAt;
+}
+
+void FileService::sortFilesIfRequested(std::vector<IndexerFileResult> &results, std::string_view query) const {
+  std::ranges::stable_sort(results, [this, query](const auto &a, const auto &b) {
+    auto const aQueryUsed = queryUsageAt(query, a.path);
+    auto const bQueryUsed = queryUsageAt(query, b.path);
+    if (aQueryUsed != bQueryUsed) { return aQueryUsed.has_value(); }
+    if (aQueryUsed && bQueryUsed && aQueryUsed != bQueryUsed) { return aQueryUsed > bQueryUsed; }
+
+    auto const aUsed = recentUsageAt(a.path);
+    auto const bUsed = recentUsageAt(b.path);
+    if (aUsed != bUsed) { return aUsed.has_value(); }
+    if (aUsed && bUsed && aUsed != bUsed) { return aUsed > bUsed; }
+
+    auto const aModified = fileModifiedAt(a.path);
+    auto const bModified = fileModifiedAt(b.path);
+    if (aModified != bModified) { return aModified.has_value(); }
+    if (aModified && bModified && aModified != bModified) { return aModified > bModified; }
+
+    return a.path < b.path;
+  });
+}
+
 void FileService::preferenceValuesChanged(const QJsonObject &preferences) {
+  m_defaultOrderingEnabled = preferences.value("defaultOrdering").toBool(false);
   m_indexer->preferenceValuesChanged(preferences);
 }
 
 FileService::FileService(OmniDatabase &db)
-    : m_db(db), m_recentFilesPath(Omnicast::stateDir() / RECENT_FILES_NAME) {
+    : m_db(db), m_recentFilesPath(Omnicast::stateDir() / RECENT_FILES_NAME),
+      m_querySelectionsPath(Omnicast::stateDir() / QUERY_SELECTIONS_NAME) {
   bool const shouldMigrateRecentFiles = !fs::is_regular_file(m_recentFilesPath);
 
   loadRecentFiles();
+  loadQuerySelections();
   if (shouldMigrateRecentFiles) { migrateRecentFilesFromDatabase(); }
 
 #if defined(Q_OS_LINUX)

--- a/src/server/src/services/files-service/file-service.hpp
+++ b/src/server/src/services/files-service/file-service.hpp
@@ -2,6 +2,7 @@
 #include "omni-database.hpp"
 #include "services/files-service/abstract-file-indexer.hpp"
 #include <QDateTime>
+#include <QJsonObject>
 #include <cstdint>
 #include <filesystem>
 #include <memory>
@@ -27,6 +28,7 @@ public:
 
   std::vector<RecentFile> getRecentlyAccessed() const;
   void saveAccess(const std::filesystem::path &path);
+  void saveQuerySelection(std::string_view query, const std::filesystem::path &path);
   bool clearRecentlyAccessed();
 
   void preferenceValuesChanged(const QJsonObject &preferences);
@@ -40,17 +42,34 @@ private:
     std::uint64_t lastAccessedAt = 0;
   };
 
+  struct QuerySelection {
+    std::string query;
+    std::string path;
+    std::uint64_t selectedAt = 0;
+  };
+
   static constexpr size_t MAX_RECENT_FILES = 50;
+  static constexpr size_t MAX_QUERY_SELECTIONS = 2000;
 
   void loadRecentFiles();
   bool saveRecentFiles();
+  void loadQuerySelections();
+  bool saveQuerySelections();
   void migrateRecentFilesFromDatabase();
   static RecentFile fromSerialized(const SerializedRecentFile &file);
   static bool recentFileMoreRecent(const SerializedRecentFile &a, const SerializedRecentFile &b);
+  static std::optional<std::uint64_t> fileModifiedAt(const std::filesystem::path &path);
+  std::optional<std::uint64_t> recentUsageAt(const std::filesystem::path &path) const;
+  std::optional<std::uint64_t> queryUsageAt(std::string_view query, const std::filesystem::path &path) const;
+  void sortFilesIfRequested(std::vector<IndexerFileResult> &results, std::string_view query) const;
 
   OmniDatabase &m_db;
   std::filesystem::path m_recentFilesPath;
   std::string m_recentFilesBuffer;
   std::vector<SerializedRecentFile> m_recentFiles;
+  std::filesystem::path m_querySelectionsPath;
+  std::string m_querySelectionsBuffer;
+  std::vector<QuerySelection> m_querySelections;
   std::unique_ptr<AbstractFileIndexer> m_indexer;
+  bool m_defaultOrderingEnabled = false;
 };

--- a/src/server/src/services/root-item-manager/root-item-manager.cpp
+++ b/src/server/src/services/root-item-manager/root-item-manager.cpp
@@ -138,28 +138,7 @@ float RootItemManager::SearchableRootItem::fuzzyScore(std::string_view pattern) 
   float const score =
       pattern.empty() ? 1 : fzf::threadLocalMatcher().fuzzy_match_v2_score_query(ss, kws, pattern);
 
-  if (score == 0) return 0;
-
-  constexpr double FRECENCY_BOOST_CAP = 25.0;
-  constexpr double FRECENCY_FREQ_SCALE = 5.0;
-  constexpr double FRECENCY_RECENCY_PEAK = 10.0;
-  constexpr double FRECENCY_RECENCY_HALF_LIFE_DAYS = 30.0;
-  constexpr double SECONDS_PER_DAY = 86400.0;
-
-  double const frequencyTerm = FRECENCY_FREQ_SCALE * std::log(1 + meta->visitCount * 0.1);
-
-  double recencyTerm = 0.0;
-  if (meta->lastVisitedAt) {
-    double const daysSince =
-        (QDateTime::currentSecsSinceEpoch() - static_cast<std::int64_t>(*meta->lastVisitedAt)) /
-        SECONDS_PER_DAY;
-    recencyTerm =
-        FRECENCY_RECENCY_PEAK * std::exp(-std::max(0.0, daysSince) / FRECENCY_RECENCY_HALF_LIFE_DAYS);
-  }
-
-  double const boost = std::min(FRECENCY_BOOST_CAP, frequencyTerm + recencyTerm);
-
-  return score + boost;
+  return score;
 }
 
 std::vector<RootItemManager::ScoredItem> RootItemManager::search(const QString &query,
@@ -185,7 +164,67 @@ void RootItemManager::search(const QString &query, std::vector<ScoredItem> &resu
 
     if (!fuzzyScore) { continue; }
 
-    results.emplace_back(ScoredItem{.meta = item.meta, .score = fuzzyScore, .item = item.item});
+    double score = fuzzyScore;
+    if (auto const &cfg = m_cfg.value(); cfg.rollingKnowledge) {
+      auto usage = m_visitTracker.getRollingUsage(item.meta->item->uniqueId());
+      constexpr double ROLLING_BOOST_CAP = 25.0;
+      constexpr double ROLLING_FREQ_SCALE = 5.0;
+      constexpr double ROLLING_RECENCY_PEAK = 10.0;
+      constexpr double ROLLING_RECENCY_HALF_LIFE_DAYS = 14.0;
+      constexpr double SECONDS_PER_DAY = 86400.0;
+
+      double const frequencyTerm = ROLLING_FREQ_SCALE * std::log(1 + usage.visitCount * 0.1);
+      double recencyTerm = 0.0;
+      if (usage.lastVisitedAt) {
+        double const daysSince =
+            (QDateTime::currentSecsSinceEpoch() - static_cast<std::int64_t>(*usage.lastVisitedAt)) /
+            SECONDS_PER_DAY;
+        recencyTerm = ROLLING_RECENCY_PEAK * std::exp(-std::max(0.0, daysSince) / ROLLING_RECENCY_HALF_LIFE_DAYS);
+      }
+
+      score += std::min(ROLLING_BOOST_CAP, frequencyTerm + recencyTerm);
+    } else {
+      constexpr double FRECENCY_BOOST_CAP = 25.0;
+      constexpr double FRECENCY_FREQ_SCALE = 5.0;
+      constexpr double FRECENCY_RECENCY_PEAK = 10.0;
+      constexpr double FRECENCY_RECENCY_HALF_LIFE_DAYS = 30.0;
+      constexpr double SECONDS_PER_DAY = 86400.0;
+
+      double const frequencyTerm = FRECENCY_FREQ_SCALE * std::log(1 + item.meta->visitCount * 0.1);
+      double recencyTerm = 0.0;
+      if (item.meta->lastVisitedAt) {
+        double const daysSince =
+            (QDateTime::currentSecsSinceEpoch() - static_cast<std::int64_t>(*item.meta->lastVisitedAt)) /
+            SECONDS_PER_DAY;
+        recencyTerm =
+            FRECENCY_RECENCY_PEAK * std::exp(-std::max(0.0, daysSince) / FRECENCY_RECENCY_HALF_LIFE_DAYS);
+      }
+
+      score += std::min(FRECENCY_BOOST_CAP, frequencyTerm + recencyTerm);
+    }
+
+    if (m_cfg.value().keywordLatching) {
+      auto queryUsage = m_visitTracker.getQueryUsage(pattern, item.meta->item->uniqueId());
+      constexpr double LATCH_BOOST_CAP = 30.0;
+      constexpr double LATCH_FREQ_SCALE = 8.0;
+      constexpr double LATCH_RECENCY_PEAK = 12.0;
+      constexpr double LATCH_RECENCY_HALF_LIFE_DAYS = 14.0;
+      constexpr double SECONDS_PER_DAY = 86400.0;
+
+      double const frequencyTerm = LATCH_FREQ_SCALE * std::log(1 + queryUsage.visitCount * 0.1);
+      double recencyTerm = 0.0;
+      if (queryUsage.lastVisitedAt) {
+        double const daysSince =
+            (QDateTime::currentSecsSinceEpoch() - static_cast<std::int64_t>(*queryUsage.lastVisitedAt)) /
+            SECONDS_PER_DAY;
+        recencyTerm =
+            LATCH_RECENCY_PEAK * std::exp(-std::max(0.0, daysSince) / LATCH_RECENCY_HALF_LIFE_DAYS);
+      }
+
+      score += std::min(LATCH_BOOST_CAP, frequencyTerm + recencyTerm);
+    }
+
+    results.emplace_back(ScoredItem{.meta = item.meta, .score = score, .item = item.item});
   }
 
   // we need stable sort to avoid flickering when updating quickly
@@ -513,10 +552,10 @@ bool RootItemManager::resetRanking(const EntrypointId &id) {
   return true;
 }
 
-bool RootItemManager::registerVisit(const EntrypointId &id) {
+bool RootItemManager::registerVisit(const EntrypointId &id, std::string_view query) {
   ++m_metadata[id].visitCount;
   m_metadata[id].lastVisitedAt = QDateTime::currentSecsSinceEpoch();
-  m_visitTracker.registerVisit(id);
+  m_visitTracker.registerVisit(id, query);
   return true;
 }
 

--- a/src/server/src/services/root-item-manager/root-item-manager.hpp
+++ b/src/server/src/services/root-item-manager/root-item-manager.hpp
@@ -288,7 +288,7 @@ public:
   bool enableFallback(const EntrypointId &id);
   std::vector<std::shared_ptr<RootItem>> queryFavorites(std::optional<int> limit = {});
   bool resetRanking(const EntrypointId &id);
-  bool registerVisit(const EntrypointId &id);
+  bool registerVisit(const EntrypointId &id, std::string_view query = {});
   bool setItemAsFavorite(const EntrypointId &item, bool value = true);
   bool setProviderEnabled(const QString &providerId, bool value);
   bool disableItem(const EntrypointId &id);

--- a/src/server/src/services/root-item-manager/visit-tracker.cpp
+++ b/src/server/src/services/root-item-manager/visit-tracker.cpp
@@ -5,15 +5,27 @@
 #include <glaze/util/key_transformers.hpp>
 #include <qlogging.h>
 #include <QDateTime>
+#include <algorithm>
 
 namespace fs = std::filesystem;
 
 VisitTracker::VisitTracker(const fs::path &path) : m_path(path) { loadFromDisk(); }
 
-void VisitTracker::registerVisit(const EntrypointId &id) {
+void VisitTracker::registerVisit(const EntrypointId &id, std::string_view query) {
   VisitInfo &data = m_data.visited[id];
   data.lastVisitedAt = QDateTime::currentSecsSinceEpoch();
   ++data.visitCount;
+  if (!query.empty()) {
+    auto now = static_cast<std::uint64_t>(QDateTime::currentSecsSinceEpoch());
+    auto &event = m_data.usageEvents.emplace_back(Data::UsageEvent{.itemId = std::string{id},
+                                                                  .query = std::string{query},
+                                                                  .visitedAt = now});
+    (void)event;
+  }
+
+  pruneUsageEvents();
+  rebuildRollingUsageIndex();
+
   // todo: we might want to flush ever X seconds instead of saving directly
   saveToDisk();
 }
@@ -23,8 +35,26 @@ VisitTracker::VisitInfo VisitTracker::getVisit(const EntrypointId &id) const {
   return {};
 }
 
+VisitTracker::QueryUsageInfo VisitTracker::getRollingUsage(const EntrypointId &id) const {
+  if (auto it = m_rollingUsageByItem.find(std::string{id}); it != m_rollingUsageByItem.end()) {
+    return it->second;
+  }
+  return {};
+}
+
+VisitTracker::QueryUsageInfo VisitTracker::getQueryUsage(std::string_view query, const EntrypointId &id) const {
+  if (query.empty()) return {};
+  if (auto it = m_queryUsageByText.find(std::string{query}); it != m_queryUsageByText.end()) {
+    if (auto it2 = it->second.find(std::string{id}); it2 != it->second.end()) { return it2->second; }
+  }
+  return {};
+}
+
 void VisitTracker::forget(const EntrypointId &id) {
   m_data.visited.erase(id);
+  std::string const sid = id;
+  std::erase_if(m_data.usageEvents, [&](const auto &event) { return event.itemId == sid; });
+  rebuildRollingUsageIndex();
   saveToDisk();
 }
 
@@ -32,6 +62,9 @@ void VisitTracker::loadFromDisk() {
   if (auto error = glz::read_file_jsonc(m_data, m_path.c_str(), m_buf)) {
     qWarning() << "Failed to load visits file from" << m_path.c_str() << glz::format_error(error);
   }
+
+  pruneUsageEvents();
+  rebuildRollingUsageIndex();
 }
 
 void VisitTracker::saveToDisk() {
@@ -40,4 +73,35 @@ void VisitTracker::saveToDisk() {
   }
 }
 
+void VisitTracker::pruneUsageEvents() {
+  auto const now = static_cast<std::uint64_t>(QDateTime::currentSecsSinceEpoch());
+  auto const cutoff = now > ROLLING_WINDOW_SECONDS ? now - ROLLING_WINDOW_SECONDS : 0;
+
+  auto firstFresh = std::ranges::find_if(m_data.usageEvents, [&](const auto &event) {
+    return event.visitedAt >= cutoff;
+  });
+
+  if (firstFresh != m_data.usageEvents.begin()) {
+    m_data.usageEvents.erase(m_data.usageEvents.begin(), firstFresh);
+  }
+}
+
+void VisitTracker::rebuildRollingUsageIndex() {
+  m_rollingUsageByItem.clear();
+  m_queryUsageByText.clear();
+
+  for (const auto &event : m_data.usageEvents) {
+    auto &itemUsage = m_rollingUsageByItem[event.itemId];
+    itemUsage.lastVisitedAt = event.visitedAt;
+    ++itemUsage.visitCount;
+
+    auto &queryUsage = m_queryUsageByText[event.query][event.itemId];
+    queryUsage.lastVisitedAt = event.visitedAt;
+    ++queryUsage.visitCount;
+  }
+}
+
 template <> struct glz::meta<VisitTracker::VisitInfo> : glz::snake_case {};
+template <> struct glz::meta<VisitTracker::Data> : glz::snake_case {};
+template <> struct glz::meta<VisitTracker::QueryUsageInfo> : glz::snake_case {};
+template <> struct glz::meta<VisitTracker::Data::UsageEvent> : glz::snake_case {};

--- a/src/server/src/services/root-item-manager/visit-tracker.hpp
+++ b/src/server/src/services/root-item-manager/visit-tracker.hpp
@@ -1,8 +1,10 @@
 #pragma once
 #include "common/entrypoint.hpp"
 #include <cstdint>
-#include <unordered_map>
 #include <filesystem>
+#include <unordered_map>
+#include <string_view>
+#include <vector>
 
 class VisitTracker {
 public:
@@ -11,21 +13,41 @@ public:
     int visitCount = 0;
   };
 
+  struct QueryUsageInfo {
+    std::optional<std::uint64_t> lastVisitedAt;
+    int visitCount = 0;
+  };
+
   struct Data {
     std::unordered_map<std::string, VisitInfo> visited;
+    struct UsageEvent {
+      std::string itemId;
+      std::string query;
+      std::uint64_t visitedAt;
+    };
+
+    std::vector<UsageEvent> usageEvents;
   };
 
   VisitTracker(const std::filesystem::path &path);
 
-  void registerVisit(const EntrypointId &id);
+  void registerVisit(const EntrypointId &id, std::string_view query = {});
   void forget(const EntrypointId &id);
   VisitInfo getVisit(const EntrypointId &id) const;
+  QueryUsageInfo getRollingUsage(const EntrypointId &id) const;
+  QueryUsageInfo getQueryUsage(std::string_view query, const EntrypointId &id) const;
 
 private:
+  static constexpr std::uint64_t ROLLING_WINDOW_SECONDS = 28ULL * 24ULL * 60ULL * 60ULL;
+
   void loadFromDisk();
   void saveToDisk();
+  void rebuildRollingUsageIndex();
+  void pruneUsageEvents();
 
   std::filesystem::path m_path;
   std::string m_buf;
   Data m_data;
+  std::unordered_map<std::string, QueryUsageInfo> m_rollingUsageByItem;
+  std::unordered_map<std::string, std::unordered_map<std::string, QueryUsageInfo>> m_queryUsageByText;
 };


### PR DESCRIPTION
- App-wide search ranking settings were added in `src/server/src/config/config.hpp`, surfaced in `src/server/src/qml/general-settings-model.hpp`, `src/server/src/qml/general-settings-model.cpp`, and exposed in the UI in `src/server/src/qml/qml/AdvancedSettingsPage.qml`. Added Rolling Knowledge and Keyword Latching as off-by-default toggles.
- Root search ranking now uses a rolling usage history plus exact-query latching in `src/server/src/services/root-item-manager/visit-tracker.hpp`, `src/server/src/services/root-item-manager/visit-tracker.cpp`, `src/server/src/services/root-item-manager/root-item-manager.hpp`, and `src/server/src/services/root-item-manager/root-item-manager.cpp`. Also routed selection recording through `src/server/src/actions/root-search/root-search-actions.cpp` so the active query is captured before execution clears it. This was necessary because the old frecency path only tracked item visits, not query-specific intent.
- File search got its own default ordering setting in `src/server/src/extensions/file/file-extension.hpp`, persisted through the existing provider preferences system, and applied in `src/server/src/services/files-service/file-service.hpp` and `src/server/src/services/files-service/file-service.cpp`. Query-to-file selections get stored in a separate JSON state file because that matches the existing pattern used for recent files, while avoiding a heavier database migration. The ordering priority is now keyword latching first, then recently selected files, then file modified time, with the default behavior preserved when the toggle is off.
- File search selection recording was hooked into `src/server/src/actions/files/file-actions.hpp`, and the file search view in `src/server/src/qml/search-files-view-host.cpp` continues to feed the shared service. The query gets captured before launching the file, because the open action can clear the search text; without that, latching would silently record empty or stale queries.