### PR TITLE
feat: platform specific navigation keys

### DIFF
--- a/extra/config.jsonc
+++ b/extra/config.jsonc
@@ -60,10 +60,7 @@
 	// If this is set to 'none', favicon loading is disabled and a placeholder icon will be used when a favicon is expected.
 	"favicon_service": "twenty",
 
-	// EXPERIMENTAL!
-	// Enable specific editing motions in the main search bar and during navigation.
-	// This will probably be changed in future updates.
-	// Supports: 'default' | 'emacs'
+	// Navigation scheme. Supports: 'default' | 'vim' | 'emacs'
 	"keybinding": "default",
 
 	"font": {
@@ -172,29 +169,30 @@
 	// Keybinds are serialized using a custom format.
 	// It is recommended to edit them through the settings GUI, which will write them to this file.
 	// NOTE: here, "control" remaps to the "command" (⌘) key on macOS.
+	// The default values are shown below, uncomment to override.
 	"keybinds": {
 		// common shortcuts
-		"open-search-filter": "control+P",
-		"open-settings": "control+,",
-		"toggle-action-panel": "control+K",
+		// "open-search-filter": "control+P",
+		// "open-settings": "control+,",
+		// "toggle-action-panel": "control+B", (control+K on macOS)
 
 		// used to assign shortcuts to generic actions
 		// if an extension provides a specific kind of action, it is encouraged to use shortcuts as defined here.
-		"action.copy": "control+shift+C",
-		"action.copy-name": "control+shift+.",
-		"action.copy-path": "control+shift+,",
-		"action.dangerous-remove": "control+shift+X",
-		"action.duplicate": "control+D",
-		"action.edit": "control+E",
-		"action.edit-secondary": "control+shift+E",
-		"action.move-down": "control+shift+ARROWDOWN",
-		"action.move-up": "control+shift+ARROWUP",
-		"action.new": "control+N",
-		"action.open": "control+O",
-		"action.pin": "control+shift+P",
-		"action.refresh": "control+R",
-		"action.remove": "control+X",
-		"action.save": "control+S"
+		// "action.copy": "control+shift+C",
+		// "action.copy-name": "control+shift+.",
+		// "action.copy-path": "control+shift+,",
+		// "action.dangerous-remove": "control+shift+X",
+		// "action.duplicate": "control+D",
+		// "action.edit": "control+E",
+		// "action.edit-secondary": "control+shift+E",
+		// "action.move-down": "control+shift+ARROWDOWN",
+		// "action.move-up": "control+shift+ARROWUP",
+		// "action.new": "control+N",
+		// "action.open": "control+O",
+		// "action.pin": "control+shift+P",
+		// "action.refresh": "control+R",
+		// "action.remove": "control+X",
+		// "action.save": "control+S"
 	},
 
 	// List of entrypoints that are tagged as "favorite".

--- a/src/server/src/internal/keyboard/keybind-manager.cpp
+++ b/src/server/src/internal/keyboard/keybind-manager.cpp
@@ -7,7 +7,11 @@ static const std::unordered_map<Keybind, KeybindInfo> infos{
 		.name = "Toggle action panel",
 		.description = "Toggle the action panel to access and filter through the list of available actions for the currently selected item",
 		.icon = "switch",
+#ifdef Q_OS_MACOS
+		.dflt = Keyboard::Shortcut(Qt::Key_K, Qt::ControlModifier)
+#else
 		.dflt = Keyboard::Shortcut(Qt::Key_B, Qt::ControlModifier)
+#endif
 	}},
 	{Keybind::OpenSearchAccessorySelector, KeybindInfo{
 		.id = "open-search-filter", 

--- a/src/server/src/qml/config-bridge.hpp
+++ b/src/server/src/qml/config-bridge.hpp
@@ -2,6 +2,7 @@
 #include "capabilities.hpp"
 #include "config/config.hpp"
 #include "service-registry.hpp"
+#include "services/keybinding/keybinding-service.hpp"
 #include <QColor>
 #include <QObject>
 
@@ -75,7 +76,7 @@ public:
 
   int windowWidth() const { return cfg().launcherWindow.size.width; }
   int windowHeight() const { return cfg().launcherWindow.size.height; }
-  bool emacsMode() const { return cfg().keybinding == "emacs"; }
+  bool emacsMode() const { return KeyBindingService::getMode(cfg().keybinding) == KeyBindingMode::Emacs; }
   bool considerPreedit() const { return cfg().considerPreedit; }
   bool activateOnSingleClick() const { return cfg().activateOnSingleClick; }
   QString windowMaterial() const {

--- a/src/server/src/qml/general-settings-model.cpp
+++ b/src/server/src/qml/general-settings-model.cpp
@@ -263,14 +263,16 @@ QVariant GeneralSettingsModel::currentFaviconService() const {
 QVariantList GeneralSettingsModel::keybindingSchemeItems() const {
   QVariantList items;
   items.append(makeDropdownItem(QStringLiteral("default"), QStringLiteral("Default")));
+  items.append(makeDropdownItem(QStringLiteral("vim"), QStringLiteral("Vim")));
   items.append(makeDropdownItem(QStringLiteral("emacs"), QStringLiteral("Emacs")));
   return wrapSection(QStringLiteral("Keybinding Schemes"), items);
 }
 
 QVariant GeneralSettingsModel::currentKeybindingScheme() const {
   auto id = QString::fromStdString(cfg().keybinding);
-  auto name = id == "emacs" ? QStringLiteral("Emacs") : QStringLiteral("Default");
-  return makeDropdownItem(id, name);
+  if (id == "vim") return makeDropdownItem(id, QStringLiteral("Vim"));
+  if (id == "emacs") return makeDropdownItem(id, QStringLiteral("Emacs"));
+  return makeDropdownItem(id, QStringLiteral("Default"));
 }
 
 void GeneralSettingsModel::selectTheme(const QString &id) {

--- a/src/server/src/qml/keyboard-bridge.hpp
+++ b/src/server/src/qml/keyboard-bridge.hpp
@@ -12,9 +12,12 @@
  */
 class KeyboardBridge : public QObject {
   Q_OBJECT
+  Q_PROPERTY(int physicalCtrlModifier READ physicalCtrlModifier CONSTANT)
 
 public:
   using QObject::QObject;
+
+  int physicalCtrlModifier() const { return static_cast<int>(KeyBindingService::PHYSICAL_CTRL); }
 
   Q_INVOKABLE QString serialize(int key, int modifiers) const {
     Keyboard::Shortcut const shortcut(static_cast<Qt::Key>(key),

--- a/src/server/src/qml/qml/AdvancedSettingsPage.qml
+++ b/src/server/src/qml/qml/AdvancedSettingsPage.qml
@@ -57,7 +57,7 @@ Flickable {
 
             SettingsRow {
                 label: "Keybinding Scheme"
-                description: "Default uses Vim-style Ctrl+J/K and Ctrl+H/L; Emacs uses Ctrl+N/P and Ctrl+Opt+B/F for navigation, plus Emacs editing in the search bar."
+                description: Qt.platform.os === "osx" ? "Default uses the standard macOS keys (arrows, Ctrl+N/P); Vim uses Ctrl+J/K and Ctrl+H/L; Emacs uses Ctrl+N/P and Ctrl+Opt+B/F for navigation, plus Emacs editing in the search bar." : "Default and Vim use Ctrl+J/K and Ctrl+H/L; Emacs uses Ctrl+N/P and Ctrl+Alt+B/F for navigation, plus Emacs editing in the search bar."
                 showSeparator: false
                 SearchableDropdown {
                     width: parent.width

--- a/src/server/src/qml/qml/SearchBar.qml
+++ b/src/server/src/qml/qml/SearchBar.qml
@@ -119,9 +119,9 @@ Item {
                     if (!Config.emacsMode)
                         return false;
 
-                    const ctrl = (event.modifiers & Qt.ControlModifier);
+                    const ctrl = (event.modifiers & Keyboard.physicalCtrlModifier);
                     const alt = (event.modifiers & Qt.AltModifier);
-                    const noOther = !(event.modifiers & ~(Qt.ControlModifier | Qt.AltModifier | Qt.KeypadModifier | Qt.GroupSwitchModifier));
+                    const noOther = !(event.modifiers & ~(Keyboard.physicalCtrlModifier | Qt.AltModifier | Qt.KeypadModifier | Qt.GroupSwitchModifier));
 
                     if (ctrl && !alt && noOther) {
                         switch (event.key) {

--- a/src/server/src/services/keybinding/keybinding-service.hpp
+++ b/src/server/src/services/keybinding/keybinding-service.hpp
@@ -3,13 +3,29 @@
 #include <string>
 #include <qevent.h>
 
-enum class KeyBindingMode { Default, Emacs };
+enum class KeyBindingMode { Native, Vim, Emacs };
 
 class KeyBindingService {
 public:
+  // Qt swaps Control and Meta on macOS, so Qt::MetaModifier is the physical Control key there.
+  // Navigation chords are physical-Control idioms on every platform; regular shortcuts keep the swap.
+#ifdef Q_OS_MACOS
+  static constexpr Qt::KeyboardModifier PHYSICAL_CTRL = Qt::MetaModifier;
+  static constexpr bool NATIVE_NAV_CHORDS = true;
+#else
+  static constexpr Qt::KeyboardModifier PHYSICAL_CTRL = Qt::ControlModifier;
+  static constexpr bool NATIVE_NAV_CHORDS = false;
+#endif
+
+  // "default" resolves to the platform scheme: vim-style on Linux, native keys on macOS.
   static KeyBindingMode getMode(const std::string &keybinding) {
+    if (keybinding == "vim") { return KeyBindingMode::Vim; }
     if (keybinding == "emacs") { return KeyBindingMode::Emacs; }
-    return KeyBindingMode::Default;
+#ifdef Q_OS_MACOS
+    return KeyBindingMode::Native;
+#else
+    return KeyBindingMode::Vim;
+#endif
   }
 
   static bool usesOnly(QKeyEvent *event, Qt::KeyboardModifiers required) {
@@ -19,40 +35,49 @@ public:
   }
 
   static bool isDownKey(QKeyEvent *event, const std::string &keybinding) {
-    KeyBindingMode mode = getMode(keybinding);
-
-    if (!usesOnly(event, Qt::ControlModifier)) { return false; }
-
-    switch (mode) {
-    case KeyBindingMode::Default:
-      return event->key() == Qt::Key_J;
+    switch (getMode(keybinding)) {
+    case KeyBindingMode::Native:
+      return NATIVE_NAV_CHORDS && usesOnly(event, PHYSICAL_CTRL) && event->key() == Qt::Key_N;
+    case KeyBindingMode::Vim:
+      return usesOnly(event, PHYSICAL_CTRL) && event->key() == Qt::Key_J;
     case KeyBindingMode::Emacs:
-      return event->key() == Qt::Key_N;
+      return usesOnly(event, PHYSICAL_CTRL) && event->key() == Qt::Key_N;
     }
     return false;
   }
 
   static bool isUpKey(QKeyEvent *event, const std::string &keybinding) {
-    KeyBindingMode mode = getMode(keybinding);
-
-    if (!usesOnly(event, Qt::ControlModifier)) { return false; }
-
-    switch (mode) {
-    case KeyBindingMode::Default:
-      return event->key() == Qt::Key_K;
+    switch (getMode(keybinding)) {
+    case KeyBindingMode::Native:
+      return NATIVE_NAV_CHORDS && usesOnly(event, PHYSICAL_CTRL) && event->key() == Qt::Key_P;
+    case KeyBindingMode::Vim:
+      return usesOnly(event, PHYSICAL_CTRL) && event->key() == Qt::Key_K;
     case KeyBindingMode::Emacs:
-      return event->key() == Qt::Key_P;
+      return usesOnly(event, PHYSICAL_CTRL) && event->key() == Qt::Key_P;
     }
     return false;
   }
 
   static bool isLeftKey(QKeyEvent *event, const std::string &keybinding) {
-    KeyBindingMode mode = getMode(keybinding);
-    switch (mode) {
-    case KeyBindingMode::Default:
-      return usesOnly(event, Qt::ControlModifier) && event->key() == Qt::Key_H;
+    switch (getMode(keybinding)) {
+    case KeyBindingMode::Native:
+      return false;
+    case KeyBindingMode::Vim:
+      return usesOnly(event, PHYSICAL_CTRL) && event->key() == Qt::Key_H;
     case KeyBindingMode::Emacs:
-      return usesOnly(event, Qt::ControlModifier | Qt::AltModifier) && event->key() == Qt::Key_B;
+      return usesOnly(event, PHYSICAL_CTRL | Qt::AltModifier) && event->key() == Qt::Key_B;
+    }
+    return false;
+  }
+
+  static bool isRightKey(QKeyEvent *event, const std::string &keybinding) {
+    switch (getMode(keybinding)) {
+    case KeyBindingMode::Native:
+      return false;
+    case KeyBindingMode::Vim:
+      return usesOnly(event, PHYSICAL_CTRL) && event->key() == Qt::Key_L;
+    case KeyBindingMode::Emacs:
+      return usesOnly(event, PHYSICAL_CTRL | Qt::AltModifier) && event->key() == Qt::Key_F;
     }
     return false;
   }
@@ -65,16 +90,5 @@ public:
     if (isLeftKey(&ev, keybinding)) return 3;
     if (isRightKey(&ev, keybinding)) return 4;
     return 0;
-  }
-
-  static bool isRightKey(QKeyEvent *event, const std::string &keybinding) {
-    KeyBindingMode mode = getMode(keybinding);
-    switch (mode) {
-    case KeyBindingMode::Default:
-      return usesOnly(event, Qt::ControlModifier) && event->key() == Qt::Key_L;
-    case KeyBindingMode::Emacs:
-      return usesOnly(event, Qt::ControlModifier | Qt::AltModifier) && event->key() == Qt::Key_F;
-    }
-    return false;
   }
 };


### PR DESCRIPTION
Makes it so that we always use ctrl on all platforms, including macOS, to implement additional navigation keys such as vim/emacs keys.

Default mode on macOS is the cocoa compatible one (ctrl+n/ctrl+p)

Default mode on linux defaults to vim navigation keys. Consequently, the default action panel bind was switched from ctrl+k to ctrl+b on linux only (macOS is not affected as ctrl is not command).

Fixes #1645 