### PR TITLE
Fix copying multiple files in macOS (and probably X11 too?)

### DIFF
--- a/src/server/src/services/clipboard/clipboard-mime.cpp
+++ b/src/server/src/services/clipboard/clipboard-mime.cpp
@@ -68,10 +68,10 @@ std::optional<ClipboardSelection> selectionFromMimeData(const QMimeData *mimeDat
     ClipboardDataOffer offer;
     offer.mimeType = "text/uri-list";
     for (const auto &url : mimeData->urls()) {
-      if (!offer.data.isEmpty()) { offer.data += ';'; }
+      if (!offer.data.isEmpty()) { offer.data += "\r\n"; }
       offer.data += url.toString().toUtf8();
     }
-    selection.offers.emplace_back(offer);
+    selection.offers.emplace_back(std::move(offer));
   }
 
   // We also want to index other formats that are not text, image, or legacy X11 target types.

--- a/src/server/src/services/clipboard/clipboard-service.cpp
+++ b/src/server/src/services/clipboard/clipboard-service.cpp
@@ -1,5 +1,6 @@
 #include <QClipboard>
 #include "clipboard-service.hpp"
+#include <algorithm>
 #include <filesystem>
 #include <numeric>
 #include <QGuiApplication>
@@ -164,7 +165,8 @@ ClipboardOfferKind ClipboardService::getKind(const ClipboardDataOffer &offer) {
   if (offer.mimeType == "text/uri-list") {
     QString const text = offer.data;
     auto uris = text.split("\r\n", Qt::SkipEmptyParts);
-    if (uris.size() == 1 && QUrl(uris.front()).isLocalFile()) return ClipboardOfferKind::File;
+    auto isLocalFile = [](const QString &uri) { return QUrl(uri).isLocalFile(); };
+    if (!uris.isEmpty() && std::ranges::all_of(uris, isLocalFile)) return ClipboardOfferKind::File;
     return ClipboardOfferKind::Text;
   }
 


### PR DESCRIPTION
On macOS and X11, if my code tracing is correct, copying multiple files to the clipboard manager of vicinae, then trying to paste it doesn't work at all. I see the `file://` urls displayed in the clipboard manager, but nothing pastes into Finder. It's because uri lists are supposed to be CRLF-separated rather than semicolon-separated. [source](https://www.rfc-editor.org/info/rfc2483/#section-5)