### PR TITLE
build: split embedded resources based on build conditions (extensions vs core)

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -44,7 +44,8 @@ if (UNIX AND NOT APPLE)
 ")
 endif()
 
-configure_file(resources.qrc.in resources.qrc)
+configure_file(resources-core.qrc.in resources-core.qrc)
+configure_file(resources-extensions.qrc.in resources-extensions.qrc)
 
 if (CMAKE_BUILD_TYPE MATCHES "Debug")
 	add_compile_definitions(LOCAL_THEME_DIR="${THEME_DIR}")
@@ -708,8 +709,9 @@ list(APPEND SRCS
 	src/services/calculator-service/qalculate/qalculate-backend.cpp
 )
 
+list(APPEND SRCS ${CMAKE_CURRENT_BINARY_DIR}/resources-core.qrc)
 if (TYPESCRIPT_EXTENSIONS)
-	list(APPEND SRCS ${CMAKE_CURRENT_BINARY_DIR}/resources.qrc)
+    list(APPEND SRCS ${CMAKE_CURRENT_BINARY_DIR}/resources-extensions.qrc)
 endif()
 
 if (AUTO_INSTALL_BROWSER_MANIFESTS)

--- a/src/server/resources-core.qrc.in
+++ b/src/server/resources-core.qrc.in
@@ -1,10 +1,7 @@
 <!DOCTYPE RCC>
 <RCC version="1.0">
-  <qresource prefix="/bin">
-  	<file alias="extension-manager">@CMAKE_BINARY_DIR@/extension-runtime.js</file>
-  </qresource>
   <qresource>
-  	<file alias="config.jsonc">@EXTRA_DIR@/config.jsonc</file>
+  	<file alias="config.jsonc">@EXTRA_PATH@/config.jsonc</file>
   </qresource>
   <qresource prefix="/fonts">
 @DEFAULT_FONT_RESOURCES@  	<file alias="NotoSansMath-Regular.ttf">@ASSET_PATH@/fonts/NotoSansMath-Regular.ttf</file>

--- a/src/server/resources-extensions.qrc.in
+++ b/src/server/resources-extensions.qrc.in
@@ -1,0 +1,6 @@
+<!DOCTYPE RCC>
+<RCC version="1.0">
+  <qresource prefix="/bin">
+  	<file alias="extension-manager">@CMAKE_BINARY_DIR@/extension-runtime.js</file>
+  </qresource>
+</RCC>


### PR DESCRIPTION
I noticed that `resources.qrc` is only added to the sources when `TYPESCRIPT_EXTENSIONS` is passed to `cmake`. But that includes the default configuration file, and my build kept throwing

```
terminate called after throwing an instance of 'std::runtime_error'
  what():  Failed to open default config
zsh: abort (core dumped)  vicinae server --open --no-extension-runtime
```

because the default config was simply not embedded in the binary.

In addition, I noticed that `@EXTRA_DIR@` in the template did not exist, and I assume `@EXTRA_PATH@` was the intended variable.