### PR TITLE
feat: support for sendDesktopNotification on macOS

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -661,6 +661,8 @@ if (APPLE)
 		src/services/permissions/macos-permission-service.mm
 		src/services/autostart/macos-login-item.hpp
 		src/services/autostart/macos-login-item.mm
+		src/services/desktop-notification/macos/macos-notification-client.hpp
+		src/services/desktop-notification/macos/macos-notification-client.mm
 	)
 	set_source_files_properties(
 		src/ui/image/mac-file-icon-loader.mm
@@ -680,8 +682,9 @@ if (APPLE)
 		src/services/update/macos-update-installer.mm
 		src/services/permissions/macos-permission-service.mm
 		src/services/autostart/macos-login-item.mm
+		src/services/desktop-notification/macos/macos-notification-client.mm
 		PROPERTIES COMPILE_OPTIONS "-fobjc-arc")
-	list(APPEND LIBS "-framework ServiceManagement")
+	list(APPEND LIBS "-framework ServiceManagement" "-framework UserNotifications")
 
 	if (AUTO_ENABLE_AUTOSTART)
 		add_compile_definitions(AUTO_ENABLE_AUTOSTART)

--- a/src/server/src/qml/qml/OnboardingWindow.qml
+++ b/src/server/src/qml/qml/OnboardingWindow.qml
@@ -164,9 +164,19 @@ Window {
                                 label: "Full Disk Access"
                                 description: "Lets file search cover your entire disk."
                                 iconSource: Img.system("internaldrive").withFillColor(Theme.foreground)
-                                showSeparator: false
+                                showSeparator: Permissions.notificationsSupported
                                 granted: Permissions.fullDiskAccessGranted
                                 onGrant: Permissions.requestFullDiskAccess()
+                            }
+
+                            PermissionRow {
+                                label: "Notifications"
+                                description: "Lets extensions send desktop notifications."
+                                iconSource: Img.system("bell.badge").withFillColor(Theme.foreground)
+                                showSeparator: false
+                                visible: Permissions.notificationsSupported
+                                granted: Permissions.notificationsGranted
+                                onGrant: Permissions.requestNotifications()
                             }
                         }
 

--- a/src/server/src/services/desktop-notification/desktop-notification-client.hpp
+++ b/src/server/src/services/desktop-notification/desktop-notification-client.hpp
@@ -1,8 +1,10 @@
 #pragma once
 #include "abstract-desktop-notification-client.hpp"
 #include <memory>
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX)
 #include "freedesktop/freedesktop-notification-client.hpp"
+#elif defined(Q_OS_MACOS)
+#include "macos/macos-notification-client.hpp"
 #else
 #include "dummy-desktop-notification-client.hpp"
 #endif
@@ -11,8 +13,10 @@ class DesktopNotificationClient {
 public:
   AbstractDesktopNotificationClient *provider() const { return m_client.get(); }
   DesktopNotificationClient() {
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX)
     m_client = std::make_unique<FreedesktopNotificationClient>();
+#elif defined(Q_OS_MACOS)
+    m_client = std::make_unique<MacosNotificationClient>();
 #else
     m_client = std::make_unique<DummyDesktopNotificationClient>();
 #endif

--- a/src/server/src/services/desktop-notification/macos/macos-notification-client.hpp
+++ b/src/server/src/services/desktop-notification/macos/macos-notification-client.hpp
@@ -1,0 +1,7 @@
+#pragma once
+#include "../abstract-desktop-notification-client.hpp"
+
+class MacosNotificationClient : public AbstractDesktopNotificationClient {
+public:
+  bool send(const Notification &notification) override;
+};

--- a/src/server/src/services/desktop-notification/macos/macos-notification-client.mm
+++ b/src/server/src/services/desktop-notification/macos/macos-notification-client.mm
@@ -1,0 +1,52 @@
+#include "macos-notification-client.hpp"
+#import <Foundation/Foundation.h>
+#import <UserNotifications/UserNotifications.h>
+
+namespace {
+
+UNNotificationInterruptionLevel mapUrgency(AbstractDesktopNotificationClient::Urgency urgency) {
+  using Urgency = AbstractDesktopNotificationClient::Urgency;
+  switch (urgency) {
+  case Urgency::Low:
+    return UNNotificationInterruptionLevelPassive;
+  case Urgency::High:
+    return UNNotificationInterruptionLevelTimeSensitive;
+  default:
+    return UNNotificationInterruptionLevelActive;
+  }
+}
+
+} // namespace
+
+bool MacosNotificationClient::send(const Notification &n) {
+  // UNUserNotificationCenter throws when the process does not run from an app bundle
+  if (!NSBundle.mainBundle.bundleIdentifier) return false;
+
+  UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
+  content.title = n.title.toNSString();
+  content.body = n.body.toNSString();
+  content.interruptionLevel = mapUrgency(n.urgency);
+  if (n.urgency != Urgency::Low) content.sound = UNNotificationSound.defaultSound;
+
+  if (n.iconPath) {
+    NSURL *url = [NSURL fileURLWithPath:n.iconPath->toNSString()];
+    NSError *error = nil;
+    UNNotificationAttachment *attachment = [UNNotificationAttachment attachmentWithIdentifier:@""
+                                                                                          URL:url
+                                                                                      options:nil
+                                                                                        error:&error];
+    if (attachment) content.attachments = @[ attachment ];
+  }
+
+  UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:NSUUID.UUID.UUIDString
+                                                                        content:content
+                                                                        trigger:nil];
+  UNUserNotificationCenter *center = UNUserNotificationCenter.currentNotificationCenter;
+
+  [center requestAuthorizationWithOptions:(UNAuthorizationOptionAlert | UNAuthorizationOptionSound)
+                        completionHandler:^(BOOL granted, NSError *) {
+                          if (granted) [center addNotificationRequest:request withCompletionHandler:nil];
+                        }];
+
+  return true;
+}

