### PR TITLE
fix: image not saved in macOS clipboard history

### DIFF
--- a/src/server/src/services/clipboard/clipboard-mime.cpp
+++ b/src/server/src/services/clipboard/clipboard-mime.cpp
@@ -1,5 +1,7 @@
+#include <QImage>
 #include "clipboard-mime.hpp"
 #include <QUrl>
+#include <QBuffer>
 #include <qlogging.h>
 #include <ranges>
 
@@ -46,8 +48,17 @@ std::optional<ClipboardSelection> selectionFromMimeData(const QMimeData *mimeDat
       }
     }
 
-    if (!selectedFormat.isEmpty()) {
-      ClipboardDataOffer offer;
+    ClipboardDataOffer offer;
+
+    if (selectedFormat.isEmpty()) {
+      auto image = qvariant_cast<QImage>(mimeData->imageData());
+      if (!image.isNull()) {
+        QBuffer buf(&offer.data);
+        image.save(&buf, "PNG");
+        offer.mimeType = "image/png";
+        selection.offers.emplace_back(offer);
+      }
+    } else {
       offer.mimeType = selectedFormat;
       offer.data = mimeData->data(selectedFormat);
       selection.offers.emplace_back(offer);

--- a/src/server/src/services/clipboard/macos/macos-clipboard-server.mm
+++ b/src/server/src/services/clipboard/macos/macos-clipboard-server.mm
@@ -104,7 +104,9 @@ void MacosClipboardServer::poll() {
   }
 
   auto selection = Clipboard::selectionFromMimeData(QGuiApplication::clipboard()->mimeData());
+
   if (!selection) return;
+
   // The pasteboard changed while we were reading it, let the next tick handle it
   if (currentChangeCount() != cc) return;
 


### PR DESCRIPTION
In some scenarios, the QT clipboard is filled with the application/x-qt-image type which means we can request the raw image data and then convert it to another format. When that happens, we now convert it to PNG automatically.

Currently the image conversion happens on the main thread, as clipboard access is not thread safe, for big images it could theoretically become a problem, but it's fine for now.

Fixes #1634