### PR TITLE
fix: change Form components to use FocusScope

### DIFF
--- a/src/server/src/qml/qml/FormCompletedInput.qml
+++ b/src/server/src/qml/qml/FormCompletedInput.qml
@@ -2,7 +2,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 
-Item {
+FocusScope {
     id: root
     implicitHeight: 36
     Layout.fillWidth: true

--- a/src/server/src/qml/qml/FormCompletedTextArea.qml
+++ b/src/server/src/qml/qml/FormCompletedTextArea.qml
@@ -2,7 +2,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 
-Item {
+FocusScope {
     id: root
     Layout.fillWidth: true
     activeFocusOnTab: true

--- a/src/server/src/qml/qml/FormDateInput.qml
+++ b/src/server/src/qml/qml/FormDateInput.qml
@@ -1,7 +1,7 @@
 import QtQuick
 import QtQuick.Layouts
 
-Item {
+FocusScope {
     id: root
     implicitHeight: 36
     Layout.fillWidth: true

--- a/src/server/src/qml/qml/FormTextArea.qml
+++ b/src/server/src/qml/qml/FormTextArea.qml
@@ -2,7 +2,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 
-Item {
+FocusScope {
     id: root
     Layout.fillWidth: true
     activeFocusOnTab: true

--- a/src/server/src/qml/qml/FormTextInput.qml
+++ b/src/server/src/qml/qml/FormTextInput.qml
@@ -1,7 +1,7 @@
 import QtQuick
 import QtQuick.Layouts
 
-Item {
+FocusScope {
     id: root
     implicitHeight: 36
     Layout.fillWidth: true


### PR DESCRIPTION
Use FocusScope to enable native Tab and Shift-Tab support
fixes #1563 