### PR TITLE
fix(api): loosen react types peer dependency

### DIFF
--- a/nix/vicinae.nix
+++ b/nix/vicinae.nix
@@ -56,7 +56,7 @@ in
 
     extensionManagerDeps = fetchNpmDeps {
       src = "${finalAttrs.src}/src/typescript/extension-manager";
-      hash = "sha256-6Kz7I8cGm1lnGPOI/gju3t5/imnbBFlDEKzWar5O770=";
+      hash = "sha256-nVLcJmkNRMXjK/ufVWkad/eRGMTGQrW9e4pTRNCbI34=";
     };
 
     cmakeFlags = lib.mapAttrsToList lib.cmakeFeature {

--- a/nix/vicinae.nix
+++ b/nix/vicinae.nix
@@ -51,7 +51,7 @@ in
 
     apiDeps = fetchNpmDeps {
       src = "${finalAttrs.src}/src/typescript/api";
-      hash = "sha256-Ki/l3PiBY3R0Bzd6leqx2OxA7c+jckjr+YD4GHHaSqI=";
+      hash = "sha256-kkiA0ygqT+lNOyJ/kF1JukLi+9t+jqz2Cc3jq+ah19o=";
     };
 
     extensionManagerDeps = fetchNpmDeps {

--- a/src/typescript/api/package-lock.json
+++ b/src/typescript/api/package-lock.json
@@ -28,7 +28,7 @@
 			},
 			"peerDependencies": {
 				"@types/node": ">=18",
-				"@types/react": "19.0.10"
+				"@types/react": "^19.0.0"
 			}
 		},
 		"node_modules/@biomejs/biome": {

--- a/src/typescript/api/package.json
+++ b/src/typescript/api/package.json
@@ -34,7 +34,7 @@
 	},
 	"peerDependencies": {
 		"@types/node": ">=18",
-		"@types/react": "19.0.10"
+		"@types/react": "^19.0.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.3.2",

--- a/src/typescript/extension-manager/package-lock.json
+++ b/src/typescript/extension-manager/package-lock.json
@@ -48,7 +48,7 @@
 			},
 			"peerDependencies": {
 				"@types/node": ">=18",
-				"@types/react": "19.0.10"
+				"@types/react": "^19.0.0"
 			}
 		},
 		"../raycast-api-compat": {


### PR DESCRIPTION
So that we don't need `--legacy-peer-deps`