### PR TITLE
feat: replace native wheel handler by kirigami's

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -1006,6 +1006,8 @@ set(VICINAE_QML_SOURCES
 	src/qml/popup-placement-attached.cpp
 	src/qml/shortcut-inhibitor-attached.hpp
 	src/qml/shortcut-inhibitor-attached.cpp
+	${CMAKE_SOURCE_DIR}/vendor/kirigami-wheelhandler/wheelhandler.h
+	${CMAKE_SOURCE_DIR}/vendor/kirigami-wheelhandler/wheelhandler.cpp
 )
 
 if(APPLE)
@@ -1040,7 +1042,7 @@ if(Qt6_FOUND)
     )
 endif()
 
-target_include_directories(${TARGET} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src ${CMAKE_CURRENT_SOURCE_DIR}/src/qml ${CMAKE_CURRENT_SOURCE_DIR}/src/qml/markdown)
+target_include_directories(${TARGET} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src ${CMAKE_CURRENT_SOURCE_DIR}/src/qml ${CMAKE_CURRENT_SOURCE_DIR}/src/qml/markdown ${CMAKE_SOURCE_DIR}/vendor/kirigami-wheelhandler)
 target_link_libraries(${TARGET} PRIVATE ${LIBS})
 if(APPLE)
 	target_link_libraries(${TARGET} PRIVATE "-framework AppKit" "-framework QuartzCore" "-framework UniformTypeIdentifiers" "-framework Carbon" "-framework CoreServices" "-framework ApplicationServices" "-framework CoreAudio" "-framework CoreFoundation" "-F/System/Library/PrivateFrameworks" "-framework login")

