### PR TITLE
feat: install browser extension native host manifests at runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,8 +52,13 @@ option(USE_SYSTEM_QT_KEYCHAIN "Use system qt-keychain instead of building it fro
 option(ENABLE_SANITIZERS "Enable ASan + UBSan for debug builds" OFF)
 option(ENABLE_CLANG_TIDY "Run clang-tidy during compilation" OFF)
 option(INSTALL_MODULES_LOAD_CONFIG "Install config files to auto load required kernel modules" ON)
+option(AUTO_INSTALL_BROWSER_MANIFESTS "Install per-user browser native messaging host manifests at server startup" ON)
 
 set(VICINAE_BUNDLE_ID "com.vicinaehq.Vicinae" CACHE STRING "macOS app bundle identifier")
+
+set(NATIVE_MESSAGING_HOST "com.vicinae.vicinae")
+set(CHROME_EXTENSION_ID "kcmipingpfbohfjckomimmahknoddnke") # https://chromewebstore.google.com/detail/vicinae-integration/kcmipingpfbohfjckomimmahknoddnke
+set(FIREFOX_EXTENSION_ID "firefox@vicinae.com")
 
 if (ENABLE_CLANG_TIDY)
 	set(CMAKE_CXX_CLANG_TIDY clang-tidy)

--- a/nix/vicinae.nix
+++ b/nix/vicinae.nix
@@ -74,7 +74,7 @@ in
       "CMAKE_INSTALL_DATAROOTDIR" = "share";
       "CMAKE_INSTALL_BINDIR" = "bin";
       "CMAKE_INSTALL_LIBDIR" = "lib";
-      "INSTALL_BROWSER_NATIVE_HOST" = "OFF";
+      "AUTO_INSTALL_BROWSER_MANIFESTS" = "OFF";
     };
 
     strictDeps = true;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -369,55 +369,6 @@ install_icons() {
 	fi
 }
 
