### PR TITLE
fix(build): resolve AppImage version from manifest

### DIFF
--- a/.github/workflows/build-appimage.yaml
+++ b/.github/workflows/build-appimage.yaml
@@ -45,9 +45,13 @@ jobs:
 
       - name: Configure CMake
         run: |
+          TAG=$(grep "tag:" manifest.yaml | cut -d'"' -f2)
+          COMMIT=$(grep "short_rev:" manifest.yaml | cut -d'"' -f2)
           cmake -S . -B build -G Ninja              \
           -DCMAKE_BUILD_TYPE=Release                \
-          -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}"
+          -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}"   \
+          -DVICINAE_GIT_TAG="$TAG"                  \
+          -DVICINAE_GIT_COMMIT_HASH="$COMMIT"
 
       - name: Build
         run: cmake --build build --parallel $(nproc)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,14 +144,16 @@ jobs:
 
       - name: Configure CMake
         run: |
+          TAG=$(grep "tag:" manifest.yaml | cut -d'"' -f2)
+          COMMIT=$(grep "short_rev:" manifest.yaml | cut -d'"' -f2)
           cd build
           cmake -G Ninja ..                           \
             -DCMAKE_BUILD_TYPE=${BUILD_TYPE}          \
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5        \
             -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}"   \
             -DVICINAE_PROVENANCE=appimage             \
-            -DVICINAE_GIT_TAG="${{ needs.build-binary.outputs.tag }}" \
-            -DVICINAE_GIT_COMMIT_HASH="${{ needs.build-binary.outputs.commit }}" \
+            -DVICINAE_GIT_TAG="$TAG"                  \
+            -DVICINAE_GIT_COMMIT_HASH="$COMMIT"       \
             -DLTO=ON
 
       - name: Build

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@
 BUILD_DIR						:= build
 BIN_DIR							:= build/bin
 RM							:= rm
-TAG 							:= $(shell git describe --tags --abbrev=0)
+TAG 							:= $(shell grep "tag:" manifest.yaml | cut -d'"' -f2)
+COMMIT							:= $(shell grep "short_rev:" manifest.yaml | cut -d'"' -f2)
 APPIMAGE_BUILD_ENV_DIR			:= ./scripts/runners/appimage/
 APPIMAGE_BUILD_ENV_IMAGE_TAG	:= vicinae/appimage-build-env
 FIGURA_CC						:= $(BIN_DIR)/figura
@@ -96,7 +97,7 @@ portable:
 .PHONY: portable
 
 appimage:
-	cmake -G Ninja -DCMAKE_INSTALL_PREFIX=./build/install -DVICINAE_PROVENANCE=appimage -B $(BUILD_DIR)
+	cmake -G Ninja -DCMAKE_INSTALL_PREFIX=./build/install -DVICINAE_PROVENANCE=appimage -DVICINAE_GIT_TAG="$(TAG)" -DVICINAE_GIT_COMMIT_HASH="$(COMMIT)" -B $(BUILD_DIR)
 	cmake --build $(BUILD_DIR)
 	cmake --install $(BUILD_DIR)
 	./scripts/mkappimage.sh ./build/install AppDir


### PR DESCRIPTION
Read version and commit directly from manifest.yaml for AppImage targets in Makefile and CI workflows. This prevents builds from defaulting to 'v0.0.0 (commit unknown)' when git commands fail or lack a git tree.

Fixes #1596