--- a/src/server/src/qml/qml/ActionListPanel.qml
+++ b/src/server/src/qml/qml/ActionListPanel.qml
@@ -133,6 +133,10 @@ Item {
             highlightMoveDuration: 0
             model: root.model
 
+            ViciWheelHandler {
+                target: listView
+            }
+
             delegate: Loader {
                 id: delegateLoader
                 width: listView.width

--- a/src/server/src/qml/qml/CompletionPopup.qml
+++ b/src/server/src/qml/qml/CompletionPopup.qml
@@ -197,6 +197,10 @@ Popup {
             clip: true
             boundsBehavior: Flickable.StopAtBounds
 
+            ViciWheelHandler {
+                target: completionList
+            }
+
             ScrollBar.vertical: ViciScrollBar {
                 policy: completionList.contentHeight > completionList.height ? ScrollBar.AsNeeded : ScrollBar.AlwaysOff
             }

--- a/src/server/src/qml/qml/GenericGridView.qml
+++ b/src/server/src/qml/qml/GenericGridView.qml
@@ -132,6 +132,10 @@ Item {
         reuseItems: true
         cacheBuffer: 200
 
+        ViciWheelHandler {
+            target: listView
+        }
+
         ScrollBar.vertical: ViciScrollBar {
             policy: listView.contentHeight > listView.height ? ScrollBar.AsNeeded : ScrollBar.AlwaysOff
         }

--- a/src/server/src/qml/qml/GenericListView.qml
+++ b/src/server/src/qml/qml/GenericListView.qml
@@ -182,6 +182,10 @@ Item {
             topMargin: 4
             bottomMargin: 4
 
+            ViciWheelHandler {
+                target: listView
+            }
+
             onCurrentIndexChanged: root.itemSelected(currentIndex)
             onCountChanged: {
                 if (root.autoWireModel && root.listModel && currentIndex < 0 && count > 0) {

--- a/src/server/src/qml/qml/ScriptOutputText.qml
+++ b/src/server/src/qml/qml/ScriptOutputText.qml
@@ -6,6 +6,8 @@ ScrollView {
 
     property alias text: textArea.text
 
+    Component.onCompleted: contentItem.boundsBehavior = Flickable.StopAtBounds
+
     function moveUp() {
         contentItem.contentY = Math.max(0, contentItem.contentY - 40);
     }

--- a/src/server/src/qml/qml/SettingsSidebar.qml
+++ b/src/server/src/qml/qml/SettingsSidebar.qml
@@ -133,6 +133,10 @@ Item {
             boundsBehavior: Flickable.StopAtBounds
             model: settings.sidebarModel
 
+            ViciWheelHandler {
+                target: navList
+            }
+
             ScrollBar.vertical: ViciScrollBar {
                 policy: navList.contentHeight > navList.height ? ScrollBar.AsNeeded : ScrollBar.AlwaysOff
             }

--- a/src/server/src/qml/qml/TextViewer.qml
+++ b/src/server/src/qml/qml/TextViewer.qml
@@ -10,6 +10,8 @@ ScrollView {
     clip: true
     contentWidth: availableWidth
 
+    Component.onCompleted: contentItem.boundsBehavior = Flickable.StopAtBounds
+
     TextEdit {
         width: root.availableWidth
         text: root.text

--- a/src/server/src/server.cpp
+++ b/src/server/src/server.cpp
@@ -128,9 +128,6 @@ int startServer(const ServerLaunchOptions &launchOpts) {
     }
   }
 
-  if (!qEnvironmentVariableIsSet("QT_QUICK_FLICKABLE_WHEEL_DECELERATION"))
-    qputenv("QT_QUICK_FLICKABLE_WHEEL_DECELERATION", "10000");
-
 #ifdef Q_OS_MACOS
   if (!qEnvironmentVariableIsSet("QT_MAC_SET_RAISE_PROCESS")) qputenv("QT_MAC_SET_RAISE_PROCESS", "0");
 #endif

--- a/vendor/kirigami-wheelhandler/COPYING
+++ b/vendor/kirigami-wheelhandler/COPYING
@@ -1,0 +1,446 @@
+GNU LIBRARY GENERAL PUBLIC LICENSE
+
+Version 2, June 1991 Copyright (C) 1991 Free Software Foundation, Inc.
+
+51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+
+Everyone is permitted to copy and distribute verbatim copies of this license
+document, but changing it is not allowed.
+
+[This is the first released version of the library GPL. It is numbered 2 because
+it goes with version 2 of the ordinary GPL.]
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to share
+and change it. By contrast, the GNU General Public Licenses are intended to
+guarantee your freedom to share and change free software--to make sure the
+software is free for all its users.
+
+This license, the Library General Public License, applies to some specially
+designated Free Software Foundation software, and to any other libraries whose
+authors decide to use it. You can use it for your libraries, too.
+
+When we speak of free software, we are referring to freedom, not price. Our
+General Public Licenses are designed to make sure that you have the freedom
+to distribute copies of free software (and charge for this service if you
+wish), that you receive source code or can get it if you want it, that you
+can change the software or use pieces of it in new free programs; and that
+you know you can do these things.
+
+To protect your rights, we need to make restrictions that forbid anyone to
+deny you these rights or to ask you to surrender the rights. These restrictions
+translate to certain responsibilities for you if you distribute copies of
+the library, or if you modify it.
+
+For example, if you distribute copies of the library, whether gratis or for
+a fee, you must give the recipients all the rights that we gave you. You must
+make sure that they, too, receive or can get the source code. If you link
+a program with the library, you must provide complete object files to the
+recipients so that they can relink them with the library, after making changes
+to the library and recompiling it. And you must show them these terms so they
+know their rights.
+
+Our method of protecting your rights has two steps: (1) copyright the library,
+and (2) offer you this license which gives you legal permission to copy, distribute
+and/or modify the library.
+
+Also, for each distributor's protection, we want to make certain that everyone
+understands that there is no warranty for this free library. If the library
+is modified by someone else and passed on, we want its recipients to know
+that what they have is not the original version, so that any problems introduced
+by others will not reflect on the original authors' reputations.
+
+Finally, any free program is threatened constantly by software patents. We
+wish to avoid the danger that companies distributing free software will individually
+obtain patent licenses, thus in effect transforming the program into proprietary
+software. To prevent this, we have made it clear that any patent must be licensed
+for everyone's free use or not licensed at all.
+
+Most GNU software, including some libraries, is covered by the ordinary GNU
+General Public License, which was designed for utility programs. This license,
+the GNU Library General Public License, applies to certain designated libraries.
+This license is quite different from the ordinary one; be sure to read it
+in full, and don't assume that anything in it is the same as in the ordinary
+license.
+
+The reason we have a separate public license for some libraries is that they
+blur the distinction we usually make between modifying or adding to a program
+and simply using it. Linking a program with a library, without changing the
+library, is in some sense simply using the library, and is analogous to running
+a utility program or application program. However, in a textual and legal
+sense, the linked executable is a combined work, a derivative of the original
+library, and the ordinary General Public License treats it as such.
+
+Because of this blurred distinction, using the ordinary General Public License
+for libraries did not effectively promote software sharing, because most developers
+did not use the libraries. We concluded that weaker conditions might promote
+sharing better.
+
+However, unrestricted linking of non-free programs would deprive the users
+of those programs of all benefit from the free status of the libraries themselves.
+This Library General Public License is intended to permit developers of non-free
+programs to use free libraries, while preserving your freedom as a user of
+such programs to change the free libraries that are incorporated in them.
+(We have not seen how to achieve this as regards changes in header files,
+but we have achieved it as regards changes in the actual functions of the
+Library.) The hope is that this will lead to faster development of free libraries.
+
+The precise terms and conditions for copying, distribution and modification
+follow. Pay close attention to the difference between a "work based on the
+library" and a "work that uses the library". The former contains code derived
+from the library, while the latter only works together with the library.
+
+Note that it is possible for a library to be covered by the ordinary General
+Public License rather than by this special one.
+
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+0. This License Agreement applies to any software library which contains a
+notice placed by the copyright holder or other authorized party saying it
+may be distributed under the terms of this Library General Public License
+(also called "this License"). Each licensee is addressed as "you".
+
+A "library" means a collection of software functions and/or data prepared
+so as to be conveniently linked with application programs (which use some
+of those functions and data) to form executables.
+
+The "Library", below, refers to any such software library or work which has
+been distributed under these terms. A "work based on the Library" means either
+the Library or any derivative work under copyright law: that is to say, a
+work containing the Library or a portion of it, either verbatim or with modifications
+and/or translated straightforwardly into another language. (Hereinafter, translation
+is included without limitation in the term "modification".)
+
+"Source code" for a work means the preferred form of the work for making modifications
+to it. For a library, complete source code means all the source code for all
+modules it contains, plus any associated interface definition files, plus
+the scripts used to control compilation and installation of the library.
+
+Activities other than copying, distribution and modification are not covered
+by this License; they are outside its scope. The act of running a program
+using the Library is not restricted, and output from such a program is covered
+only if its contents constitute a work based on the Library (independent of
+the use of the Library in a tool for writing it). Whether that is true depends
+on what the Library does and what the program that uses the Library does.
+
+1. You may copy and distribute verbatim copies of the Library's complete source
+code as you receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice and disclaimer
+of warranty; keep intact all the notices that refer to this License and to
+the absence of any warranty; and distribute a copy of this License along with
+the Library.
+
+You may charge a fee for the physical act of transferring a copy, and you
+may at your option offer warranty protection in exchange for a fee.
+
+2. You may modify your copy or copies of the Library or any portion of it,
+thus forming a work based on the Library, and copy and distribute such modifications
+or work under the terms of Section 1 above, provided that you also meet all
+of these conditions:
+
+      a) The modified work must itself be a software library.
+
+b) You must cause the files modified to carry prominent notices stating that
+you changed the files and the date of any change.
+
+c) You must cause the whole of the work to be licensed at no charge to all
+third parties under the terms of this License.
+
+d) If a facility in the modified Library refers to a function or a table of
+data to be supplied by an application program that uses the facility, other
+than as an argument passed when the facility is invoked, then you must make
+a good faith effort to ensure that, in the event an application does not supply
+such function or table, the facility still operates, and performs whatever
+part of its purpose remains meaningful.
+
+(For example, a function in a library to compute square roots has a purpose
+that is entirely well-defined independent of the application. Therefore, Subsection
+2d requires that any application-supplied function or table used by this function
+must be optional: if the application does not supply it, the square root function
+must still compute square roots.)
+
+These requirements apply to the modified work as a whole. If identifiable
+sections of that work are not derived from the Library, and can be reasonably
+considered independent and separate works in themselves, then this License,
+and its terms, do not apply to those sections when you distribute them as
+separate works. But when you distribute the same sections as part of a whole
+which is a work based on the Library, the distribution of the whole must be
+on the terms of this License, whose permissions for other licensees extend
+to the entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest your
+rights to work written entirely by you; rather, the intent is to exercise
+the right to control the distribution of derivative or collective works based
+on the Library.
+
+In addition, mere aggregation of another work not based on the Library with
+the Library (or with a work based on the Library) on a volume of a storage
+or distribution medium does not bring the other work under the scope of this
+License.
+
+3. You may opt to apply the terms of the ordinary GNU General Public License
+instead of this License to a given copy of the Library. To do this, you must
+alter all the notices that refer to this License, so that they refer to the
+ordinary GNU General Public License, version 2, instead of to this License.
+(If a newer version than version 2 of the ordinary GNU General Public License
+has appeared, then you can specify that version instead if you wish.) Do not
+make any other change in these notices.
+
+Once this change is made in a given copy, it is irreversible for that copy,
+so the ordinary GNU General Public License applies to all subsequent copies
+and derivative works made from that copy.
+
+This option is useful when you wish to copy part of the code of the Library
+into a program that is not a library.
+
+4. You may copy and distribute the Library (or a portion or derivative of
+it, under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you accompany it with the complete corresponding
+machine-readable source code, which must be distributed under the terms of
+Sections 1 and 2 above on a medium customarily used for software interchange.
+
+If distribution of object code is made by offering access to copy from a designated
+place, then offering equivalent access to copy the source code from the same
+place satisfies the requirement to distribute the source code, even though
+third parties are not compelled to copy the source along with the object code.
+
+5. A program that contains no derivative of any portion of the Library, but
+is designed to work with the Library by being compiled or linked with it,
+is called a "work that uses the Library". Such a work, in isolation, is not
+a derivative work of the Library, and therefore falls outside the scope of
+this License.
+
+However, linking a "work that uses the Library" with the Library creates an
+executable that is a derivative of the Library (because it contains portions
+of the Library), rather than a "work that uses the library". The executable
+is therefore covered by this License. Section 6 states terms for distribution
+of such executables.
+
+When a "work that uses the Library" uses material from a header file that
+is part of the Library, the object code for the work may be a derivative work
+of the Library even though the source code is not. Whether this is true is
+especially significant if the work can be linked without the Library, or if
+the work is itself a library. The threshold for this to be true is not precisely
+defined by law.
+
+If such an object file uses only numerical parameters, data structure layouts
+and accessors, and small macros and small inline functions (ten lines or less
+in length), then the use of the object file is unrestricted, regardless of
+whether it is legally a derivative work. (Executables containing this object
+code plus portions of the Library will still fall under Section 6.)
+
+Otherwise, if the work is a derivative of the Library, you may distribute
+the object code for the work under the terms of Section 6. Any executables
+containing that work also fall under Section 6, whether or not they are linked
+directly with the Library itself.
+
+6. As an exception to the Sections above, you may also compile or link a "work
+that uses the Library" with the Library to produce a work containing portions
+of the Library, and distribute that work under terms of your choice, provided
+that the terms permit modification of the work for the customer's own use
+and reverse engineering for debugging such modifications.
+
+You must give prominent notice with each copy of the work that the Library
+is used in it and that the Library and its use are covered by this License.
+You must supply a copy of this License. If the work during execution displays
+copyright notices, you must include the copyright notice for the Library among
+them, as well as a reference directing the user to the copy of this License.
+Also, you must do one of these things:
+
+a) Accompany the work with the complete corresponding machine-readable source
+code for the Library including whatever changes were used in the work (which
+must be distributed under Sections 1 and 2 above); and, if the work is an
+executable linked with the Library, with the complete machine-readable "work
+that uses the Library", as object code and/or source code, so that the user
+can modify the Library and then relink to produce a modified executable containing
+the modified Library. (It is understood that the user who changes the contents
+of definitions files in the Library will not necessarily be able to recompile
+the application to use the modified definitions.)
+
+b) Accompany the work with a written offer, valid for at least three years,
+to give the same user the materials specified in Subsection 6a, above, for
+a charge no more than the cost of performing this distribution.
+
+c) If distribution of the work is made by offering access to copy from a designated
+place, offer equivalent access to copy the above specified materials from
+the same place.
+
+d) Verify that the user has already received a copy of these materials or
+that you have already sent this user a copy.
+
+For an executable, the required form of the "work that uses the Library" must
+include any data and utility programs needed for reproducing the executable
+from it. However, as a special exception, the source code distributed need
+not include anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the operating
+system on which the executable runs, unless that component itself accompanies
+the executable.
+
+It may happen that this requirement contradicts the license restrictions of
+other proprietary libraries that do not normally accompany the operating system.
+Such a contradiction means you cannot use both them and the Library together
+in an executable that you distribute.
+
+7. You may place library facilities that are a work based on the Library side-by-side
+in a single library together with other library facilities not covered by
+this License, and distribute such a combined library, provided that the separate
+distribution of the work based on the Library and of the other library facilities
+is otherwise permitted, and provided that you do these two things:
+
+a) Accompany the combined library with a copy of the same work based on the
+Library, uncombined with any other library facilities. This must be distributed
+under the terms of the Sections above.
+
+b) Give prominent notice with the combined library of the fact that part of
+it is a work based on the Library, and explaining where to find the accompanying
+uncombined form of the same work.
+
+8. You may not copy, modify, sublicense, link with, or distribute the Library
+except as expressly provided under this License. Any attempt otherwise to
+copy, modify, sublicense, link with, or distribute the Library is void, and
+will automatically terminate your rights under this License. However, parties
+who have received copies, or rights, from you under this License will not
+have their licenses terminated so long as such parties remain in full compliance.
+
+9. You are not required to accept this License, since you have not signed
+it. However, nothing else grants you permission to modify or distribute the
+Library or its derivative works. These actions are prohibited by law if you
+do not accept this License. Therefore, by modifying or distributing the Library
+(or any work based on the Library), you indicate your acceptance of this License
+to do so, and all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+10. Each time you redistribute the Library (or any work based on the Library),
+the recipient automatically receives a license from the original licensor
+to copy, distribute, link with or modify the Library subject to these terms
+and conditions. You may not impose any further restrictions on the recipients'
+exercise of the rights granted herein. You are not responsible for enforcing
+compliance by third parties to this License.
+
+11. If, as a consequence of a court judgment or allegation of patent infringement
+or for any other reason (not limited to patent issues), conditions are imposed
+on you (whether by court order, agreement or otherwise) that contradict the
+conditions of this License, they do not excuse you from the conditions of
+this License. If you cannot distribute so as to satisfy simultaneously your
+obligations under this License and any other pertinent obligations, then as
+a consequence you may not distribute the Library at all. For example, if a
+patent license would not permit royalty-free redistribution of the Library
+by all those who receive copies directly or indirectly through you, then the
+only way you could satisfy both it and this License would be to refrain entirely
+from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any patents
+or other property right claims or to contest validity of any such claims;
+this section has the sole purpose of protecting the integrity of the free
+software distribution system which is implemented by public license practices.
+Many people have made generous contributions to the wide range of software
+distributed through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing to
+distribute software through any other system and a licensee cannot impose
+that choice.
+
+This section is intended to make thoroughly clear what is believed to be a
+consequence of the rest of this License.
+
+12. If the distribution and/or use of the Library is restricted in certain
+countries either by patents or by copyrighted interfaces, the original copyright
+holder who places the Library under this License may add an explicit geographical
+distribution limitation excluding those countries, so that distribution is
+permitted only in or among countries not thus excluded. In such case, this
+License incorporates the limitation as if written in the body of this License.
+
+13. The Free Software Foundation may publish revised and/or new versions of
+the Library General Public License from time to time. Such new versions will
+be similar in spirit to the present version, but may differ in detail to address
+new problems or concerns.
+
+Each version is given a distinguishing version number. If the Library specifies
+a version number of this License which applies to it and "any later version",
+you have the option of following the terms and conditions either of that version
+or of any later version published by the Free Software Foundation. If the
+Library does not specify a license version number, you may choose any version
+ever published by the Free Software Foundation.
+
+14. If you wish to incorporate parts of the Library into other free programs
+whose distribution conditions are incompatible with these, write to the author
+to ask for permission. For software which is copyrighted by the Free Software
+Foundation, write to the Free Software Foundation; we sometimes make exceptions
+for this. Our decision will be guided by the two goals of preserving the free
+status of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+   NO WARRANTY
+
+15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR
+THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE
+STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE LIBRARY
+"AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE
+OF THE LIBRARY IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE
+THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE
+OR INABILITY TO USE THE LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA
+OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES
+OR A FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF SUCH
+HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Libraries
+
+If you develop a new library, and you want it to be of the greatest possible
+use to the public, we recommend making it free software that everyone can
+redistribute and change. You can do so by permitting redistribution under
+these terms (or, alternatively, under the terms of the ordinary General Public
+License).
+
+To apply these terms, attach the following notices to the library. It is safest
+to attach them to the start of each source file to most effectively convey
+the exclusion of warranty; and each file should have at least the "copyright"
+line and a pointer to where the full notice is found.
+
+one line to give the library's name and an idea of what it does.
+
+Copyright (C) year name of author
+
+This library is free software; you can redistribute it and/or modify it under
+the terms of the GNU Library General Public License as published by the Free
+Software Foundation; either version 2 of the License, or (at your option)
+any later version.
+
+This library is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU Library General Public License for more
+details.
+
+You should have received a copy of the GNU Library General Public License
+along with this library; if not, write to the Free Software Foundation, Inc.,
+51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your school,
+if any, to sign a "copyright disclaimer" for the library, if necessary. Here
+is a sample; alter the names:
+
+Yoyodyne, Inc., hereby disclaims all copyright interest in
+
+the library `Frob' (a library for tweaking knobs) written
+
+by James Random Hacker.
+
+signature of Ty Coon, 1 April 1990
+
+Ty Coon, President of Vice
+
+That's all there is to it!

--- a/vendor/kirigami-wheelhandler/VENDORING.md
+++ b/vendor/kirigami-wheelhandler/VENDORING.md
@@ -7,5 +7,6 @@
 Adapted to be standalone: the Kirigami Units/Settings singletons were replaced
 with a constant animation duration and a `smoothScroll` property, and the QML
 type names were prefixed to avoid clashing with QtQuick's own WheelHandler.
-The touchpad inertia animation is gated behind an `inertiaScroll` property,
-disabled by default because of https://bugs.kde.org/show_bug.cgi?id=508229.
+The touchpad inertia animation is exposed as an `inertiaScroll` property and
+re-clamped against the target's live bounds on every animation tick, working
+around https://bugs.kde.org/show_bug.cgi?id=508229.

--- a/vendor/kirigami-wheelhandler/VENDORING.md
+++ b/vendor/kirigami-wheelhandler/VENDORING.md
@@ -7,3 +7,5 @@
 Adapted to be standalone: the Kirigami Units/Settings singletons were replaced
 with a constant animation duration and a `smoothScroll` property, and the QML
 type names were prefixed to avoid clashing with QtQuick's own WheelHandler.
+The touchpad inertia animation is gated behind an `inertiaScroll` property,
+disabled by default because of https://bugs.kde.org/show_bug.cgi?id=508229.

--- a/vendor/kirigami-wheelhandler/VENDORING.md
+++ b/vendor/kirigami-wheelhandler/VENDORING.md
@@ -1,0 +1,9 @@
+# Vendored Kirigami WheelHandler
+
+- Upstream: https://invent.kde.org/frameworks/kirigami (src/wheelhandler.h, src/wheelhandler.cpp)
+- Commit: 85ac54062cf9e0b8c1ec9282fc51cca455bd1c1f (2025-09-21)
+- License: LGPL-2.0-or-later (see COPYING)
+
+Adapted to be standalone: the Kirigami Units/Settings singletons were replaced
+with a constant animation duration and a `smoothScroll` property, and the QML
+type names were prefixed to avoid clashing with QtQuick's own WheelHandler.

--- a/vendor/kirigami-wheelhandler/wheelhandler.cpp
+++ b/vendor/kirigami-wheelhandler/wheelhandler.cpp
@@ -1,0 +1,871 @@
+/*
+ *  SPDX-FileCopyrightText: 2019 Marco Martin <mart@kde.org>
+ *
+ *  SPDX-License-Identifier: LGPL-2.0-or-later
+ *
+ *  Vendored from KDE Kirigami (src/wheelhandler.cpp), see VENDORING.md.
+ */
+
+#include "wheelhandler.h"
+
+#include <QQmlInfo>
+#include <QQuickWindow>
+#include <QWheelEvent>
+#include <QtMath>
+
+#include <algorithm>
+#include <cmath>
+
+KirigamiWheelEvent::KirigamiWheelEvent(QObject *parent)
+    : QObject(parent)
+{
+}
+
+KirigamiWheelEvent::~KirigamiWheelEvent()
+{
+}
+
+void KirigamiWheelEvent::initializeFromEvent(QWheelEvent *event)
+{
+    m_x = event->position().x();
+    m_y = event->position().y();
+    m_angleDelta = event->angleDelta();
+    m_pixelDelta = event->pixelDelta();
+    m_buttons = event->buttons();
+    m_modifiers = event->modifiers();
+    m_accepted = false;
+    m_inverted = event->inverted();
+}
+
+qreal KirigamiWheelEvent::x() const
+{
+    return m_x;
+}
+
+qreal KirigamiWheelEvent::y() const
+{
+    return m_y;
+}
+
+QPointF KirigamiWheelEvent::angleDelta() const
+{
+    return m_angleDelta;
+}
+
+QPointF KirigamiWheelEvent::pixelDelta() const
+{
+    return m_pixelDelta;
+}
+
+int KirigamiWheelEvent::buttons() const
+{
+    return m_buttons;
+}
+
+int KirigamiWheelEvent::modifiers() const
+{
+    return m_modifiers;
+}
+
+bool KirigamiWheelEvent::inverted() const
+{
+    return m_inverted;
+}
+
+bool KirigamiWheelEvent::isAccepted()
+{
+    return m_accepted;
+}
+
+void KirigamiWheelEvent::setAccepted(bool accepted)
+{
+    m_accepted = accepted;
+}
+
+///////////////////////////////
+
+WheelFilterItem::WheelFilterItem(QQuickItem *parent)
+    : QQuickItem(parent)
+{
+    setEnabled(false);
+}
+
+///////////////////////////////
+
+WheelHandler::WheelHandler(QObject *parent)
+    : QObject(parent)
+    , m_filterItem(new WheelFilterItem(nullptr))
+{
+    m_filterItem->installEventFilter(this);
+
+    m_wheelScrollingTimer.setSingleShot(true);
+    m_wheelScrollingTimer.setInterval(m_wheelScrollingDuration);
+    m_wheelScrollingTimer.callOnTimeout([this]() {
+        setScrolling(false);
+    });
+
+    m_xScrollAnimation.setEasingCurve(QEasingCurve::OutCubic);
+    m_yScrollAnimation.setEasingCurve(QEasingCurve::OutCubic);
+    m_xInertiaScrollAnimation.setEasingCurve(QEasingCurve::OutQuad);
+    m_yInertiaScrollAnimation.setEasingCurve(QEasingCurve::OutQuad);
+
+    connect(QGuiApplication::styleHints(), &QStyleHints::wheelScrollLinesChanged, this, [this](int scrollLines) {
+        m_defaultPixelStepSize = 20 * scrollLines;
+        if (!m_explicitVStepSize && m_verticalStepSize != m_defaultPixelStepSize) {
+            m_verticalStepSize = m_defaultPixelStepSize;
+            Q_EMIT verticalStepSizeChanged();
+        }
+        if (!m_explicitHStepSize && m_horizontalStepSize != m_defaultPixelStepSize) {
+            m_horizontalStepSize = m_defaultPixelStepSize;
+            Q_EMIT horizontalStepSizeChanged();
+        }
+    });
+}
+
+WheelHandler::~WheelHandler()
+{
+    delete m_filterItem;
+}
+
+QQuickItem *WheelHandler::target() const
+{
+    return m_flickable;
+}
+
+void WheelHandler::setTarget(QQuickItem *target)
+{
+    if (m_flickable == target) {
+        return;
+    }
+
+    if (target && !target->inherits("QQuickFlickable")) {
+        qmlWarning(this) << "target must be a QQuickFlickable";
+        return;
+    }
+
+    if (m_flickable) {
+        m_flickable->removeEventFilter(this);
+        disconnect(m_flickable, nullptr, m_filterItem, nullptr);
+        disconnect(m_flickable, &QQuickItem::parentChanged, this, &WheelHandler::_k_rebindScrollBars);
+    }
+
+    m_flickable = target;
+    m_filterItem->setParentItem(target);
+    if (m_xScrollAnimation.targetObject()) {
+        m_xScrollAnimation.stop();
+    }
+    m_xScrollAnimation.setTargetObject(target);
+    if (m_yScrollAnimation.targetObject()) {
+        m_yScrollAnimation.stop();
+    }
+    m_yScrollAnimation.setTargetObject(target);
+    if (m_yInertiaScrollAnimation.targetObject()) {
+        m_yInertiaScrollAnimation.stop();
+    }
+    m_yInertiaScrollAnimation.setTargetObject(target);
+    if (m_xInertiaScrollAnimation.targetObject()) {
+        m_xInertiaScrollAnimation.stop();
+    }
+    m_xInertiaScrollAnimation.setTargetObject(target);
+
+    if (target) {
+        target->installEventFilter(this);
+
+        // Stack WheelFilterItem over the Flickable's scrollable content
+        m_filterItem->stackAfter(target->property("contentItem").value<QQuickItem *>());
+        // Make it fill the Flickable
+        m_filterItem->setWidth(target->width());
+        m_filterItem->setHeight(target->height());
+        connect(target, &QQuickItem::widthChanged, m_filterItem, [this, target]() {
+            m_filterItem->setWidth(target->width());
+        });
+        connect(target, &QQuickItem::heightChanged, m_filterItem, [this, target]() {
+            m_filterItem->setHeight(target->height());
+        });
+    }
+
+    _k_rebindScrollBars();
+
+    Q_EMIT targetChanged();
+}
+
+void WheelHandler::_k_rebindScrollBars()
+{
+    struct ScrollBarAttached {
+        QObject *attached = nullptr;
+        QQuickItem *vertical = nullptr;
+        QQuickItem *horizontal = nullptr;
+    };
+
+    ScrollBarAttached attachedToFlickable;
+    ScrollBarAttached attachedToScrollView;
+
+    if (m_flickable) {
+        // Get ScrollBars so that we can filter them too, even if they're not
+        // in the bounds of the Flickable
+        const auto flickableChildren = m_flickable->children();
+        for (const auto child : flickableChildren) {
+            if (child->inherits("QQuickScrollBarAttached")) {
+                attachedToFlickable.attached = child;
+                attachedToFlickable.vertical = child->property("vertical").value<QQuickItem *>();
+                attachedToFlickable.horizontal = child->property("horizontal").value<QQuickItem *>();
+                break;
+            }
+        }
+
+        // Check ScrollView if there are no scrollbars attached to the Flickable.
+        // We need to check if the parent inherits QQuickScrollView in case the
+        // parent is another Flickable that already has a Kirigami WheelHandler.
+        auto flickableParent = m_flickable->parentItem();
+        if (m_scrollView && m_scrollView != flickableParent) {
+            m_scrollView->removeEventFilter(this);
+        }
+        if (flickableParent && flickableParent->inherits("QQuickScrollView")) {
+            if (m_scrollView != flickableParent) {
+                m_scrollView = flickableParent;
+                m_scrollView->installEventFilter(this);
+            }
+            const auto siblings = m_scrollView->children();
+            for (const auto child : siblings) {
+                if (child->inherits("QQuickScrollBarAttached")) {
+                    attachedToScrollView.attached = child;
+                    attachedToScrollView.vertical = child->property("vertical").value<QQuickItem *>();
+                    attachedToScrollView.horizontal = child->property("horizontal").value<QQuickItem *>();
+                    break;
+                }
+            }
+        }
+    }
+
+    // Dilemma: ScrollBars can be attached to both ScrollView and Flickable,
+    // but only one of them should be shown anyway. Let's prefer Flickable.
+
+    struct ChosenScrollBar {
+        QObject *attached = nullptr;
+        QQuickItem *scrollBar = nullptr;
+    };
+
+    ChosenScrollBar vertical;
+    if (attachedToFlickable.vertical) {
+        vertical.attached = attachedToFlickable.attached;
+        vertical.scrollBar = attachedToFlickable.vertical;
+    } else if (attachedToScrollView.vertical) {
+        vertical.attached = attachedToScrollView.attached;
+        vertical.scrollBar = attachedToScrollView.vertical;
+    }
+
+    ChosenScrollBar horizontal;
+    if (attachedToFlickable.horizontal) {
+        horizontal.attached = attachedToFlickable.attached;
+        horizontal.scrollBar = attachedToFlickable.horizontal;
+    } else if (attachedToScrollView.horizontal) {
+        horizontal.attached = attachedToScrollView.attached;
+        horizontal.scrollBar = attachedToScrollView.horizontal;
+    }
+
+    // Flickable may get re-parented to or out of a ScrollView, so we need to
+    // redo the discovery process. This is especially important for
+    // Kirigami.ScrollablePage component.
+    if (m_flickable) {
+        if (attachedToFlickable.horizontal && attachedToFlickable.vertical) {
+            // But if both scrollbars are already those from the preferred
+            // Flickable, there's no need for rediscovery.
+            disconnect(m_flickable, &QQuickItem::parentChanged, this, &WheelHandler::_k_rebindScrollBars);
+        } else {
+            connect(m_flickable, &QQuickItem::parentChanged, this, &WheelHandler::_k_rebindScrollBars, Qt::UniqueConnection);
+        }
+    }
+
+    if (m_verticalScrollBar != vertical.scrollBar) {
+        if (m_verticalScrollBar) {
+            m_verticalScrollBar->removeEventFilter(this);
+            disconnect(m_verticalChangedConnection);
+        }
+        m_verticalScrollBar = vertical.scrollBar;
+        if (vertical.scrollBar) {
+            vertical.scrollBar->installEventFilter(this);
+            m_verticalChangedConnection = connect(vertical.attached, SIGNAL(verticalChanged()), this, SLOT(_k_rebindScrollBars()));
+        }
+    }
+
+    if (m_horizontalScrollBar != horizontal.scrollBar) {
+        if (m_horizontalScrollBar) {
+            m_horizontalScrollBar->removeEventFilter(this);
+            disconnect(m_horizontalChangedConnection);
+        }
+        m_horizontalScrollBar = horizontal.scrollBar;
+        if (horizontal.scrollBar) {
+            horizontal.scrollBar->installEventFilter(this);
+            m_horizontalChangedConnection = connect(horizontal.attached, SIGNAL(horizontalChanged()), this, SLOT(_k_rebindScrollBars()));
+        }
+    }
+}
+
+qreal WheelHandler::verticalStepSize() const
+{
+    return m_verticalStepSize;
+}
+
+void WheelHandler::setVerticalStepSize(qreal stepSize)
+{
+    m_explicitVStepSize = true;
+    if (qFuzzyCompare(m_verticalStepSize, stepSize)) {
+        return;
+    }
+    // Mimic the behavior of QQuickScrollBar when stepSize is 0
+    if (qFuzzyIsNull(stepSize)) {
+        resetVerticalStepSize();
+        return;
+    }
+    m_verticalStepSize = stepSize;
+    Q_EMIT verticalStepSizeChanged();
+}
+
+void WheelHandler::resetVerticalStepSize()
+{
+    m_explicitVStepSize = false;
+    if (qFuzzyCompare(m_verticalStepSize, m_defaultPixelStepSize)) {
+        return;
+    }
+    m_verticalStepSize = m_defaultPixelStepSize;
+    Q_EMIT verticalStepSizeChanged();
+}
+
+qreal WheelHandler::horizontalStepSize() const
+{
+    return m_horizontalStepSize;
+}
+
+void WheelHandler::setHorizontalStepSize(qreal stepSize)
+{
+    m_explicitHStepSize = true;
+    if (qFuzzyCompare(m_horizontalStepSize, stepSize)) {
+        return;
+    }
+    // Mimic the behavior of QQuickScrollBar when stepSize is 0
+    if (qFuzzyIsNull(stepSize)) {
+        resetHorizontalStepSize();
+        return;
+    }
+    m_horizontalStepSize = stepSize;
+    Q_EMIT horizontalStepSizeChanged();
+}
+
+void WheelHandler::resetHorizontalStepSize()
+{
+    m_explicitHStepSize = false;
+    if (qFuzzyCompare(m_horizontalStepSize, m_defaultPixelStepSize)) {
+        return;
+    }
+    m_horizontalStepSize = m_defaultPixelStepSize;
+    Q_EMIT horizontalStepSizeChanged();
+}
+
+Qt::KeyboardModifiers WheelHandler::pageScrollModifiers() const
+{
+    return m_pageScrollModifiers;
+}
+
+void WheelHandler::setPageScrollModifiers(Qt::KeyboardModifiers modifiers)
+{
+    if (m_pageScrollModifiers == modifiers) {
+        return;
+    }
+    m_pageScrollModifiers = modifiers;
+    Q_EMIT pageScrollModifiersChanged();
+}
+
+void WheelHandler::resetPageScrollModifiers()
+{
+    setPageScrollModifiers(m_defaultPageScrollModifiers);
+}
+
+bool WheelHandler::filterMouseEvents() const
+{
+    return m_filterMouseEvents;
+}
+
+void WheelHandler::setFilterMouseEvents(bool enabled)
+{
+    if (m_filterMouseEvents == enabled) {
+        return;
+    }
+    m_filterMouseEvents = enabled;
+    Q_EMIT filterMouseEventsChanged();
+}
+
+bool WheelHandler::keyNavigationEnabled() const
+{
+    return m_keyNavigationEnabled;
+}
+
+void WheelHandler::setKeyNavigationEnabled(bool enabled)
+{
+    if (m_keyNavigationEnabled == enabled) {
+        return;
+    }
+    m_keyNavigationEnabled = enabled;
+    Q_EMIT keyNavigationEnabledChanged();
+}
+
+void WheelHandler::setScrolling(bool scrolling)
+{
+    if (m_wheelScrolling == scrolling) {
+        if (m_wheelScrolling) {
+            m_wheelScrollingTimer.start();
+        }
+        return;
+    }
+    m_wheelScrolling = scrolling;
+    m_filterItem->setEnabled(m_wheelScrolling);
+}
+
+void WheelHandler::startInertiaScrolling()
+{
+    const qreal width = m_flickable->width();
+    const qreal height = m_flickable->height();
+    const qreal contentWidth = m_flickable->property("contentWidth").toReal();
+    const qreal contentHeight = m_flickable->property("contentHeight").toReal();
+    const qreal topMargin = m_flickable->property("topMargin").toReal();
+    const qreal bottomMargin = m_flickable->property("bottomMargin").toReal();
+    const qreal leftMargin = m_flickable->property("leftMargin").toReal();
+    const qreal rightMargin = m_flickable->property("rightMargin").toReal();
+    const qreal originX = m_flickable->property("originX").toReal();
+    const qreal originY = m_flickable->property("originY").toReal();
+    const qreal contentX = m_flickable->property("contentX").toReal();
+    const qreal contentY = m_flickable->property("contentY").toReal();
+
+    QPointF minExtent = QPointF(leftMargin, topMargin) - QPointF(originX, originY);
+    QPointF maxExtent = QPointF(width, height) - (QPointF(contentWidth, contentHeight) + QPointF(rightMargin, bottomMargin) + QPointF(originX, originY));
+
+    QPointF totalDelta(0, 0);
+    for (const QPoint delta : m_wheelEvents) {
+        totalDelta += delta;
+    }
+    const uint64_t elapsed = std::max<uint64_t>(m_timestamps.last() - m_timestamps.first(), 1);
+
+    // The inertia is more natural if we multiply
+    // the actual scrolling speed by some factor,
+    // chosen manually here to be 2.5. Otherwise, the
+    // scrolling will appear to be too slow.
+    const qreal speedFactor = 2.5;
+
+    // We get the velocity in px/s by calculating
+    // displacement / elapsed time; we multiply by
+    // 1000 since the elapsed time is in ms.
+    QPointF vel = -totalDelta * 1000 / elapsed * speedFactor;
+    QPointF startValue = QPointF(contentX, contentY);
+
+    // We decelerate at 4000px/s^2, chosen by manual test
+    // to be natural.
+    const qreal deceleration = 4000 * speedFactor;
+
+    // We use constant deceleration formulas to find:
+    // time = |velocity / deceleration|
+    // distance_traveled = time * velocity / 2
+    QPointF time = QPointF(qAbs(vel.x() / deceleration), qAbs(vel.y() / deceleration));
+    QPointF endValue = QPointF(startValue.x() + time.x() * vel.x() / 2, startValue.y() + time.y() * vel.y() / 2);
+
+    // We bound the end value so that we don't animate
+    // beyond the scrollable amount.
+    QPointF boundedEndValue =
+        QPointF(std::max(std::min(endValue.x(), -maxExtent.x()), -minExtent.x()), std::max(std::min(endValue.y(), -maxExtent.y()), -minExtent.y()));
+
+    // If we did bound the end value, we check how much
+    // (from 0 to 1) of the animation is actually played,
+    // and we adjust the time required for it accordingly.
+    QPointF progressFactor = QPointF((boundedEndValue.x() - startValue.x()) / (endValue.x() - startValue.x()),
+                                     (boundedEndValue.y() - startValue.y()) / (endValue.y() - startValue.y()));
+    // The formula here is:
+    // partial_time = complete_time * (1 - sqrt(1 - partial_progress_factor)),
+    // with partial_progress_factor being between 0 and 1.
+    // It can be obtained by inverting the OutQad easing formula,
+    // which is f(t) = t(2 - t).
+    // We also convert back from seconds to milliseconds.
+    QPointF realTime = QPointF(time.x() * (1 - std::sqrt(1 - progressFactor.x())), time.y() * (1 - std::sqrt(1 - progressFactor.y()))) * 1000;
+    m_wheelEvents.clear();
+    m_timestamps.clear();
+
+    m_xScrollAnimation.stop();
+    m_yScrollAnimation.stop();
+    if (realTime.x() > 0) {
+        m_xInertiaScrollAnimation.setStartValue(startValue.x());
+        m_xInertiaScrollAnimation.setEndValue(boundedEndValue.x());
+        m_xInertiaScrollAnimation.setDuration(realTime.x());
+        m_xInertiaScrollAnimation.start(QAbstractAnimation::KeepWhenStopped);
+    }
+    if (realTime.y() > 0) {
+        m_yInertiaScrollAnimation.setStartValue(startValue.y());
+        m_yInertiaScrollAnimation.setEndValue(boundedEndValue.y());
+        m_yInertiaScrollAnimation.setDuration(realTime.y());
+        m_yInertiaScrollAnimation.start(QAbstractAnimation::KeepWhenStopped);
+    }
+}
+
+bool WheelHandler::scrollFlickable(QPointF pixelDelta, QPointF angleDelta, Qt::KeyboardModifiers modifiers)
+{
+    if (!m_flickable || (pixelDelta.isNull() && angleDelta.isNull())) {
+        return false;
+    }
+
+    const qreal width = m_flickable->width();
+    const qreal height = m_flickable->height();
+    const qreal contentWidth = m_flickable->property("contentWidth").toReal();
+    const qreal contentHeight = m_flickable->property("contentHeight").toReal();
+    const qreal contentX = m_flickable->property("contentX").toReal();
+    const qreal contentY = m_flickable->property("contentY").toReal();
+    const qreal topMargin = m_flickable->property("topMargin").toReal();
+    const qreal bottomMargin = m_flickable->property("bottomMargin").toReal();
+    const qreal leftMargin = m_flickable->property("leftMargin").toReal();
+    const qreal rightMargin = m_flickable->property("rightMargin").toReal();
+    const qreal originX = m_flickable->property("originX").toReal();
+    const qreal originY = m_flickable->property("originY").toReal();
+    const qreal pageWidth = width - leftMargin - rightMargin;
+    const qreal pageHeight = height - topMargin - bottomMargin;
+    const auto window = m_flickable->window();
+    const auto screen = window ? window->screen() : nullptr;
+    const qreal devicePixelRatio = window != nullptr ? window->devicePixelRatio() : qGuiApp->devicePixelRatio();
+    const qreal refreshRate = screen ? screen->refreshRate() : 0;
+
+    // HACK: Only transpose deltas when not using xcb in order to not conflict with xcb's own delta transposing
+    if (modifiers & m_defaultHorizontalScrollModifiers && qGuiApp->platformName() != QLatin1String("xcb")) {
+        angleDelta = angleDelta.transposed();
+        pixelDelta = pixelDelta.transposed();
+    }
+
+    const qreal xTicks = angleDelta.x() / 120;
+    const qreal yTicks = angleDelta.y() / 120;
+    bool scrolled = false;
+
+    auto getChange = [pageScrollModifiers = modifiers & m_pageScrollModifiers](qreal ticks, qreal pixelDelta, qreal stepSize, qreal pageSize) {
+        // Use page size with pageScrollModifiers. Matches QScrollBar, which uses QAbstractSlider behavior.
+        if (pageScrollModifiers) {
+            return qBound(-pageSize, ticks * pageSize, pageSize);
+        } else if (pixelDelta != 0) {
+            return pixelDelta;
+        } else {
+            return ticks * stepSize;
+        }
+    };
+
+    auto getPosition = [devicePixelRatio](qreal size,
+                                          qreal contentSize,
+                                          qreal contentPos,
+                                          qreal originPos,
+                                          qreal pageSize,
+                                          qreal leadingMargin,
+                                          qreal trailingMargin,
+                                          qreal change,
+                                          const QPropertyAnimation &animation) {
+        if (contentSize <= pageSize) {
+            return contentPos;
+        }
+
+        // contentX and contentY use reversed signs from what x and y would normally use, so flip the signs
+
+        qreal minExtent = leadingMargin - originPos;
+        qreal maxExtent = size - (contentSize + trailingMargin + originPos);
+        qreal newContentPos = (animation.state() == QPropertyAnimation::Running ? animation.endValue().toReal() : contentPos) - change;
+        // bound the values without asserts
+        newContentPos = std::max(-minExtent, std::min(newContentPos, -maxExtent));
+
+        // Flickable::pixelAligned rounds the position, so round to mimic that behavior.
+        // Rounding prevents fractional positioning from causing text to be
+        // clipped off on the top and bottom.
+        // Multiply by devicePixelRatio before rounding and divide by devicePixelRatio
+        // after to make position match pixels on the screen more closely.
+        return std::round(newContentPos * devicePixelRatio) / devicePixelRatio;
+    };
+
+    auto setPosition = [this, devicePixelRatio, refreshRate](qreal oldPos, qreal newPos, qreal stepSize, const char *property, QPropertyAnimation &animation) {
+        animation.stop();
+        if (oldPos == newPos) {
+            return false;
+        }
+        if (!m_smoothScroll || refreshRate <= 0) {
+            animation.setDuration(0);
+            m_flickable->setProperty(property, newPos);
+            return true;
+        }
+
+        // Can't use wheelEvent->deviceType() to determine device type since
+        // on Wayland mouse is always regarded as touchpad:
+        // https://invent.kde.org/qt/qt/qtwayland/-/blob/e695a39519a7629c1549275a148cfb9ab99a07a9/src/client/qwaylandinputdevice.cpp#L445
+        // Mouse wheel can generate angle delta like 240, 360 and so on when
+        // scrolling very fast on some mice such as the Logitech M150.
+        // Mice with hi-res mouse wheels such as the Logitech MX Master 3 can
+        // generate angle deltas as small as 16.
+        // On X11, trackpads can also generate very fine angle deltas.
+
+        // Duration is based on the duration and movement for 120 angle delta.
+        // Shorten duration for smaller movements, limit duration for big movements.
+        // We don't want fine deltas to feel extra slow and fast scrolling should still feel fast.
+        // Minimum 3 frames for a 60hz display if delta > 2 physical pixels
+        // (start already rendered -> 1/3 rendered -> 2/3 rendered -> end rendered).
+        // Skip animation if <= 2 real frames for low refresh rate screens.
+        // Otherwise, we don't scale the duration based on refresh rate or
+        // device pixel ratio to avoid making the animation unexpectedly
+        // longer or shorter on different screens.
+
+        qreal absPixelDelta = std::abs(newPos - oldPos);
+        int duration = absPixelDelta * devicePixelRatio > 2 //
+            ? std::max(qCeil(1000.0 / 60.0 * 3), std::min(qRound(absPixelDelta * m_longAnimationDuration / stepSize), m_longAnimationDuration))
+            : 0;
+        animation.setDuration(duration <= qCeil(1000.0 / refreshRate * 2) ? 0 : duration);
+        if (animation.duration() > 0) {
+            animation.setStartValue(oldPos);
+            animation.setEndValue(newPos);
+            animation.start(QAbstractAnimation::KeepWhenStopped);
+        } else {
+            m_flickable->setProperty(property, newPos);
+        }
+        return true;
+    };
+
+    qreal xChange = getChange(xTicks, pixelDelta.x(), m_horizontalStepSize, pageWidth);
+    qreal newContentX = getPosition(width, contentWidth, contentX, originX, pageWidth, leftMargin, rightMargin, xChange, m_xScrollAnimation);
+
+    qreal yChange = getChange(yTicks, pixelDelta.y(), m_verticalStepSize, pageHeight);
+    qreal newContentY = getPosition(height, contentHeight, contentY, originY, pageHeight, topMargin, bottomMargin, yChange, m_yScrollAnimation);
+
+    // Don't use `||` because we need the position to be set for contentX and contentY.
+    scrolled |= setPosition(contentX, newContentX, m_horizontalStepSize, "contentX", m_xScrollAnimation);
+    scrolled |= setPosition(contentY, newContentY, m_verticalStepSize, "contentY", m_yScrollAnimation);
+
+    return scrolled;
+}
+
+bool WheelHandler::scrollUp(qreal stepSize)
+{
+    if (qFuzzyIsNull(stepSize)) {
+        return false;
+    } else if (stepSize < 0) {
+        stepSize = m_verticalStepSize;
+    }
+    // contentY uses reversed sign
+    return scrollFlickable(QPointF(0, stepSize));
+}
+
+bool WheelHandler::scrollDown(qreal stepSize)
+{
+    if (qFuzzyIsNull(stepSize)) {
+        return false;
+    } else if (stepSize < 0) {
+        stepSize = m_verticalStepSize;
+    }
+    // contentY uses reversed sign
+    return scrollFlickable(QPointF(0, -stepSize));
+}
+
+bool WheelHandler::scrollLeft(qreal stepSize)
+{
+    if (qFuzzyIsNull(stepSize)) {
+        return false;
+    } else if (stepSize < 0) {
+        stepSize = m_horizontalStepSize;
+    }
+    // contentX uses reversed sign
+    return scrollFlickable(QPoint(stepSize, 0));
+}
+
+bool WheelHandler::scrollRight(qreal stepSize)
+{
+    if (qFuzzyIsNull(stepSize)) {
+        return false;
+    } else if (stepSize < 0) {
+        stepSize = m_horizontalStepSize;
+    }
+    // contentX uses reversed sign
+    return scrollFlickable(QPoint(-stepSize, 0));
+}
+
+bool WheelHandler::eventFilter(QObject *watched, QEvent *event)
+{
+    auto item = qobject_cast<QQuickItem *>(watched);
+    if (!item || !item->isEnabled()) {
+        return false;
+    }
+
+    // We only process keyboard events for QQuickScrollView.
+    const auto eventType = event->type();
+    if (item == m_scrollView && eventType != QEvent::KeyPress && eventType != QEvent::KeyRelease) {
+        return false;
+    }
+
+    qreal contentWidth = 0;
+    qreal contentHeight = 0;
+    qreal pageWidth = 0;
+    qreal pageHeight = 0;
+    if (m_flickable) {
+        contentWidth = m_flickable->property("contentWidth").toReal();
+        contentHeight = m_flickable->property("contentHeight").toReal();
+        pageWidth = m_flickable->width() - m_flickable->property("leftMargin").toReal() - m_flickable->property("rightMargin").toReal();
+        pageHeight = m_flickable->height() - m_flickable->property("topMargin").toReal() - m_flickable->property("bottomMargin").toReal();
+    }
+
+    // The code handling touch, mouse and hover events is mostly copied/adapted from QQuickScrollView::childMouseEventFilter()
+    switch (eventType) {
+    case QEvent::Wheel: {
+        // QQuickScrollBar::interactive handling Matches behavior in QQuickScrollView::eventFilter()
+        if (m_filterMouseEvents) {
+            if (m_verticalScrollBar) {
+                m_verticalScrollBar->setProperty("interactive", true);
+            }
+            if (m_horizontalScrollBar) {
+                m_horizontalScrollBar->setProperty("interactive", true);
+            }
+        }
+        QWheelEvent *wheelEvent = static_cast<QWheelEvent *>(event);
+
+        // NOTE: On X11 with libinput, pixelDelta is identical to angleDelta when using a mouse that shouldn't use pixelDelta.
+        // If faulty pixelDelta, reset pixelDelta to (0,0).
+        if (wheelEvent->pixelDelta() == wheelEvent->angleDelta()) {
+            // In order to change any of the data, we have to create a whole new QWheelEvent from its constructor.
+            QWheelEvent newWheelEvent(wheelEvent->position(),
+                                      wheelEvent->globalPosition(),
+                                      QPoint(0, 0), // pixelDelta
+                                      wheelEvent->angleDelta(),
+                                      wheelEvent->buttons(),
+                                      wheelEvent->modifiers(),
+                                      wheelEvent->phase(),
+                                      wheelEvent->inverted(),
+                                      wheelEvent->source());
+            m_kirigamiWheelEvent.initializeFromEvent(&newWheelEvent);
+        } else {
+            m_kirigamiWheelEvent.initializeFromEvent(wheelEvent);
+        }
+
+        Q_EMIT wheel(&m_kirigamiWheelEvent);
+
+        if (m_wheelEvents.count() > 6) {
+            m_wheelEvents.dequeue();
+            m_timestamps.dequeue();
+        }
+        if (m_wheelEvents.count() > 2 && wheelEvent->isEndEvent()) {
+            startInertiaScrolling();
+        } else {
+            m_wheelEvents.enqueue(wheelEvent->pixelDelta());
+            m_timestamps.enqueue(wheelEvent->timestamp());
+        }
+
+        if (m_kirigamiWheelEvent.isAccepted()) {
+            return true;
+        }
+
+        bool scrolled = false;
+        if (m_scrollFlickableTarget || (contentHeight <= pageHeight && contentWidth <= pageWidth)) {
+            // Don't use pixelDelta from the event unless angleDelta is not available
+            // because scrolling by pixelDelta is too slow on Wayland with libinput.
+            QPointF pixelDelta = m_kirigamiWheelEvent.angleDelta().isNull() ? m_kirigamiWheelEvent.pixelDelta() : QPoint(0, 0);
+            scrolled = scrollFlickable(pixelDelta, m_kirigamiWheelEvent.angleDelta(), Qt::KeyboardModifiers(m_kirigamiWheelEvent.modifiers()));
+        }
+        setScrolling(scrolled);
+
+        // NOTE: Wheel events created by touchpad gestures with pixel deltas will cause scrolling to jump back
+        // to where scrolling started unless the event is always accepted before it reaches the Flickable.
+        bool flickableWillUseGestureScrolling = !(wheelEvent->source() == Qt::MouseEventNotSynthesized || wheelEvent->pixelDelta().isNull());
+        return scrolled || m_blockTargetWheel || flickableWillUseGestureScrolling;
+    }
+
+    case QEvent::TouchBegin: {
+        m_wasTouched = true;
+        if (!m_filterMouseEvents) {
+            break;
+        }
+        if (m_verticalScrollBar) {
+            m_verticalScrollBar->setProperty("interactive", false);
+        }
+        if (m_horizontalScrollBar) {
+            m_horizontalScrollBar->setProperty("interactive", false);
+        }
+        break;
+    }
+
+    case QEvent::TouchEnd: {
+        m_wasTouched = false;
+        break;
+    }
+
+    case QEvent::MouseButtonPress: {
+        // NOTE: Flickable does not handle touch events, only synthesized mouse events
+        m_wasTouched = static_cast<QMouseEvent *>(event)->source() != Qt::MouseEventNotSynthesized;
+        if (!m_filterMouseEvents) {
+            break;
+        }
+        if (!m_wasTouched) {
+            if (m_verticalScrollBar) {
+                m_verticalScrollBar->setProperty("interactive", true);
+            }
+            if (m_horizontalScrollBar) {
+                m_horizontalScrollBar->setProperty("interactive", true);
+            }
+            break;
+        }
+        return !m_wasTouched && item == m_flickable;
+    }
+
+    case QEvent::MouseMove:
+    case QEvent::MouseButtonRelease: {
+        setScrolling(false);
+        if (!m_filterMouseEvents) {
+            break;
+        }
+        if (static_cast<QMouseEvent *>(event)->source() == Qt::MouseEventNotSynthesized && item == m_flickable) {
+            return true;
+        }
+        break;
+    }
+
+    case QEvent::HoverEnter:
+    case QEvent::HoverMove: {
+        if (!m_filterMouseEvents) {
+            break;
+        }
+        if (m_wasTouched && (item == m_verticalScrollBar || item == m_horizontalScrollBar)) {
+            if (m_verticalScrollBar) {
+                m_verticalScrollBar->setProperty("interactive", true);
+            }
+            if (m_horizontalScrollBar) {
+                m_horizontalScrollBar->setProperty("interactive", true);
+            }
+        }
+        break;
+    }
+
+    case QEvent::KeyPress: {
+        if (!m_keyNavigationEnabled) {
+            break;
+        }
+        QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+        bool horizontalScroll = keyEvent->modifiers() & m_defaultHorizontalScrollModifiers;
+        switch (keyEvent->key()) {
+        case Qt::Key_Up:
+            return scrollUp();
+        case Qt::Key_Down:
+            return scrollDown();
+        case Qt::Key_Left:
+            return scrollLeft();
+        case Qt::Key_Right:
+            return scrollRight();
+        case Qt::Key_PageUp:
+            return horizontalScroll ? scrollLeft(pageWidth) : scrollUp(pageHeight);
+        case Qt::Key_PageDown:
+            return horizontalScroll ? scrollRight(pageWidth) : scrollDown(pageHeight);
+        case Qt::Key_Home:
+            return horizontalScroll ? scrollLeft(contentWidth) : scrollUp(contentHeight);
+        case Qt::Key_End:
+            return horizontalScroll ? scrollRight(contentWidth) : scrollDown(contentHeight);
+        default:
+            break;
+        }
+        break;
+    }
+
+    default:
+        break;
+    }
+
+    return false;
+}
+
+#include "moc_wheelhandler.cpp"

--- a/vendor/kirigami-wheelhandler/wheelhandler.cpp
+++ b/vendor/kirigami-wheelhandler/wheelhandler.cpp
@@ -741,7 +741,7 @@ bool WheelHandler::eventFilter(QObject *watched, QEvent *event)
             m_wheelEvents.dequeue();
             m_timestamps.dequeue();
         }
-        if (m_wheelEvents.count() > 2 && wheelEvent->isEndEvent()) {
+        if (m_inertiaScroll && m_wheelEvents.count() > 2 && wheelEvent->isEndEvent()) {
             startInertiaScrolling();
         } else {
             m_wheelEvents.enqueue(wheelEvent->pixelDelta());

--- a/vendor/kirigami-wheelhandler/wheelhandler.cpp
+++ b/vendor/kirigami-wheelhandler/wheelhandler.cpp
@@ -109,6 +109,18 @@ WheelHandler::WheelHandler(QObject *parent)
     m_xInertiaScrollAnimation.setEasingCurve(QEasingCurve::OutQuad);
     m_yInertiaScrollAnimation.setEasingCurve(QEasingCurve::OutQuad);
 
+    // The inertia end value is bounded once in startInertiaScrolling(), but views that
+    // estimate their content geometry (ListView with mixed delegate heights) move those
+    // bounds while the animation runs, leaving the content stuck past the real edge
+    // (https://bugs.kde.org/show_bug.cgi?id=508229). Re-clamp against live bounds on
+    // every tick and stop at the edge instead.
+    connect(&m_xInertiaScrollAnimation, &QVariantAnimation::valueChanged, this, [this]() {
+        clampInertiaAnimation(m_xInertiaScrollAnimation, false);
+    });
+    connect(&m_yInertiaScrollAnimation, &QVariantAnimation::valueChanged, this, [this]() {
+        clampInertiaAnimation(m_yInertiaScrollAnimation, true);
+    });
+
     connect(QGuiApplication::styleHints(), &QStyleHints::wheelScrollLinesChanged, this, [this](int scrollLines) {
         m_defaultPixelStepSize = 20 * scrollLines;
         if (!m_explicitVStepSize && m_verticalStepSize != m_defaultPixelStepSize) {
@@ -499,6 +511,30 @@ void WheelHandler::startInertiaScrolling()
         m_yInertiaScrollAnimation.setEndValue(boundedEndValue.y());
         m_yInertiaScrollAnimation.setDuration(realTime.y());
         m_yInertiaScrollAnimation.start(QAbstractAnimation::KeepWhenStopped);
+    }
+}
+
+void WheelHandler::clampInertiaAnimation(QPropertyAnimation &animation, bool vertical)
+{
+    if (!m_flickable || animation.state() != QAbstractAnimation::Running) {
+        return;
+    }
+
+    const qreal size = vertical ? m_flickable->height() : m_flickable->width();
+    const qreal contentSize = m_flickable->property(vertical ? "contentHeight" : "contentWidth").toReal();
+    const qreal leadingMargin = m_flickable->property(vertical ? "topMargin" : "leftMargin").toReal();
+    const qreal trailingMargin = m_flickable->property(vertical ? "bottomMargin" : "rightMargin").toReal();
+    const qreal originPos = m_flickable->property(vertical ? "originY" : "originX").toReal();
+    const char *contentProperty = vertical ? "contentY" : "contentX";
+    const qreal contentPos = m_flickable->property(contentProperty).toReal();
+
+    // Same bounds as getPosition() in scrollFlickable(), recomputed from live geometry
+    const qreal minPos = originPos - leadingMargin;
+    const qreal maxPos = std::max(minPos, contentSize + trailingMargin + originPos - size);
+    const qreal boundedPos = std::max(minPos, std::min(contentPos, maxPos));
+    if (boundedPos != contentPos) {
+        animation.stop();
+        m_flickable->setProperty(contentProperty, boundedPos);
     }
 }
 

--- a/vendor/kirigami-wheelhandler/wheelhandler.h
+++ b/vendor/kirigami-wheelhandler/wheelhandler.h
@@ -197,6 +197,16 @@ class WheelHandler : public QObject
      */
     Q_PROPERTY(bool smoothScroll MEMBER m_smoothScroll NOTIFY smoothScrollChanged FINAL)
 
+    /*!
+     * This property holds whether an inertia animation continues scrolling after a touchpad
+     * gesture ends. Disabled by default: the upstream implementation clamps the animation
+     * against bounds captured when the gesture ends, which leaves views that estimate their
+     * content geometry (ListView with mixed delegate heights) stuck past the real edge
+     * (https://bugs.kde.org/show_bug.cgi?id=508229). Platforms with system momentum (macOS)
+     * do not need it either way.
+     */
+    Q_PROPERTY(bool inertiaScroll MEMBER m_inertiaScroll NOTIFY inertiaScrollChanged FINAL)
+
 public:
     explicit WheelHandler(QObject *parent = nullptr);
     ~WheelHandler() override;
@@ -256,6 +266,7 @@ Q_SIGNALS:
     void blockTargetWheelChanged();
     void scrollFlickableTargetChanged();
     void smoothScrollChanged();
+    void inertiaScrollChanged();
 
     /*!
      * This signal is emitted when a wheel event reaches the event filter, just before scrolling
@@ -297,6 +308,7 @@ private:
     bool m_blockTargetWheel = true;
     bool m_scrollFlickableTarget = true;
     bool m_smoothScroll = true;
+    bool m_inertiaScroll = false;
     // Same as QXcbWindow.
     constexpr static Qt::KeyboardModifiers m_defaultHorizontalScrollModifiers = Qt::AltModifier;
     // Same as QScrollBar/QAbstractSlider.

--- a/vendor/kirigami-wheelhandler/wheelhandler.h
+++ b/vendor/kirigami-wheelhandler/wheelhandler.h
@@ -199,11 +199,13 @@ class WheelHandler : public QObject
 
     /*!
      * This property holds whether an inertia animation continues scrolling after a touchpad
-     * gesture ends. Disabled by default: the upstream implementation clamps the animation
-     * against bounds captured when the gesture ends, which leaves views that estimate their
-     * content geometry (ListView with mixed delegate heights) stuck past the real edge
-     * (https://bugs.kde.org/show_bug.cgi?id=508229). Platforms with system momentum (macOS)
-     * do not need it either way.
+     * gesture ends. The default value is true. Only relevant on platforms without system
+     * momentum events (macOS delivers its own).
+     *
+     * Unlike upstream, the animation is re-clamped against the target's live bounds on every
+     * tick; the upstream implementation only bounds it once when the gesture ends, which
+     * leaves views that estimate their content geometry (ListView with mixed delegate
+     * heights) stuck past the real edge (https://bugs.kde.org/show_bug.cgi?id=508229).
      */
     Q_PROPERTY(bool inertiaScroll MEMBER m_inertiaScroll NOTIFY inertiaScrollChanged FINAL)
 
@@ -284,6 +286,7 @@ private Q_SLOTS:
 private:
     void setScrolling(bool scrolling);
     void startInertiaScrolling();
+    void clampInertiaAnimation(QPropertyAnimation &animation, bool vertical);
     bool scrollFlickable(QPointF pixelDelta, QPointF angleDelta = {}, Qt::KeyboardModifiers modifiers = Qt::NoModifier);
 
     QPointer<QQuickItem> m_flickable;
@@ -308,7 +311,7 @@ private:
     bool m_blockTargetWheel = true;
     bool m_scrollFlickableTarget = true;
     bool m_smoothScroll = true;
-    bool m_inertiaScroll = false;
+    bool m_inertiaScroll = true;
     // Same as QXcbWindow.
     constexpr static Qt::KeyboardModifiers m_defaultHorizontalScrollModifiers = Qt::AltModifier;
     // Same as QScrollBar/QAbstractSlider.

--- a/vendor/kirigami-wheelhandler/wheelhandler.h
+++ b/vendor/kirigami-wheelhandler/wheelhandler.h
@@ -1,0 +1,316 @@
+/* SPDX-FileCopyrightText: 2019 Marco Martin <mart@kde.org>
+ * SPDX-FileCopyrightText: 2021 Noah Davis <noahadvs@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ *
+ * Vendored from KDE Kirigami (src/wheelhandler.h), see VENDORING.md.
+ */
+
+#pragma once
+
+#include <QGuiApplication>
+#include <QObject>
+#include <QPoint>
+#include <QPropertyAnimation>
+#include <QQueue>
+#include <QQuickItem>
+#include <QStyleHints>
+#include <QTimer>
+#include <QtQml/qqmlregistration.h>
+
+class QWheelEvent;
+class WheelHandler;
+
+/*!
+ * Describes a mouse wheel event, as exposed to the WheelHandler::wheel signal.
+ */
+class KirigamiWheelEvent : public QObject
+{
+    Q_OBJECT
+    QML_NAMED_ELEMENT(ViciWheelEvent)
+    QML_UNCREATABLE("")
+
+    Q_PROPERTY(qreal x READ x CONSTANT FINAL)
+    Q_PROPERTY(qreal y READ y CONSTANT FINAL)
+    Q_PROPERTY(QPointF angleDelta READ angleDelta CONSTANT FINAL)
+    Q_PROPERTY(QPointF pixelDelta READ pixelDelta CONSTANT FINAL)
+    Q_PROPERTY(int buttons READ buttons CONSTANT FINAL)
+    Q_PROPERTY(int modifiers READ modifiers CONSTANT FINAL)
+    Q_PROPERTY(bool inverted READ inverted CONSTANT FINAL)
+
+    /*!
+     * If set, the event shouldn't be managed anymore,
+     * for instance it can be used to block the handler to manage the scroll of a view on some scenarios.
+     * \code
+     * // This handler handles automatically the scroll of
+     * // flickableItem, unless Ctrl is pressed, in this case the
+     * // app has custom code to handle Ctrl+wheel zooming
+     * ViciWheelHandler {
+     *   target: flickableItem
+     *   blockTargetWheel: true
+     *   scrollFlickableTarget: true
+     *   onWheel: {
+     *        if (wheel.modifiers & Qt.ControlModifier) {
+     *            wheel.accepted = true;
+     *            // Handle scaling of the view
+     *       }
+     *   }
+     * }
+     * \endcode
+     */
+    Q_PROPERTY(bool accepted READ isAccepted WRITE setAccepted FINAL)
+
+public:
+    KirigamiWheelEvent(QObject *parent = nullptr);
+    ~KirigamiWheelEvent() override;
+
+    void initializeFromEvent(QWheelEvent *event);
+
+    qreal x() const;
+    qreal y() const;
+    QPointF angleDelta() const;
+    QPointF pixelDelta() const;
+    int buttons() const;
+    int modifiers() const;
+    bool inverted() const;
+    bool isAccepted();
+    void setAccepted(bool accepted);
+
+private:
+    qreal m_x = 0;
+    qreal m_y = 0;
+    QPointF m_angleDelta;
+    QPointF m_pixelDelta;
+    Qt::MouseButtons m_buttons = Qt::NoButton;
+    Qt::KeyboardModifiers m_modifiers = Qt::NoModifier;
+    bool m_inverted = false;
+    bool m_accepted = false;
+};
+
+class WheelFilterItem : public QQuickItem
+{
+    Q_OBJECT
+public:
+    WheelFilterItem(QQuickItem *parent = nullptr);
+};
+
+/*!
+ * Handles scrolling for a Flickable and 2 attached ScrollBars.
+ *
+ * WheelHandler filters events from a Flickable, a vertical ScrollBar and a horizontal ScrollBar.
+ * Wheel and KeyPress events (when keyNavigationEnabled is true) are used to scroll the Flickable.
+ * When filterMouseEvents is true, WheelHandler blocks mouse button input from reaching the Flickable
+ * and sets the interactive property of the scrollbars to false when touch input is used.
+ *
+ * Wheel event handling behavior:
+ * - Pixel delta is ignored unless angle delta is not available because pixel delta scrolling is
+ *   too slow. Qt Widgets doesn't use pixel delta either, so the default scroll speed should be
+ *   consistent with Qt Widgets.
+ * - When using angle delta, scroll using the step increments defined by verticalStepSize and
+ *   horizontalStepSize.
+ * - When one of the keyboard modifiers in pageScrollModifiers is used, scroll by pages.
+ * - When using a device that doesn't use 120 angle delta unit increments such as a touchpad,
+ *   the verticalStepSize, horizontalStepSize and page increments (if using page scrolling)
+ *   will be multiplied by angle delta / 120 to keep scrolling smooth.
+ * - If scrolling has happened in the last 400ms, use an internal QQuickItem stacked over the
+ *   Flickable's contentItem to catch wheel events and use those wheel events to scroll, if
+ *   possible. This prevents controls inside the Flickable's contentItem that allow scrolling
+ *   to change the value (e.g., Sliders, SpinBoxes) from conflicting with scrolling the page.
+ */
+class WheelHandler : public QObject
+{
+    Q_OBJECT
+    QML_NAMED_ELEMENT(ViciWheelHandler)
+
+    /*!
+     * This property holds the Qt Quick Flickable that the WheelHandler will control.
+     */
+    Q_PROPERTY(QQuickItem *target READ target WRITE setTarget NOTIFY targetChanged FINAL)
+
+    /*!
+     * This property holds the vertical step size.
+     * The default value is equivalent to 20 * Qt.styleHints.wheelScrollLines. This is consistent
+     * with the default increment for QScrollArea.
+     */
+    Q_PROPERTY(qreal verticalStepSize READ verticalStepSize WRITE setVerticalStepSize RESET resetVerticalStepSize NOTIFY verticalStepSizeChanged FINAL)
+
+    /*!
+     * This property holds the horizontal step size.
+     * The default value is equivalent to 20 * Qt.styleHints.wheelScrollLines. This is consistent
+     * with the default increment for QScrollArea.
+     */
+    Q_PROPERTY(
+        qreal horizontalStepSize READ horizontalStepSize WRITE setHorizontalStepSize RESET resetHorizontalStepSize NOTIFY horizontalStepSizeChanged FINAL)
+
+    /*!
+     * This property holds the keyboard modifiers that will be used to start page scrolling.
+     * The default value is equivalent to Qt.ControlModifier | Qt.ShiftModifier. This matches
+     * QScrollBar, which uses QAbstractSlider behavior.
+     */
+    Q_PROPERTY(Qt::KeyboardModifiers pageScrollModifiers READ pageScrollModifiers WRITE setPageScrollModifiers RESET resetPageScrollModifiers NOTIFY
+                   pageScrollModifiersChanged FINAL)
+
+    /*!
+     * This property holds whether the WheelHandler filters mouse events like a Qt Quick Controls
+     * ScrollView would.
+     *
+     * Touch events are allowed to flick the view and they make the scrollbars not interactive.
+     * Mouse events are not allowed to flick the view and they make the scrollbars interactive.
+     * Hover events on the scrollbars and wheel events on anything also make the scrollbars
+     * interactive when this property is set to true.
+     *
+     * The default value is false.
+     */
+    Q_PROPERTY(bool filterMouseEvents READ filterMouseEvents WRITE setFilterMouseEvents NOTIFY filterMouseEventsChanged FINAL)
+
+    /*!
+     * This property holds whether the WheelHandler handles keyboard scrolling.
+     * Arrows scroll a step, PageUp/PageDown scroll by pages, Home/End scroll to the
+     * beginning/end. When Alt is held, scrolling is horizontal.
+     *
+     * The default value is false.
+     */
+    Q_PROPERTY(bool keyNavigationEnabled READ keyNavigationEnabled WRITE setKeyNavigationEnabled NOTIFY keyNavigationEnabledChanged FINAL)
+
+    /*!
+     * This property holds whether the WheelHandler blocks all wheel events from reaching the Flickable.
+     *
+     * When this property is false, scrolling the Flickable with WheelHandler will only block an
+     * event from reaching the Flickable if the Flickable is actually scrolled by WheelHandler.
+     *
+     * NOTE: Wheel events created by touchpad gestures with pixel deltas will always be accepted
+     * no matter what. This is because they will cause the Flickable to jump back to where
+     * scrolling started unless the events are always accepted before they reach the Flickable.
+     *
+     * The default value is true.
+     */
+    Q_PROPERTY(bool blockTargetWheel MEMBER m_blockTargetWheel NOTIFY blockTargetWheelChanged FINAL)
+
+    /*!
+     * This property holds whether the WheelHandler can use wheel events to scroll the Flickable.
+     * The default value is true.
+     */
+    Q_PROPERTY(bool scrollFlickableTarget MEMBER m_scrollFlickableTarget NOTIFY scrollFlickableTargetChanged FINAL)
+
+    /*!
+     * This property holds whether step scrolling (mouse wheel, keyboard) is animated.
+     * The default value is true.
+     */
+    Q_PROPERTY(bool smoothScroll MEMBER m_smoothScroll NOTIFY smoothScrollChanged FINAL)
+
+public:
+    explicit WheelHandler(QObject *parent = nullptr);
+    ~WheelHandler() override;
+
+    QQuickItem *target() const;
+    void setTarget(QQuickItem *target);
+
+    qreal verticalStepSize() const;
+    void setVerticalStepSize(qreal stepSize);
+    void resetVerticalStepSize();
+
+    qreal horizontalStepSize() const;
+    void setHorizontalStepSize(qreal stepSize);
+    void resetHorizontalStepSize();
+
+    Qt::KeyboardModifiers pageScrollModifiers() const;
+    void setPageScrollModifiers(Qt::KeyboardModifiers modifiers);
+    void resetPageScrollModifiers();
+
+    bool filterMouseEvents() const;
+    void setFilterMouseEvents(bool enabled);
+
+    bool keyNavigationEnabled() const;
+    void setKeyNavigationEnabled(bool enabled);
+
+    /*!
+     * Scroll up one step. If the stepSize parameter is less than 0, the verticalStepSize will be used.
+     * Returns true if the contentItem was moved.
+     */
+    Q_INVOKABLE bool scrollUp(qreal stepSize = -1);
+
+    /*!
+     * Scroll down one step. If the stepSize parameter is less than 0, the verticalStepSize will be used.
+     * Returns true if the contentItem was moved.
+     */
+    Q_INVOKABLE bool scrollDown(qreal stepSize = -1);
+
+    /*!
+     * Scroll left one step. If the stepSize parameter is less than 0, the horizontalStepSize will be used.
+     * Returns true if the contentItem was moved.
+     */
+    Q_INVOKABLE bool scrollLeft(qreal stepSize = -1);
+
+    /*!
+     * Scroll right one step. If the stepSize parameter is less than 0, the horizontalStepSize will be used.
+     * Returns true if the contentItem was moved.
+     */
+    Q_INVOKABLE bool scrollRight(qreal stepSize = -1);
+
+Q_SIGNALS:
+    void targetChanged();
+    void verticalStepSizeChanged();
+    void horizontalStepSizeChanged();
+    void pageScrollModifiersChanged();
+    void filterMouseEventsChanged();
+    void keyNavigationEnabledChanged();
+    void blockTargetWheelChanged();
+    void scrollFlickableTargetChanged();
+    void smoothScrollChanged();
+
+    /*!
+     * This signal is emitted when a wheel event reaches the event filter, just before scrolling
+     * is handled. Accepting the wheel event in the onWheel signal handler prevents scrolling
+     * from happening.
+     */
+    void wheel(KirigamiWheelEvent *wheel);
+
+protected:
+    bool eventFilter(QObject *watched, QEvent *event) override;
+
+private Q_SLOTS:
+    void _k_rebindScrollBars();
+
+private:
+    void setScrolling(bool scrolling);
+    void startInertiaScrolling();
+    bool scrollFlickable(QPointF pixelDelta, QPointF angleDelta = {}, Qt::KeyboardModifiers modifiers = Qt::NoModifier);
+
+    QPointer<QQuickItem> m_flickable;
+    QPointer<QQuickItem> m_verticalScrollBar;
+    QPointer<QQuickItem> m_horizontalScrollBar;
+    QPointer<QQuickItem> m_scrollView;
+    QMetaObject::Connection m_verticalChangedConnection;
+    QMetaObject::Connection m_horizontalChangedConnection;
+    QPointer<QQuickItem> m_filterItem;
+    // Matches QScrollArea and QTextEdit
+    qreal m_defaultPixelStepSize = 20 * QGuiApplication::styleHints()->wheelScrollLines();
+    qreal m_verticalStepSize = m_defaultPixelStepSize;
+    qreal m_horizontalStepSize = m_defaultPixelStepSize;
+    bool m_explicitVStepSize = false;
+    bool m_explicitHStepSize = false;
+    bool m_wheelScrolling = false;
+    constexpr static qreal m_wheelScrollingDuration = 400;
+    // Replaces Kirigami::Platform::Units::longDuration for scroll animation durations.
+    constexpr static int m_longAnimationDuration = 200;
+    bool m_filterMouseEvents = false;
+    bool m_keyNavigationEnabled = false;
+    bool m_blockTargetWheel = true;
+    bool m_scrollFlickableTarget = true;
+    bool m_smoothScroll = true;
+    // Same as QXcbWindow.
+    constexpr static Qt::KeyboardModifiers m_defaultHorizontalScrollModifiers = Qt::AltModifier;
+    // Same as QScrollBar/QAbstractSlider.
+    constexpr static Qt::KeyboardModifiers m_defaultPageScrollModifiers = Qt::ControlModifier | Qt::ShiftModifier;
+    Qt::KeyboardModifiers m_pageScrollModifiers = m_defaultPageScrollModifiers;
+    QTimer m_wheelScrollingTimer;
+    KirigamiWheelEvent m_kirigamiWheelEvent;
+    QQueue<QPoint> m_wheelEvents;
+    QQueue<uint64_t> m_timestamps;
+
+    // Smooth scrolling
+    QPropertyAnimation m_xScrollAnimation{nullptr, "contentX"};
+    QPropertyAnimation m_yScrollAnimation{nullptr, "contentY"};
+    QPropertyAnimation m_xInertiaScrollAnimation{nullptr, "contentX"};
+    QPropertyAnimation m_yInertiaScrollAnimation{nullptr, "contentY"};
+    bool m_wasTouched = false;
+};


### PR DESCRIPTION
Use the [kirigami](https://github.com/KDE/kirigami) wheel handler for the major flickables.

This fixes slow scrolling issues on Linux/Wayland and also disables the weird macOS bounce thingy, which doesn't seem to fully work anyways.

We also fix a bug where the scroll inertia wouldn't be capped to the list view bounds properly as the ListView updates its height calculation.