### PR TITLE
ci: bump install-nix-action v25 -> v31

### DIFF
--- a/.github/workflows/cachix.yaml
+++ b/.github/workflows/cachix.yaml
@@ -19,7 +19,7 @@ jobs:
         os: [depot-ubuntu-24.04-16, depot-ubuntu-24.04-arm-16, depot-macos-26]
     steps:
     - uses: actions/checkout@v4
-    - uses: cachix/install-nix-action@v25
+    - uses: cachix/install-nix-action@v31
     - name: Cache Nix Evaluation
       uses: actions/cache@v4
       with:


### PR DESCRIPTION
v25 ships the Nix 2.19.2 installer, which assigns `_nixbld1` to UID 301. On macOS Sequoia (15) and later that UID is already taken by a system account, so the installer fails with `eDSRecordAlreadyExists` on the depot-macos-26 runner. v31 bundles a fixed installer that uses a non-colliding UID range.

Refs: https://github.com/NixOS/nix/issues/10892

fixes https://github.com/vicinaehq/vicinae/actions/runs/28321040747/job/83902909328