### PR TITLE
build: macOS development codesigning

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,2 @@
 use flake
+source_env_if_exists .envrc.local

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ heaptrack*
 
 
 .worktrees
+.envrc.local

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,8 @@ option(ENABLE_SANITIZERS "Enable ASan + UBSan for debug builds" OFF)
 option(ENABLE_CLANG_TIDY "Run clang-tidy during compilation" OFF)
 option(INSTALL_MODULES_LOAD_CONFIG "Install config files to auto load required kernel modules" ON)
 
+set(VICINAE_BUNDLE_ID "com.vicinaehq.Vicinae" CACHE STRING "macOS app bundle identifier")
+
 if (ENABLE_CLANG_TIDY)
 	set(CMAKE_CXX_CLANG_TIDY clang-tidy)
 endif()

--- a/extra/Info.plist.in
+++ b/extra/Info.plist.in
@@ -11,7 +11,7 @@
 	<key>CFBundleIconFile</key>
 	<string>vicinae</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.vicinaehq.Vicinae</string>
+	<string>@VICINAE_BUNDLE_ID@</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -1014,6 +1014,15 @@ target_link_libraries(${TARGET} PRIVATE ${LIBS})
 if(APPLE)
 	target_link_libraries(${TARGET} PRIVATE "-framework AppKit" "-framework QuartzCore" "-framework UniformTypeIdentifiers" "-framework Carbon" "-framework CoreServices" "-framework ApplicationServices" "-F/System/Library/PrivateFrameworks" "-framework login")
 endif()
+
+if(APPLE AND DEFINED ENV{VICINAE_CODESIGN_IDENTITY})
+	add_custom_command(TARGET ${TARGET} POST_BUILD
+		COMMAND codesign --force --identifier ${VICINAE_BUNDLE_ID}
+			--sign "$ENV{VICINAE_CODESIGN_IDENTITY}" $<TARGET_FILE:${TARGET}>
+		VERBATIM
+		COMMENT "codesign ${TARGET} ($ENV{VICINAE_CODESIGN_IDENTITY})")
+endif()
+
 target_compile_features(${TARGET} PUBLIC cxx_std_23)
 
 # Workaround: libc++ pre-C++26 has unconstrained std::variant relational operators,


### PR DESCRIPTION
Handle codesigning as a postbuild step during development, so that TCC/keychain prompts do not have to be repeated all the time