### PR TITLE
fix: do not use QDBusInterface for desktop notifications

### DIFF
--- a/src/server/src/services/desktop-notification/freedesktop/freedesktop-notification-client.cpp
+++ b/src/server/src/services/desktop-notification/freedesktop/freedesktop-notification-client.cpp
@@ -1,28 +1,19 @@
 #include "freedesktop-notification-client.hpp"
 #include <QDBusConnection>
-#include <QDBusInterface>
 #include <QDBusMessage>
-#include <qcontainerfwd.h>
-#include <qlogging.h>
 
 // https://specifications.freedesktop.org/notification/latest/protocol.html
 
-FreedesktopNotificationClient::FreedesktopNotificationClient() {
-  m_iface = std::make_unique<QDBusInterface>(DBUS_SERVICE, DBUS_PATH, DBUS_INTERFACE,
-                                             QDBusConnection::sessionBus());
-}
-
 bool FreedesktopNotificationClient::send(const Notification &n) {
-  if (!m_iface->isValid()) return false;
-
   QVariantMap hints;
   hints[QStringLiteral("urgency")] = QVariant::fromValue(mapUrgency(n.urgency));
 
-  QDBusMessage reply =
-      m_iface->call(QStringLiteral("Notify"), QStringLiteral("Vicinae"), uint(0),
-                    n.iconPath.value_or(QString()), n.title, n.body, QStringList(), hints, -1);
+  QDBusMessage msg =
+      QDBusMessage::createMethodCall(DBUS_SERVICE, DBUS_PATH, DBUS_INTERFACE, QStringLiteral("Notify"));
+  msg << QStringLiteral("Vicinae") << uint(0) << n.iconPath.value_or(QString()) << n.title << n.body
+      << QStringList() << hints << -1;
 
-  return reply.type() != QDBusMessage::ErrorMessage;
+  return QDBusConnection::sessionBus().send(msg);
 }
 
 uchar FreedesktopNotificationClient::mapUrgency(Urgency urgency) {

--- a/src/server/src/services/desktop-notification/freedesktop/freedesktop-notification-client.hpp
+++ b/src/server/src/services/desktop-notification/freedesktop/freedesktop-notification-client.hpp
@@ -1,11 +1,8 @@
 #pragma once
 #include "../abstract-desktop-notification-client.hpp"
-#include <QDBusInterface>
-#include <memory>
 
 class FreedesktopNotificationClient : public AbstractDesktopNotificationClient {
 public:
-  FreedesktopNotificationClient();
   bool send(const Notification &notification) override;
 
 private:
@@ -14,6 +11,4 @@ private:
   static constexpr const char *DBUS_INTERFACE = "org.freedesktop.Notifications";
 
   static uchar mapUrgency(Urgency urgency);
-
-  std::unique_ptr<QDBusInterface> m_iface;
 };


### PR DESCRIPTION
Fixes #1538 

The `QDBusInterface` constructor hangs if it cannot reach the desktop notification object on the bus, which happens if no desktop notification daemon is running.

We fix that by constructing the DBus call on the fly.