### PR TITLE
feat: use standard unix data dirs on macOS

### DIFF
--- a/src/server/src/image-fetcher.hpp
+++ b/src/server/src/image-fetcher.hpp
@@ -5,7 +5,6 @@
 #include <qnetworkdiskcache.h>
 #include <qnetworkreply.h>
 #include <qobject.h>
-#include <qstandardpaths.h>
 #include <qstringview.h>
 #include <qthread.h>
 #include <deque>
@@ -42,7 +41,7 @@ class FetcherWorker : public QObject {
 
 public:
   void initialize() {
-    QString directory = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/images";
+    QString directory = QString::fromStdString((Omnicast::cacheDir() / "images").string());
 
     m_manager = new QNetworkAccessManager;
     m_diskCache = new QNetworkDiskCache;

--- a/src/server/src/internal/http-client.hpp
+++ b/src/server/src/internal/http-client.hpp
@@ -2,9 +2,9 @@
 #include <algorithm>
 #include <expected>
 #include "common/types.hpp"
+#include "vicinae.hpp"
 #include <glaze/core/reflect.hpp>
 #include <QNetworkDiskCache>
-#include <QStandardPaths>
 #include <qdir.h>
 #include <qfuture.h>
 #include <qfuturewatcher.h>
@@ -23,7 +23,7 @@ inline QNetworkAccessManager *networkManager() {
   static auto *mgr = [] {
     auto *m = new QNetworkAccessManager;
     auto *cache = new QNetworkDiskCache(m);
-    const QString cacheDir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/http";
+    const QString cacheDir = QString::fromStdString((Omnicast::cacheDir() / "http").string());
     QDir().mkpath(cacheDir);
     cache->setCacheDirectory(cacheDir);
     m->setCache(cache);

--- a/src/server/src/qml/clipboard-history-view-host.cpp
+++ b/src/server/src/qml/clipboard-history-view-host.cpp
@@ -4,10 +4,10 @@
 #include "service-registry.hpp"
 #include "services/clipboard/clipboard-service.hpp"
 #include "utils/utils.hpp"
+#include "vicinae.hpp"
 #include <QDateTime>
 #include <QDir>
 #include <QFile>
-#include <QStandardPaths>
 #include <QUrl>
 
 static std::optional<ClipboardOfferKind> kindFromFilterIndex(int index) {
@@ -230,7 +230,7 @@ void ClipboardHistoryViewHost::loadDetail(const ClipboardHistoryEntry &entry) {
   }
 
   if (mime.startsWith("image/")) {
-    auto const cacheDir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+    auto const cacheDir = QString::fromStdString(Omnicast::cacheDir().string());
     QDir().mkpath(cacheDir);
     QString const path = cacheDir + QStringLiteral("/clipboard-") + entry.md5sum;
     QFile f(path);

--- a/src/server/src/vicinae.cpp
+++ b/src/server/src/vicinae.cpp
@@ -1,4 +1,5 @@
 #include "vicinae.hpp"
+#include "utils.hpp"
 #include <qcoreapplication.h>
 #include <qlogging.h>
 #include <qprocess.h>
@@ -24,8 +25,7 @@ fs::path Omnicast::runtimeDir() {
 
 fs::path Omnicast::dataDir() {
 #ifdef Q_OS_MACOS
-  return fs::path(QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation).toStdString()) /
-         "vicinae";
+  return homeDir() / ".local" / "share" / "vicinae";
 #else
   return xdgpp::dataHome() / "vicinae";
 #endif
@@ -33,7 +33,7 @@ fs::path Omnicast::dataDir() {
 
 fs::path Omnicast::configDir() {
 #ifdef Q_OS_MACOS
-  return dataDir();
+  return homeDir() / ".config" / "vicinae";
 #else
   return xdgpp::configHome() / "vicinae";
 #endif
@@ -41,9 +41,17 @@ fs::path Omnicast::configDir() {
 
 fs::path Omnicast::stateDir() {
 #ifdef Q_OS_MACOS
-  return dataDir();
+  return homeDir() / ".local" / "state" / "vicinae";
 #else
   return xdgpp::stateHome() / "vicinae";
+#endif
+}
+
+fs::path Omnicast::cacheDir() {
+#ifdef Q_OS_MACOS
+  return homeDir() / ".cache" / "vicinae";
+#else
+  return xdgpp::cacheHome() / "vicinae";
 #endif
 }
 
@@ -89,7 +97,7 @@ fs::path Omnicast::commandSocketPath() { return runtimeDir() / "vicinae.sock"; }
 fs::path Omnicast::pidFile() { return runtimeDir() / "vicinae.pid"; }
 
 void Omnicast::ensureDirectories() {
-  for (auto const &dir : {runtimeDir(), dataDir(), stateDir(), configDir()}) {
+  for (auto const &dir : {runtimeDir(), dataDir(), stateDir(), configDir(), cacheDir()}) {
     std::error_code ec;
     fs::create_directories(dir, ec);
     if (ec) { qWarning() << "Failed to create directory" << dir.c_str() << ec.message(); }

--- a/src/server/src/vicinae.hpp
+++ b/src/server/src/vicinae.hpp
@@ -42,6 +42,7 @@ std::filesystem::path pidFile();
 std::filesystem::path dataDir();
 std::filesystem::path stateDir();
 std::filesystem::path configDir();
+std::filesystem::path cacheDir();
 
 // Read-only resources shipped with the application. On macOS this is
 // Vicinae.app/Contents/Resources; on other platforms it is the install-prefix


### PR DESCRIPTION
A lot of apps use the standard unix config/data directories on macOS although some of that can be stored under ~/Library. Since vicinae is going to be available both on Linux and macOS we think using these directories will be more familiar to most users.