### PR TITLE
nix: SoulverCore support

### DIFF
--- a/.github/workflows/cachix.yaml
+++ b/.github/workflows/cachix.yaml
@@ -35,6 +35,6 @@ jobs:
       run: nix build -L
     - name: Build Soulver backend
       if: matrix.os == 'depot-ubuntu-24.04-16'
-      run: nix build -L .#soulver-cpp .#with-soulver
+      run: nix build -L .#with-soulver
     - name: Run Test Shell
       run: nix develop --command echo OK

--- a/.github/workflows/cachix.yaml
+++ b/.github/workflows/cachix.yaml
@@ -30,7 +30,11 @@ jobs:
       with:
         name: vicinae
         authToken: ${{ github.ref == 'refs/heads/main' && secrets.CACHIX_AUTH_TOKEN || '' }}
+        pushFilter: "(swift-bin|swift-.*-RELEASE.*\\.tar\\.gz)"
     - name: Build Flake
       run: nix build -L
+    - name: Build Soulver backend
+      if: matrix.os == 'depot-ubuntu-24.04-16'
+      run: nix build -L .#soulver-cpp .#with-soulver
     - name: Run Test Shell
       run: nix develop --command echo OK

--- a/flake.lock
+++ b/flake.lock
@@ -16,10 +16,62 @@
         "type": "github"
       }
     },