-install_browser_manifests() {
-    echo "Installing browser native messaging manifests..." >&2
-
-    local templates_dir="$INSTALL_DIR/usr/share/vicinae/native-messaging-hosts"
-    local native_host_bin="$INSTALL_DIR/usr/libexec/vicinae/vicinae-browser-link"
-    local chrome_extension_id="com.vicinae.vicinae"
-
-    if [[ ! -d "$templates_dir" ]]; then
-        echo "Note: No browser manifest templates found" >&2
-        return
-    fi
-
-    if [[ $EUID -ne 0 ]]; then
-        warn "Note: Skipping browser native messaging manifest installation (not root)"
-        echo "  See $DOCS_URL for manual setup instructions." >&2
-        return
-    fi
-
-	# Chromium
-    local chromium_dest="/etc/chromium/native-messaging-hosts"
-    local chromium_template="$templates_dir/com.vicinae.vicinae.chromium.json.in"
-    if [[ -f "$chromium_template" ]]; then
-        if ! mkdir -p "$chromium_dest" 2>/tmp/vic.err; then
-            warn "Chromium: cannot create $chromium_dest"
-        elif ! sed -e "s|@NATIVE_HOST_BIN@|$native_host_bin|g" \
-                   -e "s|@CHROME_EXTENSION_ID@|$chrome_extension_id|g" \
-                   "$chromium_template" > "$chromium_dest/com.vicinae.vicinae.json" 2>/tmp/vic.err; then
-            warn "Chromium: failed to write manifest"
-        else
-            ok "Chromium native messaging manifest installed to $chromium_dest"
-        fi
-    fi
-
-	# Firefox
-    local firefox_dest="/usr/lib/mozilla/native-messaging-hosts"
-    local firefox_template="$templates_dir/com.vicinae.vicinae.firefox.json.in"
-    if [[ -f "$firefox_template" ]]; then
-        if ! mkdir -p "$firefox_dest" 2>/tmp/vic.err; then
-            warn "Firefox: cannot create $firefox_dest"
-        elif ! sed -e "s|@NATIVE_HOST_BIN@|$native_host_bin|g" \
-                   "$firefox_template" > "$firefox_dest/com.vicinae.vicinae.json" 2>/tmp/vic.err; then
-            warn "Firefox: failed to write manifest"
-			echo
-        else
-            ok "Firefox native messaging manifest installed"
-        fi
-    fi
-}
-
 install_input_server_capabilities() {
 	echo "Setting input server capabilities (for keyboard monitoring and injection)..." >&2
 
@@ -534,7 +485,6 @@ install_vicinae() {
 		install_desktop_files
 		install_icons
 		install_systemd_service
-		install_browser_manifests
 		install_modules_load
 		install_input_server_capabilities
 	else

--- a/scripts/macdeploy.sh
+++ b/scripts/macdeploy.sh
@@ -24,9 +24,10 @@ SIGN_IDENTITY="${VICINAE_CODESIGN_IDENTITY:--}"
 
 SERVER_BIN="$BUILD_DIR/bin/vicinae-server"
 CLI_BIN="$BUILD_DIR/bin/vicinae"
+BROWSER_LINK_BIN="$BUILD_DIR/bin/vicinae-browser-link"
 INFO_PLIST="$BUILD_DIR/Info.plist"
 
-for f in "$SERVER_BIN" "$CLI_BIN" "$INFO_PLIST"; do
+for f in "$SERVER_BIN" "$CLI_BIN" "$BROWSER_LINK_BIN" "$INFO_PLIST"; do
   if [[ ! -f "$f" ]]; then
     echo "macdeploy.sh: missing $f (build first)" >&2
     exit 1
@@ -53,7 +54,9 @@ cp "$SRC_DIR/extra/vicinae.icns" "$BUNDLE/Contents/Resources/vicinae.icns"
 cp -R "$SRC_DIR/extra/themes" "$BUNDLE/Contents/Resources/themes"
 cp "$SERVER_BIN" "$BUNDLE/Contents/MacOS/Vicinae"
 cp "$CLI_BIN" "$BUNDLE/Contents/MacOS/vicinae-cli"
-chmod +w "$BUNDLE/Contents/MacOS/Vicinae" "$BUNDLE/Contents/MacOS/vicinae-cli"
+cp "$BROWSER_LINK_BIN" "$BUNDLE/Contents/MacOS/vicinae-browser-link"
+chmod +w "$BUNDLE/Contents/MacOS/Vicinae" "$BUNDLE/Contents/MacOS/vicinae-cli" \
+         "$BUNDLE/Contents/MacOS/vicinae-browser-link"
 
 echo "==> macdeployqt"
 macdeployqt "$BUNDLE" -qmldir="$SRC_DIR/src/server/src/qml" -verbose=2
@@ -119,7 +122,8 @@ dyl_args=(-of -b -cd
   -p "@executable_path/../Frameworks/"
   -s "$BUNDLE/Contents/Frameworks"
   -x "$BUNDLE/Contents/MacOS/Vicinae"
-  -x "$BUNDLE/Contents/MacOS/vicinae-cli")
+  -x "$BUNDLE/Contents/MacOS/vicinae-cli"
+  -x "$BUNDLE/Contents/MacOS/vicinae-browser-link")
 # loose Frameworks/ dylibs included so dylibbundler rewrites any absolute
 # LC_ID_DYLIB macdeployqt left in place
 while IFS= read -r -d '' p; do
@@ -142,7 +146,8 @@ while IFS= read -r -d '' bin; do
 done < <(find "$BUNDLE/Contents/MacOS" "$BUNDLE/Contents/Frameworks" "$BUNDLE/Contents/PlugIns" -type f -print0)
 
 echo "==> strip"
-strip -x "$BUNDLE/Contents/MacOS/Vicinae" "$BUNDLE/Contents/MacOS/vicinae-cli"
+strip -x "$BUNDLE/Contents/MacOS/Vicinae" "$BUNDLE/Contents/MacOS/vicinae-cli" \
+      "$BUNDLE/Contents/MacOS/vicinae-browser-link"
 
 echo "==> signing bundle"
 sign_args=(--force --deep --sign "$SIGN_IDENTITY")

--- a/src/browser-extension/CMakeLists.txt
+++ b/src/browser-extension/CMakeLists.txt
@@ -1,8 +1,6 @@
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(TARGET vicinae-browser-link)
-set(CHROME_EXTENSION_ID "kcmipingpfbohfjckomimmahknoddnke") # https://chromewebstore.google.com/detail/vicinae-integration/kcmipingpfbohfjckomimmahknoddnke
-set(NATIVE_MESSAGING_HOST "com.vicinae.vicinae")
-set(NATIVE_HOST_BIN ${VICINAE_LIBEXEC_PATH}/${TARGET})
+# NATIVE_MESSAGING_HOST and CHROME_EXTENSION_ID are set in the top-level CMakeLists.txt
 
 include("Figura")
 
@@ -21,25 +19,6 @@ target_include_directories(${TARGET} PRIVATE ${GENOUT})
 target_compile_features(${TARGET} PUBLIC cxx_std_23)
 target_compile_definitions(${TARGET} PUBLIC NATIVE_MESSAGING_HOST="${NATIVE_MESSAGING_HOST}")
 target_link_libraries(${TARGET} PUBLIC glaze::glaze)
-
-set(DATA_DIR ${CMAKE_INSTALL_DATADIR}/vicinae)
-set(NATIVE_HOST_DATA_DIR ${DATA_DIR}/native-host)
-set(CHROMIUM_MANIFEST_TEMPLATE native-host/${NATIVE_MESSAGING_HOST}.chromium.json.in)
-set(FIREFOX_MANIFEST_TEMPLATE native-host/${NATIVE_MESSAGING_HOST}.firefox.json.in)
-
-configure_file(${CHROMIUM_MANIFEST_TEMPLATE} ${NATIVE_MESSAGING_HOST}.chromium.json)
-configure_file(${FIREFOX_MANIFEST_TEMPLATE} ${NATIVE_MESSAGING_HOST}.firefox.json)
-
-# template files (needed by the script install that needs to configure them depending on the chosen install path)
-install(FILES ${CHROMIUM_MANIFEST_TEMPLATE} DESTINATION ${NATIVE_HOST_DATA_DIR} RENAME ${NATIVE_MESSAGING_HOST}.chromium.json.in)
-install(FILES ${FIREFOX_MANIFEST_TEMPLATE} DESTINATION ${NATIVE_HOST_DATA_DIR} RENAME ${NATIVE_MESSAGING_HOST}.firefox.json.in)
-
-# we install the configured files in share/ because chromium doesn't support installing native host manifests under /usr (!) and mozilla doesn't seem
-# to support any other prefix than "/usr/lib/mozilla/native-messaging-hosts/".
-# for these reasons, it is up to the packager to decide how to deal with installing this, and we provide both the template and configured version
-# so that it can be simply processed or copied at the appropriate location.
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${NATIVE_MESSAGING_HOST}.chromium.json DESTINATION ${NATIVE_HOST_DATA_DIR}/chromium RENAME ${NATIVE_MESSAGING_HOST}.json)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${NATIVE_MESSAGING_HOST}.firefox.json DESTINATION ${NATIVE_HOST_DATA_DIR}/firefox RENAME ${NATIVE_MESSAGING_HOST}.json)
 
 install(TARGETS ${TARGET}
 	RUNTIME DESTINATION ${VICINAE_LIBEXEC_DIR}

--- a/src/browser-extension/CMakeLists.txt
+++ b/src/browser-extension/CMakeLists.txt
@@ -18,7 +18,7 @@ add_executable(${TARGET} src/browser.cpp ${SRCS})
 target_include_directories(${TARGET} PRIVATE ${GENOUT})
 target_compile_features(${TARGET} PUBLIC cxx_std_23)
 target_compile_definitions(${TARGET} PUBLIC NATIVE_MESSAGING_HOST="${NATIVE_MESSAGING_HOST}")
-target_link_libraries(${TARGET} PUBLIC glaze::glaze)
+target_link_libraries(${TARGET} PUBLIC glaze::glaze vicinae::common)
 
 install(TARGETS ${TARGET}
 	RUNTIME DESTINATION ${VICINAE_LIBEXEC_DIR}

--- a/src/browser-extension/README.md
+++ b/src/browser-extension/README.md
@@ -15,21 +15,16 @@ If you can't install the extension from the official stores, you can install the
 
 The browser extension uses [Native messaging](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging) to communicate with the vicinae daemon.
 
-You need to install the corresponding native host manifest at one of the expected locations.
+The vicinae server installs per-user native host manifests automatically at startup, for every supported browser it detects on the system. Manifests are rewritten whenever their content is stale, so moving or updating vicinae self-heals on the next launch. There is nothing to do for a regular install.
 
-Installing the manifests in system directories is **strongly recommended** because it makes them automatically discoverable by any chromium/firefox based browser.
+The manifests are written to the standard per-user locations, for example:
 
-### Using CMake
+- chromium family (Linux): `~/.config/<browser>/NativeMessagingHosts/com.vicinae.vicinae.json`
+- chromium family (macOS): `~/Library/Application Support/<browser>/NativeMessagingHosts/com.vicinae.vicinae.json`
+- firefox family (Linux): `~/.mozilla/native-messaging-hosts/com.vicinae.vicinae.json`
+- firefox family (macOS): `~/Library/Application Support/Mozilla/NativeMessagingHosts/com.vicinae.vicinae.json`
 
-The recommended way of installing the manifests is to use the provided CMake install rule to install vicinae. This rule will automatically install both manifests in the correct system locations (root access required).
-
-### Manual native host manifest install
-
-Copy the right manifest template from `./native-host/` and change the placeholder values.
-
-For firefox, you only need to replace `@NATIVE_HOST_BIN` with the absolute path to the `vicinae-browser-link` executable (e.g: `/usr/local/libexec/vicinae/vicinae-browser-link`). Then copy the manifest at `/usr/lib/mozilla/native-messaging-hosts/com.vicinae.vicinae.json`.
-
-For chromium you will also need to change the allowed origins, more on that below. The manifest needs to be copied at `/etc/chromium/native-messaging-hosts/com.vicinae.vicinae.json`.
+Packagers can disable this behavior with the `AUTO_INSTALL_BROWSER_MANIFESTS` CMake option and provision manifests themselves (the expected JSON is shown below).
 
 ## Load the browser extension
 
@@ -37,7 +32,9 @@ For chromium you will also need to change the allowed origins, more on that belo
 
 You can load the `./chrome/` directory as any unpacked extension. 
 
-Then modify the native host manifest (likely at `/etc/chromium/native-messaging-hosts/com.vicinae.vicinae.json`) and change the origin in the `allowed_origins` array to use the local extension ID that was automatically generated upon loading the unpacked extension.
+Then modify the native host manifest (e.g at `~/.config/chromium/NativeMessagingHosts/com.vicinae.vicinae.json`) and change the origin in the `allowed_origins` array to use the local extension ID that was automatically generated upon loading the unpacked extension.
+
+Note that the vicinae server rewrites manifests it does not recognize at startup, so make the file read-only (`chmod -w`) to keep your custom extension ID during development.
 
 Once that is done, reloading the extension should automatically establish a connection with vicinae if the vicinae server is running.
 
@@ -50,10 +47,6 @@ Once that is done, reloading the extension should automatically establish a conn
   * install and configure general prerequisites like git and make
 
 #### Instructions
-
-Copy the right manifest template from `./native-host/` and change the placeholder values.
-
-For firefox, you only need to replace `@NATIVE_HOST_BIN` with the absolute path to the `vicinae-browser-link` executable (e.g: `/usr/local/libexec/vicinae/vicinae-browser-link` or `/usr/libexec/vicinae/vicinae-browser-link`). Then copy the manifest at `/usr/lib/mozilla/native-messaging-hosts/com.vicinae.vicinae.json`.
 
 The following shell script demonstrates how to build and sign the app starting with cloning the repo, just update the variables at the beginning with your api secrets and the email address associated with them.
 

--- a/src/browser-extension/README.md
+++ b/src/browser-extension/README.md
@@ -7,88 +7,32 @@ This subdirectory contains:
 
 For now the extension is not published to the official stores, this is a work in progress.
 
-# Manual install
-
-If you can't install the extension from the official stores, you can install the browser extension manually.
-
-## Install native host manifest
+## Native host manifest
 
 The browser extension uses [Native messaging](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging) to communicate with the vicinae daemon.
 
-The vicinae server installs per-user native host manifests automatically at startup, for every supported browser it detects on the system. Manifests are rewritten whenever their content is stale, so moving or updating vicinae self-heals on the next launch. There is nothing to do for a regular install.
+The vicinae server writes the required per-user manifests automatically at startup for every browser it detects, so there is nothing to set up. Packagers can opt out with the `AUTO_INSTALL_BROWSER_MANIFESTS` CMake option.
 
-The manifests are written to the standard per-user locations, for example:
+## Development
 
-- chromium family (Linux): `~/.config/<browser>/NativeMessagingHosts/com.vicinae.vicinae.json`
-- chromium family (macOS): `~/Library/Application Support/<browser>/NativeMessagingHosts/com.vicinae.vicinae.json`
-- firefox family (Linux): `~/.mozilla/native-messaging-hosts/com.vicinae.vicinae.json`
-- firefox family (macOS): `~/Library/Application Support/Mozilla/NativeMessagingHosts/com.vicinae.vicinae.json`
+### Chromium
 
-Packagers can disable this behavior with the `AUTO_INSTALL_BROWSER_MANIFESTS` CMake option and provision manifests themselves (the expected JSON is shown below).
+Load the `./chrome/` directory as an unpacked extension, then edit `allowed_origins` in the installed manifest (e.g `~/.config/chromium/NativeMessagingHosts/com.vicinae.vicinae.json`) to use the extension ID chromium generated for you. Make the file read-only (`chmod -w`) so vicinae does not rewrite it at startup, then reload the extension.
 
-## Load the browser extension
+### Firefox
 
-### Chromium bases
-
-You can load the `./chrome/` directory as any unpacked extension. 
-
-Then modify the native host manifest (e.g at `~/.config/chromium/NativeMessagingHosts/com.vicinae.vicinae.json`) and change the origin in the `allowed_origins` array to use the local extension ID that was automatically generated upon loading the unpacked extension.
-
-Note that the vicinae server rewrites manifests it does not recognize at startup, so make the file read-only (`chmod -w`) to keep your custom extension ID during development.
-
-Once that is done, reloading the extension should automatically establish a connection with vicinae if the vicinae server is running.
-
-### Firefox bases
-
-#### Prerequisites
-
-  * install the [web-ext](https://github.com/mozilla/web-ext) CLI tool.
-  * register and authenticate a [Mozilla Add-on (AMO) account](https://addons.mozilla.org/en-US/firefox/#login) and generate your API keys in the [Mozilla Add-on Developer Hub](https://addons.mozilla.org/en-US/developers/addon/api/key/)
-  * install and configure general prerequisites like git and make
-
-#### Instructions
-
-The following shell script demonstrates how to build and sign the app starting with cloning the repo, just update the variables at the beginning with your api secrets and the email address associated with them.
+Firefox only loads signed extensions, so you need the [web-ext](https://github.com/mozilla/web-ext) CLI and [AMO API credentials](https://addons.mozilla.org/en-US/developers/addon/api/key/):
 
 ```
-#!/bin/bash
-
-AMO_EMAIL_ADDRESS="<yourAMO@email>"
-WEB_EXT_API_KEY="<api cred:JWT issuer>" # user:[num:num] "user:12345678:123"
-WEB_EXT_API_SECRET="<api cred:JWT secret>" # string  "123abc789abc............................................345abc90" 
-WEB_EXT_CHANNEL="unlisted" # to build and distribute locally as opposed to the store with "listed"
-
-git clone https://github.com/vicinaehq/vicinae
-cd ./vicinae/src/browser-extension
-sudo make firefox
-
-cat > /lib/mozilla/native-messaging-hosts/com.vicinae.vicinae.json <<EOF
-{
-  "name": "com.vicinae.vicinae",
-  "description": "Vicinae Native Messaging Host",
-  "path": "/usr/libexec/vicinae/vicinae-browser-link",
-  "type": "stdio",
-  "allowed_extensions": [
-    "$AMO_EMAIL_ADDRESS"
-  ]
-}
-EOF
-
-cd ./build/firefox
-sed 's|"id": "vicinae@vicinae\.com"|"id": ""$AMO_EMAIL_ADDRESS"",\n      "data_collection_permissions": \{\n      "required": \["none"\],\n      "optional": \[\]\n      }|' -i ./manifest.json
-web-ext sign
+cd src/browser-extension
+make firefox
+cd build/firefox
+web-ext sign --channel unlisted
 ```
-At this point the terminal will usually churn for around 6 minutes while the automated checks run online, it can be flagged for a human check which would delay it.
-Once that's resolved a .xpi file will have populated in the firefox/web-ext-artifacts/ folder, import that into firefox.
 
-* open Firefox and open the extensions menu, or enter 'about:addons' into your address bar and hit enter
-* click the gear icon on the top right, select 'Install Add-on From File...'
-* select the .xpi file
-
-And upon restarting Firefox you should be good to go.  If you run into issues with signing [this page holds information on all 4 signing methods,](https://extensionworkshop.com/documentation/publish/signing-and-distribution-overview/) but you'll still need to alter the manifest if you submit through the webui
+The signed `.xpi` lands in `web-ext-artifacts/`; install it via `about:addons` > gear icon > "Install Add-on From File...". If you sign under a custom extension ID, update `allowed_extensions` in the manifest (`~/.mozilla/native-messaging-hosts/com.vicinae.vicinae.json`) the same way as for chromium.
 
 # Architecture schema
-
 
 If that's any helpful, here is a very simple schema of how communication between vicinae and the browser works:
 

--- a/src/browser-extension/native-host/com.vicinae.vicinae.chromium.json.in
+++ b/src/browser-extension/native-host/com.vicinae.vicinae.chromium.json.in
@@ -1,9 +1,0 @@
-{
-  "name": "com.vicinae.vicinae",
-  "description": "IPC Native Messaging Host",
-  "path": "@NATIVE_HOST_BIN@",
-  "type": "stdio",
-  "allowed_origins": [
-    "chrome-extension://@CHROME_EXTENSION_ID@/"
-  ]
-}

--- a/src/browser-extension/native-host/com.vicinae.vicinae.firefox.json.in
+++ b/src/browser-extension/native-host/com.vicinae.vicinae.firefox.json.in
@@ -1,9 +1,0 @@
-{
-  "name": "com.vicinae.vicinae",
-  "description": "Vicinae Native Messaging Host",
-  "path": "@NATIVE_HOST_BIN@",
-  "type": "stdio",
-  "allowed_extensions": [
-    "firefox@vicinae.com"
-  ]
-}

--- a/src/browser-extension/src/browser.cpp
+++ b/src/browser-extension/src/browser.cpp
@@ -10,6 +10,7 @@
 #include <sys/un.h>
 #include <unistd.h>
 #include <filesystem>
+#include "common/common.hpp"
 #include "generated/browser-ipc-client.hpp"
 
 #ifdef NDEBUG
@@ -63,9 +64,7 @@ private:
   Handler m_fn;
 };
 
-static std::filesystem::path socketPath() {
-  return std::filesystem::path(getenv("XDG_RUNTIME_DIR")) / "vicinae" / "vicinae.sock";
-}
+static std::filesystem::path socketPath() { return vicinae::serverSocketPath(); }
 
 static void sendToExtension(std::string_view message) {
   uint32_t size = message.size();

--- a/src/cli/src/ipc-client.hpp
+++ b/src/cli/src/ipc-client.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <common/common.hpp>
 #include <common/enumerate.hpp>
 #include <cstring>
 #include <expected>
@@ -13,24 +14,7 @@
 
 namespace cli {
 
-inline std::filesystem::path socketPath() {
-  std::filesystem::path base;
-#ifdef __APPLE__
-  if (const char *t = getenv("TMPDIR")) {
-    base = t;
-  } else {
-    base = "/tmp";
-  }
-#else
-  if (const char *r = getenv("XDG_RUNTIME_DIR")) {
-    base = r;
-  } else {
-    const char *user = getenv("USER");
-    base = std::filesystem::path("/tmp") / (std::string("runtime-") + (user ? user : "unknown"));
-  }
-#endif
-  return base / "vicinae" / "vicinae.sock";
-}
+inline std::filesystem::path socketPath() { return vicinae::serverSocketPath(); }
 
 class IpcClient {
 public:

--- a/src/lib/common/include/common/common.hpp
+++ b/src/lib/common/include/common/common.hpp
@@ -14,4 +14,7 @@ std::vector<std::filesystem::path> helperProgramCandidates(std::string_view prog
 std::string slurp(std::istream &ifs);
 
 std::optional<std::filesystem::path> findServerBinary();
+
+std::filesystem::path runtimeDir();
+std::filesystem::path serverSocketPath();
 }; // namespace vicinae

--- a/src/lib/common/src/common.cpp
+++ b/src/lib/common/src/common.cpp
@@ -1,4 +1,5 @@
 #include "common/common.hpp"
+#include <cstdlib>
 #include <filesystem>
 #include <sstream>
 #include <string>
@@ -58,6 +59,18 @@ std::optional<fs::path> findHelperProgram(std::string_view program) {
 
   return {};
 }
+
+fs::path runtimeDir() {
+#ifdef __APPLE__
+  if (const char *t = std::getenv("TMPDIR")) return fs::path(t) / "vicinae";
+  return "/tmp/vicinae";
+#else
+  if (const char *r = std::getenv("XDG_RUNTIME_DIR")) return fs::path(r) / "vicinae";
+  return "/tmp/vicinae";
+#endif
+}
+
+fs::path serverSocketPath() { return runtimeDir() / "vicinae.sock"; }
 
 std::optional<fs::path> findServerBinary() {
 #ifdef __APPLE__

--- a/src/lib/vicinae-ipc/include/vicinae-ipc/client.hpp
+++ b/src/lib/vicinae-ipc/include/vicinae-ipc/client.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <common/common.hpp>
 #include <common/enumerate.hpp>
 #include <cstring>
 #include <filesystem>
@@ -22,9 +23,7 @@ template <IsRpcSchema SchemaType = CliSchema> class Client {
   using Schema = SchemaType;
 
 public:
-  static std::filesystem::path vicinaeSocketPath() {
-    return std::filesystem::path(getenv("XDG_RUNTIME_DIR")) / "vicinae" / "vicinae.sock";
-  }
+  static std::filesystem::path vicinaeSocketPath() { return vicinae::serverSocketPath(); }
 
   static std::expected<Client, std::string> make() {
     const int fd = socket(AF_UNIX, SOCK_STREAM, 0);

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -701,6 +701,19 @@ if (TYPESCRIPT_EXTENSIONS)
 	list(APPEND SRCS ${CMAKE_CURRENT_BINARY_DIR}/resources.qrc)
 endif()
 
+if (AUTO_INSTALL_BROWSER_MANIFESTS)
+	add_compile_definitions(
+		AUTO_INSTALL_BROWSER_MANIFESTS
+		NATIVE_MESSAGING_HOST="${NATIVE_MESSAGING_HOST}"
+		CHROME_EXTENSION_ID="${CHROME_EXTENSION_ID}"
+		FIREFOX_EXTENSION_ID="${FIREFOX_EXTENSION_ID}"
+	)
+	list(APPEND SRCS
+		src/services/browser-extension/native-host-installer.hpp
+		src/services/browser-extension/native-host-installer.cpp
+	)
+endif()
+
 if (UNIX AND NOT APPLE)
 	list(APPEND SRCS
 		src/services/clipboard/gnome/gnome-clipboard-server.hpp

--- a/src/server/src/server.cpp
+++ b/src/server/src/server.cpp
@@ -29,6 +29,9 @@
 #include "qml/shortcut-inhibitor-attached.hpp"
 #include "services/file-chooser/file-chooser-service.hpp"
 #include "services/browser-extension-service.hpp"
+#ifdef AUTO_INSTALL_BROWSER_MANIFESTS
+#include "services/browser-extension/native-host-installer.hpp"
+#endif
 #include "services/calculator-service/calculator-service.hpp"
 #include "services/clipboard/clipboard-service.hpp"
 #include "db/database-key.hpp"
@@ -163,6 +166,10 @@ int startServer(const ServerLaunchOptions &launchOpts) {
   QQuickStyle::setStyle(QStringLiteral("Basic"));
 
   Omnicast::ensureDirectories();
+
+#ifdef AUTO_INSTALL_BROWSER_MANIFESTS
+  vicinae::browser::installNativeHostManifests();
+#endif
 
   {
     auto registry = ServiceRegistry::instance();

--- a/src/server/src/server.cpp
+++ b/src/server/src/server.cpp
@@ -124,6 +124,11 @@ static QFont resolveAppFont(const config::FontConfig &fontConfig) {
 int startServer(const ServerLaunchOptions &launchOpts) {
   qInstallMessageHandler(coloredMessageHandler);
 
+#ifdef AUTO_INSTALL_BROWSER_MANIFESTS
+  // always refresh manifests
+  vicinae::browser::installNativeHostManifests();
+#endif
+
   // Cheap single-instance probe before building any Qt state. macOS spawns
   // a fresh process on every `open` of the .app; without this guard, each
   // launch would proceed and steal focus.
@@ -166,10 +171,6 @@ int startServer(const ServerLaunchOptions &launchOpts) {
   QQuickStyle::setStyle(QStringLiteral("Basic"));
 
   Omnicast::ensureDirectories();
-
-#ifdef AUTO_INSTALL_BROWSER_MANIFESTS
-  vicinae::browser::installNativeHostManifests();
-#endif
 
   {
     auto registry = ServiceRegistry::instance();

--- a/src/server/src/services/browser-extension/native-host-installer.cpp
+++ b/src/server/src/services/browser-extension/native-host-installer.cpp
@@ -1,0 +1,191 @@
+#include <QtGlobal>
+#include <filesystem>
+#include <format>
+#include <fstream>
+#include <glaze/glaze.hpp>
+#include <qlogging.h>
+#include <string>
+#include <vector>
+
+#include "common/common.hpp"
+#include "services/browser-extension/native-host-installer.hpp"
+#include "utils/utils.hpp"
+
+#ifndef Q_OS_MACOS
+#include "xdgpp/env/env.hpp"
+#endif
+
+namespace fs = std::filesystem;
+
+namespace vicinae::browser {
+
+struct ChromiumManifest {
+  std::string name;
+  std::string description;
+  std::string path;
+  std::string type;
+  std::vector<std::string> allowed_origins;
+};
+
+struct GeckoManifest {
+  std::string name;
+  std::string description;
+  std::string path;
+  std::string type;
+  std::vector<std::string> allowed_extensions;
+};
+
+}; // namespace vicinae::browser
+
+namespace {
+
+constexpr const char *MANIFEST_FILENAME = NATIVE_MESSAGING_HOST ".json";
+constexpr const char *MANIFEST_DESCRIPTION = "Vicinae Native Messaging Host";
+
+struct ManifestTarget {
+  fs::path probe;
+  fs::path manifestDir;
+  const std::string *content = nullptr;
+};
+
+std::vector<ManifestTarget> manifestTargets(const std::string &chromium, const std::string &gecko) {
+  std::vector<ManifestTarget> targets;
+
+#ifdef Q_OS_MACOS
+  const fs::path base = homeDir() / "Library" / "Application Support";
+
+  constexpr auto CHROMIUM_DATA_DIRS = std::array{
+      "Google/Chrome",
+      "Google/Chrome Beta",
+      "Google/Chrome Canary",
+      "Chromium",
+      "Thorium",
+      "BraveSoftware/Brave-Browser",
+      "Microsoft Edge",
+      "Vivaldi",
+      "com.operasoftware.Opera",
+      "Arc/User Data",
+      "Helium",
+  };
+
+  targets.reserve(std::size(CHROMIUM_DATA_DIRS) + 6);
+
+  for (const auto &dir : CHROMIUM_DATA_DIRS) {
+    targets.emplace_back(base / dir, base / dir / "NativeMessagingHosts", &chromium);
+  }
+
+  // gecko forks read the shared Mozilla path unless patched (librewolf); zen: zen-browser/desktop#10622
+  const fs::path mozilla = base / "Mozilla" / "NativeMessagingHosts";
+
+  targets.emplace_back(base / "Firefox", mozilla, &gecko);
+  targets.emplace_back(base / "Waterfox", mozilla, &gecko);
+  targets.emplace_back(base / "Floorp", mozilla, &gecko);
+  targets.emplace_back(base / "zen", mozilla, &gecko);
+  targets.emplace_back(base / "zen", base / "zen" / "NativeMessagingHosts", &gecko);
+  targets.emplace_back(base / "LibreWolf", base / "LibreWolf" / "NativeMessagingHosts", &gecko);
+#else
+  const fs::path cfg = xdgpp::configHome();
+  const fs::path home = homeDir();
+
+  constexpr std::string_view CHROMIUM_DATA_DIRS[] = {
+      "google-chrome",
+      "google-chrome-beta",
+      "google-chrome-unstable",
+      "chromium",
+      "thorium",
+      "BraveSoftware/Brave-Browser",
+      "microsoft-edge",
+      "vivaldi",
+      "opera",
+      "net.imput.helium",
+  };
+
+  targets.reserve(std::size(CHROMIUM_DATA_DIRS) + 6);
+
+  for (const auto &dir : CHROMIUM_DATA_DIRS) {
+    targets.emplace_back(cfg / dir, cfg / dir / "NativeMessagingHosts", &chromium);
+  }
+
+  const fs::path mozilla = home / ".mozilla" / "native-messaging-hosts";
+
+  targets.emplace_back(home / ".mozilla", mozilla, &gecko);
+  targets.emplace_back(home / ".waterfox", mozilla, &gecko);
+  targets.emplace_back(home / ".floorp", mozilla, &gecko);
+  targets.emplace_back(home / ".zen", mozilla, &gecko);
+  targets.emplace_back(home / ".zen", home / ".zen" / "native-messaging-hosts", &gecko);
+  targets.emplace_back(home / ".librewolf", home / ".librewolf" / "native-messaging-hosts", &gecko);
+#endif
+
+  return targets;
+}
+
+void writeManifest(const ManifestTarget &target) {
+  std::error_code ec;
+
+  if (!fs::is_directory(target.probe, ec)) return;
+
+  const auto file = target.manifestDir / MANIFEST_FILENAME;
+
+  if (std::ifstream ifs(file); ifs && vicinae::slurp(ifs) == *target.content) return;
+
+  fs::create_directories(target.manifestDir, ec);
+
+  std::ofstream ofs(file, std::ios::trunc);
+
+  if (!ofs || !(ofs << *target.content)) {
+    qInfo() << "browser-link: skipped unwritable manifest" << file.c_str();
+    return;
+  }
+
+  qInfo() << "browser-link: installed manifest" << file.c_str();
+}
+
+}; // namespace
+
+namespace vicinae::browser {
+
+void installNativeHostManifests() {
+  const auto bin = findHelperProgram("vicinae-browser-link");
+
+  if (!bin) {
+    qWarning() << "browser-link: helper binary not found, skipping manifest installation";
+    return;
+  }
+
+#ifdef Q_OS_MACOS
+  // Gatekeeper translocation runs the app from a throwaway randomized path
+  if (selfPath().string().starts_with("/private/var/folders")) {
+    qInfo() << "browser-link: app is translocated, skipping manifest installation";
+    return;
+  }
+#endif
+
+  const ChromiumManifest chromium{
+      .name = NATIVE_MESSAGING_HOST,
+      .description = MANIFEST_DESCRIPTION,
+      .path = bin->string(),
+      .type = "stdio",
+      .allowed_origins = {std::format("chrome-extension://{}/", CHROME_EXTENSION_ID)},
+  };
+  const GeckoManifest gecko{
+      .name = NATIVE_MESSAGING_HOST,
+      .description = MANIFEST_DESCRIPTION,
+      .path = bin->string(),
+      .type = "stdio",
+      .allowed_extensions = {FIREFOX_EXTENSION_ID},
+  };
+
+  const auto chromiumJson = glz::write<glz::opts{.prettify = true}>(chromium);
+  const auto geckoJson = glz::write<glz::opts{.prettify = true}>(gecko);
+
+  if (!chromiumJson || !geckoJson) {
+    qWarning() << "browser-link: failed to serialize native messaging manifests";
+    return;
+  }
+
+  for (const auto &target : manifestTargets(*chromiumJson, *geckoJson)) {
+    writeManifest(target);
+  }
+}
+
+}; // namespace vicinae::browser

--- a/src/server/src/services/browser-extension/native-host-installer.hpp
+++ b/src/server/src/services/browser-extension/native-host-installer.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace vicinae::browser {
+
+void installNativeHostManifests();
+
+}; // namespace vicinae::browser

--- a/src/server/src/vicinae.cpp
+++ b/src/server/src/vicinae.cpp
@@ -1,4 +1,5 @@
 #include "vicinae.hpp"
+#include "common/common.hpp"
 #include "utils.hpp"
 #include <qcoreapplication.h>
 #include <qlogging.h>
@@ -13,15 +14,7 @@
 
 namespace fs = std::filesystem;
 
-fs::path Omnicast::runtimeDir() {
-#ifdef Q_OS_MACOS
-  if (const char *t = std::getenv("TMPDIR")) return fs::path(t) / "vicinae";
-  return "/tmp/vicinae";
-#else
-  return fs::path(QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation).toStdString()) /
-         "vicinae";
-#endif
-}
+fs::path Omnicast::runtimeDir() { return vicinae::runtimeDir(); }
 
 fs::path Omnicast::dataDir() {
 #ifdef Q_OS_MACOS
@@ -93,7 +86,7 @@ std::vector<fs::path> Omnicast::dataSearchPaths(std::string_view subdir) {
   return paths;
 }
 
-fs::path Omnicast::commandSocketPath() { return runtimeDir() / "vicinae.sock"; }
+fs::path Omnicast::commandSocketPath() { return vicinae::serverSocketPath(); }
 fs::path Omnicast::pidFile() { return runtimeDir() / "vicinae.pid"; }
 
 void Omnicast::ensureDirectories() {


### PR DESCRIPTION
install browser extension native host manifests in user directories directly, so that all installed browsers can directly consume the vicinae browser extension without further configuration