### PR TITLE
refactor: move keyboard navigation to global helper

### DIFF
--- a/src/server/src/qml/keyboard-bridge.hpp
+++ b/src/server/src/qml/keyboard-bridge.hpp
@@ -2,6 +2,9 @@
 #include <QObject>
 #include <QVariantList>
 #include "keyboard/keyboard.hpp"
+#include "config/config.hpp"
+#include "service-registry.hpp"
+#include "services/keybinding/keybinding-service.hpp"
 
 /**
  * Exposes the generic Keyboard::Shortcut conversions to QML so shortcut widgets don't have to
@@ -28,6 +31,11 @@ public:
     if (shortcut.isEmpty()) return {};
     Keyboard::Shortcut const parsed = Keyboard::Shortcut::fromString(shortcut);
     return parsed.isValid() ? parsed.toDisplayTokens() : QVariantList{};
+  }
+
+  Q_INVOKABLE int matchNavigation(int key, int modifiers) const {
+    return KeyBindingService::matchNavigation(key, modifiers,
+                                              ServiceRegistry::instance()->config()->value().keybinding);
   }
 
   Q_INVOKABLE QString validate(int key, int modifiers) const {

--- a/src/server/src/qml/launcher-window.cpp
+++ b/src/server/src/qml/launcher-window.cpp
@@ -1,6 +1,7 @@
 #include "launcher-window.hpp"
 #include "hud-bridge.hpp"
 #include "keybind-bridge.hpp"
+#include "keyboard-bridge.hpp"
 #include "view-utils.hpp"
 #include "action-panel-controller.hpp"
 #include "ui/image/image-renderer.hpp"
@@ -17,7 +18,6 @@
 #include "extensions/vicinae/bug-report-url.hpp"
 #include "qml/vicinae-store-view-host.hpp"
 #include "settings-controller/settings-controller.hpp"
-#include "services/keybinding/keybinding-service.hpp"
 #include "services/toast/toast-service.hpp"
 #include "config/config.hpp"
 #include "service-registry.hpp"
@@ -50,7 +50,8 @@ LauncherWindow::LauncherWindow(ApplicationContext &ctx, QObject *parent)
       m_footerPanel(new ActionPanelController(ctx, this)),
       m_alertModel(new AlertModel(*ctx.navigation, this)), m_configBridge(new ConfigBridge(this)),
       m_imgSource(new ImageSource(this)), m_keybindProxy(new KeybindBridge(this)),
-      m_platformBridge(new PlatformBridge(this)), m_themeBridge(new ThemeBridge(this)) {
+      m_keyboardBridge(new KeyboardBridge(this)), m_platformBridge(new PlatformBridge(this)),
+      m_themeBridge(new ThemeBridge(this)) {
 
 #ifndef Q_OS_MACOS
   // Ensure Wayland app_id / X11 WM_CLASS is "vicinae"
@@ -70,6 +71,7 @@ LauncherWindow::LauncherWindow(ApplicationContext &ctx, QObject *parent)
   rootCtx->setContextProperty(QStringLiteral("actionPanel"), m_actionPanel);
   rootCtx->setContextProperty(QStringLiteral("footerPanel"), m_footerPanel);
   rootCtx->setContextProperty(QStringLiteral("Keybinds"), m_keybindProxy);
+  rootCtx->setContextProperty(QStringLiteral("Keyboard"), m_keyboardBridge);
   rootCtx->setContextProperty(QStringLiteral("FileChooser"), ctx.services->fileChooserService());
 
   updateLayerShellProps();
@@ -517,10 +519,6 @@ void LauncherWindow::popToRoot() {
 }
 
 bool LauncherWindow::popOnBackspace() { return m_ctx.services->config()->value().popOnBackspace; }
-
-int LauncherWindow::matchNavigationKey(int key, int modifiers) {
-  return KeyBindingService::matchNavigation(key, modifiers, m_ctx.services->config()->value().keybinding);
-}
 
 void LauncherWindow::setCompleterValue(int index, const QString &value) {
   auto *nav = m_ctx.navigation.get();

--- a/src/server/src/qml/launcher-window.hpp
+++ b/src/server/src/qml/launcher-window.hpp
@@ -13,6 +13,7 @@ class ConfigBridge;
 class HudBridge;
 class ImageSource;
 class KeybindBridge;
+class KeyboardBridge;
 class PlatformBridge;
 class ThemeBridge;
 class ViewHostBase;
@@ -94,7 +95,6 @@ public:
   Q_INVOKABLE void handleEscape();
   Q_INVOKABLE void goBack();
   Q_INVOKABLE void popToRoot();
-  Q_INVOKABLE int matchNavigationKey(int key, int modifiers);
   Q_INVOKABLE void setCompleterValue(int index, const QString &value);
   Q_INVOKABLE QRect cursorScreenGeometry() const;
   Q_INVOKABLE void positionOnCursorScreen();
@@ -146,6 +146,7 @@ private:
   ConfigBridge *m_configBridge;
   ImageSource *m_imgSource;
   KeybindBridge *m_keybindProxy;
+  KeyboardBridge *m_keyboardBridge;
   PlatformBridge *m_platformBridge;
   ThemeBridge *m_themeBridge;
 

--- a/src/server/src/qml/onboarding-window.cpp
+++ b/src/server/src/qml/onboarding-window.cpp
@@ -4,6 +4,7 @@
 #include "global-shortcut-bridge.hpp"
 #include "image-source.hpp"
 #include "keyboard-bridge.hpp"
+#include "platform-bridge.hpp"
 #include "theme-bridge.hpp"
 #include "services/app-service/app-service.hpp"
 #include "vicinae.hpp"
@@ -98,6 +99,7 @@ void OnboardingWindow::ensureInitialized() {
   m_imgSource = new ImageSource(this);
   m_keyboardBridge = new KeyboardBridge(this);
   m_globalShortcutBridge = new GlobalShortcutBridge(this);
+  m_platformBridge = new PlatformBridge(this);
   m_generalModel = new GeneralSettingsModel(this);
 
   auto *rootCtx = m_engine.rootContext();
@@ -106,6 +108,7 @@ void OnboardingWindow::ensureInitialized() {
   rootCtx->setContextProperty(QStringLiteral("Img"), m_imgSource);
   rootCtx->setContextProperty(QStringLiteral("Keyboard"), m_keyboardBridge);
   rootCtx->setContextProperty(QStringLiteral("GlobalShortcuts"), m_globalShortcutBridge);
+  rootCtx->setContextProperty(QStringLiteral("Platform"), m_platformBridge);
   rootCtx->setContextProperty(QStringLiteral("onboarding"), this);
 
 #ifdef Q_OS_MACOS

--- a/src/server/src/qml/onboarding-window.hpp
+++ b/src/server/src/qml/onboarding-window.hpp
@@ -8,6 +8,7 @@ class ConfigBridge;
 class ImageSource;
 class KeyboardBridge;
 class GlobalShortcutBridge;
+class PlatformBridge;
 class GeneralSettingsModel;
 class MacosPermissionService;
 class QQuickWindow;
@@ -51,6 +52,7 @@ private:
   ImageSource *m_imgSource = nullptr;
   KeyboardBridge *m_keyboardBridge = nullptr;
   GlobalShortcutBridge *m_globalShortcutBridge = nullptr;
+  PlatformBridge *m_platformBridge = nullptr;
   GeneralSettingsModel *m_generalModel = nullptr;
   MacosPermissionService *m_permissions = nullptr;
   QQuickWindow *m_window = nullptr;

--- a/src/server/src/qml/qml/ActionListPanel.qml
+++ b/src/server/src/qml/qml/ActionListPanel.qml
@@ -260,7 +260,7 @@ Item {
                     onTextEdited: filterDebounce.restart()
 
                     Keys.onPressed: function (event) {
-                        const nav = launcher.matchNavigationKey(event.key, event.modifiers);
+                        const nav = Keyboard.matchNavigation(event.key, event.modifiers);
                         if (nav === 1) {
                             root.moveUp();
                             event.accepted = true;

--- a/src/server/src/qml/qml/ActionPanelPopover.qml
+++ b/src/server/src/qml/qml/ActionPanelPopover.qml
@@ -37,7 +37,7 @@ ViciPopover {
         focus: true
 
         Keys.onPressed: event => {
-            const nav = launcher.matchNavigationKey(event.key, event.modifiers);
+            const nav = Keyboard.matchNavigation(event.key, event.modifiers);
             if (event.key === Qt.Key_Escape) {
                 root.controller.pop();
                 event.accepted = true;

--- a/src/server/src/qml/qml/AlertDialog.qml
+++ b/src/server/src/qml/qml/AlertDialog.qml
@@ -80,7 +80,7 @@ ViciPopover {
                 onClicked: root.close()
                 Keys.onRightPressed: confirmBtn.forceActiveFocus()
                 Keys.onPressed: event => {
-                    const nav = launcher.matchNavigationKey(event.key, event.modifiers);
+                    const nav = Keyboard.matchNavigation(event.key, event.modifiers);
                     if (nav === 4) {
                         confirmBtn.forceActiveFocus();
                         event.accepted = true;
@@ -108,7 +108,7 @@ ViciPopover {
                 }
                 Keys.onLeftPressed: cancelBtn.forceActiveFocus()
                 Keys.onPressed: event => {
-                    const nav = launcher.matchNavigationKey(event.key, event.modifiers);
+                    const nav = Keyboard.matchNavigation(event.key, event.modifiers);
                     if (nav === 3) {
                         cancelBtn.forceActiveFocus();
                         event.accepted = true;

--- a/src/server/src/qml/qml/CompletionPopup.qml
+++ b/src/server/src/qml/qml/CompletionPopup.qml
@@ -176,7 +176,7 @@ Popup {
                     }
 
                     Keys.onPressed: function (event) {
-                        const nav = launcher.matchNavigationKey(event.key, event.modifiers);
+                        const nav = Keyboard.matchNavigation(event.key, event.modifiers);
                         if (event.key === Qt.Key_Up || nav === 1) {
                             root.moveUp();
                             event.accepted = true;

--- a/src/server/src/qml/qml/SearchBar.qml
+++ b/src/server/src/qml/qml/SearchBar.qml
@@ -193,7 +193,7 @@ Item {
                 }
 
                 function _handleNavigation(event) {
-                    const nav = launcher.matchNavigationKey(event.key, event.modifiers);
+                    const nav = Keyboard.matchNavigation(event.key, event.modifiers);
                     if (nav === 0)
                         return false;
 


### PR DESCRIPTION
Untie navigation primitive from the launcher global and move it into a proper Keyboard global helper. This way it also works outside of the launcher window.