### PR TITLE
Add dmenu index output format

### DIFF
--- a/src/cli/src/cli.cpp
+++ b/src/cli/src/cli.cpp
@@ -260,6 +260,7 @@ class DMenuCommand : public AbstractCommandLineCommand {
                   "Do not show quick look if available for a given entry");
     app->add_flag("--no-metadata", m_req.noMetadata, "Do not show metadata section in quick look");
     app->add_flag("--no-footer", m_req.noFooter, "Hide the status bar footer");
+    app->add_option("--format", m_req.format, "Output format")->check(CLI::IsMember({"text", "index"}));
   }
 
   bool run(CLI::App *) override {

--- a/src/lib/vicinae-ipc/include/vicinae-ipc/ipc.hpp
+++ b/src/lib/vicinae-ipc/include/vicinae-ipc/ipc.hpp
@@ -96,6 +96,7 @@ struct DMenu {
     std::optional<int> width;
     std::optional<int> height;
     bool noFooter = false;
+    std::optional<std::string> format;
   };
 
   struct Response {

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -443,6 +443,7 @@ set(SRCS
 
 	src/qml/dmenu-model.hpp
 	src/qml/dmenu-model.cpp
+	src/qml/dmenu-output.hpp
 	src/qml/dmenu-view-host.hpp
 	src/qml/dmenu-view-host.cpp
 
@@ -1155,6 +1156,7 @@ if (BUILD_TESTS AND UNIX AND NOT APPLE)
 	target_sources(${TEST_TARGET} PRIVATE
 		src/services/calculator-service/qalculate/qalculate-backend.cpp
 		tests/calculator/qalculate-backend.cpp
+		tests/dmenu-output.cpp
 	)
 	target_link_libraries(${TEST_TARGET} PRIVATE qalculate Qt6::Concurrent)
 	target_link_libraries(${TEST_TARGET} PRIVATE Catch2::Catch2WithMain Qt6::Core Qt6::Gui)

--- a/src/server/src/qml/dmenu-model.cpp
+++ b/src/server/src/qml/dmenu-model.cpp
@@ -1,5 +1,6 @@
 #include "dmenu-model.hpp"
 #include "clipboard-actions.hpp"
+#include "dmenu-output.hpp"
 #include "fuzzy/fzf.hpp"
 #include "navigation-controller.hpp"
 #include "service-registry.hpp"
@@ -14,8 +15,9 @@
 void DMenuSection::setRawEntries(std::vector<std::string_view> entries) {
   m_entries = std::move(entries);
   m_filtered.clear();
-  for (auto e : m_entries) {
-    m_filtered.push_back({e, 0});
+  m_filtered.reserve(m_entries.size());
+  for (size_t i = 0; i < m_entries.size(); ++i) {
+    m_filtered.emplace_back(i, 0);
   }
   notifyChanged();
 }
@@ -25,9 +27,11 @@ void DMenuSection::setFilter(std::string_view query) {
   m_currentSearchText = QString::fromUtf8(query.data(), query.size());
 
   m_filtered.clear();
-  for (auto e : m_entries) {
+  m_filtered.reserve(m_entries.size());
+  for (size_t i = 0; i < m_entries.size(); ++i) {
+    auto const e = m_entries[i];
     int const score = fzf::threadLocalMatcher().fuzzy_match_v2_score_query(e, queryStr);
-    if (queryStr.empty() || score > 0) { m_filtered.push_back({e, score}); }
+    if (queryStr.empty() || score > 0) { m_filtered.emplace_back(i, score); }
   }
   std::ranges::stable_sort(m_filtered, std::greater{});
 }
@@ -45,7 +49,7 @@ QString DMenuSection::expandSectionName(size_t count) const {
 
 std::string_view DMenuSection::entryAt(int i) const {
   if (i < 0 || std::cmp_greater_equal(i, m_filtered.size())) return {};
-  return m_filtered[i].data;
+  return m_entries[m_filtered[i].data];
 }
 
 QString DMenuSection::itemTitle(int i) const {
@@ -87,19 +91,20 @@ std::unique_ptr<ActionPanelState> DMenuSection::actionPanel(int i) const {
   if (entry.empty()) return nullptr;
 
   auto text = QString::fromUtf8(entry.data(), entry.size());
+  auto output = formatDMenuOutput(text, m_filtered[i].data, m_outputIndex);
   auto panel = std::make_unique<ListActionPanelState>();
   auto *main = panel->createSection();
 
   main->addAction(new StaticAction("Select entry", ImageURL::builtin("save-document"),
-                                   [this, text](ApplicationContext *) { selectEntry(text); }));
+                                   [this, output](ApplicationContext *) { selectEntry(output); }));
 
   main->addAction(new StaticAction("Pass search text", ImageURL::builtin("save-document"),
                                    [this](ApplicationContext *) { selectEntry(m_currentSearchText); }));
 
   auto *selectAndCopy = new StaticAction("Select and copy entry", ImageURL::builtin("copy-clipboard"),
-                                         [this, text](ApplicationContext *ctx) {
+                                         [this, text, output](ApplicationContext *ctx) {
                                            ctx->services->clipman()->copyText(text);
-                                           selectEntry(text);
+                                           selectEntry(output);
                                          });
   selectAndCopy->setShortcut(Keybind::CopyAction);
   main->addAction(selectAndCopy);

--- a/src/server/src/qml/dmenu-model.hpp
+++ b/src/server/src/qml/dmenu-model.hpp
@@ -12,6 +12,7 @@ public:
   void setSectionTemplate(std::string_view tpl) { m_sectionTemplate = tpl; }
   void setNoSection(bool v) { m_noSection = v; }
   void setNoQuickLook(bool v) { m_noQuickLook = v; }
+  void setOutputIndex(bool v) { m_outputIndex = v; }
   void setFilter(std::string_view query) override;
 
   QString sectionName() const override;
@@ -34,11 +35,12 @@ private:
   void selectEntry(const QString &text) const;
 
   std::vector<std::string_view> m_entries;
-  std::vector<Scored<std::string_view>> m_filtered;
+  std::vector<Scored<size_t>> m_filtered;
   std::string_view m_sectionTemplate = "Entries ({count})";
   QString m_currentSearchText;
   bool m_noSection = false;
   bool m_noQuickLook = false;
+  bool m_outputIndex = false;
 
   std::function<void(const QString &)> m_onEntryChosen;
   std::function<void(std::string_view)> m_onFileHighlighted;

--- a/src/server/src/qml/dmenu-output.hpp
+++ b/src/server/src/qml/dmenu-output.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <QString>
+#include <cstddef>
+
+inline QString formatDMenuOutput(const QString &text, std::size_t originalIndex, bool outputIndex) {
+  return outputIndex ? QString::number(static_cast<qulonglong>(originalIndex)) : text;
+}

--- a/src/server/src/qml/dmenu-view-host.cpp
+++ b/src/server/src/qml/dmenu-view-host.cpp
@@ -27,6 +27,7 @@ void DMenuViewHost::initialize() {
   if (m_data.noQuickLook) m_section.setNoQuickLook(true);
   if (m_data.noSection) m_section.setNoSection(true);
   if (m_data.sectionTitle) m_section.setSectionTemplate(*m_data.sectionTitle);
+  m_section.setOutputIndex(m_data.format.value_or("text") == "index");
   if (m_data.noFooter) setStatusBarVisiblity(false);
   if (m_data.navigationTitle) setNavigationTitle(QString::fromStdString(*m_data.navigationTitle));
 

--- a/src/server/tests/dmenu-output.cpp
+++ b/src/server/tests/dmenu-output.cpp
@@ -1,0 +1,11 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "qml/dmenu-output.hpp"
+
+TEST_CASE("dmenu formats selected entries") {
+  QString const text = QStringLiteral("duplicate");
+
+  CHECK(formatDMenuOutput(text, 0, false) == text);
+  CHECK(formatDMenuOutput(text, 0, true) == QStringLiteral("0"));
+  CHECK(formatDMenuOutput(text, 2, true) == QStringLiteral("2"));
+}


### PR DESCRIPTION
## Summary
- add `--format index` to dmenu mode
- preserve original zero-based input indices through fuzzy filtering
- keep text output as the default and copy selected text to the clipboard

## Validation
- focused output-format test
- `clang-format --dry-run -Werror` on touched C++ files
- `git diff --check`
- standalone Qt 6 smoke build and run for the formatter

Closes #1605

Prepared with OpenAI Codex assistance; validation performed is listed above.