--- a/src/server/src/services/permissions/macos-permission-service.hpp
+++ b/src/server/src/services/permissions/macos-permission-service.hpp
@@ -6,26 +6,36 @@ class MacosPermissionService : public QObject {
   Q_OBJECT
   Q_PROPERTY(bool accessibilityGranted READ accessibilityGranted NOTIFY accessibilityGrantedChanged)
   Q_PROPERTY(bool fullDiskAccessGranted READ fullDiskAccessGranted NOTIFY fullDiskAccessGrantedChanged)
+  Q_PROPERTY(bool notificationsGranted READ notificationsGranted NOTIFY notificationsGrantedChanged)
+  Q_PROPERTY(bool notificationsSupported READ notificationsSupported CONSTANT)
 
 signals:
   void accessibilityGrantedChanged();
   void fullDiskAccessGrantedChanged();
+  void notificationsGrantedChanged();
 
 public:
   explicit MacosPermissionService(QObject *parent = nullptr);
 
   bool accessibilityGranted() const { return m_accessibilityGranted; }
   bool fullDiskAccessGranted() const { return m_fullDiskAccessGranted; }
+  bool notificationsGranted() const { return m_notificationsGranted; }
+  bool notificationsSupported() const { return m_notificationsSupported; }
 
   void setWatching(bool value);
 
   Q_INVOKABLE void requestAccessibility();
   Q_INVOKABLE void requestFullDiskAccess();
+  Q_INVOKABLE void requestNotifications();
 
 private:
   void refresh();
+  void refreshNotifications();
 
   QTimer m_pollTimer;
   bool m_accessibilityGranted = false;
   bool m_fullDiskAccessGranted = false;
+  bool m_notificationsGranted = false;
+  bool m_notificationsNotDetermined = false;
+  bool m_notificationsSupported = false;
 };

--- a/src/server/src/services/permissions/macos-permission-service.mm
+++ b/src/server/src/services/permissions/macos-permission-service.mm
@@ -2,7 +2,9 @@
 #include <ApplicationServices/ApplicationServices.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <QPointer>
 #import <AppKit/AppKit.h>
+#import <UserNotifications/UserNotifications.h>
 
 namespace {
 
@@ -41,8 +43,10 @@ void openPane(const char *url) {
 MacosPermissionService::MacosPermissionService(QObject *parent) : QObject(parent) {
   m_accessibilityGranted = AXIsProcessTrusted();
   m_fullDiskAccessGranted = probeFullDiskAccess();
+  m_notificationsSupported = NSBundle.mainBundle.bundleIdentifier != nil;
   m_pollTimer.setInterval(POLL_INTERVAL_MS);
   connect(&m_pollTimer, &QTimer::timeout, this, &MacosPermissionService::refresh);
+  refreshNotifications();
 }
 
 void MacosPermissionService::setWatching(bool value) {
@@ -70,6 +74,47 @@ void MacosPermissionService::requestAccessibility() {
 
 void MacosPermissionService::requestFullDiskAccess() { openPane(FULL_DISK_PANE_URL); }
 
+void MacosPermissionService::requestNotifications() {
+  if (!m_notificationsSupported) return;
+
+  if (m_notificationsNotDetermined) {
+    QPointer<MacosPermissionService> self(this);
+    [UNUserNotificationCenter.currentNotificationCenter
+        requestAuthorizationWithOptions:(UNAuthorizationOptionAlert | UNAuthorizationOptionSound)
+                      completionHandler:^(BOOL, NSError *) {
+                        dispatch_async(dispatch_get_main_queue(), ^{
+                          if (self) self->refreshNotifications();
+                        });
+                      }];
+    return;
+  }
+
+  NSString *url =
+      [NSString stringWithFormat:@"x-apple.systempreferences:com.apple.Notifications-Settings.extension?id=%@",
+                                 NSBundle.mainBundle.bundleIdentifier];
+  [NSWorkspace.sharedWorkspace openURL:[NSURL URLWithString:url]];
+}
+
+void MacosPermissionService::refreshNotifications() {
+  if (!m_notificationsSupported) return;
+
+  QPointer<MacosPermissionService> self(this);
+  [UNUserNotificationCenter.currentNotificationCenter
+      getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings *settings) {
+        const UNAuthorizationStatus status = settings.authorizationStatus;
+        dispatch_async(dispatch_get_main_queue(), ^{
+          if (!self) return;
+          self->m_notificationsNotDetermined = status == UNAuthorizationStatusNotDetermined;
+          const bool granted =
+              status == UNAuthorizationStatusAuthorized || status == UNAuthorizationStatusProvisional;
+          if (granted != self->m_notificationsGranted) {
+            self->m_notificationsGranted = granted;
+            emit self->notificationsGrantedChanged();
+          }
+        });
+      }];
+}
+
 void MacosPermissionService::refresh() {
   const bool accessibility = AXIsProcessTrusted();
   if (accessibility != m_accessibilityGranted) {
@@ -82,4 +127,6 @@ void MacosPermissionService::refresh() {
     m_fullDiskAccessGranted = fullDisk;
     emit fullDiskAccessGrantedChanged();
   }
+
+  refreshNotifications();
 }


### PR DESCRIPTION
Requires notification permission, we asked for it during onboarding (optional)