### PR TITLE
feat: add active key to WindowManagement.Screen

### DIFF
--- a/figura/tsapi.fig
+++ b/figura/tsapi.fig
@@ -162,6 +162,7 @@ struct Screen {
   serial?: string;
   bounds: Rect;
   physicalResolution: Size;
+  active: bool;
 };
 
 struct Workspace {

--- a/src/server/src/extension/extension-command-runtime.cpp
+++ b/src/server/src/extension/extension-command-runtime.cpp
@@ -49,7 +49,7 @@ void ExtensionCommandRuntime::initialize() {
   auto *ui = new ExtUIService(*m_transport, context()->navigation.get(), m_command, eventCore,
                               *services->toastService());
   auto *wm = new ExtWindowManagementService(*m_transport, *services->windowManager(), *services->appDb(),
-                                            *services->appRuntime());
+                                            *services->appRuntime(), *ctx.navigation);
   auto *clipboard = new ExtClipboardService(*m_transport, *services->clipman(), *services->pasteService());
   auto *storage = new ExtStorageService(*m_transport, *services->localStorage(), storageNamespace);
   auto *fileSearch = new ExtFileSearchService(*m_transport, *services->fileService());

--- a/src/server/src/extension/services/wm-service.hpp
+++ b/src/server/src/extension/services/wm-service.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "generated/tsapi.hpp"
+#include "navigation-controller.hpp"
 #include "services/app-runtime/app-runtime.hpp"
 #include "services/app-service/app-service.hpp"
 #include "services/window-manager/window-manager.hpp"
@@ -9,8 +10,8 @@ class ExtWindowManagementService : public tsapi::AbstractWindowManagement {
 
 public:
   ExtWindowManagementService(tsapi::RpcTransport &transport, WindowManager &wm, AppService &app,
-                             AppRuntime &runtime)
-      : AbstractWindowManagement(transport), m_wm(wm), m_app(app), m_runtime(runtime) {}
+                             AppRuntime &runtime, NavigationController &nav)
+      : AbstractWindowManagement(transport), m_wm(wm), m_app(app), m_runtime(runtime), m_nav(nav) {}
 
   tsapi::Result<bool>::Future focusWindow(std::string winId) override {
     auto win = m_wm.findWindowById(QString::fromStdString(winId));
@@ -76,7 +77,7 @@ public:
   }
 
   tsapi::Result<std::vector<tsapi::Screen>>::Future getScreens() override {
-    auto screens = m_wm.provider()->listScreensSync();
+    auto screens = m_wm.provider()->listScreensSync(m_nav.window());
     std::vector<tsapi::Screen> result;
     result.reserve(screens.size());
 
@@ -91,6 +92,7 @@ public:
                      .height = screen.bounds.height()},
           .physicalResolution = {.width = screen.physicalResolution.width(),
                                  .height = screen.physicalResolution.height()},
+          .active = screen.active,
       };
       if (screen.serial) sc.serial = screen.serial->toStdString();
       result.emplace_back(std::move(sc));
@@ -156,4 +158,5 @@ private:
   WindowManager &m_wm;
   AppService &m_app;
   AppRuntime &m_runtime;
+  NavigationController &m_nav;
 };

--- a/src/server/src/navigation-controller.hpp
+++ b/src/server/src/navigation-controller.hpp
@@ -18,6 +18,7 @@
 class BaseView;
 class DialogContentWidget;
 class ActionPanelView;
+class QWindow;
 
 #define VALUE_OR(VALUE, FALLBACK) (VALUE ? VALUE : FALLBACK)
 
@@ -135,6 +136,12 @@ public:
 
   bool windowActivated();
   void setWindowActivated(bool value = true);
+
+  /**
+   * Non-owning reference to the launcher window, registered by the QML window host.
+   */
+  void setWindow(QWindow *window) { m_window = window; }
+  QWindow *window() const { return m_window; }
 
   void setPopToRootOnClose(bool value);
 
@@ -267,6 +274,7 @@ private:
   bool m_popToRootOnClose = false;
   bool m_instantDismiss = false;
   bool m_closeOnFocusLoss = false;
+  QWindow *m_window = nullptr;
   std::vector<std::unique_ptr<ViewState>> m_views;
   std::optional<PendingPopToRoot> m_pendingPopToRoot;
 };

