### PR TITLE
fix: copy/paste file from macOS clipboard history

### DIFF
--- a/src/server/src/services/clipboard/clipboard-service.cpp
+++ b/src/server/src/services/clipboard/clipboard-service.cpp
@@ -526,7 +526,7 @@ bool ClipboardService::copySelection(const ClipboardSelection &selection,
                  << "size:" << offer.data.size();
       }
     } else {
-      if (Utils::isTextMimeType(offer.mimeType)) {
+      if (offer.mimeType != "text/uri-list" && Utils::isTextMimeType(offer.mimeType)) {
         mimeData->setText(QString::fromUtf8(offer.data));
       } else {
         mimeData->setData(offer.mimeType, offer.data);


### PR DESCRIPTION
text/uri-list should never be stored in the clipboard as a plain text string.

Presumably this works on linux because QMimeDatabase does not categorize text/uri-list as inheriting from text/plain.