+    "nixpkgs-libxml2": {
+      "locked": {
+        "lastModified": 1751274312,
+        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
+        "soulver-cpp": "soulver-cpp",
         "systems": "systems"
+      }
+    },
+    "soulver-cpp": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2",
+        "nixpkgs-libxml2": "nixpkgs-libxml2"
+      },
+      "locked": {
+        "lastModified": 1783621734,
+        "narHash": "sha256-YBFO+aurlz2y2hTRN1Kl0RjX6JzHn0mYBmt4zb436Yg=",
+        "owner": "vicinaehq",
+        "repo": "soulver-cpp",
+        "rev": "00e926e2bd03118638c88981f6a67bfa107210c2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vicinaehq",
+        "repo": "soulver-cpp",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -44,20 +44,20 @@
       // {
         default = vicinae;
         nix-update-script = pkgs.writeShellScriptBin "nix-update-script" ''
-        OLD_API_DEPS_HASH=$(${pkgs.lib.getExe pkgs.nix} eval --raw .#packages.x86_64-linux.default.apiDeps.hash)
-        OLD_EXT_MAN_DEPS_HASH=$(${pkgs.lib.getExe pkgs.nix} eval --raw .#packages.x86_64-linux.default.extensionManagerDeps.hash)
+          OLD_API_DEPS_HASH=$(${pkgs.lib.getExe pkgs.nix} eval --raw .#packages.x86_64-linux.default.apiDeps.hash)
+          OLD_EXT_MAN_DEPS_HASH=$(${pkgs.lib.getExe pkgs.nix} eval --raw .#packages.x86_64-linux.default.extensionManagerDeps.hash)
 
-        cd src/typescript/api
-        NEW_API_DEPS_HASH=$(${pkgs.lib.getExe pkgs.prefetch-npm-deps} package-lock.json)
-        cd ../extension-manager
-        NEW_EXT_MAN_DEPS_HASH=$(${pkgs.lib.getExe pkgs.prefetch-npm-deps} package-lock.json)
-        cd ..
+          cd src/typescript/api
+          NEW_API_DEPS_HASH=$(${pkgs.lib.getExe pkgs.prefetch-npm-deps} package-lock.json)
+          cd ../extension-manager
+          NEW_EXT_MAN_DEPS_HASH=$(${pkgs.lib.getExe pkgs.prefetch-npm-deps} package-lock.json)
+          cd ..
 
-        [[ "$OLD_API_DEPS_HASH" == "$NEW_API_DEPS_HASH" ]] || { echo -e "\e[31mHash mismatch for API npm deps, please replace the value in vicinae.nix with '$NEW_API_DEPS_HASH'.\e[0m" >&2; exit 1;}
+          [[ "$OLD_API_DEPS_HASH" == "$NEW_API_DEPS_HASH" ]] || { echo -e "\e[31mHash mismatch for API npm deps, please replace the value in vicinae.nix with '$NEW_API_DEPS_HASH'.\e[0m" >&2; exit 1;}
 
-        [[ "$OLD_EXT_MAN_DEPS_HASH" == "$NEW_EXT_MAN_DEPS_HASH" ]] || { echo -e "\e[31mHash mismatch for extension-manager npm deps, please replace the value in vicinae.nix with '$NEW_EXT_MAN_DEPS_HASH'.\e[0m" >&2; exit 1;}
-      '';
-    });
+          [[ "$OLD_EXT_MAN_DEPS_HASH" == "$NEW_EXT_MAN_DEPS_HASH" ]] || { echo -e "\e[31mHash mismatch for extension-manager npm deps, please replace the value in vicinae.nix with '$NEW_EXT_MAN_DEPS_HASH'.\e[0m" >&2; exit 1;}
+        '';
+      });
     lib = forEachPkgs (pkgs: {
       mkVicinaeExtension = pkgs.callPackage ./nix/mkVicinaeExtension.nix {};
       mkRayCastExtension = pkgs.callPackage ./nix/mkRayCastExtension.nix {};

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,6 @@
       soulver = soulver-cpp.packages.${pkgs.stdenv.hostPlatform.system}.default or null;
     in
       lib.optionalAttrs (soulver != null) {
-        soulver-cpp = soulver;
         with-soulver = pkgs.symlinkJoin {
           name = "${vicinae.name}-with-soulver";
           paths = [vicinae];

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-unstable";
     systems.url = "github:nix-systems/default";
+    soulver-cpp.url = "github:vicinaehq/soulver-cpp";
   };
 
   nixConfig = {
@@ -15,13 +16,34 @@
     self,
     nixpkgs,
     systems,
+    soulver-cpp,
   }: let
     inherit (nixpkgs) lib;
     forEachPkgs = f: lib.genAttrs (import systems) (system: f nixpkgs.legacyPackages.${system});
   in {
-    packages = forEachPkgs (pkgs: {
-      default = pkgs.callPackage ./nix/vicinae.nix {gcc15Stdenv = pkgs.gcc15Stdenv;};
-      nix-update-script = pkgs.writeShellScriptBin "nix-update-script" ''
+    packages = forEachPkgs (pkgs: let
+      vicinae = pkgs.callPackage ./nix/vicinae.nix {gcc15Stdenv = pkgs.gcc15Stdenv;};
+      soulver = soulver-cpp.packages.${pkgs.stdenv.hostPlatform.system}.default or null;
+    in
+      lib.optionalAttrs (soulver != null) {
+        soulver-cpp = soulver;
+        with-soulver = pkgs.symlinkJoin {
+          name = "${vicinae.name}-with-soulver";
+          paths = [vicinae];
+          nativeBuildInputs = [pkgs.makeWrapper];
+          postBuild = ''
+            for bin in $out/bin/*; do
+              wrapProgram "$bin" \
+                --prefix LD_LIBRARY_PATH : ${soulver}/lib \
+                --prefix XDG_DATA_DIRS : ${soulver}/share
+            done
+          '';
+          inherit (vicinae) meta;
+        };
+      }
+      // {
+        default = vicinae;
+        nix-update-script = pkgs.writeShellScriptBin "nix-update-script" ''
         OLD_API_DEPS_HASH=$(${pkgs.lib.getExe pkgs.nix} eval --raw .#packages.x86_64-linux.default.apiDeps.hash)
         OLD_EXT_MAN_DEPS_HASH=$(${pkgs.lib.getExe pkgs.nix} eval --raw .#packages.x86_64-linux.default.extensionManagerDeps.hash)
 

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -7,7 +7,13 @@ self: {
   cfg = config.programs.vicinae;
 
   inherit (pkgs.stdenv.hostPlatform) system;
-  vicinaePkg = self.packages.${system}.default;
+  soulverVicinaePkg = self.packages.${system}.with-soulver or null;
+  vicinaePkg =
+    if cfg.package != null
+    then cfg.package
+    else if cfg.enableSoulver && soulverVicinaePkg != null
+    then soulverVicinaePkg
+    else self.packages.${system}.default;
 
   jsonFormat = pkgs.formats.json {};
   tomlFormat = pkgs.formats.toml {};
@@ -41,10 +47,13 @@ in {
     enable = lib.mkEnableOption "vicinae launcher daemon";
 
     package = lib.mkOption {
-      type = lib.types.package;
-      default = vicinaePkg;
-      defaultText = lib.literalExpression "vicinae";
-      description = "The vicinae package to use";
+      type = lib.types.nullOr lib.types.package;
+      default = null;
+      defaultText = lib.literalExpression "vicinae.packages.\${system}.default, or vicinae.packages.\${system}.with-soulver when enableSoulver is true";
+      description = ''
+        The vicinae package to use. When null, this will default to the flake's
+        `default` package, or `with-soulver` when `enableSoulver` is true.
+      '';
     };
 
     enableSoulver = lib.mkOption {
@@ -53,18 +62,8 @@ in {
       description = ''
         Whether to enable the SoulverCore calculator backend.
         SoulverCore is considered unfree software, therefore disabled by default.
-        Only adds a wrapper exposing `soulverPackage` to vicinae, so it works
-        with any `package` and never triggers a rebuild of vicinae itself.
-      '';
-    };
-
-    soulverPackage = lib.mkOption {
-      type = lib.types.nullOr lib.types.package;
-      default = self.packages.${system}.soulver-cpp or null;
-      defaultText = lib.literalExpression "vicinae.packages.\${system}.soulver-cpp";
-      description = ''
-        The soulver-cpp package providing libSoulverWrapper.so and the
-        SoulverCore resources. Only used when `enableSoulver` is true.
+        Uses the flake's `with-soulver` package.
+        Ignored when `package` is set, wrap your own package if absolutely needed.
       '';
     };
 
@@ -232,28 +231,33 @@ in {
     settingsFile = jsonFormat.generate "vicinae-settings.json" cfg.settings;
 
     wrappedVicinae = pkgs.symlinkJoin {
-      name = "${cfg.package.name}-configured";
-      paths = [cfg.package];
+      name = "${vicinaePkg.name}-configured";
+      paths = [vicinaePkg];
       nativeBuildInputs = [pkgs.makeWrapper];
       postBuild = let
         allOverrides = (lib.optional (cfg.settings != {}) settingsFile) ++ cfg.settingOverrides;
         overrideString = lib.concatStringsSep ":" allOverrides;
       in ''
         wrapProgram $out/bin/vicinae \
-          ${lib.optionalString (allOverrides != []) ''--set VICINAE_OVERRIDES "${overrideString}"''} \
-          ${lib.optionalString cfg.enableSoulver ''--prefix LD_LIBRARY_PATH : "${cfg.soulverPackage}/lib" --prefix XDG_DATA_DIRS : "${cfg.soulverPackage}/share"''}
+          ${lib.optionalString (allOverrides != []) ''--set VICINAE_OVERRIDES "${overrideString}"''}
       '';
     };
   in
     lib.mkIf cfg.enable {
       assertions = [
         {
-          assertion = cfg.enableSoulver -> cfg.soulverPackage != null;
-          message = "programs.vicinae.enableSoulver: the soulver backend is not available on ${system} and no soulverPackage was set";
+          assertion = cfg.enableSoulver -> (cfg.package != null || soulverVicinaePkg != null);
+          message = "programs.vicinae.enableSoulver: the soulver backend is not available on ${system}";
         }
       ];
 
+      warnings = lib.optional (cfg.enableSoulver && cfg.package != null) "programs.vicinae.enableSoulver is ignored because programs.vicinae.package is set; wrap your package with soulver-cpp yourself";
+
       home.packages = [wrappedVicinae];
+
+      programs.vicinae.settings = lib.mkIf cfg.enableSoulver {
+        providers.calculator.preferences.backend = lib.mkDefault "soulver-core";
+      };
 
       xdg = let
         themeFiles =
@@ -278,12 +282,12 @@ in {
           // themeFiles;
       };
 
-      programs.firefox.nativeMessagingHosts = lib.mkIf (cfg.enableFirefoxIntegration && cfg.package != null) [
+      programs.firefox.nativeMessagingHosts = lib.mkIf cfg.enableFirefoxIntegration [
         (pkgs.writeTextDir "lib/mozilla/native-messaging-hosts/com.vicinae.vicinae.json" (
           builtins.toJSON {
             name = "com.vicinae.vicinae";
             description = "Vicinae Native Messaging Host";
-            path = "${cfg.package}/libexec/vicinae/vicinae-browser-link";
+            path = "${vicinaePkg}/libexec/vicinae/vicinae-browser-link";
             type = "stdio";
             allowed_extensions = ["firefox@vicinae.com"];
           }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -47,6 +47,27 @@ in {
       description = "The vicinae package to use";
     };
 
+    enableSoulver = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to enable the SoulverCore calculator backend.
+        SoulverCore is considered unfree software, therefore disabled by default.
+        Only adds a wrapper exposing `soulverPackage` to vicinae, so it works
+        with any `package` and never triggers a rebuild of vicinae itself.
+      '';
+    };
+
+    soulverPackage = lib.mkOption {
+      type = lib.types.nullOr lib.types.package;
+      default = self.packages.${system}.soulver-cpp or null;
+      defaultText = lib.literalExpression "vicinae.packages.\${system}.soulver-cpp";
+      description = ''
+        The soulver-cpp package providing libSoulverWrapper.so and the
+        SoulverCore resources. Only used when `enableSoulver` is true.
+      '';
+    };
+
     enableFirefoxIntegration = lib.mkOption {
       default = true;
       description = ''
@@ -219,11 +240,19 @@ in {
         overrideString = lib.concatStringsSep ":" allOverrides;
       in ''
         wrapProgram $out/bin/vicinae \
-          ${lib.optionalString (allOverrides != []) ''--set VICINAE_OVERRIDES "${overrideString}"''}
+          ${lib.optionalString (allOverrides != []) ''--set VICINAE_OVERRIDES "${overrideString}"''} \
+          ${lib.optionalString cfg.enableSoulver ''--prefix LD_LIBRARY_PATH : "${cfg.soulverPackage}/lib" --prefix XDG_DATA_DIRS : "${cfg.soulverPackage}/share"''}
       '';
     };
   in
     lib.mkIf cfg.enable {
+      assertions = [
+        {
+          assertion = cfg.enableSoulver -> cfg.soulverPackage != null;
+          message = "programs.vicinae.enableSoulver: the soulver backend is not available on ${system} and no soulverPackage was set";
+        }
+      ];
+
       home.packages = [wrappedVicinae];
 
       xdg = let


### PR DESCRIPTION
This PR adds a SoulverCore implementation to the nix module toggleable with `programs.vicinae.enableSoulver` using the [soulver-cpp](https://github.com/vicinaehq/soulver-cpp) flake.