### PR TITLE
feat: macOS compatible extension store

### DIFF
--- a/src/server/src/extensions/raycast/raycast-store-command.hpp
+++ b/src/server/src/extensions/raycast/raycast-store-command.hpp
@@ -1,5 +1,6 @@
 #include "qml/raycast-store-view-host.hpp"
 #include "qml/store-intro-view-host.hpp"
+#include "services/raycast/raycast-store.hpp"
 #include "single-view-command-context.hpp"
 #include "theme.hpp"
 
@@ -25,15 +26,25 @@ class RaycastStoreCommand : public BuiltinCallbackCommand {
     auto alwaysShowIntro = ctrl->preferenceValues().value("alwaysShowIntro").toBool(false);
 
     if (alwaysShowIntro || !ctrl->storage().getItem("introCompleted").toBool()) {
-      static const QString INTRO = QStringLiteral(R"(
+      static const QString INTRO = [] {
+        QString intro = QStringLiteral(R"(
 # Welcome to the Raycast Extension Store
 
 Vicinae provides direct integration with the official [Raycast store](https://www.raycast.com/store), allowing you to search and install Raycast extensions directly from Vicinae.
-
+)");
+        if constexpr (Raycast::hasCompatSheet()) {
+          intro += QStringLiteral(R"(
 Each extension has a colored compatibility indicator showing how well it works on Linux.
 
-Vicinae also has its own [extension store](vicinae://extensions/vicinae/core/store), which does not suffer from these limitations.
+Vicinae also has its own [extension store](vicinae://launch/core/store), which does not suffer from these limitations.
 )");
+        } else {
+          intro += QStringLiteral(R"(
+Vicinae also has its own [extension store](vicinae://launch/core/store).
+)");
+        }
+        return intro;
+      }();
       auto icon = iconUrl();
       auto storage = ctrl->storage();
       ctx->navigation->pushView(

--- a/src/server/src/qml/markdown/markdown-model.cpp
+++ b/src/server/src/qml/markdown/markdown-model.cpp
@@ -35,6 +35,7 @@ QString imageProviderUrl(const QString &rawUrl) {
   QUrl const url(rawUrl);
   auto const scheme = url.scheme();
 
+  if (scheme == "icon") return rawUrl;
   if (scheme == "https" || scheme == "http") return ImageURL::http(url).toString();
 
   if (scheme == "data") {

--- a/src/server/src/qml/raycast-store-detail-host.cpp
+++ b/src/server/src/qml/raycast-store-detail-host.cpp
@@ -88,6 +88,8 @@ void RaycastStoreDetailHost::hydrate(const Raycast::Extension &extension) {
 }
 
 void RaycastStoreDetailHost::buildAlert() {
+  if constexpr (!Raycast::hasCompatSheet()) return;
+
   const auto &compat = context()->services->raycastStore()->compatMap();
   if (auto it = compat.find(m_ext.name.toStdString()); it != compat.end()) {
     auto tier = Raycast::compatTierFromInfo(it->second);

--- a/src/server/src/qml/raycast-store-model.cpp
+++ b/src/server/src/qml/raycast-store-model.cpp
@@ -13,9 +13,12 @@ void RaycastStoreSection::setEntries(const std::vector<Raycast::Extension> &exte
   m_entries.clear();
   m_entries.reserve(extensions.size());
   for (const auto &ext : extensions) {
-    auto tier = Raycast::CompatTier::Unknown;
-    if (auto it = compat.find(ext.name.toStdString()); it != compat.end()) {
-      tier = Raycast::compatTierFromInfo(it->second);
+    std::optional<Raycast::CompatTier> tier;
+    if constexpr (Raycast::hasCompatSheet()) {
+      tier = Raycast::CompatTier::Unknown;
+      if (auto it = compat.find(ext.name.toStdString()); it != compat.end()) {
+        tier = Raycast::compatTierFromInfo(it->second);
+      }
     }
     m_entries.push_back({.extension = ext, .installed = registry->isInstalled(ext.id), .compatTier = tier});
   }
@@ -63,7 +66,7 @@ QVariant RaycastStoreSection::customData(int i, int role) const {
   case IsInstalled:
     return entry.installed;
   case CompatTierRole:
-    return static_cast<int>(entry.compatTier);
+    return entry.compatTier ? static_cast<int>(*entry.compatTier) : -1;
   default:
     return {};
   }

--- a/src/server/src/qml/raycast-store-model.hpp
+++ b/src/server/src/qml/raycast-store-model.hpp
@@ -16,7 +16,7 @@ public:
   struct Entry {
     Raycast::Extension extension;
     bool installed = false;
-    Raycast::CompatTier compatTier = Raycast::CompatTier::Unknown;
+    std::optional<Raycast::CompatTier> compatTier;
   };
 
   void setEntries(const std::vector<Raycast::Extension> &extensions, ExtensionRegistry *registry,

--- a/src/server/src/qml/raycast-store-view-host.hpp
+++ b/src/server/src/qml/raycast-store-view-host.hpp
@@ -42,5 +42,5 @@ private:
   QString m_lastQueryText;
   QTimer m_debounce;
   std::optional<Raycast::ListResponse> m_pendingPage;
-  bool m_compatReady = false;
+  bool m_compatReady = !Raycast::hasCompatSheet();
 };

--- a/src/server/src/services/extension-store/vicinae-store.cpp
+++ b/src/server/src/services/extension-store/vicinae-store.cpp
@@ -4,6 +4,8 @@
 #include "environment.hpp"
 #include "theme.hpp"
 #include "theme/theme-file.hpp"
+#include "utils/capabilities.hpp"
+#include <algorithm>
 
 namespace VicinaeStore {
 
@@ -19,12 +21,23 @@ std::optional<ImageURL> Command::themedIcon() const { return icons.themedIcon();
 
 ImageURL Extension::themedIcon() const {
   if (auto icon = icons.themedIcon()) return *icon;
-  return ImageURL::builtin("puzzle-piece");
+  return ImageURL::builtin("plug");
 }
 
 } // namespace VicinaeStore
 
+static bool availableOnCurrentPlatform(const VicinaeStore::Extension &ext) {
+  if (ext.platforms.empty()) return true;
+
+  constexpr std::string_view name = platform::extensionPlatform();
+  const QLatin1StringView current(name.data(), static_cast<qsizetype>(name.size()));
+  return std::ranges::any_of(ext.platforms, [&](const QString &p) {
+    return QStringView(p).trimmed().compare(current, Qt::CaseInsensitive) == 0;
+  });
+}
+
 static void postProcess(VicinaeStore::ListResponse &response) {
+  std::erase_if(response.extensions, [](const auto &ext) { return !availableOnCurrentPlatform(ext); });
   for (auto &ext : response.extensions) {
     ext.id = QString("store.vicinae.%1").arg(ext.name);
   }

--- a/src/server/src/services/extension-store/vicinae-store.cpp
+++ b/src/server/src/services/extension-store/vicinae-store.cpp
@@ -27,13 +27,8 @@ ImageURL Extension::themedIcon() const {
 } // namespace VicinaeStore
 
 static bool availableOnCurrentPlatform(const VicinaeStore::Extension &ext) {
-  if (ext.platforms.empty()) return true;
-
-  constexpr std::string_view name = platform::extensionPlatform();
-  const QLatin1StringView current(name.data(), static_cast<qsizetype>(name.size()));
-  return std::ranges::any_of(ext.platforms, [&](const QString &p) {
-    return QStringView(p).trimmed().compare(current, Qt::CaseInsensitive) == 0;
-  });
+  return ext.platforms.empty() || std::ranges::contains(ext.platforms, platform::extensionPlatform(),
+                                                        [](const QString &p) { return p.toLower(); });
 }
 
 static void postProcess(VicinaeStore::ListResponse &response) {

--- a/src/server/src/services/raycast/raycast-store.cpp
+++ b/src/server/src/services/raycast/raycast-store.cpp
@@ -1,6 +1,20 @@
 #include "raycast-store.hpp"
 #include "environment.hpp"
 #include "internal/glaze-qt.hpp"
+#include "utils/capabilities.hpp"
+#include <algorithm>
+
+static bool availableOnCurrentPlatform(const Raycast::Extension &ext) {
+  if constexpr (!Raycast::isNativePlatform()) return true;
+
+  if (!ext.platforms) return platform::extensionPlatform() == "macOS";
+
+  constexpr std::string_view name = platform::extensionPlatform();
+  const QLatin1StringView current(name.data(), static_cast<qsizetype>(name.size()));
+  return std::ranges::any_of(*ext.platforms, [&](const QString &p) {
+    return QStringView(p).trimmed().compare(current, Qt::CaseInsensitive) == 0;
+  });
+}
 
 RaycastStoreService::RaycastStoreService() {
   m_client.setBaseUrl(QStringLiteral("https://backend.raycast.com/api/v1"));
@@ -21,6 +35,7 @@ void RaycastStoreService::postProcess(Raycast::Extension &ext) {
 }
 
 void RaycastStoreService::postProcess(std::vector<Raycast::Extension> &extensions) {
+  std::erase_if(extensions, [](const auto &ext) { return !availableOnCurrentPlatform(ext); });
   for (auto &ext : extensions) {
     postProcess(ext);
   }
@@ -59,7 +74,9 @@ QFuture<Raycast::DownloadExtensionResult> RaycastStoreService::downloadExtension
 }
 
 QFuture<Raycast::CompatResult> RaycastStoreService::fetchCompat() {
-  if (m_compatFetched) { return QtFuture::makeReadyValueFuture<Raycast::CompatResult>(m_compat); }
+  if (!Raycast::hasCompatSheet() || m_compatFetched) {
+    return QtFuture::makeReadyValueFuture<Raycast::CompatResult>(m_compat);
+  }
 
   return m_vicinaeClient.get<Raycast::CompatMap>(QStringLiteral("/raycast/get-compat"))
       .then([this](http::Client::Result<Raycast::CompatMap> result) -> Raycast::CompatResult {

--- a/src/server/src/services/raycast/raycast-store.cpp
+++ b/src/server/src/services/raycast/raycast-store.cpp
@@ -7,13 +7,10 @@
 static bool availableOnCurrentPlatform(const Raycast::Extension &ext) {
   if constexpr (!Raycast::isNativePlatform()) return true;
 
-  if (!ext.platforms) return platform::extensionPlatform() == "macOS";
+  if (!ext.platforms) return platform::extensionPlatform() == u"macos";
 
-  constexpr std::string_view name = platform::extensionPlatform();
-  const QLatin1StringView current(name.data(), static_cast<qsizetype>(name.size()));
-  return std::ranges::any_of(*ext.platforms, [&](const QString &p) {
-    return QStringView(p).trimmed().compare(current, Qt::CaseInsensitive) == 0;
-  });
+  return std::ranges::contains(*ext.platforms, platform::extensionPlatform(),
+                               [](const QString &p) { return p.toLower(); });
 }
 
 RaycastStoreService::RaycastStoreService() {

--- a/src/server/src/services/raycast/raycast-store.hpp
+++ b/src/server/src/services/raycast/raycast-store.hpp
@@ -68,7 +68,7 @@ struct Command {
   ImageURL themedIcon() const {
     if (auto icon = icons.themedIcon()) return *icon;
     if (auto icon = extensionIcons.themedIcon()) return *icon;
-    return ImageURL::builtin("puzzle-piece");
+    return ImageURL::builtin("plug");
   }
 };
 
@@ -106,7 +106,7 @@ struct Extension {
 
   ImageURL themedIcon() const {
     if (auto icon = icons.themedIcon()) return *icon;
-    return ImageURL::builtin("puzzle-piece");
+    return ImageURL::builtin("plug");
   }
 
   QDateTime createdAtDateTime() const { return QDateTime::fromSecsSinceEpoch(created_at); }
@@ -140,6 +140,22 @@ struct ListPaginationOptions {
   int page = 1;
   int perPage = 50;
 };
+
+constexpr bool isNativePlatform() {
+#if defined(Q_OS_MACOS) || defined(Q_OS_WIN)
+  return true;
+#else
+  return false;
+#endif
+}
+
+constexpr bool hasCompatSheet() {
+#ifdef Q_OS_LINUX
+  return true;
+#else
+  return false;
+#endif
+}
 
 struct CompatInfo {
   std::string status;

--- a/src/server/src/utils/capabilities.hpp
+++ b/src/server/src/utils/capabilities.hpp
@@ -1,7 +1,18 @@
 #pragma once
+#include <QtGlobal>
 #include <string_view>
 
 namespace platform {
+
+constexpr std::string_view extensionPlatform() {
+#if defined(Q_OS_MACOS)
+  return "macOS";
+#elif defined(Q_OS_WIN)
+  return "Windows";
+#else
+  return "linux";
+#endif
+}
 
 /**
  * A runtime fact about what the current install can do, as opposed to which OS

--- a/src/server/src/utils/capabilities.hpp
+++ b/src/server/src/utils/capabilities.hpp
@@ -1,16 +1,16 @@
 #pragma once
-#include <QtGlobal>
+#include <QStringView>
 #include <string_view>
 
 namespace platform {
 
-constexpr std::string_view extensionPlatform() {
+constexpr QStringView extensionPlatform() {
 #if defined(Q_OS_MACOS)
-  return "macOS";
+  return u"macos";
 #elif defined(Q_OS_WIN)
-  return "Windows";
+  return u"windows";
 #else
-  return "linux";
+  return u"linux";
 #endif
 }
 


### PR DESCRIPTION
Make it so that the Vicinae extension store only shows extensions that have been flagged as macOS compatible (still has to be done, display an empty list right now)