### PR TITLE
build(linux): allow skipping file installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,12 @@ option(
 	but they are still required build the project."
 	ON
 )
+option(
+    INSTALL_SHARED_FILES
+    "Create directories in CMAKE_INSTALL_PREFIX and install shared files (themes, .desktop files,
+    systemd unit, kernel module configuration)."
+    ON
+)
 
 option(WAYLAND_LAYER_SHELL "Enable support for the layer shell Wayland protocol" ON)
 option(TYPESCRIPT_EXTENSIONS "Enable support for extensions built with React/Typescript (no browser involved)" ON)
@@ -302,32 +308,34 @@ if (UNIX AND NOT APPLE)
 	add_subdirectory(src/data-control-server)
 endif()
 
-set(INSTALL_SHARE ${CMAKE_INSTALL_PREFIX}/share)
-set(INSTALL_MODULES ${CMAKE_INSTALL_PREFIX}/lib/modules-load.d)
-set(VICINAE_INSTALL_SHARE ${INSTALL_SHARE}/vicinae)
-set(VICINAE_THEME_DIR ${VICINAE_INSTALL_SHARE}/themes)
+if (INSTALL_SHARED_FILES)
+    set(INSTALL_SHARE ${CMAKE_INSTALL_PREFIX}/share)
+    set(INSTALL_MODULES ${CMAKE_INSTALL_PREFIX}/lib/modules-load.d)
+    set(VICINAE_INSTALL_SHARE ${INSTALL_SHARE}/vicinae)
+    set(VICINAE_THEME_DIR ${VICINAE_INSTALL_SHARE}/themes)
 
-if(NOT APPLE)
-	make_directory(${VICINAE_INSTALL_SHARE})
-	file(REMOVE_RECURSE ${VICINAE_THEME_DIR})
-	install(DIRECTORY ./extra/themes DESTINATION ${VICINAE_INSTALL_SHARE})
-endif()
+    if(NOT APPLE)
+        make_directory(${VICINAE_INSTALL_SHARE})
+        file(REMOVE_RECURSE ${VICINAE_THEME_DIR})
+        install(DIRECTORY ./extra/themes DESTINATION ${VICINAE_INSTALL_SHARE})
+    endif()
 
-if (UNIX AND NOT APPLE)
-	if (INSTALL_MODULES_LOAD_CONFIG)
-		install(DIRECTORY ${EXTRA_DIR}/modules-load.d/ DESTINATION ${INSTALL_MODULES})
-	endif()
+    if (UNIX AND NOT APPLE)
+        if (INSTALL_MODULES_LOAD_CONFIG)
+            install(DIRECTORY ${EXTRA_DIR}/modules-load.d/ DESTINATION ${INSTALL_MODULES})
+        endif()
 
-	set(APP_DIR ${INSTALL_SHARE}/applications)
-	make_directory(${APP_DIR})
-	install(FILES ./extra/vicinae.desktop DESTINATION ${APP_DIR})
-	install(FILES ./extra/vicinae-url-handler.desktop DESTINATION ${APP_DIR})
+        set(APP_DIR ${INSTALL_SHARE}/applications)
+        make_directory(${APP_DIR})
+        install(FILES ./extra/vicinae.desktop DESTINATION ${APP_DIR})
+        install(FILES ./extra/vicinae-url-handler.desktop DESTINATION ${APP_DIR})
 
-	set(ICON_DIR ${INSTALL_SHARE}/icons/hicolor/512x512/apps)
-	make_directory(${ICON_DIR})
-	install(FILES ./extra/vicinae.png DESTINATION ${ICON_DIR})
+        set(ICON_DIR ${INSTALL_SHARE}/icons/hicolor/512x512/apps)
+        make_directory(${ICON_DIR})
+        install(FILES ./extra/vicinae.png DESTINATION ${ICON_DIR})
 
-	set(SYSTEMD_USER_DIR ${CMAKE_INSTALL_PREFIX}/lib/systemd/user)
-	make_directory(${SYSTEMD_USER_DIR})
-	install(FILES ./extra/vicinae.service DESTINATION ${SYSTEMD_USER_DIR})
+        set(SYSTEMD_USER_DIR ${CMAKE_INSTALL_PREFIX}/lib/systemd/user)
+        make_directory(${SYSTEMD_USER_DIR})
+        install(FILES ./extra/vicinae.service DESTINATION ${SYSTEMD_USER_DIR})
+    endif()
 endif()


### PR DESCRIPTION
I'm one of the Gentoo chads called out here: https://github.com/vicinaehq/vicinae/blob/9878d64f2d964752a200647b7956afbbe51b288c/CMakeLists.txt#L26

I am admittedly new to writing ebuilds (the packaging instructions for Gentoo), but noticed that the unconditional attempt to install files into `CMAKE_INSTALL_PREFIX` (`/usr` in practice, I suppose) was violating the build sandbox for my ebuild.

Instead of letting cmake install those files (themes, `.desktop` files, icons, systemd unit), I would like the package manager to do it from `extra/` directly.

This adds `INSTALL_SHARED_FILES`, `ON` by default (so my little snowflake distribution doesn't break everyone else's build/install process), which can be toggled `OFF` to delegate installation of files to an external process. Hope this is useful, if not please feel free to close.