--- a/src/server/src/qml/launcher-window.cpp
+++ b/src/server/src/qml/launcher-window.cpp
@@ -107,6 +107,7 @@ LauncherWindow::LauncherWindow(ApplicationContext &ctx, QObject *parent)
 
   // Track window activation so toggleWindow() and closeOnFocusLoss work correctly
   if (m_window) {
+    nav->setWindow(m_window);
     connect(m_window, &QQuickWindow::activeChanged, this,
             [this]() { m_ctx.navigation->setWindowActivated(m_window->isActive()); });
     m_window->installEventFilter(this);

--- a/src/server/src/services/window-manager/abstract-wayland-window-manager.cpp
+++ b/src/server/src/services/window-manager/abstract-wayland-window-manager.cpp
@@ -1,8 +1,9 @@
 #include "abstract-wayland-window-manager.hpp"
 #include "internal/wayland/globals.hpp"
 
-std::vector<AbstractWindowManager::Screen> AbstractWaylandWindowManager::listScreensSync() const {
-  auto screens = AbstractWindowManager::listScreensSync();
+std::vector<AbstractWindowManager::Screen>
+AbstractWaylandWindowManager::listScreensSync(QWindow *activeWindow) const {
+  auto screens = AbstractWindowManager::listScreensSync(activeWindow);
 
   // the DPR-derived default is wrong under fractional scaling, the current output mode is ground truth
   for (auto &screen : screens) {

--- a/src/server/src/services/window-manager/abstract-wayland-window-manager.hpp
+++ b/src/server/src/services/window-manager/abstract-wayland-window-manager.hpp
@@ -3,5 +3,5 @@
 
 class AbstractWaylandWindowManager : public AbstractWindowManager {
 public:
-  std::vector<Screen> listScreensSync() const override;
+  std::vector<Screen> listScreensSync(QWindow *activeWindow) const override;
 };

--- a/src/server/src/services/window-manager/abstract-window-manager.hpp
+++ b/src/server/src/services/window-manager/abstract-window-manager.hpp
@@ -8,6 +8,7 @@
 #include "services/app-service/abstract-app-db.hpp"
 #include <QGuiApplication>
 #include <QScreen>
+#include <QWindow>
 #include <ranges>
 #include <vector>
 
@@ -54,6 +55,12 @@ public:
     QString manufacturer;
     QString model;
     std::optional<QString> serial;
+
+    /**
+     * Whether this screen currently displays the launcher window. Always false when the window
+     * is not shown.
+     */
+    bool active = false;
   };
 
   struct BlurConfig {
@@ -117,14 +124,20 @@ public:
 
   virtual WindowList listWindowsSync() const { return {}; };
 
-  virtual std::vector<Screen> listScreensSync() const {
-    auto tr = [](const QScreen *qtScreen) -> Screen {
+  /**
+   * List available screens, marking the one displaying `activeWindow` as active, if any.
+   */
+  virtual std::vector<Screen> listScreensSync(QWindow *activeWindow = nullptr) const {
+    const QScreen *activeScreen =
+        activeWindow && activeWindow->isVisible() ? activeWindow->screen() : nullptr;
+    auto tr = [&](const QScreen *qtScreen) -> Screen {
       Screen sc{.name = qtScreen->name(),
                 .bounds = qtScreen->geometry(),
                 .physicalResolution = qtScreen->size() * qtScreen->devicePixelRatio(),
                 .manufacturer = qtScreen->manufacturer(),
                 .model = qtScreen->model()};
       if (auto serial = qtScreen->serialNumber(); !serial.isEmpty()) { sc.serial = serial; }
+      sc.active = qtScreen == activeScreen;
       return sc;
     };
     return QGuiApplication::screens() | std::views::transform(tr) | std::ranges::to<std::vector>();

--- a/src/server/src/services/window-manager/macos/macos-window-manager.hpp
+++ b/src/server/src/services/window-manager/macos/macos-window-manager.hpp
@@ -29,7 +29,7 @@ public:
   QString displayName() const override { return "macOS"; }
 
   WindowList listWindowsSync() const override;
-  std::vector<Screen> listScreensSync() const override;
+  std::vector<Screen> listScreensSync(QWindow *activeWindow) const override;
   std::shared_ptr<AbstractWindow> getFocusedWindowSync() const override;
   bool supportsFocusTracking() const override { return true; }
   void focusWindowSync(const AbstractWindow &window) const override;

--- a/src/server/src/services/window-manager/macos/macos-window-manager.mm
+++ b/src/server/src/services/window-manager/macos/macos-window-manager.mm
@@ -385,7 +385,7 @@ static CGDirectDisplayID screenDisplayId(NSScreen *screen) {
 static std::optional<CGDirectDisplayID> windowDisplayId(QWindow *window) {
   if (!window || !window->isVisible() || !window->handle()) return std::nullopt;
 
-  auto *view = (NSView *)window->winId();
+  auto *view = (__bridge NSView *)reinterpret_cast<void *>(window->winId());
   NSScreen *screen = view.window.screen;
   if (!screen) return std::nullopt;
 

--- a/src/server/src/services/window-manager/macos/macos-window-manager.mm
+++ b/src/server/src/services/window-manager/macos/macos-window-manager.mm
@@ -378,15 +378,30 @@ static std::optional<QSize> displayScanoutSize(CGDirectDisplayID display) {
   return native ? *native : pixels;
 }
 
-std::vector<AbstractWindowManager::Screen> MacosWindowManager::listScreensSync() const {
+static CGDirectDisplayID screenDisplayId(NSScreen *screen) {
+  return (CGDirectDisplayID)[screen.deviceDescription[@"NSScreenNumber"] unsignedIntValue];
+}
+
+static std::optional<CGDirectDisplayID> windowDisplayId(QWindow *window) {
+  if (!window || !window->isVisible() || !window->handle()) return std::nullopt;
+
+  auto *view = (NSView *)window->winId();
+  NSScreen *screen = view.window.screen;
+  if (!screen) return std::nullopt;
+
+  return screenDisplayId(screen);
+}
+
+std::vector<AbstractWindowManager::Screen> MacosWindowManager::listScreensSync(QWindow *activeWindow) const {
   std::vector<Screen> screens;
 
   @autoreleasepool {
+    auto activeDisplay = windowDisplayId(activeWindow);
     NSArray<NSScreen *> *nsScreens = [NSScreen screens];
     screens.reserve(nsScreens.count);
 
     for (NSScreen *nsScreen in nsScreens) {
-      auto display = (CGDirectDisplayID)[nsScreen.deviceDescription[@"NSScreenNumber"] unsignedIntValue];
+      auto display = screenDisplayId(nsScreen);
       const CGRect bounds = CGDisplayBounds(display);
       const QSize logicalSize(qRound(bounds.size.width), qRound(bounds.size.height));
 
@@ -394,6 +409,7 @@ std::vector<AbstractWindowManager::Screen> MacosWindowManager::listScreensSync()
                     .bounds = QRect(QPoint(qRound(bounds.origin.x), qRound(bounds.origin.y)), logicalSize),
                     .physicalResolution =
                         displayScanoutSize(display).value_or(logicalSize * nsScreen.backingScaleFactor)};
+      screen.active = activeDisplay == display;
       screens.emplace_back(std::move(screen));
     }
   }

--- a/src/typescript/api/src/api/proto/api.ts
+++ b/src/typescript/api/src/api/proto/api.ts
@@ -186,6 +186,7 @@ export type Screen = {
 	serial?: string;
 	bounds: Rect;
 	physicalResolution: Size;
+	active: boolean;
 }
 
 export type Workspace = {

--- a/src/typescript/api/src/api/window-management.ts
+++ b/src/typescript/api/src/api/window-management.ts
@@ -132,6 +132,12 @@ export namespace WindowManagement {
 		 * The real pixel size of the screen, unaffected by any kind of display scaling.
 		 */
 		physicalResolution: { width: number; height: number };
+
+		/**
+		 * Whether this screen is the one the Vicinae window is currently displayed on.
+		 * Always `false` for every screen if the Vicinae window is not shown.
+		 */
+		active: boolean;
 	};
 
 	export async function getWindows(
@@ -180,6 +186,7 @@ export namespace WindowManagement {
 						width: sc.physicalResolution.width,
 						height: sc.physicalResolution.height,
 					},
+					active: sc.active,
 				})),
 			);
 	}


### PR DESCRIPTION
Add `active` key to `WindowManagement.Screen` so that the callers can know which screen the vicinae window is currently shown on. Always set to false if the vicinae window is not shown (e.g the extension command runs in the background).