### PR TITLE
fix(xdg): append terminal arg value to flags ending with '='

### DIFF
--- a/src/server/src/services/app-service/xdg/xdg-app-database.cpp
+++ b/src/server/src/services/app-service/xdg/xdg-app-database.cpp
@@ -438,9 +438,19 @@ bool XdgAppDatabase::launchTerminalCommand(const std::vector<QString> &cmdline,
   std::ranges::for_each(exec | std::views::drop(1), [&](auto &&arg) { argv << arg; });
   auto texec = getTermExec(*xdgApp);
 
-  if (texec.appId && opts.appId) { argv << texec.appId->c_str() << opts.appId.value(); }
-  if (texec.title && opts.title) { argv << texec.title->c_str() << opts.title.value(); }
-  if (texec.dir && opts.workingDirectory) { argv << texec.dir->c_str() << opts.workingDirectory.value(); }
+  // per the xdg-terminal-exec spec, a flag ending with '=' takes its value appended
+  // to the same argument, without whitespace
+  auto addFlag = [&argv](const std::string &flag, const QString &value) {
+    if (flag.ends_with('=')) {
+      argv << QString::fromStdString(flag) + value;
+    } else {
+      argv << flag.c_str() << value;
+    }
+  };
+
+  if (texec.appId && opts.appId) { addFlag(*texec.appId, opts.appId.value()); }
+  if (texec.title && opts.title) { addFlag(*texec.title, opts.title.value()); }
+  if (texec.dir && opts.workingDirectory) { addFlag(*texec.dir, opts.workingDirectory.value()); }
   if (texec.hold && opts.hold) { argv << texec.hold->c_str(); }
   if (texec.exec) { argv << texec.exec->c_str(); }
 


### PR DESCRIPTION
Per the [xdg-terminal-exec spec](https://github.com/Vladimir-csp/xdg-terminal-exec): "If argument expects a value and is defined as ending with `=`, value should be appended to the same argument without a white space."

`XdgAppDatabase::launchTerminalCommand` always emits the flag and its value as two separate argv entries. Terminals that declare the `=` form break — ghostty ships `X-TerminalArgAppId=--class=`, so since #1522 started passing an app id, launching any `Terminal=true` desktop entry produces `--class= <app-id>` and ghostty rejects the bare app id argument with a "Configuration Errors" dialog (`cli:3:nvim.desktop: invalid field`). Ghostty only accepts `--flag=value`, so appending per the spec is required there.

Repro: set ghostty as the default terminal (xdg-terminals.list), launch any `Terminal=true` app (e.g. btop) from vicinae. On v0.21.7+ the ghostty config-error dialog appears on every launch.

Built locally on Arch (ghostty 1.3.1, which reproduces the dialog reliably).