### PR TITLE
fix: qmlls support in Nix devshells

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ __cmake*
 *.tgz
 
 /qt6
+**/.qmlls.ini
 
 /AppDir
 *AppImage

--- a/flake.nix
+++ b/flake.nix
@@ -70,6 +70,9 @@
             export CXX=${pkgs.gcc15}/bin/g++
             export CMAKE_C_COMPILER=$CC
             export CMAKE_CXX_COMPILER=$CXX
+
+            export QML2_IMPORT_PATH=${pkgs.qt6.qtdeclarative}/lib/qt-6/qml
+            export QML_IMPORT_PATH=${pkgs.qt6.qtdeclarative}/lib/qt-6/qml
           '';
         };
       }


### PR DESCRIPTION
without that, qmlls and Qt Creator don't see Nix-installed `qtdeclarative`