### PR TITLE
fix(api): expose Grid.throttle

### DIFF
--- a/src/typescript/api/src/api/components/grid.tsx
+++ b/src/typescript/api/src/api/components/grid.tsx
@@ -99,7 +99,7 @@ export namespace Grid {
 		columns?: number;
 		fit?: GridFit;
 		aspectRatio?: Grid.AspectRatio;
-
+		throttle?: boolean;
 		actions?: React.ReactNode;
 		children?: React.ReactNode;
 		filtering?: boolean;
@@ -181,6 +181,7 @@ const GridRoot: React.FC<Grid.Props> = ({
 	fit = GridFit.Contain,
 	aspectRatio = "1",
 	searchText,
+	throttle = false,
 	onSearchTextChange,
 	...props
 }) => {
@@ -207,6 +208,7 @@ const GridRoot: React.FC<Grid.Props> = ({
 	return (
 		<grid
 			fit={fit}
+			throttle
 			inset={inset}
 			aspectRatio={aspectRatioMap[aspectRatio]}
 			searchText={countedSearchText}

--- a/src/typescript/api/src/api/components/grid.tsx
+++ b/src/typescript/api/src/api/components/grid.tsx
@@ -208,7 +208,7 @@ const GridRoot: React.FC<Grid.Props> = ({
 	return (
 		<grid
 			fit={fit}
-			throttle
+			throttle={throttle}
 			inset={inset}
 			aspectRatio={aspectRatioMap[aspectRatio]}
 			searchText={countedSearchText}

--- a/src/typescript/api/types/jsx.d.ts
+++ b/src/typescript/api/types/jsx.d.ts
@@ -65,6 +65,7 @@ declare module "react" {
 				columns?: number;
 				fit: Grid.Fit;
 				aspectRatio: number;
+				throttle: boolean;
 
 				children?: React.ReactNode;
 				filtering?: boolean;


### PR DESCRIPTION
For some reason the `Grid` root component didn't expose a `throttle` prop like `List` does, although fully implemented. This fixes that.