### PR TITLE
Fix image scale in extension grid

### DIFF
--- a/src/server/src/qml/qml/ExtensionGridView.qml
+++ b/src/server/src/qml/qml/ExtensionGridView.qml
@@ -16,8 +16,6 @@ GenericGridView {
             readonly property var model: parent ? parent.cmdModel : null
             readonly property int sec: parent ? parent.cellSection : 0
             readonly property int itm: parent ? parent.cellItem : 0
-            readonly property bool _isFill: cellRoot.model ? cellRoot.model.fit === 1 : false
-
             readonly property string _cellColor: {
                 var _rev = cellRoot.model ? cellRoot.model.dataRevision : 0;
                 return cellRoot.model ? cellRoot.model.cellColor(cellRoot.sec, cellRoot.itm) : "";
@@ -39,10 +37,8 @@ GenericGridView {
             }
 
             ViciImage {
-                visible: cellRoot._cellColor === "" && !cellRoot._isFill
-                anchors.centerIn: parent
-                width: Math.min(implicitWidth, parent.width)
-                height: Math.min(implicitHeight, parent.height)
+                visible: cellRoot._cellColor === ""
+                anchors.fill: parent
                 // ObjectFit enum: 0=Contain, 1=Fill, 2=Stretch
                 fillMode: {
                     var fit = cellRoot.model ? cellRoot.model.fit : 0;
@@ -52,14 +48,6 @@ GenericGridView {
                         return Image.Stretch;
                     return Image.PreserveAspectFit;
                 }
-                source: cellRoot._imageSource
-                sourceSize: cellRoot._sourceSize
-            }
-
-            ViciImage {
-                visible: cellRoot._cellColor === "" && cellRoot._isFill
-                anchors.fill: parent
-                fillMode: Image.PreserveAspectCrop
                 source: cellRoot._imageSource
                 sourceSize: cellRoot._sourceSize
             }


### PR DESCRIPTION
Grid images using the stretch or contain fit currently underfill their cells by what appeared to be about 50% on my macbook. This was especially obvious using the gif search extension for raycast, where it was difficult to even make out what the gifs it brought up were supposed to be. This PR makes all fit modes scale to the cell as documented.

I've collapsed the delegate's two ViciImage branches into a single `anchors.fill` image whose `fillMode` is driven by the fit mode:

- A fit of Contain gets a fill of PreserveAspectFit (scale to fit, letterboxed, never cropped, matches raycast)
- A fit of Fill gets a fill of PreserveAspectCrop (scale to fill, cropped)
- A fit of Stretch gets a fill of Stretch

From what I can tell, svg, emoji, etc, icon rendering is unchanged with this PR, as they were already decoded at the cell resolution and filled properly. Lower resolution rasters like gifs now scale up to fill instead of underfilling, which matches the documented raycast-like behavior.

Note that this also fixes Stretch, which was previously capped at native size and so didn't actually stretch small images.

Here's what the gif search extension looks like after this change:
<img width="816" height="526" alt="image" src="https://github.com/user-attachments/assets/30e61c71-f25f-4cab-84c5-55ae72b2d6c4" />