### PR TITLE
feat: use macOS native API to enumerate screens

### DIFF
--- a/src/server/src/services/window-manager/macos/macos-window-manager.hpp
+++ b/src/server/src/services/window-manager/macos/macos-window-manager.hpp
@@ -29,6 +29,7 @@ public:
   QString displayName() const override { return "macOS"; }
 
   WindowList listWindowsSync() const override;
+  std::vector<Screen> listScreensSync() const override;
   std::shared_ptr<AbstractWindow> getFocusedWindowSync() const override;
   bool supportsFocusTracking() const override { return true; }
   void focusWindowSync(const AbstractWindow &window) const override;

--- a/src/server/src/services/window-manager/macos/macos-window-manager.mm
+++ b/src/server/src/services/window-manager/macos/macos-window-manager.mm
@@ -2,6 +2,7 @@
 
 #import <AppKit/AppKit.h>
 #import <Foundation/Foundation.h>
+#include <IOKit/graphics/IOGraphicsTypes.h>
 
 #include <QFutureWatcher>
 #include <QPointer>
@@ -348,6 +349,57 @@ void MacosWindowManager::rebuildCache() {
 }
 
 AbstractWindowManager::WindowList MacosWindowManager::listWindowsSync() const { return m_cache; }
+
+static std::optional<QSize> displayScanoutSize(CGDirectDisplayID display) {
+  CGDisplayModeRef current = CGDisplayCopyDisplayMode(display);
+  if (!current) return std::nullopt;
+
+  const QSize pixels(CGDisplayModeGetPixelWidth(current), CGDisplayModeGetPixelHeight(current));
+  const bool scaled = CGDisplayModeGetPixelWidth(current) != CGDisplayModeGetWidth(current);
+  CGDisplayModeRelease(current);
+
+  if (!scaled) return pixels;
+
+  CFArrayRef modes = CGDisplayCopyAllDisplayModes(display, nullptr);
+  if (!modes) return pixels;
+
+  std::optional<QSize> native;
+
+  for (CFIndex i = 0; i < CFArrayGetCount(modes); ++i) {
+    auto mode = (CGDisplayModeRef)CFArrayGetValueAtIndex(modes, i);
+
+    if (CGDisplayModeGetIOFlags(mode) & kDisplayModeNativeFlag) {
+      native = QSize(CGDisplayModeGetPixelWidth(mode), CGDisplayModeGetPixelHeight(mode));
+      break;
+    }
+  }
+
+  CFRelease(modes);
+  return native ? *native : pixels;
+}
+
+std::vector<AbstractWindowManager::Screen> MacosWindowManager::listScreensSync() const {
+  std::vector<Screen> screens;
+
+  @autoreleasepool {
+    NSArray<NSScreen *> *nsScreens = [NSScreen screens];
+    screens.reserve(nsScreens.count);
+
+    for (NSScreen *nsScreen in nsScreens) {
+      auto display = (CGDirectDisplayID)[nsScreen.deviceDescription[@"NSScreenNumber"] unsignedIntValue];
+      const CGRect bounds = CGDisplayBounds(display);
+      const QSize logicalSize(qRound(bounds.size.width), qRound(bounds.size.height));
+
+      Screen screen{.name = QString::fromNSString(nsScreen.localizedName),
+                    .bounds = QRect(QPoint(qRound(bounds.origin.x), qRound(bounds.origin.y)), logicalSize),
+                    .physicalResolution =
+                        displayScanoutSize(display).value_or(logicalSize * nsScreen.backingScaleFactor)};
+      screens.emplace_back(std::move(screen));
+    }
+  }
+
+  return screens;
+}
 
 AbstractWindowManager::WindowPtr MacosWindowManager::getFocusedWindowSync() const {
   if (!AXIsProcessTrusted()) return nullptr;


### PR DESCRIPTION
Use the native macOS API to get screen information since QT does not allow us to know the physical resolution of the current mode.