### PR TITLE
fix(extensions): do not miss detail updates

### DIFF
--- a/src/server/src/qml/extension-list-model.cpp
+++ b/src/server/src/qml/extension-list-model.cpp
@@ -1,5 +1,6 @@
 #include "extension-list-model.hpp"
 
+#include <chrono>
 #include <utility>
 #include "fuzzy/fuzzy-searchable.hpp"
 #include "view-utils.hpp"
@@ -77,10 +78,16 @@ std::unique_ptr<ActionPanelState> ExtensionListSection::actionPanel(int i) const
 
 // --- ExtensionListModel ---
 
+static constexpr std::chrono::milliseconds DETAIL_CLEAR_DEBOUNCE(150);
+
 ExtensionListModel::ExtensionListModel(NotifyFn notify, QObject *parent)
-    : SectionListModel(parent), m_notify(std::move(notify)) {}
+    : SectionListModel(parent), m_notify(std::move(notify)) {
+  m_detailClearTimer.setSingleShot(true);
+  connect(&m_detailClearTimer, &QTimer::timeout, this, [this]() { setCurrentDetail(nullptr); });
+}
 
 void ExtensionListModel::setExtensionData(const ListModel &model, bool resetSelection) {
+  bool const wasShowingDetail = m_model.isShowingDetail;
   m_model = model;
   m_placeholder = QString::fromStdString(model.searchPlaceholderText);
 
@@ -128,8 +135,47 @@ void ExtensionListModel::setExtensionData(const ListModel &model, bool resetSele
     refreshActionPanel();
   }
 
+  refreshCurrentDetail();
+
+  if (wasShowingDetail != m_model.isShowingDetail) emit isShowingDetailChanged();
+
   emit emptyViewChanged();
+}
+
+void ExtensionListModel::refreshCurrentDetail() {
+  const DetailModel *detail = nullptr;
+
+  int sourceIdx = 0;
+  int itemIdx = 0;
+  if (dataItemAt(selectedIndex(), sourceIdx, itemIdx)) {
+    const auto &item = m_ownedSections[sourceIdx]->itemAt(itemIdx);
+    if (item.detail) detail = &*item.detail;
+  }
+
+  setCurrentDetail(detail);
+}
+
+void ExtensionListModel::setCurrentDetail(const DetailModel *detail) {
+  m_detailClearTimer.stop();
+
+  QString markdown;
+  QVariantList metadata;
+
+  if (detail) {
+    if (detail->markdown) markdown = QString::fromStdString(*detail->markdown);
+    metadata = qml::metadataToVariantList(detail->metadata);
+  }
+
+  if (markdown == m_detailMarkdown && metadata == m_detailMetadata) return;
+
+  m_detailMarkdown = std::move(markdown);
+  m_detailMetadata = std::move(metadata);
   emit detailChanged();
+}
+
+void ExtensionListModel::scheduleDetailClear() {
+  if (m_detailMarkdown.isEmpty() && m_detailMetadata.isEmpty()) return;
+  m_detailClearTimer.start(DETAIL_CLEAR_DEBOUNCE);
 }
 
 void ExtensionListModel::setFilter(const QString &text) {
@@ -158,17 +204,7 @@ ImageUrl ExtensionListModel::emptyIcon() const {
 
 bool ExtensionListModel::isShowingDetail() const { return m_model.isShowingDetail; }
 
-bool ExtensionListModel::hasDetail() const { return m_currentDetail.has_value(); }
-
-QString ExtensionListModel::detailMarkdown() const {
-  if (m_currentDetail && m_currentDetail->markdown) return QString::fromStdString(*m_currentDetail->markdown);
-  return {};
-}
-
-QVariantList ExtensionListModel::detailMetadata() const {
-  if (!m_currentDetail) return {};
-  return qml::metadataToVariantList(m_currentDetail->metadata);
-}
+QString ExtensionListModel::detailMarkdown() const { return m_detailMarkdown; }
 
 void ExtensionListModel::onSelectionCleared() {
   std::unique_ptr<ActionPanelState> panel;
@@ -190,8 +226,11 @@ void ExtensionListModel::onSelectionCleared() {
 }
 
 void ExtensionListModel::handleItemSelected(const ListItemViewModel *item) {
-  m_currentDetail = item ? item->detail : std::nullopt;
-  emit detailChanged();
+  if (item && item->detail) {
+    setCurrentDetail(&*item->detail);
+  } else {
+    scheduleDetailClear();
+  }
 
   if (auto handler = m_model.onSelectionChanged) {
     if (item) { m_notify(handler->c_str(), {item->id.c_str()}); }

--- a/src/server/src/qml/extension-list-model.cpp
+++ b/src/server/src/qml/extension-list-model.cpp
@@ -83,7 +83,7 @@ static constexpr std::chrono::milliseconds DETAIL_CLEAR_DEBOUNCE(150);
 ExtensionListModel::ExtensionListModel(NotifyFn notify, QObject *parent)
     : SectionListModel(parent), m_notify(std::move(notify)) {
   m_detailClearTimer.setSingleShot(true);
-  connect(&m_detailClearTimer, &QTimer::timeout, this, [this]() { setCurrentDetail(nullptr); });
+  connect(&m_detailClearTimer, &QTimer::timeout, this, [this]() { refreshCurrentDetail(); });
 }
 
 void ExtensionListModel::setExtensionData(const ListModel &model, bool resetSelection) {

--- a/src/server/src/qml/extension-list-model.hpp
+++ b/src/server/src/qml/extension-list-model.hpp
@@ -5,6 +5,7 @@
 #include "fuzzy/scored.hpp"
 #include "section-list-model.hpp"
 #include "section-source.hpp"
+#include <QTimer>
 #include <functional>
 #include <memory>
 #include <vector>
@@ -25,6 +26,8 @@ public:
   }
   void onSelected(int i) override;
 
+  const ListItemViewModel &itemAt(int i) const;
+
 protected:
   QString itemTitle(int i) const override;
   QString itemSubtitle(int i) const override;
@@ -33,8 +36,6 @@ protected:
   std::unique_ptr<ActionPanelState> actionPanel(int i) const override;
 
 private:
-  const ListItemViewModel &itemAt(int i) const;
-
   std::string m_name;
   std::vector<ListItemViewModel> m_items;
   std::vector<Scored<int>> m_filtered;
@@ -50,8 +51,7 @@ class ExtensionListModel : public SectionListModel {
   Q_PROPERTY(QString emptyTitle READ emptyTitle NOTIFY emptyViewChanged)
   Q_PROPERTY(QString emptyDescription READ emptyDescription NOTIFY emptyViewChanged)
   Q_PROPERTY(ImageUrl emptyIcon READ emptyIcon NOTIFY emptyViewChanged)
-  Q_PROPERTY(bool isShowingDetail READ isShowingDetail NOTIFY detailChanged)
-  Q_PROPERTY(bool hasDetail READ hasDetail NOTIFY detailChanged)
+  Q_PROPERTY(bool isShowingDetail READ isShowingDetail NOTIFY isShowingDetailChanged)
   Q_PROPERTY(QString detailMarkdown READ detailMarkdown NOTIFY detailChanged)
   Q_PROPERTY(QVariantList detailMetadata READ detailMetadata NOTIFY detailChanged)
 
@@ -70,12 +70,12 @@ public:
   ImageUrl emptyIcon() const;
 
   bool isShowingDetail() const;
-  bool hasDetail() const;
   QString detailMarkdown() const;
-  QVariantList detailMetadata() const;
+  QVariantList detailMetadata() const { return m_detailMetadata; }
 
 signals:
   void detailChanged();
+  void isShowingDetailChanged();
   void emptyViewChanged();
 
 protected:
@@ -83,9 +83,14 @@ protected:
 
 private:
   void handleItemSelected(const ListItemViewModel *item);
+  void refreshCurrentDetail();
+  void setCurrentDetail(const DetailModel *detail);
+  void scheduleDetailClear();
 
   NotifyFn m_notify;
-  std::optional<DetailModel> m_currentDetail;
+  QTimer m_detailClearTimer;
+  QString m_detailMarkdown;
+  QVariantList m_detailMetadata;
   std::vector<std::unique_ptr<ExtensionListSection>> m_ownedSections;
   ListModel m_model;
   QString m_filter;

--- a/src/server/src/qml/qml/ExtensionView.qml
+++ b/src/server/src/qml/qml/ExtensionView.qml
@@ -98,7 +98,7 @@ Item {
                 emptyIcon: root.host.contentModel.emptyIcon?.valid ? root.host.contentModel.emptyIcon : Img.builtin("magnifying-glass").withFillColor(Theme.foreground)
 
                 detailComponent: detailPanel
-                detailVisible: root.host.contentModel.isShowingDetail && root.host.contentModel.hasDetail
+                detailVisible: root.host.contentModel.isShowingDetail
 
                 delegate: Loader {
                     id: delegateLoader


### PR DESCRIPTION
We didn't update the list detail if the update came from a subsequent render. Also we added a slight debounce so that quick detail changes do not flicker.

fixes #1552