### PR TITLE
fix: manage fallback command state and ordering

### DIFF
--- a/src/server/src/config/config.cpp
+++ b/src/server/src/config/config.cpp
@@ -184,9 +184,7 @@ bool Manager::writeUser(const Partial<ConfigValue> &cfg) {
     ofs << TOP_COMMENT << "\n\n" << glz::prettify_json(buf);
   }
 
-  // XXX - we needed this at some point, maybe I'm breaking something
-  // The idea is that the watcher should take care of this already, we don't want double firing
-  // reloadConfig();
+  reloadConfig();
 
   return true;
 }
@@ -211,6 +209,12 @@ void Manager::reloadConfig() {
 
   ConfigValue const prev = std::move(m_user);
   m_user = std::move(res.value());
+
+  std::string prevJson;
+  std::string nextJson;
+  bool const comparable = !glz::write_json(prev, prevJson) && !glz::write_json(m_user, nextJson);
+  if (comparable && prevJson == nextJson) return;
+
   emit configChanged(m_user, prev);
 }
 

--- a/src/server/src/qml/fuzzy-section.hpp
+++ b/src/server/src/qml/fuzzy-section.hpp
@@ -30,6 +30,8 @@ public:
 protected:
   const T &at(int i) const { return m_items[m_filtered[i].data]; }
 
+  virtual void sortFiltered() {}
+
   virtual QString displayTitle(const T &item) const = 0;
   virtual QString displaySubtitle(const T &) const { return {}; }
   virtual QString displayIconSource(const T &item) const = 0;
@@ -42,7 +44,10 @@ protected:
   std::string m_query;
 
 private:
-  void refilter() { fuzzy::fuzzyFilter<T>(std::span<const T>(m_items), m_query, m_filtered); }
+  void refilter() {
+    fuzzy::fuzzyFilter<T>(std::span<const T>(m_items), m_query, m_filtered);
+    sortFiltered();
+  }
 
   QString itemId(int i) const override { return displayId(at(i)); }
   QString itemTitle(int i) const override { return displayTitle(at(i)); }

--- a/src/server/src/qml/manage-fallback-model.cpp
+++ b/src/server/src/qml/manage-fallback-model.cpp
@@ -4,15 +4,13 @@
 
 // --- EnabledFallbackSection ---
 
-void EnabledFallbackSection::setFilter(std::string_view query) {
-  m_query = std::string(query);
-  fuzzy::fuzzyFilter<RootItemPtr>(std::span<const RootItemPtr>(m_items), m_query, m_filtered);
+void EnabledFallbackSection::sortFiltered() {
+  auto fallbackPos = [&](const auto &scored) {
+    return std::distance(m_fallbacks.begin(), std::ranges::find(m_fallbacks, m_items[scored.data]));
+  };
 
-  std::ranges::stable_sort(m_filtered, [&](const auto &a, const auto &b) {
-    auto posA = std::distance(m_fallbacks.begin(), std::ranges::find(m_fallbacks, m_items[a.data]));
-    auto posB = std::distance(m_fallbacks.begin(), std::ranges::find(m_fallbacks, m_items[b.data]));
-    return posA < posB;
-  });
+  std::ranges::stable_sort(m_filtered,
+                           [&](const auto &a, const auto &b) { return fallbackPos(a) < fallbackPos(b); });
 }
 
 QString EnabledFallbackSection::displayTitle(const RootItemPtr &item) const { return item->title(); }

--- a/src/server/src/qml/manage-fallback-model.hpp
+++ b/src/server/src/qml/manage-fallback-model.hpp
@@ -29,9 +29,9 @@ public:
 
   void setFallbackOrder(std::vector<RootItemPtr> fallbacks) { m_fallbacks = std::move(fallbacks); }
 
-  void setFilter(std::string_view query) override;
-
 protected:
+  void sortFiltered() override;
+
   QString displayTitle(const RootItemPtr &item) const override;
   QString displaySubtitle(const RootItemPtr &item) const override;
   QString displayIconSource(const RootItemPtr &item) const override;

--- a/src/server/src/services/root-item-manager/root-item-manager.cpp
+++ b/src/server/src/services/root-item-manager/root-item-manager.cpp
@@ -65,9 +65,11 @@ bool RootItemManager::enableFallback(const EntrypointId &id) {
 
 bool RootItemManager::disableFallback(const EntrypointId &id) {
   auto fbs = m_cfg.value().fallbacks;
-  std::string const sid = id;
+  auto it = std::ranges::find(fbs, std::string{id});
 
-  fbs.erase(std::ranges::find(fbs, sid));
+  if (it == fbs.end()) return false;
+
+  fbs.erase(it);
   m_cfg.mergeWithUser({.fallbacks = fbs});
   emit fallbackDisabled(id);
   emit metadataChanged();


### PR DESCRIPTION
fixes a bug due to a stale config state where the configured fallback commands would not be reflected in the UI.