### PR TITLE
feat: implement environment.canAccess API

### DIFF
--- a/extra/extension-boilerplate/package.json
+++ b/extra/extension-boilerplate/package.json
@@ -110,6 +110,12 @@
 			"mode": "view"
 		},
 		{
+			"name": "capabilities",
+			"title": "Capabilities",
+			"description": "Check capabilities of install",
+			"mode": "view"
+		},
+		{
 			"name": "desktop-notif-interval",
 			"title": "Desktop Notification Interval",
 			"description": "Desktop Notification Interval",

--- a/extra/extension-boilerplate/src/capabilities.tsx
+++ b/extra/extension-boilerplate/src/capabilities.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import {
+	AI,
+	BrowserExtension,
+	Color,
+	environment,
+	FileSearch,
+	Icon,
+	ImageLike,
+	List,
+	Wallpaper,
+	WindowManagement,
+} from "@vicinae/api";
+
+export default function Capabilities() {
+	const supportedIcon = (b: boolean): ImageLike =>
+		b
+			? { source: Icon.CheckCircle, tintColor: Color.Green }
+			: { source: Icon.XMarkCircle, tintColor: Color.Red };
+
+	return (
+		<List searchBarPlaceholder={"Search capabilities"}>
+			<List.Item
+				title="File Search"
+				icon={supportedIcon(environment.canAccess(FileSearch))}
+			/>
+			<List.Item
+				title="Window Management"
+				icon={supportedIcon(environment.canAccess(WindowManagement))}
+			/>
+			<List.Item
+				title="Wallpaper"
+				icon={supportedIcon(environment.canAccess(Wallpaper))}
+			/>
+			<List.Item
+				title="Browser Extension"
+				icon={supportedIcon(environment.canAccess(BrowserExtension))}
+			/>
+			<List.Item title="AI" icon={supportedIcon(environment.canAccess(AI))} />
+		</List>
+	);
+}

--- a/figura/manager-extension.fig
+++ b/figura/manager-extension.fig
@@ -17,6 +17,13 @@ enum LaunchType {
   Background
 };
 
+struct Capabilities {
+  browserExtension: bool;
+  windowManagement: bool;
+  wallpaper: bool;
+  fileSearch: bool;
+};
+
 struct LaunchEventData {
   extension_name: string;
   command_name: string;
@@ -29,6 +36,7 @@ struct LaunchEventData {
   is_raycast: bool;
   owner_or_author_name: string;
   launch_type: LaunchType;
+  capabilities: Capabilities;
 };
 
 service Lifecycle {

--- a/figura/manager.fig
+++ b/figura/manager.fig
@@ -19,6 +19,13 @@ enum LaunchType {
   Background
 };
 
+struct Capabilities {
+  browserExtension: bool;
+  windowManagement: bool;
+  wallpaper: bool;
+  fileSearch: bool;
+};
+
 struct LoadOptions {
   mode: CommandMode;
   env: CommandEnv;
@@ -32,6 +39,7 @@ struct LoadOptions {
   arguments: any;
   preferences: any;
   launch_type: LaunchType;
+  capabilities: Capabilities;
 };
 
 struct LoadResponse {

--- a/src/server/src/extension/extension-command-runtime.cpp
+++ b/src/server/src/extension/extension-command-runtime.cpp
@@ -103,6 +103,11 @@ void ExtensionCommandRuntime::load(const LaunchProps &props) {
                    }) |
                    std::ranges::to<std::unordered_map<std::string, std::string>>();
 
+  opts.capabilities.browserExtension = !context()->services->browserExtension()->browsers().empty();
+  opts.capabilities.windowManagement = context()->services->windowManager()->isCapable();
+  opts.capabilities.wallpaper = context()->services->wallpaperManager()->canSetWallpaper();
+  opts.capabilities.fileSearch = context()->services->fileService()->isAvailable();
+
   if (m_headless) {
     opts.launch_type = manager::LaunchType::Background;
   } else {

--- a/src/server/src/services/files-service/abstract-file-indexer.hpp
+++ b/src/server/src/services/files-service/abstract-file-indexer.hpp
@@ -53,6 +53,7 @@ public:
   virtual void preferenceValuesChanged(const QJsonObject &preferences) = 0;
   virtual QFuture<std::vector<IndexerFileResult>> queryAsync(std::string_view view,
                                                              const IndexerQueryParams &params = {}) = 0;
+  virtual bool isAvailable() const = 0;
 
   virtual ~AbstractFileIndexer() = default;
 };

--- a/src/server/src/services/files-service/file-indexer/file-indexer.cpp
+++ b/src/server/src/services/files-service/file-indexer/file-indexer.cpp
@@ -233,6 +233,8 @@ void FileIndexer::rebuildIndex() {
   m_client.fileindexer()->rebuildIndex();
 }
 
+bool FileIndexer::isAvailable() const { return isRunning(); }
+
 void FileIndexer::preferenceValuesChanged(const QJsonObject &preferences) {
   auto arrayField = [&](const char *key) {
     std::vector<std::string> out;
@@ -248,8 +250,9 @@ void FileIndexer::preferenceValuesChanged(const QJsonObject &preferences) {
 
   m_config.paths = arrayField("indexingPaths");
   m_config.excluded_paths = arrayField("excludedIndexingPaths");
+  m_wantRunning = preferences.value("autoIndexing").toBool();
 
-  if (preferences.value("autoIndexing").toBool()) {
+  if (m_wantRunning) {
     if (isRunning()) {
       sendConfigure();
     } else {

--- a/src/server/src/services/files-service/file-indexer/file-indexer.hpp
+++ b/src/server/src/services/files-service/file-indexer/file-indexer.hpp
@@ -37,6 +37,7 @@ public:
 
   void start() override;
   void rebuildIndex() override;
+  bool isAvailable() const override;
   void preferenceValuesChanged(const QJsonObject &preferences) override;
   QFuture<std::vector<IndexerFileResult>> queryAsync(std::string_view view,
                                                      const IndexerQueryParams &params = {}) override;

--- a/src/server/src/services/files-service/file-service.cpp
+++ b/src/server/src/services/files-service/file-service.cpp
@@ -142,6 +142,8 @@ void FileService::preferenceValuesChanged(const QJsonObject &preferences) {
   m_indexer->preferenceValuesChanged(preferences);
 }
 
+bool FileService::isAvailable() const { return m_indexer->isAvailable(); }
+
 FileService::FileService(OmniDatabase &db)
     : m_db(db), m_recentFilesPath(Omnicast::stateDir() / RECENT_FILES_NAME) {
   bool const shouldMigrateRecentFiles = !fs::is_regular_file(m_recentFilesPath);

--- a/src/server/src/services/files-service/file-service.hpp
+++ b/src/server/src/services/files-service/file-service.hpp
@@ -18,6 +18,8 @@ public:
     int accessCount = 0;
   };
 
+  bool isAvailable() const;
+
   AbstractFileIndexer *indexer() const;
 
   void rebuildIndex();

--- a/src/server/src/services/files-service/macos/spotlight-file-indexer.hpp
+++ b/src/server/src/services/files-service/macos/spotlight-file-indexer.hpp
@@ -10,6 +10,7 @@
 class SpotlightFileIndexer : public AbstractFileIndexer {
 public:
   void start() override {}
+  bool isAvailable() const override;
   void rebuildIndex() override {}
   void preferenceValuesChanged(const QJsonObject &) override {}
 

--- a/src/server/src/services/files-service/macos/spotlight-file-indexer.mm
+++ b/src/server/src/services/files-service/macos/spotlight-file-indexer.mm
@@ -238,6 +238,11 @@ std::vector<IndexerFileResult> runQuery(const std::string &query, const IndexerQ
 
 } // namespace
 
+
+bool SpotlightFileIndexer::isAvailable() const {
+	return true;
+}
+
 QFuture<std::vector<IndexerFileResult>> SpotlightFileIndexer::queryAsync(std::string_view query,
                                                                          const IndexerQueryParams &params) {
   return QtConcurrent::run([params, q = std::string(query)]() {

--- a/src/server/src/services/window-manager/window-manager.cpp
+++ b/src/server/src/services/window-manager/window-manager.cpp
@@ -75,6 +75,8 @@ AbstractWindowManager::WindowList WindowManager::findAppWindows(const AbstractAp
 
 void WindowManager::updateWindowCache() { m_windows = m_provider->listWindowsSync(); }
 
+bool WindowManager::isCapable() const { return m_provider->id() != "dummy"; }
+
 WindowManager::WindowManager() {
   m_provider = createProvider();
   updateWindowCache();

--- a/src/server/src/services/window-manager/window-manager.hpp
+++ b/src/server/src/services/window-manager/window-manager.hpp
@@ -10,6 +10,8 @@ signals:
   void focusChanged() const;
 
 public:
+  bool isCapable() const;
+
   AbstractWindowManager *provider() const;
   AbstractWindowManager::WindowList listWindowsSync();
   AbstractWindowManager::WindowPtr getFocusedWindow();

--- a/src/typescript/api/src/api/environment.ts
+++ b/src/typescript/api/src/api/environment.ts
@@ -1,4 +1,9 @@
-import { Form } from "./components";
+import type { AI } from "./ai";
+import type { BrowserExtension } from "./browser";
+import type { Form } from "./components";
+import type { FileSearch } from "./file-search";
+import type { Wallpaper } from "./wallpaper";
+import type { WindowManagement } from "./window-management";
 
 export interface LaunchContext {
 	[item: string]: any;
@@ -52,6 +57,14 @@ export enum LaunchType {
 	 */
 	Background = "background",
 }
+
+// every API we can check availability for using environment.canAccess
+type AccessCheckable =
+	| typeof FileSearch
+	| typeof BrowserExtension
+	| typeof Wallpaper
+	| typeof AI
+	| typeof WindowManagement;
 
 export interface Environment {
 	/**
@@ -111,20 +124,16 @@ export interface Environment {
 	 *
 	 *  @example
 	 * ```typescript
-	 * import { unstableAI, environment } from "@raycast/api";
+	 * import { BrowserExtension, environment } from "@vicinae/api";
 	 *
-	 * export default function Command() {
-	 *   if (environment.canAccess(unstableAI)) {
-	 *     // use unstableAI
+	 * export default async function Command() {
+	 *   if (environment.canAccess(BrowserExtension)) {
+	 *   	const tabs = await BrowserExtension.getTabs();
 	 *   }
 	 * }
 	 * ```
 	 */
-	canAccess(api: unknown): boolean;
-	/**
-	 * @deprecated Use the top-level prop `launchContext` instead.
-	 */
-	launchContext?: LaunchContext;
+	canAccess(api: AccessCheckable): boolean;
 
 	/**
 	 * The Vicinae version. Vicinae extensions should rely on this and ignore `raycastVersion`.

--- a/src/typescript/extension-manager/src/index.ts
+++ b/src/typescript/extension-manager/src/index.ts
@@ -132,7 +132,7 @@ class ExtensionManager extends manager.ManagerService {
 			logger.error(`worker error: ${error}`);
 		});
 
-		worker.on("online", () => { });
+		worker.on("online", () => {});
 
 		const stdoutStream = fs.createWriteStream(stdoutLog);
 		const stderrStream = fs.createWriteStream(stderrLog);

--- a/src/typescript/extension-manager/src/index.ts
+++ b/src/typescript/extension-manager/src/index.ts
@@ -102,6 +102,7 @@ class ExtensionManager extends manager.ManagerService {
 				owner_or_author_name: load.owner_or_author_name,
 				command_name: load.command_name,
 				launch_type: load.launch_type,
+				capabilities: load.capabilities,
 			},
 		};
 
@@ -131,7 +132,7 @@ class ExtensionManager extends manager.ManagerService {
 			logger.error(`worker error: ${error}`);
 		});
 
-		worker.on("online", () => {});
+		worker.on("online", () => { });
 
 		const stdoutStream = fs.createWriteStream(stdoutLog);
 		const stderrStream = fs.createWriteStream(stderrLog);

--- a/src/typescript/extension-manager/src/worker.tsx
+++ b/src/typescript/extension-manager/src/worker.tsx
@@ -1,6 +1,13 @@
 import "./globals";
 import { parentPort, workerData } from "node:worker_threads";
-import { LaunchType } from "@vicinae/api";
+import {
+	AI,
+	BrowserExtension,
+	FileSearch,
+	LaunchType,
+	Wallpaper,
+	WindowManagement,
+} from "@vicinae/api";
 import { callbackManager } from "./callback";
 import { globalState } from "./globals";
 import loadNoView from "./loaders/load-no-view-command";
@@ -74,7 +81,15 @@ const loadEnviron = (
 		theme: "dark",
 		textSize: "medium",
 		appearance: "dark",
-		canAccess: (_: unknown) => false,
+		canAccess: (api: unknown) => {
+			if (api === WindowManagement) return data.capabilities.windowManagement;
+			if (api === BrowserExtension) return data.capabilities.browserExtension;
+			if (api === Wallpaper) return data.capabilities.wallpaper;
+			if (api === FileSearch) return data.capabilities.fileSearch;
+			if (api === AI) return false; // not supported yet
+
+			return false;
+		},
 		isDevelopment: environment === "development",
 		commandName: data.command_name,
 		commandMode: data.mode === "View" ? "view" : "no-view",


### PR DESCRIPTION
Check API access from within an extension using e.g:

```ts
import { BrowserExtension, environment } from '@vicinae/api'

environment.canAccess(BrowserExtension)
```