### PR TITLE
feat: windows app provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .cache
 /build
-/build-release
+/build-*
+.vscode
 CMakeUserPresets.json
 .tmp
 extension-manager/runtime/node_modules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,9 @@ vicinae is a multi purpose launcher built with QtQuick. This file focuses on exp
 It uses QML for presentation and C++ for business logic.
 React/Typescript is used to power the extension API.
 
-Build debug: `make debug`.
+For development: 
+- On UNIXes, use `make debug`.
+- On Windows use `cmake --preset windows-relwithdebinfo` (full debug builds only when needed)
 
 ## Separation of concerns
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -29,6 +29,13 @@
       "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug" }
     },
     {
+      "name": "windows-relwithdebinfo",
+      "displayName": "Windows x64 (MSVC, RelWithDebInfo)",
+      "inherits": "windows-base",
+      "binaryDir": "${sourceDir}/build-relwithdebinfo",
+      "cacheVariables": { "CMAKE_BUILD_TYPE": "RelWithDebInfo", "LTO": "OFF" }
+    },
+    {
       "name": "windows-release",
       "displayName": "Windows x64 (MSVC, Release)",
       "inherits": "windows-base",
@@ -120,6 +127,7 @@
   ],
   "buildPresets": [
     { "name": "windows-debug", "configurePreset": "windows-debug" },
+    { "name": "windows-relwithdebinfo", "configurePreset": "windows-relwithdebinfo" },
     { "name": "windows-release", "configurePreset": "windows-release" },
     { "name": "windows-ci", "configurePreset": "windows-ci" },
     { "name": "linux-debug", "configurePreset": "linux-debug" },

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -701,7 +701,7 @@ elseif (WIN32)
 		src/services/app-service/windows/win-app-database.hpp
 		src/services/app-service/windows/win-app-database.cpp
 	)
-	list(APPEND LIBS shell32 ole32 shlwapi user32 gdi32 advapi32 windowsapp)
+	list(APPEND LIBS shell32 ole32 shlwapi user32 gdi32 advapi32 version windowsapp)
 else()
 	list(APPEND SRCS
 		src/services/app-runtime/linux/linux-app-runtime.hpp

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -694,6 +694,14 @@ if (APPLE)
 		add_compile_definitions(AUTO_ENABLE_AUTOSTART)
 	endif()
 elseif (WIN32)
+	list(APPEND SRCS
+		src/ui/image/win-file-icon-loader.hpp
+		src/ui/image/win-file-icon-loader.cpp
+		src/services/app-service/windows/win-app.hpp
+		src/services/app-service/windows/win-app-database.hpp
+		src/services/app-service/windows/win-app-database.cpp
+	)
+	list(APPEND LIBS shell32 ole32 shlwapi user32 gdi32 advapi32 windowsapp)
 else()
 	list(APPEND SRCS
 		src/services/app-runtime/linux/linux-app-runtime.hpp

--- a/src/server/src/navigation-controller.cpp
+++ b/src/server/src/navigation-controller.cpp
@@ -413,6 +413,20 @@ void NavigationController::executeAction(AbstractAction *action) {
   std::shared_ptr<AbstractAction> guard;
   if (auto *root = state->sender->actionPanelRoot()) { guard = root->retainAction(action); }
 
+  if (!guard) {
+    executeActionNow(action);
+    return;
+  }
+
+  // The action might tear down the window and the panel before the qml handler gets to run,
+  // so defer execution to next event loop turn
+  QMetaObject::invokeMethod(this, [this, action, guard] { executeActionNow(action); }, Qt::QueuedConnection);
+}
+
+void NavigationController::executeActionNow(AbstractAction *action) {
+  auto state = topState();
+  if (!state) return;
+
   if (action->isSubmenu()) {
     openActionPanel();
     return;

--- a/src/server/src/navigation-controller.hpp
+++ b/src/server/src/navigation-controller.hpp
@@ -200,6 +200,10 @@ public:
   bool executePrimaryAction();
   void executeAction(AbstractAction *action);
 
+private:
+  void executeActionNow(AbstractAction *action);
+
+public:
   void setHeaderVisiblity(bool value, const BaseView *caller = nullptr);
   void setSearchVisibility(bool value, const BaseView *caller = nullptr);
   void setSearchInteractive(bool value, const BaseView *caller = nullptr);

--- a/src/server/src/root-search/apps/app-root-provider.cpp
+++ b/src/server/src/root-search/apps/app-root-provider.cpp
@@ -17,7 +17,10 @@
 
 double AppRootItem::baseScoreWeight() const { return 1; }
 
-QString AppRootItem::typeDisplayName() const { return "Application"; }
+QString AppRootItem::typeDisplayName() const {
+  const QString category = m_app->category();
+  return category.isEmpty() ? QStringLiteral("Application") : category;
+}
 
 std::vector<QString> AppRootItem::keywords() const {
   auto keywords = m_app->keywords();
@@ -44,7 +47,9 @@ std::vector<std::pair<QString, QString>> AppRootItem::settingsMetadata() const {
 bool AppRootItem::isActive() const { return ServiceRegistry::instance()->appRuntime()->isRunning(*m_app); }
 
 AccessoryList AppRootItem::accessories() const {
-  return {{.text = "Application", .color = SemanticColor::TextMuted}};
+  const QString category = m_app->category();
+  return {{.text = category.isEmpty() ? QStringLiteral("Application") : category,
+           .color = SemanticColor::TextMuted}};
 }
 
 EntrypointId AppRootItem::uniqueId() const {

--- a/src/server/src/services/app-service/abstract-app-db.hpp
+++ b/src/server/src/services/app-service/abstract-app-db.hpp
@@ -106,6 +106,8 @@ struct LaunchTerminalCommandOptions {
 };
 
 class AbstractAppDatabase : public QObject {
+  Q_OBJECT
+
 public:
   using AppPtr = std::shared_ptr<AbstractApplication>;
 
@@ -219,4 +221,8 @@ public:
    * gracefully fall back to opening the containing folder when that is not supported.
    */
   virtual bool showInFileBrowser(const std::filesystem::path &path, bool select) const = 0;
+
+signals:
+  // The provider detected an out-of-band change to installed apps (e.g. a package install).
+  void changed();
 };

--- a/src/server/src/services/app-service/abstract-app-db.hpp
+++ b/src/server/src/services/app-service/abstract-app-db.hpp
@@ -89,6 +89,9 @@ public:
    */
   virtual QString description() const = 0;
 
+  // Type label for the root search; empty means the default "Application".
+  virtual QString category() const { return {}; }
+
   // whether the executable can open url(s) or file(s)
   virtual bool isOpener() { return true; }
 };

--- a/src/server/src/services/app-service/app-service.cpp
+++ b/src/server/src/services/app-service/app-service.cpp
@@ -162,7 +162,7 @@ bool AppService::reinstallWatches(const std::vector<fs::path> &paths) {
   auto isDir = [](auto &&path) { return fs::is_directory(path); };
 
   for (const auto &path : paths | std::views::filter(isDir)) {
-    m_watcher->addPath(QString::fromStdString(path.string()));
+    m_watcher->addPath(QString::fromStdWString(path.wstring()));
   }
 
   return true;

--- a/src/server/src/services/app-service/app-service.cpp
+++ b/src/server/src/services/app-service/app-service.cpp
@@ -181,4 +181,5 @@ AppService::AppService(OmniDatabase &db) : m_db(db), m_provider(createLocalProvi
 
   reinstallWatches(mergedPaths());
   connect(m_watcher, &QFileSystemWatcher::directoryChanged, this, &AppService::handleDirectoryChanged);
+  connect(m_provider.get(), &AbstractAppDatabase::changed, this, [this] { m_rescanDebounce->start(); });
 }

--- a/src/server/src/services/app-service/app-service.cpp
+++ b/src/server/src/services/app-service/app-service.cpp
@@ -2,7 +2,7 @@
 #ifdef Q_OS_MACOS
 #include "services/app-service/macos/mac-app-database.hpp"
 #elif defined(Q_OS_WIN)
-#include "services/app-service/dummy-app-database.hpp"
+#include "services/app-service/windows/win-app-database.hpp"
 #else
 #include "services/app-service/xdg/xdg-app-database.hpp"
 #endif
@@ -43,7 +43,7 @@ std::unique_ptr<AbstractAppDatabase> AppService::createLocalProvider() {
 #ifdef Q_OS_MACOS
   return std::make_unique<MacAppDatabase>();
 #elif defined(Q_OS_WIN)
-  return std::make_unique<DummyAppDatabase>();
+  return std::make_unique<WindowsAppDatabase>();
 #else
   return std::make_unique<XdgAppDatabase>();
 #endif

--- a/src/server/src/services/app-service/windows/win-app-database.cpp
+++ b/src/server/src/services/app-service/windows/win-app-database.cpp
@@ -90,7 +90,7 @@ ShortcutInfo readShortcutInfo(const fs::path &lnk) {
             info.target = fs::path(name);
           } else if (SUCCEEDED(SHGetNameFromIDList(pidl, SIGDN_DESKTOPABSOLUTEPARSING, &name)) &&
                      name) {
-            // the File Explorer CLSID; without a target exe, launch() cannot pass it arguments
+            // the File Explorer CLSID
             if (_wcsicmp(name, L"::{52205FD8-5DFB-447D-801A-D0B52F2E83E1}") == 0) {
               if (const wchar_t *windir = _wgetenv(L"WINDIR"); windir && *windir) {
                 info.target = fs::path(windir) / L"explorer.exe";
@@ -304,9 +304,39 @@ QString fromHString(const winrt::hstring &s) {
 }
 
 std::wstring quoteArg(const QString &arg) {
-  std::wstring w = arg.toStdWString();
-  if (w.find_first_of(L" \t") == std::wstring::npos) return w;
-  return L"\"" + w + L"\"";
+  const std::wstring w = arg.toStdWString();
+  if (!w.empty() && w.find_first_of(L" \t\"") == std::wstring::npos) return w;
+
+  // argv rules: backslashes are literal except before a quote
+  std::wstring out = L"\"";
+  size_t backslashes = 0;
+  for (const wchar_t c : w) {
+    if (c == L'\\') {
+      ++backslashes;
+      continue;
+    }
+    if (c == L'"') {
+      out.append(backslashes * 2 + 1, L'\\');
+    } else {
+      out.append(backslashes, L'\\');
+    }
+    backslashes = 0;
+    out += c;
+  }
+  out.append(backslashes * 2, L'\\');
+  out += L'"';
+  return out;
+}
+
+// quotes included, so cmd never enters quote mode
+std::wstring cmdEscape(const std::wstring &s) {
+  std::wstring out;
+  out.reserve(s.size());
+  for (const wchar_t c : s) {
+    if (wcschr(L"()%!^\"<>&|", c)) out += L'^';
+    out += c;
+  }
+  return out;
 }
 
 std::wstring joinArgs(const std::vector<QString> &args) {
@@ -340,8 +370,10 @@ Assoc classifyTarget(const QString &target) {
     }
   }
 
+  // a dead UNC host can block for seconds
   std::error_code ec;
-  if (fs::is_directory(fs::path(target.toStdWString()), ec)) {
+  if (!target.startsWith(QLatin1String("\\\\")) &&
+      fs::is_directory(fs::path(target.toStdWString()), ec)) {
     return {AssocKind::Directory, L"Directory"};
   }
 
@@ -428,7 +460,7 @@ IShellItemArray *shellItemArrayFromParsingNames(const std::vector<QString> &name
 // WindowsApps cannot be spawned directly.
 bool invokeAssocHandler(const std::wstring &ext, const QString &handlerName,
                         const std::vector<QString> &files) {
-  // NONE: "Directory" handlers are not in the recommended set; the name match keeps it exact
+  // "Directory" handlers are not in the recommended set
   IEnumAssocHandlers *handlers = nullptr;
   if (FAILED(SHAssocEnumHandlers(ext.c_str(), ASSOC_FILTER_NONE, &handlers)) || !handlers) {
     return false;
@@ -497,6 +529,17 @@ bool activatePackaged(const std::wstring &aumid, const std::vector<QString> &fil
 
   manager->Release();
   return ok;
+}
+
+bool defaultTerminalIsConhost() {
+  wchar_t buf[64] = {};
+  DWORD cb = sizeof(buf);
+  if (RegGetValueW(HKEY_CURRENT_USER, L"Console\\%%Startup", L"DelegationTerminal", RRF_RT_REG_SZ,
+                   nullptr, buf, &cb) != ERROR_SUCCESS) {
+    return false;
+  }
+  // the classic conhost delegation CLSID
+  return _wcsicmp(buf, L"{B23D10C0-E52E-411E-9D5B-C09FDF709C7D}") == 0;
 }
 
 // SearchPathW also resolves App Execution Aliases such as wt.exe.
@@ -799,8 +842,8 @@ bool WindowsAppDatabase::launchTerminalCommand(const std::vector<QString> &cmdli
   if (const wchar_t *env = _wgetenv(L"ComSpec"); env && *env) comspec = env;
 
   std::wstring inner;
-  if (opts.title) inner += L"title " + opts.title->toStdWString() + L" & ";
-  inner += joinArgs(cmdline);
+  if (opts.title) inner += L"title " + cmdEscape(opts.title->toStdWString()) + L" & ";
+  inner += cmdEscape(joinArgs(cmdline));
 
   const std::wstring params = (opts.hold ? L"/k " : L"/c ") + inner;
   const std::wstring workdir =
@@ -816,7 +859,7 @@ bool WindowsAppDatabase::launchTerminalCommand(const std::vector<QString> &cmdli
 // executables we never scanned (packaged handlers, apps without shortcuts).
 WindowsAppDatabase::AppPtr WindowsAppDatabase::resolveExecutable(const fs::path &exe, const QString &name,
                                                                 const QString &openerExtension) const {
-  // registry handler paths can contain doubled separators, breaking id matches and icon parsing names
+  // registry handler paths can contain doubled separators
   const fs::path normalized = exe.lexically_normal();
   const auto it = m_appsById.find(win32AppId(QString::fromStdWString(normalized.wstring())));
   if (it != m_appsById.end()) return it->second;
@@ -936,7 +979,9 @@ WindowsAppDatabase::AppPtr WindowsAppDatabase::webBrowser() const {
 
 WindowsAppDatabase::AppPtr WindowsAppDatabase::terminalEmulator() const {
   ScopedCom com;
-  if (auto wt = searchExecutable(L"wt.exe")) return appForExecutable(*wt, QStringLiteral("Terminal"));
+  if (!defaultTerminalIsConhost()) {
+    if (auto wt = searchExecutable(L"wt.exe")) return appForExecutable(*wt, QStringLiteral("Terminal"));
+  }
   fs::path comspec = L"cmd.exe";
   if (const wchar_t *env = _wgetenv(L"ComSpec"); env && *env) comspec = env;
   return appForExecutable(comspec, QStringLiteral("Command Prompt"));

--- a/src/server/src/services/app-service/windows/win-app-database.cpp
+++ b/src/server/src/services/app-service/windows/win-app-database.cpp
@@ -11,6 +11,9 @@
 #include <shellapi.h>
 #include <shlwapi.h>
 #include <shobjidl_core.h>
+#include <propsys.h>
+#include <initguid.h>
+#include <propkey.h>
 
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>
@@ -53,15 +56,20 @@ std::optional<fs::path> knownFolder(REFKNOWNFOLDERID id) {
   return result;
 }
 
-// Reads the stored target without IShellLink::Resolve, which can block on the network. Returns
-// nullopt for shortcuts backed by a PIDL rather than a filesystem path (AppsFolder, Control Panel).
-std::optional<fs::path> readShortcutTarget(const fs::path &lnk) {
+struct ShortcutInfo {
+  std::optional<fs::path> target; // nullopt for PIDL-backed shortcuts (AppsFolder, Control Panel)
+  QString arguments;
+  QString aumid; // explicit System.AppUserModel.ID, when the shortcut carries one (PWAs do)
+};
+
+// Reads the stored link data without IShellLink::Resolve, which can block on the network.
+ShortcutInfo readShortcutInfo(const fs::path &lnk) {
+  ShortcutInfo info;
+
   IShellLinkW *link = nullptr;
   if (FAILED(CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&link)))) {
-    return std::nullopt;
+    return info;
   }
-
-  std::optional<fs::path> result;
 
   IPersistFile *persist = nullptr;
   if (SUCCEEDED(link->QueryInterface(IID_PPV_ARGS(&persist)))) {
@@ -69,15 +77,47 @@ std::optional<fs::path> readShortcutTarget(const fs::path &lnk) {
       wchar_t buf[MAX_PATH] = {};
       WIN32_FIND_DATAW find = {};
       if (SUCCEEDED(link->GetPath(buf, MAX_PATH, &find, 0)) && buf[0] != L'\0') {
-        result = fs::path(buf);
+        info.target = fs::path(buf);
+      }
+
+      wchar_t args[1024] = {};
+      if (SUCCEEDED(link->GetArguments(args, 1024)) && args[0] != L'\0') {
+        info.arguments = QString::fromWCharArray(args).trimmed();
+      }
+
+      IPropertyStore *store = nullptr;
+      if (SUCCEEDED(link->QueryInterface(IID_PPV_ARGS(&store)))) {
+        PROPVARIANT value;
+        PropVariantInit(&value);
+        if (SUCCEEDED(store->GetValue(PKEY_AppUserModel_ID, &value)) && value.vt == VT_LPWSTR &&
+            value.pwszVal) {
+          info.aumid = QString::fromWCharArray(value.pwszVal);
+        }
+        PropVariantClear(&value);
+        store->Release();
       }
     }
     persist->Release();
   }
 
   link->Release();
-  return result;
+  return info;
 }
+
+// Identity mirrors the shell's: explicit AUMID, else target + args (args distinguish e.g. PWAs
+// all launched through the same proxy exe), else the shortcut file itself.
+QString win32AppId(const QString &program, const QString &arguments = {}, const QString &aumid = {},
+                   const fs::path &shortcut = {}) {
+  if (!aumid.isEmpty()) return QStringLiteral("win32:aumid:") + aumid.toLower();
+  if (!program.isEmpty()) {
+    QString id = QStringLiteral("win32:") + program.toLower();
+    if (!arguments.isEmpty()) id += QLatin1Char(' ') + arguments.toLower();
+    return id;
+  }
+  return QStringLiteral("win32:") + QString::fromStdWString(shortcut.wstring()).toLower();
+}
+
+QString uwpAppId(const QString &aumid) { return QStringLiteral("uwp:") + aumid; }
 
 QString readUrlTarget(const fs::path &url) {
   wchar_t buf[2048] = {};
@@ -367,20 +407,23 @@ void WindowsAppDatabase::addShortcut(const fs::path &file) {
   if (!isLnk && !isUrl && !isAppRef) return;
 
   QString program; // .lnk: target exe. .url: target URL.
+  QString arguments;
+  QString aumid;
   if (isLnk) {
-    auto target = readShortcutTarget(file);
-    if (target && looksLikeUninstaller(*target)) return;
-    if (target) program = QString::fromStdWString(target->wstring());
+    const ShortcutInfo info = readShortcutInfo(file);
+    if (info.target && looksLikeUninstaller(*info.target)) return;
+    // A shortcut carrying the AUMID of an installed package is that package's app; the UWP scan
+    // (run first) already listed it.
+    if (!info.aumid.isEmpty() && m_appsById.contains(uwpAppId(info.aumid))) return;
+    if (info.target) program = QString::fromStdWString(info.target->wstring());
+    arguments = info.arguments;
+    aumid = info.aumid;
   } else if (isUrl) {
     program = readUrlTarget(file);
   }
 
-  // Key on the target when known so the same app in Start Menu + Desktop collapses; otherwise
-  // fall back to the shortcut path.
-  const QString idBase = program.isEmpty() ? QString::fromStdWString(file.wstring()) : program;
-
   WindowsApplication::Data data;
-  data.id = QStringLiteral("win32:") + idBase.toLower();
+  data.id = win32AppId(program, arguments, aumid, file);
   data.displayName = QString::fromStdWString(file.stem().wstring());
   data.program = program;
   data.path = file;
@@ -440,7 +483,7 @@ void WindowsAppDatabase::scanAppPaths() {
     if (!fs::exists(exe, ec) || looksLikeUninstaller(exe)) continue;
 
     WindowsApplication::Data data;
-    data.id = QStringLiteral("win32:") + QString::fromStdWString(exe.wstring()).toLower();
+    data.id = win32AppId(QString::fromStdWString(exe.wstring()));
     data.displayName = QString::fromStdWString(exe.stem().wstring());
     data.program = QString::fromStdWString(exe.wstring());
     data.path = exe;
@@ -491,7 +534,7 @@ void WindowsAppDatabase::scanUwp() {
         if (name.isEmpty()) continue;
 
         WindowsApplication::Data data;
-        data.id = QStringLiteral("uwp:") + aumid;
+        data.id = uwpAppId(aumid);
         data.displayName = name;
         data.program = aumid;
         data.path = installPath;
@@ -511,10 +554,10 @@ bool WindowsAppDatabase::scan(const std::vector<fs::path> &paths) {
   m_appsById.clear();
 
   ScopedCom com;
+  scanUwp(); // first: addShortcut skips .lnk files whose AUMID names an already-listed package
   scanWin32(paths);
   scanDesktop();
   scanAppPaths();
-  scanUwp();
 
   return !m_apps.empty();
 }
@@ -583,7 +626,7 @@ WindowsAppDatabase::AppPtr WindowsAppDatabase::appForExecutable(const fs::path &
   const QString exeStr = QString::fromStdWString(exe.wstring());
 
   WindowsApplication::Data data;
-  data.id = QStringLiteral("win32:") + exeStr.toLower();
+  data.id = win32AppId(exeStr);
   data.displayName = name.isEmpty() ? QString::fromStdWString(exe.stem().wstring()) : name;
   data.program = exeStr;
   data.path = exe;

--- a/src/server/src/services/app-service/windows/win-app-database.cpp
+++ b/src/server/src/services/app-service/windows/win-app-database.cpp
@@ -15,6 +15,7 @@
 #include <initguid.h> // defines the BHID_*/PKEY_* GUIDs below in this TU
 #include <shlguid.h>
 #include <propkey.h>
+#include <wrl/client.h>
 
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>
@@ -28,6 +29,7 @@
 #include <string>
 
 namespace fs = std::filesystem;
+using Microsoft::WRL::ComPtr;
 
 namespace {
 
@@ -75,68 +77,64 @@ struct ShortcutInfo {
 ShortcutInfo readShortcutInfo(const fs::path &lnk) {
   ShortcutInfo info;
 
-  IShellLinkW *link = nullptr;
+  ComPtr<IShellLinkW> link;
   if (FAILED(CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&link)))) {
     return info;
   }
 
-  IPersistFile *persist = nullptr;
-  if (SUCCEEDED(link->QueryInterface(IID_PPV_ARGS(&persist)))) {
-    if (SUCCEEDED(persist->Load(lnk.wstring().c_str(), STGM_READ))) {
-      wchar_t buf[MAX_PATH] = {};
-      WIN32_FIND_DATAW find = {};
-      if (SUCCEEDED(link->GetPath(buf, MAX_PATH, &find, 0)) && buf[0] != L'\0') {
-        info.target = fs::path(buf);
-      }
-
-      if (!info.target) {
-        PIDLIST_ABSOLUTE pidl = nullptr;
-        if (SUCCEEDED(link->GetIDList(&pidl)) && pidl) {
-          PWSTR name = nullptr;
-          if (SUCCEEDED(SHGetNameFromIDList(pidl, SIGDN_FILESYSPATH, &name)) && name) {
-            info.target = fs::path(name);
-          } else if (SUCCEEDED(SHGetNameFromIDList(pidl, SIGDN_DESKTOPABSOLUTEPARSING, &name)) &&
-                     name) {
-            // the File Explorer CLSID
-            if (_wcsicmp(name, L"::{52205FD8-5DFB-447D-801A-D0B52F2E83E1}") == 0) {
-              if (const wchar_t *windir = _wgetenv(L"WINDIR"); windir && *windir) {
-                info.target = fs::path(windir) / L"explorer.exe";
-              }
-            }
-          }
-          if (name) CoTaskMemFree(name);
-          CoTaskMemFree(pidl);
-        }
-      }
-
-      wchar_t args[1024] = {};
-      if (SUCCEEDED(link->GetArguments(args, 1024)) && args[0] != L'\0') {
-        info.arguments = QString::fromWCharArray(args).trimmed();
-      }
-
-      wchar_t dir[MAX_PATH] = {};
-      if (SUCCEEDED(link->GetWorkingDirectory(dir, MAX_PATH)) && dir[0] != L'\0') {
-        wchar_t expanded[MAX_PATH] = {};
-        const DWORD n = ExpandEnvironmentStringsW(dir, expanded, MAX_PATH);
-        info.workingDirectory = QString::fromWCharArray((n > 0 && n <= MAX_PATH) ? expanded : dir);
-      }
-
-      IPropertyStore *store = nullptr;
-      if (SUCCEEDED(link->QueryInterface(IID_PPV_ARGS(&store)))) {
-        PROPVARIANT value;
-        PropVariantInit(&value);
-        if (SUCCEEDED(store->GetValue(PKEY_AppUserModel_ID, &value)) && value.vt == VT_LPWSTR &&
-            value.pwszVal) {
-          info.aumid = QString::fromWCharArray(value.pwszVal);
-        }
-        PropVariantClear(&value);
-        store->Release();
-      }
-    }
-    persist->Release();
+  ComPtr<IPersistFile> persist;
+  if (FAILED(link.As(&persist)) || FAILED(persist->Load(lnk.wstring().c_str(), STGM_READ))) {
+    return info;
   }
 
-  link->Release();
+  wchar_t buf[MAX_PATH] = {};
+  WIN32_FIND_DATAW find = {};
+  if (SUCCEEDED(link->GetPath(buf, MAX_PATH, &find, 0)) && buf[0] != L'\0') {
+    info.target = fs::path(buf);
+  }
+
+  if (!info.target) {
+    PIDLIST_ABSOLUTE pidl = nullptr;
+    if (SUCCEEDED(link->GetIDList(&pidl)) && pidl) {
+      PWSTR name = nullptr;
+      if (SUCCEEDED(SHGetNameFromIDList(pidl, SIGDN_FILESYSPATH, &name)) && name) {
+        info.target = fs::path(name);
+      } else if (SUCCEEDED(SHGetNameFromIDList(pidl, SIGDN_DESKTOPABSOLUTEPARSING, &name)) && name) {
+        // the File Explorer CLSID
+        if (_wcsicmp(name, L"::{52205FD8-5DFB-447D-801A-D0B52F2E83E1}") == 0) {
+          if (const wchar_t *windir = _wgetenv(L"WINDIR"); windir && *windir) {
+            info.target = fs::path(windir) / L"explorer.exe";
+          }
+        }
+      }
+      if (name) CoTaskMemFree(name);
+      CoTaskMemFree(pidl);
+    }
+  }
+
+  wchar_t args[1024] = {};
+  if (SUCCEEDED(link->GetArguments(args, 1024)) && args[0] != L'\0') {
+    info.arguments = QString::fromWCharArray(args).trimmed();
+  }
+
+  wchar_t dir[MAX_PATH] = {};
+  if (SUCCEEDED(link->GetWorkingDirectory(dir, MAX_PATH)) && dir[0] != L'\0') {
+    wchar_t expanded[MAX_PATH] = {};
+    const DWORD n = ExpandEnvironmentStringsW(dir, expanded, MAX_PATH);
+    info.workingDirectory = QString::fromWCharArray((n > 0 && n <= MAX_PATH) ? expanded : dir);
+  }
+
+  ComPtr<IPropertyStore> store;
+  if (SUCCEEDED(link.As(&store))) {
+    PROPVARIANT value;
+    PropVariantInit(&value);
+    if (SUCCEEDED(store->GetValue(PKEY_AppUserModel_ID, &value)) && value.vt == VT_LPWSTR &&
+        value.pwszVal) {
+      info.aumid = QString::fromWCharArray(value.pwszVal);
+    }
+    PropVariantClear(&value);
+  }
+
   return info;
 }
 
@@ -415,12 +413,12 @@ std::vector<std::pair<fs::path, QString>> enumExtensionHandlers(const std::wstri
                                                                 ASSOC_FILTER filter) {
   std::vector<std::pair<fs::path, QString>> result;
 
-  IEnumAssocHandlers *handlers = nullptr;
+  ComPtr<IEnumAssocHandlers> handlers;
   if (FAILED(SHAssocEnumHandlers(ext.c_str(), filter, &handlers)) || !handlers) {
     return result;
   }
 
-  IAssocHandler *handler = nullptr;
+  ComPtr<IAssocHandler> handler;
   ULONG fetched = 0;
   while (handlers->Next(1, &handler, &fetched) == S_OK && fetched == 1) {
     LPWSTR path = nullptr;
@@ -432,28 +430,24 @@ std::vector<std::pair<fs::path, QString>> enumExtensionHandlers(const std::wstri
     }
     if (path) CoTaskMemFree(path);
     if (ui) CoTaskMemFree(ui);
-    handler->Release();
-    handler = nullptr;
   }
 
-  handlers->Release();
   return result;
 }
 
-IShellItemArray *shellItemArrayFromParsingNames(const std::vector<QString> &names) {
+ComPtr<IShellItemArray> shellItemArrayFromParsingNames(const std::vector<QString> &names) {
   std::vector<PIDLIST_ABSOLUTE> pidls;
   for (const auto &name : names) {
-    IShellItem *item = nullptr;
+    ComPtr<IShellItem> item;
     if (SUCCEEDED(SHCreateItemFromParsingName(name.toStdWString().c_str(), nullptr,
                                               IID_PPV_ARGS(&item))) &&
         item) {
       PIDLIST_ABSOLUTE pidl = nullptr;
-      if (SUCCEEDED(SHGetIDListFromObject(item, &pidl))) pidls.push_back(pidl);
-      item->Release();
+      if (SUCCEEDED(SHGetIDListFromObject(item.Get(), &pidl))) pidls.push_back(pidl);
     }
   }
 
-  IShellItemArray *array = nullptr;
+  ComPtr<IShellItemArray> array;
   if (!pidls.empty()) {
     SHCreateShellItemArrayFromIDLists(static_cast<UINT>(pidls.size()),
                                       const_cast<PCIDLIST_ABSOLUTE *>(pidls.data()), &array);
@@ -468,50 +462,42 @@ IShellItemArray *shellItemArrayFromParsingNames(const std::vector<QString> &name
 bool invokeAssocHandler(const std::wstring &ext, const QString &handlerName,
                         const std::vector<QString> &files) {
   // "Directory" handlers are not in the recommended set
-  IEnumAssocHandlers *handlers = nullptr;
+  ComPtr<IEnumAssocHandlers> handlers;
   if (FAILED(SHAssocEnumHandlers(ext.c_str(), ASSOC_FILTER_NONE, &handlers)) || !handlers) {
     return false;
   }
 
-  bool ok = false;
-  IAssocHandler *handler = nullptr;
+  ComPtr<IAssocHandler> handler;
   ULONG fetched = 0;
   while (handlers->Next(1, &handler, &fetched) == S_OK && fetched == 1) {
     LPWSTR name = nullptr;
     const bool match = SUCCEEDED(handler->GetName(&name)) && name &&
                        handlerName.compare(QString::fromWCharArray(name), Qt::CaseInsensitive) == 0;
     if (name) CoTaskMemFree(name);
+    if (!match) continue;
 
-    if (match) {
-      if (IShellItemArray *array = shellItemArrayFromParsingNames(files)) {
-        IDataObject *dataObject = nullptr;
-        if (SUCCEEDED(array->BindToHandler(nullptr, BHID_DataObject, IID_PPV_ARGS(&dataObject))) &&
-            dataObject) {
-          IAssocHandlerInvoker *invoker = nullptr;
-          if (SUCCEEDED(handler->CreateInvoker(dataObject, &invoker)) && invoker) {
-            ok = SUCCEEDED(invoker->Invoke());
-            invoker->Release();
-          }
-          dataObject->Release();
-        }
-        array->Release();
-      }
-      handler->Release();
-      break;
+    const auto array = shellItemArrayFromParsingNames(files);
+    if (!array) return false;
+
+    ComPtr<IDataObject> dataObject;
+    if (FAILED(array->BindToHandler(nullptr, BHID_DataObject, IID_PPV_ARGS(&dataObject))) ||
+        !dataObject) {
+      return false;
     }
 
-    handler->Release();
-    handler = nullptr;
+    ComPtr<IAssocHandlerInvoker> invoker;
+    if (FAILED(handler->CreateInvoker(dataObject.Get(), &invoker)) || !invoker) return false;
+
+    return SUCCEEDED(invoker->Invoke());
   }
 
-  handlers->Release();
-  return ok;
+  return false;
 }
 
 // Packaged apps never receive argv; documents and URIs are handed over through activation.
 bool activatePackaged(const std::wstring &aumid, const std::vector<QString> &files,
                       const std::vector<QString> &uris) {
-  IApplicationActivationManager *manager = nullptr;
+  ComPtr<IApplicationActivationManager> manager;
   if (FAILED(CoCreateInstance(CLSID_ApplicationActivationManager, nullptr, CLSCTX_INPROC_SERVER,
                               IID_PPV_ARGS(&manager))) ||
       !manager) {
@@ -522,19 +508,16 @@ bool activatePackaged(const std::wstring &aumid, const std::vector<QString> &fil
   DWORD pid = 0;
 
   if (!files.empty()) {
-    IShellItemArray *array = shellItemArrayFromParsingNames(files);
-    ok = array && SUCCEEDED(manager->ActivateForFile(aumid.c_str(), array, L"open", &pid));
-    if (array) array->Release();
+    const auto array = shellItemArrayFromParsingNames(files);
+    ok = array && SUCCEEDED(manager->ActivateForFile(aumid.c_str(), array.Get(), L"open", &pid));
   }
 
   // Protocol activation takes a single URI at a time.
   for (const auto &uri : uris) {
-    IShellItemArray *array = shellItemArrayFromParsingNames({uri});
-    ok = array && SUCCEEDED(manager->ActivateForProtocol(aumid.c_str(), array, &pid)) && ok;
-    if (array) array->Release();
+    const auto array = shellItemArrayFromParsingNames({uri});
+    ok = array && SUCCEEDED(manager->ActivateForProtocol(aumid.c_str(), array.Get(), &pid)) && ok;
   }
 
-  manager->Release();
   return ok;
 }
 
@@ -567,13 +550,13 @@ struct UwpPackageWatcher {
 };
 
 WindowsAppDatabase::WindowsAppDatabase() {
+  connect(&m_watcher, &QFileSystemWatcher::directoryChanged, this, [this] { Q_EMIT changed(); });
+
   scan(defaultSearchPaths());
 
-  for (const auto &root : desktopRoots()) {
-    m_desktopWatcher.addPath(QString::fromStdWString(root.wstring()));
-  }
-  connect(&m_desktopWatcher, &QFileSystemWatcher::directoryChanged, this,
-          [this] { Q_EMIT changed(); });
+  m_rescanTimer.setInterval(std::chrono::minutes(5));
+  connect(&m_rescanTimer, &QTimer::timeout, this, [this] { Q_EMIT changed(); });
+  m_rescanTimer.start();
 
   using namespace winrt::Windows::ApplicationModel;
   try {
@@ -581,7 +564,10 @@ WindowsAppDatabase::WindowsAppDatabase() {
     watcher->catalog = PackageCatalog::OpenForCurrentUser();
     // Progress events fire repeatedly; only rescan on completion. Cross-thread emit is queued.
     auto handler = [this](const auto &, const auto &args) {
-      if (args.IsComplete()) Q_EMIT changed();
+      if (args.IsComplete()) {
+        m_uwpDirty.store(true);
+        Q_EMIT changed();
+      }
     };
     watcher->installing = watcher->catalog.PackageInstalling(winrt::auto_revoke, handler);
     watcher->uninstalling = watcher->catalog.PackageUninstalling(winrt::auto_revoke, handler);
@@ -654,6 +640,8 @@ void WindowsAppDatabase::scanWin32(const std::vector<fs::path> &paths) {
     std::error_code ec;
     if (!fs::is_directory(root, ec)) continue;
 
+    m_watchDirs.insert(QString::fromStdWString(root.wstring()));
+
     fs::recursive_directory_iterator it(root, fs::directory_options::skip_permission_denied, ec);
     const fs::recursive_directory_iterator end;
     if (ec) continue;
@@ -663,7 +651,11 @@ void WindowsAppDatabase::scanWin32(const std::vector<fs::path> &paths) {
         ec.clear();
         continue;
       }
-      if (it->is_regular_file(ec)) addShortcut(it->path());
+      if (it->is_directory(ec)) {
+        m_watchDirs.insert(QString::fromStdWString(it->path().wstring()));
+      } else if (it->is_regular_file(ec)) {
+        addShortcut(it->path());
+      }
     }
   }
 }
@@ -672,6 +664,8 @@ void WindowsAppDatabase::scanDesktop() {
   for (const auto &root : desktopRoots()) {
     std::error_code ec;
     if (!fs::is_directory(root, ec)) continue;
+
+    m_watchDirs.insert(QString::fromStdWString(root.wstring()));
 
     fs::directory_iterator it(root, fs::directory_options::skip_permission_denied, ec);
     const fs::directory_iterator end;
@@ -720,6 +714,12 @@ void WindowsAppDatabase::scanAppPaths() {
 }
 
 void WindowsAppDatabase::scanUwp() {
+  if (m_uwpDirty.load()) refreshUwpCache();
+  for (const auto &app : m_uwpCache)
+    addApp(app);
+}
+
+void WindowsAppDatabase::refreshUwpCache() {
   using namespace winrt::Windows::Management::Deployment;
   using namespace winrt::Windows::ApplicationModel;
 
@@ -733,6 +733,9 @@ void WindowsAppDatabase::scanUwp() {
     qWarning() << "[win-app-db] PackageManager query failed:" << fromHString(e.message());
     return;
   }
+
+  m_uwpCache.clear();
+  m_uwpDirty.store(false);
 
   for (const auto &pkg : packages) {
     try {
@@ -765,7 +768,7 @@ void WindowsAppDatabase::scanUwp() {
         data.shellParsingName = QStringLiteral("shell:AppsFolder\\") + aumid;
         data.packaged = true;
 
-        addApp(std::make_shared<WindowsApplication>(std::move(data)));
+        m_uwpCache.push_back(std::make_shared<WindowsApplication>(std::move(data)));
       }
     } catch (const winrt::hresult_error &) {
       // skip a single bad package rather than aborting the scan
@@ -776,6 +779,7 @@ void WindowsAppDatabase::scanUwp() {
 bool WindowsAppDatabase::scan(const std::vector<fs::path> &paths) {
   m_apps.clear();
   m_appsById.clear();
+  m_watchDirs.clear();
 
   ScopedCom com;
   scanUwp(); // first: addShortcut drops shortcuts whose AUMID is already listed
@@ -783,7 +787,13 @@ bool WindowsAppDatabase::scan(const std::vector<fs::path> &paths) {
   scanDesktop();
   scanAppPaths();
 
+  installWatches();
   return !m_apps.empty();
+}
+
+void WindowsAppDatabase::installWatches() {
+  if (const QStringList old = m_watcher.directories(); !old.isEmpty()) m_watcher.removePaths(old);
+  if (!m_watchDirs.empty()) m_watcher.addPaths(QStringList(m_watchDirs.begin(), m_watchDirs.end()));
 }
 
 bool WindowsAppDatabase::launch(const AbstractApplication &app, const std::vector<QString> &args) const {

--- a/src/server/src/services/app-service/windows/win-app-database.cpp
+++ b/src/server/src/services/app-service/windows/win-app-database.cpp
@@ -12,7 +12,8 @@
 #include <shlwapi.h>
 #include <shobjidl_core.h>
 #include <propsys.h>
-#include <initguid.h>
+#include <initguid.h> // defines the BHID_*/PKEY_* GUIDs below in this TU
+#include <shlguid.h>
 #include <propkey.h>
 
 #include <winrt/Windows.Foundation.h>
@@ -57,9 +58,10 @@ std::optional<fs::path> knownFolder(REFKNOWNFOLDERID id) {
 }
 
 struct ShortcutInfo {
-  std::optional<fs::path> target; // nullopt for PIDL-backed shortcuts (AppsFolder, Control Panel)
+  std::optional<fs::path> target; // nullopt for PIDL-backed shortcuts we cannot resolve
   QString arguments;
-  QString aumid; // explicit System.AppUserModel.ID, when the shortcut carries one (PWAs do)
+  QString workingDirectory;
+  QString aumid;
 };
 
 // Reads the stored link data without IShellLink::Resolve, which can block on the network.
@@ -80,9 +82,36 @@ ShortcutInfo readShortcutInfo(const fs::path &lnk) {
         info.target = fs::path(buf);
       }
 
+      if (!info.target) {
+        PIDLIST_ABSOLUTE pidl = nullptr;
+        if (SUCCEEDED(link->GetIDList(&pidl)) && pidl) {
+          PWSTR name = nullptr;
+          if (SUCCEEDED(SHGetNameFromIDList(pidl, SIGDN_FILESYSPATH, &name)) && name) {
+            info.target = fs::path(name);
+          } else if (SUCCEEDED(SHGetNameFromIDList(pidl, SIGDN_DESKTOPABSOLUTEPARSING, &name)) &&
+                     name) {
+            // the File Explorer CLSID; without a target exe, launch() cannot pass it arguments
+            if (_wcsicmp(name, L"::{52205FD8-5DFB-447D-801A-D0B52F2E83E1}") == 0) {
+              if (const wchar_t *windir = _wgetenv(L"WINDIR"); windir && *windir) {
+                info.target = fs::path(windir) / L"explorer.exe";
+              }
+            }
+          }
+          if (name) CoTaskMemFree(name);
+          CoTaskMemFree(pidl);
+        }
+      }
+
       wchar_t args[1024] = {};
       if (SUCCEEDED(link->GetArguments(args, 1024)) && args[0] != L'\0') {
         info.arguments = QString::fromWCharArray(args).trimmed();
+      }
+
+      wchar_t dir[MAX_PATH] = {};
+      if (SUCCEEDED(link->GetWorkingDirectory(dir, MAX_PATH)) && dir[0] != L'\0') {
+        wchar_t expanded[MAX_PATH] = {};
+        const DWORD n = ExpandEnvironmentStringsW(dir, expanded, MAX_PATH);
+        info.workingDirectory = QString::fromWCharArray((n > 0 && n <= MAX_PATH) ? expanded : dir);
       }
 
       IPropertyStore *store = nullptr;
@@ -104,8 +133,7 @@ ShortcutInfo readShortcutInfo(const fs::path &lnk) {
   return info;
 }
 
-// Identity mirrors the shell's: explicit AUMID, else target + args (args distinguish e.g. PWAs
-// all launched through the same proxy exe), else the shortcut file itself.
+// AUMID if present, else target + args, else the shortcut file itself
 QString win32AppId(const QString &program, const QString &arguments = {}, const QString &aumid = {},
                    const fs::path &shortcut = {}) {
   if (!aumid.isEmpty()) return QStringLiteral("win32:aumid:") + aumid.toLower();
@@ -143,11 +171,68 @@ bool looksLikeUninstaller(const fs::path &target) {
   return name.find(L"unins") != std::wstring::npos;
 }
 
+bool isMsiUninstall(const std::optional<fs::path> &target, const QString &arguments) {
+  if (!target) return false;
+  auto name = target->filename().wstring();
+  for (auto &c : name)
+    c = static_cast<wchar_t>(::towlower(c));
+  return name == L"msiexec.exe" && arguments.contains(QLatin1String("/x"), Qt::CaseInsensitive);
+}
+
 std::wstring lowerExtension(const fs::path &p) {
   auto ext = p.extension().wstring();
   for (auto &c : ext)
     c = static_cast<wchar_t>(::towlower(c));
   return ext;
+}
+
+bool isUnderDirectory(const fs::path &p, const fs::path &dir) {
+  std::wstring a = p.wstring();
+  std::wstring b = dir.wstring();
+  for (auto &c : a)
+    c = static_cast<wchar_t>(::towlower(c));
+  for (auto &c : b)
+    c = static_cast<wchar_t>(::towlower(c));
+  if (!b.empty() && b.back() != L'\\') b += L'\\';
+  return a.starts_with(b);
+}
+
+QString exeFileDescription(const fs::path &exe) {
+  DWORD ignored = 0;
+  const DWORD size = GetFileVersionInfoSizeW(exe.c_str(), &ignored);
+  if (!size) return {};
+
+  std::vector<BYTE> info(size);
+  if (!GetFileVersionInfoW(exe.c_str(), 0, size, info.data())) return {};
+
+  struct LangCp {
+    WORD lang;
+    WORD codepage;
+  };
+  std::vector<LangCp> translations;
+  LangCp *table = nullptr;
+  UINT cb = 0;
+  if (VerQueryValueW(info.data(), L"\\VarFileInfo\\Translation", reinterpret_cast<void **>(&table),
+                     &cb) &&
+      table) {
+    translations.assign(table, table + cb / sizeof(LangCp));
+  }
+  translations.push_back({0x0409, 0x04B0}); // en-US Unicode, common even without a table
+
+  for (const wchar_t *field : {L"FileDescription", L"ProductName"}) {
+    for (const auto &t : translations) {
+      wchar_t query[64];
+      swprintf_s(query, L"\\StringFileInfo\\%04x%04x\\%s", t.lang, t.codepage, field);
+      wchar_t *value = nullptr;
+      UINT len = 0;
+      if (VerQueryValueW(info.data(), query, reinterpret_cast<void **>(&value), &len) && value &&
+          len > 1) {
+        const QString name = QString::fromWCharArray(value).trimmed();
+        if (!name.isEmpty()) return name;
+      }
+    }
+  }
+  return {};
 }
 
 std::optional<fs::path> readAppPathValue(HKEY appPathsKey, const std::wstring &subName) {
@@ -207,9 +292,10 @@ std::vector<fs::path> enumerateAppPaths() {
   return result;
 }
 
-bool shellExecuteOpen(const std::wstring &target, const wchar_t *params = nullptr) {
+bool shellExecuteOpen(const std::wstring &target, const wchar_t *params = nullptr,
+                      const wchar_t *workdir = nullptr) {
   const HINSTANCE ret =
-      ShellExecuteW(nullptr, L"open", target.c_str(), params, nullptr, SW_SHOWNORMAL);
+      ShellExecuteW(nullptr, L"open", target.c_str(), params, workdir, SW_SHOWNORMAL);
   return reinterpret_cast<INT_PTR>(ret) > 32;
 }
 
@@ -309,19 +395,11 @@ std::vector<std::pair<fs::path, QString>> enumExtensionHandlers(const std::wstri
   return result;
 }
 
-// Packaged apps never receive argv; a document is handed over through activation instead.
-bool activatePackagedForFiles(const std::wstring &aumid, const std::vector<QString> &files) {
-  IApplicationActivationManager *manager = nullptr;
-  if (FAILED(CoCreateInstance(CLSID_ApplicationActivationManager, nullptr, CLSCTX_INPROC_SERVER,
-                              IID_PPV_ARGS(&manager))) ||
-      !manager) {
-    return false;
-  }
-
+IShellItemArray *shellItemArrayFromParsingNames(const std::vector<QString> &names) {
   std::vector<PIDLIST_ABSOLUTE> pidls;
-  for (const auto &file : files) {
+  for (const auto &name : names) {
     IShellItem *item = nullptr;
-    if (SUCCEEDED(SHCreateItemFromParsingName(file.toStdWString().c_str(), nullptr,
+    if (SUCCEEDED(SHCreateItemFromParsingName(name.toStdWString().c_str(), nullptr,
                                               IID_PPV_ARGS(&item))) &&
         item) {
       PIDLIST_ABSOLUTE pidl = nullptr;
@@ -330,19 +408,86 @@ bool activatePackagedForFiles(const std::wstring &aumid, const std::vector<QStri
     }
   }
 
-  bool ok = false;
   IShellItemArray *array = nullptr;
-  if (!pidls.empty() &&
-      SUCCEEDED(SHCreateShellItemArrayFromIDLists(static_cast<UINT>(pidls.size()),
-                                                  const_cast<PCIDLIST_ABSOLUTE *>(pidls.data()),
-                                                  &array))) {
-    DWORD pid = 0;
-    ok = SUCCEEDED(manager->ActivateForFile(aumid.c_str(), array, L"open", &pid));
-    array->Release();
+  if (!pidls.empty()) {
+    SHCreateShellItemArrayFromIDLists(static_cast<UINT>(pidls.size()),
+                                      const_cast<PCIDLIST_ABSOLUTE *>(pidls.data()), &array);
   }
-
   for (auto *pidl : pidls)
     CoTaskMemFree(pidl);
+  return array;
+}
+
+// Re-resolves the handler by name and invokes it; works for packaged handlers, whose exe under
+// WindowsApps cannot be spawned directly.
+bool invokeAssocHandler(const std::wstring &ext, const QString &handlerName,
+                        const std::vector<QString> &files) {
+  IEnumAssocHandlers *handlers = nullptr;
+  if (FAILED(SHAssocEnumHandlers(ext.c_str(), ASSOC_FILTER_RECOMMENDED, &handlers)) || !handlers) {
+    return false;
+  }
+
+  bool ok = false;
+  IAssocHandler *handler = nullptr;
+  ULONG fetched = 0;
+  while (handlers->Next(1, &handler, &fetched) == S_OK && fetched == 1) {
+    LPWSTR name = nullptr;
+    const bool match = SUCCEEDED(handler->GetName(&name)) && name &&
+                       handlerName.compare(QString::fromWCharArray(name), Qt::CaseInsensitive) == 0;
+    if (name) CoTaskMemFree(name);
+
+    if (match) {
+      if (IShellItemArray *array = shellItemArrayFromParsingNames(files)) {
+        IDataObject *dataObject = nullptr;
+        if (SUCCEEDED(array->BindToHandler(nullptr, BHID_DataObject, IID_PPV_ARGS(&dataObject))) &&
+            dataObject) {
+          IAssocHandlerInvoker *invoker = nullptr;
+          if (SUCCEEDED(handler->CreateInvoker(dataObject, &invoker)) && invoker) {
+            ok = SUCCEEDED(invoker->Invoke());
+            invoker->Release();
+          }
+          dataObject->Release();
+        }
+        array->Release();
+      }
+      handler->Release();
+      break;
+    }
+
+    handler->Release();
+    handler = nullptr;
+  }
+
+  handlers->Release();
+  return ok;
+}
+
+// Packaged apps never receive argv; documents and URIs are handed over through activation.
+bool activatePackaged(const std::wstring &aumid, const std::vector<QString> &files,
+                      const std::vector<QString> &uris) {
+  IApplicationActivationManager *manager = nullptr;
+  if (FAILED(CoCreateInstance(CLSID_ApplicationActivationManager, nullptr, CLSCTX_INPROC_SERVER,
+                              IID_PPV_ARGS(&manager))) ||
+      !manager) {
+    return false;
+  }
+
+  bool ok = true;
+  DWORD pid = 0;
+
+  if (!files.empty()) {
+    IShellItemArray *array = shellItemArrayFromParsingNames(files);
+    ok = array && SUCCEEDED(manager->ActivateForFile(aumid.c_str(), array, L"open", &pid));
+    if (array) array->Release();
+  }
+
+  // Protocol activation takes a single URI at a time.
+  for (const auto &uri : uris) {
+    IShellItemArray *array = shellItemArrayFromParsingNames({uri});
+    ok = array && SUCCEEDED(manager->ActivateForProtocol(aumid.c_str(), array, &pid)) && ok;
+    if (array) array->Release();
+  }
+
   manager->Release();
   return ok;
 }
@@ -406,30 +551,37 @@ void WindowsAppDatabase::addShortcut(const fs::path &file) {
   const bool isAppRef = ext == L".appref-ms";
   if (!isLnk && !isUrl && !isAppRef) return;
 
+  if (looksLikeUninstaller(file)) return;
+
+  ShortcutInfo info;
   QString program; // .lnk: target exe. .url: target URL.
-  QString arguments;
-  QString aumid;
   if (isLnk) {
-    const ShortcutInfo info = readShortcutInfo(file);
+    info = readShortcutInfo(file);
     if (info.target && looksLikeUninstaller(*info.target)) return;
-    // A shortcut carrying the AUMID of an installed package is that package's app; the UWP scan
-    // (run first) already listed it.
+    if (isMsiUninstall(info.target, info.arguments)) return;
     if (!info.aumid.isEmpty() && m_appsById.contains(uwpAppId(info.aumid))) return;
     if (info.target) program = QString::fromStdWString(info.target->wstring());
-    arguments = info.arguments;
-    aumid = info.aumid;
   } else if (isUrl) {
     program = readUrlTarget(file);
   }
 
   WindowsApplication::Data data;
-  data.id = win32AppId(program, arguments, aumid, file);
+  data.id = win32AppId(program, info.arguments, info.aumid, file);
   data.displayName = QString::fromStdWString(file.stem().wstring());
   data.program = program;
+  data.arguments = info.arguments;
+  data.workingDirectory = info.workingDirectory;
   data.path = file;
   data.shellParsingName = QString::fromStdWString(file.wstring());
   data.packaged = false;
-  data.game = isUrl && isGameLauncherUrl(program);
+  if (isUrl) {
+    if (isGameLauncherUrl(program)) {
+      data.category = QStringLiteral("Game");
+    } else if (program.startsWith(QLatin1String("http://"), Qt::CaseInsensitive) ||
+               program.startsWith(QLatin1String("https://"), Qt::CaseInsensitive)) {
+      data.category = QStringLiteral("Link");
+    }
+  }
 
   addApp(std::make_shared<WindowsApplication>(std::move(data)));
 }
@@ -458,7 +610,6 @@ void WindowsAppDatabase::scanDesktop() {
   if (auto user = knownFolder(FOLDERID_Desktop)) roots.emplace_back(std::move(*user));
   if (auto common = knownFolder(FOLDERID_PublicDesktop)) roots.emplace_back(std::move(*common));
 
-  // Non-recursive: we want top-level shortcuts, not to descend into folders sitting on the Desktop.
   for (const auto &root : roots) {
     std::error_code ec;
     if (!fs::is_directory(root, ec)) continue;
@@ -478,13 +629,27 @@ void WindowsAppDatabase::scanDesktop() {
 }
 
 void WindowsAppDatabase::scanAppPaths() {
+  fs::path systemRoot;
+  if (const wchar_t *env = _wgetenv(L"SystemRoot"); env && *env) systemRoot = env;
+
+  fs::path windowsApps; // packaged apps register execution aliases here; scanUwp already lists them
+  if (const wchar_t *env = _wgetenv(L"ProgramW6432"); env && *env) {
+    windowsApps = fs::path(env) / L"WindowsApps";
+  }
+
   for (const auto &exe : enumerateAppPaths()) {
     std::error_code ec;
     if (!fs::exists(exe, ec) || looksLikeUninstaller(exe)) continue;
+    if (!systemRoot.empty() && isUnderDirectory(exe, systemRoot)) continue;
+    if (!windowsApps.empty() && isUnderDirectory(exe, windowsApps)) continue;
+
+    // nameless exes are almost always helper binaries
+    const QString description = exeFileDescription(exe);
+    if (description.isEmpty()) continue;
 
     WindowsApplication::Data data;
     data.id = win32AppId(QString::fromStdWString(exe.wstring()));
-    data.displayName = QString::fromStdWString(exe.stem().wstring());
+    data.displayName = description;
     data.program = QString::fromStdWString(exe.wstring());
     data.path = exe;
     data.shellParsingName = QString::fromStdWString(exe.wstring());
@@ -554,7 +719,7 @@ bool WindowsAppDatabase::scan(const std::vector<fs::path> &paths) {
   m_appsById.clear();
 
   ScopedCom com;
-  scanUwp(); // first: addShortcut skips .lnk files whose AUMID names an already-listed package
+  scanUwp(); // first: addShortcut drops shortcuts whose AUMID is already listed
   scanWin32(paths);
   scanDesktop();
   scanAppPaths();
@@ -568,29 +733,48 @@ bool WindowsAppDatabase::launch(const AbstractApplication &app, const std::vecto
 
   ScopedCom com;
 
-  // Let the shell pick the default handler; the only way to open a target whose handler is a pure
-  // UWP app (e.g. Photos for images), which exposes no executable.
+  // only way to open a target whose default handler is a UWP app with no exe
   if (winApp->opensViaShell()) {
     if (args.empty()) return false;
     bool ok = true;
-    for (const auto &target : args)
+    for (const auto &target : args) {
+      qInfo() << "Shell-opening" << target;
       ok = shellExecuteOpen(target.toStdWString()) && ok;
+    }
     return ok;
   }
 
   if (winApp->isPackaged() && !args.empty()) {
-    const bool allFiles = std::ranges::none_of(
-        args, [](const QString &a) { return a.contains(QStringLiteral("://")); });
-    if (allFiles) {
-      if (activatePackagedForFiles(winApp->program().toStdWString(), args)) return true;
-      bool ok = true;
-      for (const auto &target : args)
-        ok = shellExecuteOpen(target.toStdWString()) && ok;
-      return ok;
+    std::vector<QString> files;
+    std::vector<QString> uris;
+    for (const auto &arg : args) {
+      (classifyTarget(arg).kind == AssocKind::Protocol ? uris : files).emplace_back(arg);
     }
+    qInfo() << "Activating packaged app" << winApp->program() << "files" << files << "uris" << uris;
+    return activatePackaged(winApp->program().toStdWString(), files, uris);
+  }
+
+  if (!args.empty() && !winApp->openerExtension().isEmpty() &&
+      invokeAssocHandler(winApp->openerExtension().toStdWString(), winApp->program(), args)) {
+    qInfo() << "Invoked assoc handler" << winApp->program() << "with" << args;
+    return true;
   }
 
   const std::wstring params = joinArgs(args);
+
+  // ShellExecute ignores lpParameters for .lnk targets
+  if (!args.empty() && !winApp->program().isEmpty() &&
+      classifyTarget(winApp->program()).kind != AssocKind::Protocol) {
+    std::wstring combined = winApp->arguments().toStdWString();
+    if (!combined.empty()) combined += L' ';
+    combined += params;
+    const std::wstring workdir = winApp->workingDirectory().toStdWString();
+    qInfo() << "Launching" << winApp->program() << "args" << QString::fromStdWString(combined);
+    return shellExecuteOpen(winApp->program().toStdWString(), combined.c_str(),
+                            workdir.empty() ? nullptr : workdir.c_str());
+  }
+
+  qInfo() << "Launching" << winApp->shellParsingName() << "args" << QString::fromStdWString(params);
   if (!shellExecuteOpen(winApp->shellParsingName().toStdWString(),
                         params.empty() ? nullptr : params.c_str())) {
     qWarning() << "Failed to launch" << winApp->displayName();
@@ -621,8 +805,18 @@ bool WindowsAppDatabase::launchTerminalCommand(const std::vector<QString> &cmdli
   return reinterpret_cast<INT_PTR>(ret) > 32;
 }
 
+// Prefers the scanned app for the same executable, like the XDG provider; synthesizes one only for
+// executables we never scanned (packaged handlers, apps without shortcuts).
+WindowsAppDatabase::AppPtr WindowsAppDatabase::resolveExecutable(const fs::path &exe, const QString &name,
+                                                                const QString &openerExtension) const {
+  const auto it = m_appsById.find(win32AppId(QString::fromStdWString(exe.wstring())));
+  if (it != m_appsById.end()) return it->second;
+  return appForExecutable(exe, name, openerExtension);
+}
+
 WindowsAppDatabase::AppPtr WindowsAppDatabase::appForExecutable(const fs::path &exe,
-                                                               const QString &name) const {
+                                                               const QString &name,
+                                                               const QString &openerExtension) const {
   const QString exeStr = QString::fromStdWString(exe.wstring());
 
   WindowsApplication::Data data;
@@ -631,6 +825,7 @@ WindowsAppDatabase::AppPtr WindowsAppDatabase::appForExecutable(const fs::path &
   data.program = exeStr;
   data.path = exe;
   data.shellParsingName = exeStr;
+  data.openerExtension = openerExtension;
   data.packaged = false;
   return std::make_shared<WindowsApplication>(std::move(data));
 }
@@ -655,15 +850,16 @@ std::vector<WindowsAppDatabase::AppPtr> WindowsAppDatabase::findOpeners(const Ta
   std::vector<AppPtr> result;
 
   if (assoc.kind == AssocKind::Extension) {
+    const QString ext = QString::fromStdWString(assoc.value);
     for (auto &[exe, display] : enumExtensionHandlers(assoc.value)) {
-      result.emplace_back(appForExecutable(exe, display));
+      result.emplace_back(resolveExecutable(exe, display, ext));
     }
   }
 
   // Protocols have no handler enumeration, and UWP handlers expose no exe.
   if (result.empty()) {
     if (auto exe = defaultHandlerExe(assoc.value))
-      result.emplace_back(appForExecutable(*exe, friendlyAppName(assoc.value)));
+      result.emplace_back(resolveExecutable(*exe, friendlyAppName(assoc.value)));
     else
       result.emplace_back(makeShellOpenApp(target));
   }
@@ -677,7 +873,7 @@ WindowsAppDatabase::AppPtr WindowsAppDatabase::findDefaultOpener(const Target &t
 
   ScopedCom com;
   if (auto exe = defaultHandlerExe(assoc.value))
-    return appForExecutable(*exe, friendlyAppName(assoc.value));
+    return resolveExecutable(*exe, friendlyAppName(assoc.value));
   return makeShellOpenApp(target); // UWP handler: defer to the shell
 }
 
@@ -707,14 +903,14 @@ WindowsAppDatabase::AppPtr WindowsAppDatabase::fileBrowser() const {
 
 WindowsAppDatabase::AppPtr WindowsAppDatabase::genericTextEditor() const {
   ScopedCom com;
-  if (auto exe = defaultHandlerExe(L".txt")) return appForExecutable(*exe, friendlyAppName(L".txt"));
+  if (auto exe = defaultHandlerExe(L".txt")) return resolveExecutable(*exe, friendlyAppName(L".txt"));
   if (auto notepad = searchExecutable(L"notepad.exe")) return appForExecutable(*notepad, {});
   return nullptr;
 }
 
 WindowsAppDatabase::AppPtr WindowsAppDatabase::webBrowser() const {
   ScopedCom com;
-  if (auto exe = defaultHandlerExe(L"http")) return appForExecutable(*exe, friendlyAppName(L"http"));
+  if (auto exe = defaultHandlerExe(L"http")) return resolveExecutable(*exe, friendlyAppName(L"http"));
   return nullptr;
 }
 

--- a/src/server/src/services/app-service/windows/win-app-database.cpp
+++ b/src/server/src/services/app-service/windows/win-app-database.cpp
@@ -57,6 +57,13 @@ std::optional<fs::path> knownFolder(REFKNOWNFOLDERID id) {
   return result;
 }
 
+std::vector<fs::path> desktopRoots() {
+  std::vector<fs::path> roots;
+  if (auto user = knownFolder(FOLDERID_Desktop)) roots.emplace_back(std::move(*user));
+  if (auto common = knownFolder(FOLDERID_PublicDesktop)) roots.emplace_back(std::move(*common));
+  return roots;
+}
+
 struct ShortcutInfo {
   std::optional<fs::path> target; // nullopt for PIDL-backed shortcuts we cannot resolve
   QString arguments;
@@ -562,6 +569,12 @@ struct UwpPackageWatcher {
 WindowsAppDatabase::WindowsAppDatabase() {
   scan(defaultSearchPaths());
 
+  for (const auto &root : desktopRoots()) {
+    m_desktopWatcher.addPath(QString::fromStdWString(root.wstring()));
+  }
+  connect(&m_desktopWatcher, &QFileSystemWatcher::directoryChanged, this,
+          [this] { Q_EMIT changed(); });
+
   using namespace winrt::Windows::ApplicationModel;
   try {
     auto watcher = std::make_unique<UwpPackageWatcher>();
@@ -579,7 +592,7 @@ WindowsAppDatabase::WindowsAppDatabase() {
   }
 }
 
-WindowsAppDatabase::~WindowsAppDatabase() = default;
+WindowsAppDatabase::~WindowsAppDatabase() { m_uwpWatcher.reset(); }
 
 std::vector<fs::path> WindowsAppDatabase::defaultSearchPaths() const {
   std::vector<fs::path> paths;
@@ -656,11 +669,7 @@ void WindowsAppDatabase::scanWin32(const std::vector<fs::path> &paths) {
 }
 
 void WindowsAppDatabase::scanDesktop() {
-  std::vector<fs::path> roots;
-  if (auto user = knownFolder(FOLDERID_Desktop)) roots.emplace_back(std::move(*user));
-  if (auto common = knownFolder(FOLDERID_PublicDesktop)) roots.emplace_back(std::move(*common));
-
-  for (const auto &root : roots) {
+  for (const auto &root : desktopRoots()) {
     std::error_code ec;
     if (!fs::is_directory(root, ec)) continue;
 

--- a/src/server/src/services/app-service/windows/win-app-database.cpp
+++ b/src/server/src/services/app-service/windows/win-app-database.cpp
@@ -56,6 +56,25 @@ private:
   bool m_owns = false;
 };
 
+std::wstring toLower(std::wstring s) {
+  for (auto &c : s)
+    c = static_cast<wchar_t>(::towlower(c));
+  return s;
+}
+
+QString toQString(const fs::path &p) { return QString::fromStdWString(p.wstring()); }
+
+std::optional<fs::path> envPath(const wchar_t *name) {
+  if (const wchar_t *value = _wgetenv(name); value && *value) return fs::path(value);
+  return std::nullopt;
+}
+
+std::wstring expandEnv(const std::wstring &s) {
+  wchar_t buf[1024] = {};
+  const DWORD n = ExpandEnvironmentStringsW(s.c_str(), buf, 1024);
+  return (n > 0 && n <= 1024) ? std::wstring(buf, n - 1) : s;
+}
+
 std::optional<fs::path> knownFolder(REFKNOWNFOLDERID id) {
   PWSTR raw = nullptr;
   const HRESULT hr = SHGetKnownFolderPath(id, KF_FLAG_DEFAULT, nullptr, &raw);
@@ -107,9 +126,7 @@ ShortcutInfo readShortcutInfo(const fs::path &lnk) {
         info.target = fs::path(name);
       } else if (SUCCEEDED(SHGetNameFromIDList(pidl, SIGDN_DESKTOPABSOLUTEPARSING, &name)) && name) {
         if (_wcsicmp(name, FILE_EXPLORER_CLSID) == 0) {
-          if (const wchar_t *windir = _wgetenv(L"WINDIR"); windir && *windir) {
-            info.target = fs::path(windir) / L"explorer.exe";
-          }
+          if (auto windir = envPath(L"WINDIR")) info.target = *windir / L"explorer.exe";
         }
       }
       if (name) CoTaskMemFree(name);
@@ -124,9 +141,7 @@ ShortcutInfo readShortcutInfo(const fs::path &lnk) {
 
   wchar_t dir[MAX_PATH] = {};
   if (SUCCEEDED(link->GetWorkingDirectory(dir, MAX_PATH)) && dir[0] != L'\0') {
-    wchar_t expanded[MAX_PATH] = {};
-    const DWORD n = ExpandEnvironmentStringsW(dir, expanded, MAX_PATH);
-    info.workingDirectory = QString::fromWCharArray((n > 0 && n <= MAX_PATH) ? expanded : dir);
+    info.workingDirectory = QString::fromStdWString(expandEnv(dir));
   }
 
   ComPtr<IPropertyStore> store;
@@ -161,7 +176,7 @@ QString win32AppId(const QString &program, const QString &arguments = {}, const 
     if (!arguments.isEmpty()) id += QLatin1Char(' ') + arguments.toLower();
     return id;
   }
-  return QStringLiteral("win32:") + QString::fromStdWString(shortcut.wstring()).toLower();
+  return QStringLiteral("win32:") + toQString(shortcut).toLower();
 }
 
 QString uwpAppId(const QString &aumid) { return QStringLiteral("uwp:") + aumid.toLower(); }
@@ -184,36 +199,21 @@ bool isGameLauncherUrl(const QString &url) {
 }
 
 bool looksLikeUninstaller(const fs::path &target) {
-  auto name = target.filename().wstring();
-  for (auto &c : name)
-    c = static_cast<wchar_t>(::towlower(c));
-  return name.find(L"unins") != std::wstring::npos;
+  return toLower(target.filename().wstring()).find(L"unins") != std::wstring::npos;
 }
 
 bool isMsiUninstall(const std::optional<fs::path> &target, const QString &arguments) {
   if (!target) return false;
-  auto name = target->filename().wstring();
-  for (auto &c : name)
-    c = static_cast<wchar_t>(::towlower(c));
-  return name == L"msiexec.exe" && arguments.contains(QLatin1String("/x"), Qt::CaseInsensitive);
+  return toLower(target->filename().wstring()) == L"msiexec.exe" &&
+         arguments.contains(QLatin1String("/x"), Qt::CaseInsensitive);
 }
 
-std::wstring lowerExtension(const fs::path &p) {
-  auto ext = p.extension().wstring();
-  for (auto &c : ext)
-    c = static_cast<wchar_t>(::towlower(c));
-  return ext;
-}
+std::wstring lowerExtension(const fs::path &p) { return toLower(p.extension().wstring()); }
 
 bool isUnderDirectory(const fs::path &p, const fs::path &dir) {
-  std::wstring a = p.wstring();
-  std::wstring b = dir.wstring();
-  for (auto &c : a)
-    c = static_cast<wchar_t>(::towlower(c));
-  for (auto &c : b)
-    c = static_cast<wchar_t>(::towlower(c));
-  if (!b.empty() && b.back() != L'\\') b += L'\\';
-  return a.starts_with(b);
+  std::wstring prefix = toLower(dir.wstring());
+  if (!prefix.empty() && prefix.back() != L'\\') prefix += L'\\';
+  return toLower(p.wstring()).starts_with(prefix);
 }
 
 QString exeFileDescription(const fs::path &exe) {
@@ -273,11 +273,7 @@ std::optional<fs::path> readAppPathValue(HKEY appPathsKey, const std::wstring &s
     if (value.size() >= 2 && value.front() == L'"' && value.back() == L'"') {
       value = value.substr(1, value.size() - 2);
     }
-    if (!value.empty()) {
-      wchar_t expanded[1024] = {};
-      const DWORD n = ExpandEnvironmentStringsW(value.c_str(), expanded, 1024);
-      result = fs::path((n > 0 && n <= 1024) ? std::wstring(expanded, n - 1) : value);
-    }
+    if (!value.empty()) result = fs::path(expandEnv(value));
   }
 
   RegCloseKey(sub);
@@ -389,38 +385,35 @@ Assoc classifyTarget(const QString &target) {
     }
   }
 
+  const fs::path path(target.toStdWString());
+
   // a dead UNC host can block for seconds
   std::error_code ec;
-  if (!target.startsWith(QLatin1String("\\\\")) &&
-      fs::is_directory(fs::path(target.toStdWString()), ec)) {
+  if (!target.startsWith(QLatin1String("\\\\")) && fs::is_directory(path, ec)) {
     return {AssocKind::Directory, L"Directory"};
   }
 
-  std::wstring ext = fs::path(target.toStdWString()).extension().wstring();
+  std::wstring ext = lowerExtension(path);
   if (ext.empty()) return {};
-  for (auto &c : ext)
-    c = static_cast<wchar_t>(::towlower(c));
   return {AssocKind::Extension, std::move(ext)};
 }
 
-QString friendlyAppName(const std::wstring &assoc) {
-  wchar_t buf[512];
-  DWORD len = 512;
-  if (SUCCEEDED(AssocQueryStringW(ASSOCF_NONE, ASSOCSTR_FRIENDLYAPPNAME, assoc.c_str(), nullptr, buf,
-                                  &len)) &&
-      len > 1) {
-    return QString::fromWCharArray(buf, len - 1);
+std::optional<std::wstring> assocQueryString(ASSOCSTR type, const std::wstring &assoc) {
+  wchar_t buf[1024];
+  DWORD len = 1024;
+  if (SUCCEEDED(AssocQueryStringW(ASSOCF_NONE, type, assoc.c_str(), nullptr, buf, &len)) && len > 1) {
+    return std::wstring(buf, len - 1);
   }
-  return {};
+  return std::nullopt;
+}
+
+QString friendlyAppName(const std::wstring &assoc) {
+  const auto name = assocQueryString(ASSOCSTR_FRIENDLYAPPNAME, assoc);
+  return name ? QString::fromStdWString(*name) : QString();
 }
 
 std::optional<fs::path> defaultHandlerExe(const std::wstring &assoc) {
-  wchar_t buf[1024];
-  DWORD len = 1024;
-  const HRESULT hr =
-      AssocQueryStringW(ASSOCF_NONE, ASSOCSTR_EXECUTABLE, assoc.c_str(), nullptr, buf, &len);
-  if (SUCCEEDED(hr) && len > 1) return fs::path(std::wstring(buf, len - 1));
-  return std::nullopt;
+  return assocQueryString(ASSOCSTR_EXECUTABLE, assoc);
 }
 
 std::vector<std::pair<fs::path, QString>> enumExtensionHandlers(const std::wstring &ext,
@@ -621,7 +614,7 @@ void WindowsAppDatabase::addShortcut(const fs::path &file) {
     if (info.target && looksLikeUninstaller(*info.target)) return;
     if (isMsiUninstall(info.target, info.arguments)) return;
     if (!info.aumid.isEmpty() && m_appsById.contains(uwpAppId(info.aumid))) return;
-    if (info.target) program = QString::fromStdWString(info.target->wstring());
+    if (info.target) program = toQString(*info.target);
   } else if (isUrl) {
     program = readUrlTarget(file);
   }
@@ -630,12 +623,12 @@ void WindowsAppDatabase::addShortcut(const fs::path &file) {
 
   WindowsApplication::Data data;
   data.id = win32AppId(program, info.arguments, info.aumid, file);
-  data.displayName = display.isEmpty() ? QString::fromStdWString(file.stem().wstring()) : display;
+  data.displayName = display.isEmpty() ? toQString(file.stem()) : display;
   data.program = program;
   data.arguments = info.arguments;
   data.workingDirectory = info.workingDirectory;
   data.path = file;
-  data.shellParsingName = QString::fromStdWString(file.wstring());
+  data.shellParsingName = toQString(file);
   data.packaged = false;
   if (isUrl) {
     if (isGameLauncherUrl(program)) {
@@ -654,7 +647,7 @@ void WindowsAppDatabase::scanWin32(const std::vector<fs::path> &paths) {
     std::error_code ec;
     if (!fs::is_directory(root, ec)) continue;
 
-    m_watchDirs.insert(QString::fromStdWString(root.wstring()));
+    m_watchDirs.insert(toQString(root));
 
     fs::recursive_directory_iterator it(root, fs::directory_options::skip_permission_denied, ec);
     const fs::recursive_directory_iterator end;
@@ -666,7 +659,7 @@ void WindowsAppDatabase::scanWin32(const std::vector<fs::path> &paths) {
         continue;
       }
       if (it->is_directory(ec)) {
-        m_watchDirs.insert(QString::fromStdWString(it->path().wstring()));
+        m_watchDirs.insert(toQString(it->path()));
       } else if (it->is_regular_file(ec)) {
         addShortcut(it->path());
       }
@@ -679,7 +672,7 @@ void WindowsAppDatabase::scanDesktop() {
     std::error_code ec;
     if (!fs::is_directory(root, ec)) continue;
 
-    m_watchDirs.insert(QString::fromStdWString(root.wstring()));
+    m_watchDirs.insert(toQString(root));
 
     fs::directory_iterator it(root, fs::directory_options::skip_permission_denied, ec);
     const fs::directory_iterator end;
@@ -696,13 +689,10 @@ void WindowsAppDatabase::scanDesktop() {
 }
 
 void WindowsAppDatabase::scanAppPaths() {
-  fs::path systemRoot;
-  if (const wchar_t *env = _wgetenv(L"SystemRoot"); env && *env) systemRoot = env;
+  const fs::path systemRoot = envPath(L"SystemRoot").value_or(fs::path());
 
   fs::path windowsApps; // packaged apps register execution aliases here; scanUwp already lists them
-  if (const wchar_t *env = _wgetenv(L"ProgramW6432"); env && *env) {
-    windowsApps = fs::path(env) / L"WindowsApps";
-  }
+  if (auto programFiles = envPath(L"ProgramW6432")) windowsApps = *programFiles / L"WindowsApps";
 
   for (const auto &exe : enumerateAppPaths()) {
     std::error_code ec;
@@ -714,12 +704,14 @@ void WindowsAppDatabase::scanAppPaths() {
     const QString description = exeFileDescription(exe);
     if (description.isEmpty()) continue;
 
+    const QString exeStr = toQString(exe);
+
     WindowsApplication::Data data;
-    data.id = win32AppId(QString::fromStdWString(exe.wstring()));
+    data.id = win32AppId(exeStr);
     data.displayName = description;
-    data.program = QString::fromStdWString(exe.wstring());
+    data.program = exeStr;
     data.path = exe;
-    data.shellParsingName = QString::fromStdWString(exe.wstring());
+    data.shellParsingName = exeStr;
     data.packaged = false;
 
     addApp(std::make_shared<WindowsApplication>(std::move(data)));
@@ -870,8 +862,7 @@ bool WindowsAppDatabase::launchTerminalCommand(const std::vector<QString> &cmdli
   if (cmdline.empty()) return false;
 
   // cmd.exe is always present and gives us /k (hold) vs /c plus a working directory.
-  std::wstring comspec = L"cmd.exe";
-  if (const wchar_t *env = _wgetenv(L"ComSpec"); env && *env) comspec = env;
+  const fs::path comspec = envPath(L"ComSpec").value_or(L"cmd.exe");
 
   std::wstring inner;
   if (opts.title) inner += L"title " + cmdEscape(opts.title->toStdWString()) + L" & ";
@@ -892,7 +883,7 @@ WindowsAppDatabase::AppPtr WindowsAppDatabase::resolveExecutable(const fs::path 
                                                                 const QString &openerExtension) const {
   // registry handler paths can contain doubled separators
   const fs::path normalized = exe.lexically_normal();
-  const auto it = m_appsById.find(win32AppId(QString::fromStdWString(normalized.wstring())));
+  const auto it = m_appsById.find(win32AppId(toQString(normalized)));
   if (it != m_appsById.end()) return it->second;
   return appForExecutable(normalized, name, openerExtension);
 }
@@ -900,11 +891,11 @@ WindowsAppDatabase::AppPtr WindowsAppDatabase::resolveExecutable(const fs::path 
 WindowsAppDatabase::AppPtr WindowsAppDatabase::appForExecutable(const fs::path &exe,
                                                                const QString &name,
                                                                const QString &openerExtension) const {
-  const QString exeStr = QString::fromStdWString(exe.wstring());
+  const QString exeStr = toQString(exe);
 
   WindowsApplication::Data data;
   data.id = win32AppId(exeStr);
-  data.displayName = name.isEmpty() ? QString::fromStdWString(exe.stem().wstring()) : name;
+  data.displayName = name.isEmpty() ? toQString(exe.stem()) : name;
   data.program = exeStr;
   data.path = exe;
   data.shellParsingName = exeStr;
@@ -942,7 +933,7 @@ std::vector<WindowsAppDatabase::AppPtr> WindowsAppDatabase::findOpeners(const Ta
   if (assoc.kind == AssocKind::Directory) {
     if (auto browser = fileBrowser()) result.emplace_back(std::move(browser));
     for (auto &[exe, display] : enumExtensionHandlers(assoc.value, ASSOC_FILTER_NONE)) {
-      auto app = resolveExecutable(exe, display, QStringLiteral("Directory"));
+      auto app = resolveExecutable(exe, display, QString::fromStdWString(assoc.value));
       const bool dup =
           std::ranges::any_of(result, [&](const AppPtr &r) { return r->id() == app->id(); });
       if (!dup) result.emplace_back(std::move(app));
@@ -985,8 +976,8 @@ WindowsAppDatabase::AppPtr WindowsAppDatabase::findByClass(const QString &) cons
 WindowsAppDatabase::AppPtr WindowsAppDatabase::fileBrowser() const {
   ScopedCom com;
   fs::path explorer;
-  if (const wchar_t *windir = _wgetenv(L"WINDIR"); windir && *windir) {
-    explorer = fs::path(windir) / L"explorer.exe";
+  if (auto windir = envPath(L"WINDIR")) {
+    explorer = *windir / L"explorer.exe";
   } else if (auto found = searchExecutable(L"explorer.exe")) {
     explorer = *found;
   } else {
@@ -1013,9 +1004,7 @@ WindowsAppDatabase::AppPtr WindowsAppDatabase::terminalEmulator() const {
   if (!defaultTerminalIsConhost()) {
     if (auto wt = searchExecutable(L"wt.exe")) return appForExecutable(*wt, QStringLiteral("Terminal"));
   }
-  fs::path comspec = L"cmd.exe";
-  if (const wchar_t *env = _wgetenv(L"ComSpec"); env && *env) comspec = env;
-  return appForExecutable(comspec, QStringLiteral("Command Prompt"));
+  return appForExecutable(envPath(L"ComSpec").value_or(L"cmd.exe"), QStringLiteral("Command Prompt"));
 }
 
 bool WindowsAppDatabase::showInFileBrowser(const fs::path &path, bool select) const {

--- a/src/server/src/services/app-service/windows/win-app-database.cpp
+++ b/src/server/src/services/app-service/windows/win-app-database.cpp
@@ -108,15 +108,11 @@ ShortcutInfo readShortcutInfo(const fs::path &lnk) {
   }
 
   ComPtr<IPersistFile> persist;
-  if (FAILED(link.As(&persist)) || FAILED(persist->Load(lnk.wstring().c_str(), STGM_READ))) {
-    return info;
-  }
+  if (FAILED(link.As(&persist)) || FAILED(persist->Load(lnk.wstring().c_str(), STGM_READ))) { return info; }
 
   wchar_t buf[MAX_PATH] = {};
   WIN32_FIND_DATAW find = {};
-  if (SUCCEEDED(link->GetPath(buf, MAX_PATH, &find, 0)) && buf[0] != L'\0') {
-    info.target = fs::path(buf);
-  }
+  if (SUCCEEDED(link->GetPath(buf, MAX_PATH, &find, 0)) && buf[0] != L'\0') { info.target = fs::path(buf); }
 
   if (!info.target) {
     PIDLIST_ABSOLUTE pidl = nullptr;
@@ -148,8 +144,7 @@ ShortcutInfo readShortcutInfo(const fs::path &lnk) {
   if (SUCCEEDED(link.As(&store))) {
     PROPVARIANT value;
     PropVariantInit(&value);
-    if (SUCCEEDED(store->GetValue(PKEY_AppUserModel_ID, &value)) && value.vt == VT_LPWSTR &&
-        value.pwszVal) {
+    if (SUCCEEDED(store->GetValue(PKEY_AppUserModel_ID, &value)) && value.vt == VT_LPWSTR && value.pwszVal) {
       info.aumid = QString::fromWCharArray(value.pwszVal);
     }
     PropVariantClear(&value);
@@ -188,14 +183,13 @@ QString readUrlTarget(const fs::path &url) {
 }
 
 bool isGameLauncherUrl(const QString &url) {
-  static constexpr std::array schemes = {"steam:",   "com.epicgames.launcher:",
-                                         "goggalaxy:", "uplay:",
-                                         "ubisoft:",  "battlenet:",
-                                         "origin:",   "link2ea:",
+  static constexpr std::array schemes = {"steam:",       "com.epicgames.launcher:",
+                                         "goggalaxy:",   "uplay:",
+                                         "ubisoft:",     "battlenet:",
+                                         "origin:",      "link2ea:",
                                          "amazon-games:"};
   const QString lower = url.toLower();
-  return std::ranges::any_of(schemes,
-                             [&](const char *s) { return lower.startsWith(QLatin1String(s)); });
+  return std::ranges::any_of(schemes, [&](const char *s) { return lower.startsWith(QLatin1String(s)); });
 }
 
 bool looksLikeUninstaller(const fs::path &target) {
@@ -231,8 +225,7 @@ QString exeFileDescription(const fs::path &exe) {
   std::vector<LangCp> translations;
   LangCp *table = nullptr;
   UINT cb = 0;
-  if (VerQueryValueW(info.data(), L"\\VarFileInfo\\Translation", reinterpret_cast<void **>(&table),
-                     &cb) &&
+  if (VerQueryValueW(info.data(), L"\\VarFileInfo\\Translation", reinterpret_cast<void **>(&table), &cb) &&
       table) {
     translations.assign(table, table + cb / sizeof(LangCp));
   }
@@ -245,8 +238,7 @@ QString exeFileDescription(const fs::path &exe) {
       swprintf_s(query, L"\\StringFileInfo\\%04x%04x\\%s", t.lang, t.codepage, field);
       wchar_t *value = nullptr;
       UINT len = 0;
-      if (VerQueryValueW(info.data(), query, reinterpret_cast<void **>(&value), &len) && value &&
-          len > 1) {
+      if (VerQueryValueW(info.data(), query, reinterpret_cast<void **>(&value), &len) && value && len > 1) {
         const QString name = QString::fromWCharArray(value).trimmed();
         if (!name.isEmpty()) return name;
       }
@@ -265,11 +257,11 @@ std::optional<fs::path> readAppPathValue(HKEY appPathsKey, const std::wstring &s
   wchar_t buf[1024] = {};
   DWORD cb = sizeof(buf);
   DWORD type = 0;
-  if (RegQueryValueExW(sub, nullptr, nullptr, &type, reinterpret_cast<LPBYTE>(buf), &cb) ==
-          ERROR_SUCCESS &&
+  if (RegQueryValueExW(sub, nullptr, nullptr, &type, reinterpret_cast<LPBYTE>(buf), &cb) == ERROR_SUCCESS &&
       (type == REG_SZ || type == REG_EXPAND_SZ)) {
     std::wstring value(buf, cb / sizeof(wchar_t));
-    while (!value.empty() && (value.back() == L'\0')) value.pop_back();
+    while (!value.empty() && (value.back() == L'\0'))
+      value.pop_back();
     if (value.size() >= 2 && value.front() == L'"' && value.back() == L'"') {
       value = value.substr(1, value.size() - 2);
     }
@@ -282,8 +274,7 @@ std::optional<fs::path> readAppPathValue(HKEY appPathsKey, const std::wstring &s
 
 std::vector<fs::path> enumerateAppPaths() {
   std::vector<fs::path> result;
-  static constexpr const wchar_t *APP_PATHS_KEY =
-      L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths";
+  static constexpr const wchar_t *APP_PATHS_KEY = L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths";
 
   auto readHive = [&](HKEY root, REGSAM extraSam) {
     HKEY key = nullptr;
@@ -310,8 +301,7 @@ std::vector<fs::path> enumerateAppPaths() {
 
 bool shellExecuteOpen(const std::wstring &target, const wchar_t *params = nullptr,
                       const wchar_t *workdir = nullptr) {
-  const HINSTANCE ret =
-      ShellExecuteW(nullptr, L"open", target.c_str(), params, workdir, SW_SHOWNORMAL);
+  const HINSTANCE ret = ShellExecuteW(nullptr, L"open", target.c_str(), params, workdir, SW_SHOWNORMAL);
   return reinterpret_cast<INT_PTR>(ret) > 32;
 }
 
@@ -373,8 +363,7 @@ Assoc classifyTarget(const QString &target) {
   if (target.isEmpty()) return {};
 
   const int schemeSep = target.indexOf(QStringLiteral("://"));
-  const bool driveLetter =
-      target.size() >= 2 && target[1] == QLatin1Char(':') && target[0].isLetter();
+  const bool driveLetter = target.size() >= 2 && target[1] == QLatin1Char(':') && target[0].isLetter();
 
   if (schemeSep > 0) {
     QString scheme = target.left(schemeSep).toLower();
@@ -421,9 +410,7 @@ std::vector<std::pair<fs::path, QString>> enumExtensionHandlers(const std::wstri
   std::vector<std::pair<fs::path, QString>> result;
 
   ComPtr<IEnumAssocHandlers> handlers;
-  if (FAILED(SHAssocEnumHandlers(ext.c_str(), filter, &handlers)) || !handlers) {
-    return result;
-  }
+  if (FAILED(SHAssocEnumHandlers(ext.c_str(), filter, &handlers)) || !handlers) { return result; }
 
   ComPtr<IAssocHandler> handler;
   ULONG fetched = 0;
@@ -446,8 +433,7 @@ ComPtr<IShellItemArray> shellItemArrayFromParsingNames(const std::vector<QString
   std::vector<PIDLIST_ABSOLUTE> pidls;
   for (const auto &name : names) {
     ComPtr<IShellItem> item;
-    if (SUCCEEDED(SHCreateItemFromParsingName(name.toStdWString().c_str(), nullptr,
-                                              IID_PPV_ARGS(&item))) &&
+    if (SUCCEEDED(SHCreateItemFromParsingName(name.toStdWString().c_str(), nullptr, IID_PPV_ARGS(&item))) &&
         item) {
       PIDLIST_ABSOLUTE pidl = nullptr;
       if (SUCCEEDED(SHGetIDListFromObject(item.Get(), &pidl))) pidls.push_back(pidl);
@@ -469,9 +455,7 @@ bool invokeAssocHandler(const std::wstring &ext, const QString &handlerName,
                         const std::vector<QString> &files) {
   // "Directory" handlers are not in the recommended set
   ComPtr<IEnumAssocHandlers> handlers;
-  if (FAILED(SHAssocEnumHandlers(ext.c_str(), ASSOC_FILTER_NONE, &handlers)) || !handlers) {
-    return false;
-  }
+  if (FAILED(SHAssocEnumHandlers(ext.c_str(), ASSOC_FILTER_NONE, &handlers)) || !handlers) { return false; }
 
   ComPtr<IAssocHandler> handler;
   ULONG fetched = 0;
@@ -486,8 +470,7 @@ bool invokeAssocHandler(const std::wstring &ext, const QString &handlerName,
     if (!array) return false;
 
     ComPtr<IDataObject> dataObject;
-    if (FAILED(array->BindToHandler(nullptr, BHID_DataObject, IID_PPV_ARGS(&dataObject))) ||
-        !dataObject) {
+    if (FAILED(array->BindToHandler(nullptr, BHID_DataObject, IID_PPV_ARGS(&dataObject))) || !dataObject) {
       return false;
     }
 
@@ -530,8 +513,8 @@ bool activatePackaged(const std::wstring &aumid, const std::vector<QString> &fil
 bool defaultTerminalIsConhost() {
   wchar_t buf[64] = {};
   DWORD cb = sizeof(buf);
-  if (RegGetValueW(HKEY_CURRENT_USER, L"Console\\%%Startup", L"DelegationTerminal", RRF_RT_REG_SZ,
-                   nullptr, buf, &cb) != ERROR_SUCCESS) {
+  if (RegGetValueW(HKEY_CURRENT_USER, L"Console\\%%Startup", L"DelegationTerminal", RRF_RT_REG_SZ, nullptr,
+                   buf, &cb) != ERROR_SUCCESS) {
     return false;
   }
   return _wcsicmp(buf, CONHOST_DELEGATION_CLSID) == 0;
@@ -761,8 +744,7 @@ void WindowsAppDatabase::refreshUwpCache() {
         QString name;
         try {
           name = fromHString(entry.DisplayInfo().DisplayName());
-        } catch (const winrt::hresult_error &) {
-        }
+        } catch (const winrt::hresult_error &) {}
         if (name.isEmpty()) continue;
 
         WindowsApplication::Data data;
@@ -869,8 +851,7 @@ bool WindowsAppDatabase::launchTerminalCommand(const std::vector<QString> &cmdli
   inner += cmdEscape(joinArgs(cmdline));
 
   const std::wstring params = (opts.hold ? L"/k " : L"/c ") + inner;
-  const std::wstring workdir =
-      opts.workingDirectory ? opts.workingDirectory->toStdWString() : std::wstring();
+  const std::wstring workdir = opts.workingDirectory ? opts.workingDirectory->toStdWString() : std::wstring();
 
   ScopedCom com;
   const HINSTANCE ret = ShellExecuteW(nullptr, L"open", comspec.c_str(), params.c_str(),
@@ -880,7 +861,7 @@ bool WindowsAppDatabase::launchTerminalCommand(const std::vector<QString> &cmdli
 
 // prefers the scanned app for the same executable, like the XDG provider
 WindowsAppDatabase::AppPtr WindowsAppDatabase::resolveExecutable(const fs::path &exe, const QString &name,
-                                                                const QString &openerExtension) const {
+                                                                 const QString &openerExtension) const {
   // registry handler paths can contain doubled separators
   const fs::path normalized = exe.lexically_normal();
   const auto it = m_appsById.find(win32AppId(toQString(normalized)));
@@ -888,9 +869,8 @@ WindowsAppDatabase::AppPtr WindowsAppDatabase::resolveExecutable(const fs::path 
   return appForExecutable(normalized, name, openerExtension);
 }
 
-WindowsAppDatabase::AppPtr WindowsAppDatabase::appForExecutable(const fs::path &exe,
-                                                               const QString &name,
-                                                               const QString &openerExtension) const {
+WindowsAppDatabase::AppPtr WindowsAppDatabase::appForExecutable(const fs::path &exe, const QString &name,
+                                                                const QString &openerExtension) const {
   const QString exeStr = toQString(exe);
 
   WindowsApplication::Data data;
@@ -934,8 +914,7 @@ std::vector<WindowsAppDatabase::AppPtr> WindowsAppDatabase::findOpeners(const Ta
     if (auto browser = fileBrowser()) result.emplace_back(std::move(browser));
     for (auto &[exe, display] : enumExtensionHandlers(assoc.value, ASSOC_FILTER_NONE)) {
       auto app = resolveExecutable(exe, display, QString::fromStdWString(assoc.value));
-      const bool dup =
-          std::ranges::any_of(result, [&](const AppPtr &r) { return r->id() == app->id(); });
+      const bool dup = std::ranges::any_of(result, [&](const AppPtr &r) { return r->id() == app->id(); });
       if (!dup) result.emplace_back(std::move(app));
     }
   }
@@ -957,8 +936,7 @@ WindowsAppDatabase::AppPtr WindowsAppDatabase::findDefaultOpener(const Target &t
   if (assoc.kind == AssocKind::Directory) return fileBrowser();
 
   ScopedCom com;
-  if (auto exe = defaultHandlerExe(assoc.value))
-    return resolveExecutable(*exe, friendlyAppName(assoc.value));
+  if (auto exe = defaultHandlerExe(assoc.value)) return resolveExecutable(*exe, friendlyAppName(assoc.value));
   return makeShellOpenApp(target); // UWP handler: defer to the shell
 }
 
@@ -1033,8 +1011,7 @@ bool WindowsAppDatabase::openLocation(const AbstractApplication &app) const {
 }
 
 WindowsAppDatabase::AppPtr WindowsAppDatabase::locationOpener(const AbstractApplication &app) const {
-  if (const auto *winApp = dynamic_cast<const WindowsApplication *>(&app);
-      winApp && winApp->isPackaged()) {
+  if (const auto *winApp = dynamic_cast<const WindowsApplication *>(&app); winApp && winApp->isPackaged()) {
     return nullptr; // packaged apps live under the ACL-locked WindowsApps folder
   }
   return fileBrowser();

--- a/src/server/src/services/app-service/windows/win-app-database.cpp
+++ b/src/server/src/services/app-service/windows/win-app-database.cpp
@@ -24,6 +24,8 @@
 #include <winrt/Windows.ApplicationModel.h>
 #include <winrt/Windows.ApplicationModel.Core.h>
 
+#include "utils/scoped-com.hpp"
+
 #include <QDebug>
 #include <array>
 #include <chrono>
@@ -38,23 +40,6 @@ constexpr const wchar_t *FILE_EXPLORER_CLSID = L"::{52205FD8-5DFB-447D-801A-D0B5
 constexpr const wchar_t *CONHOST_DELEGATION_CLSID = L"{B23D10C0-E52E-411E-9D5B-C09FDF709C7D}";
 constexpr const wchar_t *CMD_METACHARS = L"()%!^\"<>&|"; // quotes too: cmd must never enter quote mode
 constexpr auto APP_PATHS_RESCAN_INTERVAL = std::chrono::minutes(5);
-
-// Tolerates Qt's existing COM init (S_FALSE) and a foreign apartment mode (RPC_E_CHANGED_MODE).
-class ScopedCom {
-public:
-  ScopedCom() {
-    const HRESULT hr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
-    m_owns = hr == S_OK || hr == S_FALSE;
-  }
-  ~ScopedCom() {
-    if (m_owns) CoUninitialize();
-  }
-  ScopedCom(const ScopedCom &) = delete;
-  ScopedCom &operator=(const ScopedCom &) = delete;
-
-private:
-  bool m_owns = false;
-};
 
 std::wstring toLower(std::wstring s) {
   for (auto &c : s)

--- a/src/server/src/services/app-service/windows/win-app-database.cpp
+++ b/src/server/src/services/app-service/windows/win-app-database.cpp
@@ -839,8 +839,7 @@ bool WindowsAppDatabase::launch(const AbstractApplication &app, const std::vecto
                                   workdir.empty() ? nullptr : workdir.c_str());
         }
         const std::wstring params = joinArgs(args);
-        qInfo() << "Launching" << toQString(shortcut.shortcut) << "args"
-                << QString::fromStdWString(params);
+        qInfo() << "Launching" << toQString(shortcut.shortcut) << "args" << QString::fromStdWString(params);
         if (!shellExecuteOpen(shortcut.shortcut.wstring(), params.empty() ? nullptr : params.c_str())) {
           qWarning() << "Failed to launch" << winApp->displayName();
           return false;
@@ -942,7 +941,8 @@ WindowsAppDatabase::AppPtr WindowsAppDatabase::findDefaultOpener(const Target &t
   if (assoc->kind == AssocKind::Directory) return fileBrowser();
 
   ScopedCom com;
-  if (auto exe = defaultHandlerExe(assoc->value)) return resolveExecutable(*exe, friendlyAppName(assoc->value));
+  if (auto exe = defaultHandlerExe(assoc->value))
+    return resolveExecutable(*exe, friendlyAppName(assoc->value));
   return makeShellOpenApp(target); // UWP handler: defer to the shell
 }
 

--- a/src/server/src/services/app-service/windows/win-app-database.cpp
+++ b/src/server/src/services/app-service/windows/win-app-database.cpp
@@ -318,10 +318,10 @@ std::wstring joinArgs(const std::vector<QString> &args) {
   return out;
 }
 
-enum class AssocKind { None, Protocol, Extension };
+enum class AssocKind { None, Protocol, Extension, Directory };
 struct Assoc {
   AssocKind kind = AssocKind::None;
-  std::wstring value; // "http" for a protocol, ".txt" for an extension
+  std::wstring value; // "http" for a protocol, ".txt" for an extension, "Directory" for a folder
 };
 
 Assoc classifyTarget(const QString &target) {
@@ -338,6 +338,11 @@ Assoc classifyTarget(const QString &target) {
     if (const int colon = target.indexOf(QLatin1Char(':')); colon > 1) {
       return {AssocKind::Protocol, target.left(colon).toLower().toStdWString()};
     }
+  }
+
+  std::error_code ec;
+  if (fs::is_directory(fs::path(target.toStdWString()), ec)) {
+    return {AssocKind::Directory, L"Directory"};
   }
 
   std::wstring ext = fs::path(target.toStdWString()).extension().wstring();
@@ -367,11 +372,12 @@ std::optional<fs::path> defaultHandlerExe(const std::wstring &assoc) {
   return std::nullopt;
 }
 
-std::vector<std::pair<fs::path, QString>> enumExtensionHandlers(const std::wstring &ext) {
+std::vector<std::pair<fs::path, QString>> enumExtensionHandlers(const std::wstring &ext,
+                                                                ASSOC_FILTER filter) {
   std::vector<std::pair<fs::path, QString>> result;
 
   IEnumAssocHandlers *handlers = nullptr;
-  if (FAILED(SHAssocEnumHandlers(ext.c_str(), ASSOC_FILTER_RECOMMENDED, &handlers)) || !handlers) {
+  if (FAILED(SHAssocEnumHandlers(ext.c_str(), filter, &handlers)) || !handlers) {
     return result;
   }
 
@@ -422,8 +428,9 @@ IShellItemArray *shellItemArrayFromParsingNames(const std::vector<QString> &name
 // WindowsApps cannot be spawned directly.
 bool invokeAssocHandler(const std::wstring &ext, const QString &handlerName,
                         const std::vector<QString> &files) {
+  // NONE: "Directory" handlers are not in the recommended set; the name match keeps it exact
   IEnumAssocHandlers *handlers = nullptr;
-  if (FAILED(SHAssocEnumHandlers(ext.c_str(), ASSOC_FILTER_RECOMMENDED, &handlers)) || !handlers) {
+  if (FAILED(SHAssocEnumHandlers(ext.c_str(), ASSOC_FILTER_NONE, &handlers)) || !handlers) {
     return false;
   }
 
@@ -809,9 +816,11 @@ bool WindowsAppDatabase::launchTerminalCommand(const std::vector<QString> &cmdli
 // executables we never scanned (packaged handlers, apps without shortcuts).
 WindowsAppDatabase::AppPtr WindowsAppDatabase::resolveExecutable(const fs::path &exe, const QString &name,
                                                                 const QString &openerExtension) const {
-  const auto it = m_appsById.find(win32AppId(QString::fromStdWString(exe.wstring())));
+  // registry handler paths can contain doubled separators, breaking id matches and icon parsing names
+  const fs::path normalized = exe.lexically_normal();
+  const auto it = m_appsById.find(win32AppId(QString::fromStdWString(normalized.wstring())));
   if (it != m_appsById.end()) return it->second;
-  return appForExecutable(exe, name, openerExtension);
+  return appForExecutable(normalized, name, openerExtension);
 }
 
 WindowsAppDatabase::AppPtr WindowsAppDatabase::appForExecutable(const fs::path &exe,
@@ -851,8 +860,18 @@ std::vector<WindowsAppDatabase::AppPtr> WindowsAppDatabase::findOpeners(const Ta
 
   if (assoc.kind == AssocKind::Extension) {
     const QString ext = QString::fromStdWString(assoc.value);
-    for (auto &[exe, display] : enumExtensionHandlers(assoc.value)) {
+    for (auto &[exe, display] : enumExtensionHandlers(assoc.value, ASSOC_FILTER_RECOMMENDED)) {
       result.emplace_back(resolveExecutable(exe, display, ext));
+    }
+  }
+
+  if (assoc.kind == AssocKind::Directory) {
+    if (auto browser = fileBrowser()) result.emplace_back(std::move(browser));
+    for (auto &[exe, display] : enumExtensionHandlers(assoc.value, ASSOC_FILTER_NONE)) {
+      auto app = resolveExecutable(exe, display, QStringLiteral("Directory"));
+      const bool dup =
+          std::ranges::any_of(result, [&](const AppPtr &r) { return r->id() == app->id(); });
+      if (!dup) result.emplace_back(std::move(app));
     }
   }
 
@@ -870,6 +889,7 @@ std::vector<WindowsAppDatabase::AppPtr> WindowsAppDatabase::findOpeners(const Ta
 WindowsAppDatabase::AppPtr WindowsAppDatabase::findDefaultOpener(const Target &target) const {
   const Assoc assoc = classifyTarget(target);
   if (assoc.kind == AssocKind::None) return nullptr;
+  if (assoc.kind == AssocKind::Directory) return fileBrowser();
 
   ScopedCom com;
   if (auto exe = defaultHandlerExe(assoc.value))

--- a/src/server/src/services/app-service/windows/win-app-database.cpp
+++ b/src/server/src/services/app-service/windows/win-app-database.cpp
@@ -317,7 +317,34 @@ std::optional<fs::path> searchExecutable(const wchar_t *name) {
 
 } // namespace
 
-WindowsAppDatabase::WindowsAppDatabase() { scan(defaultSearchPaths()); }
+struct UwpPackageWatcher {
+  winrt::Windows::ApplicationModel::PackageCatalog catalog{nullptr};
+  winrt::Windows::ApplicationModel::PackageCatalog::PackageInstalling_revoker installing;
+  winrt::Windows::ApplicationModel::PackageCatalog::PackageUninstalling_revoker uninstalling;
+  winrt::Windows::ApplicationModel::PackageCatalog::PackageUpdating_revoker updating;
+};
+
+WindowsAppDatabase::WindowsAppDatabase() {
+  scan(defaultSearchPaths());
+
+  using namespace winrt::Windows::ApplicationModel;
+  try {
+    auto watcher = std::make_unique<UwpPackageWatcher>();
+    watcher->catalog = PackageCatalog::OpenForCurrentUser();
+    // Progress events fire repeatedly; only rescan on completion. Cross-thread emit is queued.
+    auto handler = [this](const auto &, const auto &args) {
+      if (args.IsComplete()) Q_EMIT changed();
+    };
+    watcher->installing = watcher->catalog.PackageInstalling(winrt::auto_revoke, handler);
+    watcher->uninstalling = watcher->catalog.PackageUninstalling(winrt::auto_revoke, handler);
+    watcher->updating = watcher->catalog.PackageUpdating(winrt::auto_revoke, handler);
+    m_uwpWatcher = std::move(watcher);
+  } catch (const winrt::hresult_error &e) {
+    qWarning() << "[win-app-db] package watcher unavailable:" << fromHString(e.message());
+  }
+}
+
+WindowsAppDatabase::~WindowsAppDatabase() = default;
 
 std::vector<fs::path> WindowsAppDatabase::defaultSearchPaths() const {
   std::vector<fs::path> paths;
@@ -681,6 +708,10 @@ bool WindowsAppDatabase::openLocation(const AbstractApplication &app) const {
   return showInFileBrowser(app.path(), true);
 }
 
-WindowsAppDatabase::AppPtr WindowsAppDatabase::locationOpener(const AbstractApplication &) const {
-  return nullptr;
+WindowsAppDatabase::AppPtr WindowsAppDatabase::locationOpener(const AbstractApplication &app) const {
+  if (const auto *winApp = dynamic_cast<const WindowsApplication *>(&app);
+      winApp && winApp->isPackaged()) {
+    return nullptr; // packaged apps live under the ACL-locked WindowsApps folder
+  }
+  return fileBrowser();
 }

--- a/src/server/src/services/app-service/windows/win-app-database.cpp
+++ b/src/server/src/services/app-service/windows/win-app-database.cpp
@@ -26,12 +26,18 @@
 
 #include <QDebug>
 #include <array>
+#include <chrono>
 #include <string>
 
 namespace fs = std::filesystem;
 using Microsoft::WRL::ComPtr;
 
 namespace {
+
+constexpr const wchar_t *FILE_EXPLORER_CLSID = L"::{52205FD8-5DFB-447D-801A-D0B52F2E83E1}";
+constexpr const wchar_t *CONHOST_DELEGATION_CLSID = L"{B23D10C0-E52E-411E-9D5B-C09FDF709C7D}";
+constexpr const wchar_t *CMD_METACHARS = L"()%!^\"<>&|"; // quotes too: cmd must never enter quote mode
+constexpr auto APP_PATHS_RESCAN_INTERVAL = std::chrono::minutes(5);
 
 // Tolerates Qt's existing COM init (S_FALSE) and a foreign apartment mode (RPC_E_CHANGED_MODE).
 class ScopedCom {
@@ -67,7 +73,7 @@ std::vector<fs::path> desktopRoots() {
 }
 
 struct ShortcutInfo {
-  std::optional<fs::path> target; // nullopt for PIDL-backed shortcuts we cannot resolve
+  std::optional<fs::path> target;
   QString arguments;
   QString workingDirectory;
   QString aumid;
@@ -100,8 +106,7 @@ ShortcutInfo readShortcutInfo(const fs::path &lnk) {
       if (SUCCEEDED(SHGetNameFromIDList(pidl, SIGDN_FILESYSPATH, &name)) && name) {
         info.target = fs::path(name);
       } else if (SUCCEEDED(SHGetNameFromIDList(pidl, SIGDN_DESKTOPABSOLUTEPARSING, &name)) && name) {
-        // the File Explorer CLSID
-        if (_wcsicmp(name, L"::{52205FD8-5DFB-447D-801A-D0B52F2E83E1}") == 0) {
+        if (_wcsicmp(name, FILE_EXPLORER_CLSID) == 0) {
           if (const wchar_t *windir = _wgetenv(L"WINDIR"); windir && *windir) {
             info.target = fs::path(windir) / L"explorer.exe";
           }
@@ -138,7 +143,16 @@ ShortcutInfo readShortcutInfo(const fs::path &lnk) {
   return info;
 }
 
-// AUMID if present, else target + args, else the shortcut file itself
+QString shellDisplayName(const fs::path &file) {
+  ComPtr<IShellItem> item;
+  if (FAILED(SHCreateItemFromParsingName(file.c_str(), nullptr, IID_PPV_ARGS(&item)))) return {};
+  PWSTR name = nullptr;
+  if (FAILED(item->GetDisplayName(SIGDN_NORMALDISPLAY, &name)) || !name) return {};
+  QString result = QString::fromWCharArray(name);
+  CoTaskMemFree(name);
+  return result;
+}
+
 QString win32AppId(const QString &program, const QString &arguments = {}, const QString &aumid = {},
                    const fs::path &shortcut = {}) {
   if (!aumid.isEmpty()) return QStringLiteral("win32:aumid:") + aumid.toLower();
@@ -222,7 +236,8 @@ QString exeFileDescription(const fs::path &exe) {
       table) {
     translations.assign(table, table + cb / sizeof(LangCp));
   }
-  translations.push_back({0x0409, 0x04B0}); // en-US Unicode, common even without a table
+  constexpr LangCp EN_US_UNICODE{0x0409, 0x04B0};
+  translations.push_back(EN_US_UNICODE);
 
   for (const wchar_t *field : {L"FileDescription", L"ProductName"}) {
     for (const auto &t : translations) {
@@ -271,12 +286,12 @@ std::optional<fs::path> readAppPathValue(HKEY appPathsKey, const std::wstring &s
 
 std::vector<fs::path> enumerateAppPaths() {
   std::vector<fs::path> result;
-  static constexpr const wchar_t *kSubKey =
+  static constexpr const wchar_t *APP_PATHS_KEY =
       L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths";
 
   auto readHive = [&](HKEY root, REGSAM extraSam) {
     HKEY key = nullptr;
-    if (RegOpenKeyExW(root, kSubKey, 0, KEY_READ | extraSam, &key) != ERROR_SUCCESS) return;
+    if (RegOpenKeyExW(root, APP_PATHS_KEY, 0, KEY_READ | extraSam, &key) != ERROR_SUCCESS) return;
 
     for (DWORD i = 0;; ++i) {
       wchar_t nameBuf[256];
@@ -333,12 +348,11 @@ std::wstring quoteArg(const QString &arg) {
   return out;
 }
 
-// quotes included, so cmd never enters quote mode
 std::wstring cmdEscape(const std::wstring &s) {
   std::wstring out;
   out.reserve(s.size());
   for (const wchar_t c : s) {
-    if (wcschr(L"()%!^\"<>&|", c)) out += L'^';
+    if (wcschr(CMD_METACHARS, c)) out += L'^';
     out += c;
   }
   return out;
@@ -457,8 +471,7 @@ ComPtr<IShellItemArray> shellItemArrayFromParsingNames(const std::vector<QString
   return array;
 }
 
-// Re-resolves the handler by name and invokes it; works for packaged handlers, whose exe under
-// WindowsApps cannot be spawned directly.
+// works for packaged handlers, whose exe cannot be spawned directly
 bool invokeAssocHandler(const std::wstring &ext, const QString &handlerName,
                         const std::vector<QString> &files) {
   // "Directory" handlers are not in the recommended set
@@ -528,8 +541,7 @@ bool defaultTerminalIsConhost() {
                    nullptr, buf, &cb) != ERROR_SUCCESS) {
     return false;
   }
-  // the classic conhost delegation CLSID
-  return _wcsicmp(buf, L"{B23D10C0-E52E-411E-9D5B-C09FDF709C7D}") == 0;
+  return _wcsicmp(buf, CONHOST_DELEGATION_CLSID) == 0;
 }
 
 // SearchPathW also resolves App Execution Aliases such as wt.exe.
@@ -554,7 +566,7 @@ WindowsAppDatabase::WindowsAppDatabase() {
 
   scan(defaultSearchPaths());
 
-  m_rescanTimer.setInterval(std::chrono::minutes(5));
+  m_rescanTimer.setInterval(APP_PATHS_RESCAN_INTERVAL);
   connect(&m_rescanTimer, &QTimer::timeout, this, [this] { Q_EMIT changed(); });
   m_rescanTimer.start();
 
@@ -562,7 +574,7 @@ WindowsAppDatabase::WindowsAppDatabase() {
   try {
     auto watcher = std::make_unique<UwpPackageWatcher>();
     watcher->catalog = PackageCatalog::OpenForCurrentUser();
-    // Progress events fire repeatedly; only rescan on completion. Cross-thread emit is queued.
+    // progress events fire repeatedly; only rescan on completion
     auto handler = [this](const auto &, const auto &args) {
       if (args.IsComplete()) {
         m_uwpDirty.store(true);
@@ -603,7 +615,7 @@ void WindowsAppDatabase::addShortcut(const fs::path &file) {
   if (looksLikeUninstaller(file)) return;
 
   ShortcutInfo info;
-  QString program; // .lnk: target exe. .url: target URL.
+  QString program;
   if (isLnk) {
     info = readShortcutInfo(file);
     if (info.target && looksLikeUninstaller(*info.target)) return;
@@ -614,9 +626,11 @@ void WindowsAppDatabase::addShortcut(const fs::path &file) {
     program = readUrlTarget(file);
   }
 
+  const QString display = shellDisplayName(file);
+
   WindowsApplication::Data data;
   data.id = win32AppId(program, info.arguments, info.aumid, file);
-  data.displayName = QString::fromStdWString(file.stem().wstring());
+  data.displayName = display.isEmpty() ? QString::fromStdWString(file.stem().wstring()) : display;
   data.program = program;
   data.arguments = info.arguments;
   data.workingDirectory = info.workingDirectory;
@@ -708,7 +722,6 @@ void WindowsAppDatabase::scanAppPaths() {
     data.shellParsingName = QString::fromStdWString(exe.wstring());
     data.packaged = false;
 
-    // Deduped by id, so this only contributes apps without a Start Menu / Desktop shortcut.
     addApp(std::make_shared<WindowsApplication>(std::move(data)));
   }
 }
@@ -874,8 +887,7 @@ bool WindowsAppDatabase::launchTerminalCommand(const std::vector<QString> &cmdli
   return reinterpret_cast<INT_PTR>(ret) > 32;
 }
 
-// Prefers the scanned app for the same executable, like the XDG provider; synthesizes one only for
-// executables we never scanned (packaged handlers, apps without shortcuts).
+// prefers the scanned app for the same executable, like the XDG provider
 WindowsAppDatabase::AppPtr WindowsAppDatabase::resolveExecutable(const fs::path &exe, const QString &name,
                                                                 const QString &openerExtension) const {
   // registry handler paths can contain doubled separators
@@ -908,7 +920,7 @@ WindowsAppDatabase::AppPtr WindowsAppDatabase::makeShellOpenApp(const QString &t
   const QString friendly = assoc.kind == AssocKind::None ? QString() : friendlyAppName(assoc.value);
   data.id = QStringLiteral("shell-open:") + QString::fromStdWString(assoc.value);
   data.displayName = friendly.isEmpty() ? QStringLiteral("Open") : friendly;
-  data.shellParsingName = target; // icon resolves to the target's type icon
+  data.shellParsingName = target;
   data.shellOpen = true;
   return std::make_shared<WindowsApplication>(std::move(data));
 }

--- a/src/server/src/services/app-service/windows/win-app-database.cpp
+++ b/src/server/src/services/app-service/windows/win-app-database.cpp
@@ -296,6 +296,13 @@ bool shellExecuteOpen(const std::wstring &target, const wchar_t *params = nullpt
   return reinterpret_cast<INT_PTR>(ret) > 32;
 }
 
+bool launchElevated(const std::wstring &target, const std::wstring &params, const std::wstring &workdir) {
+  const HINSTANCE ret =
+      ShellExecuteW(nullptr, L"runas", target.c_str(), params.empty() ? nullptr : params.c_str(),
+                    workdir.empty() ? nullptr : workdir.c_str(), SW_SHOWNORMAL);
+  return reinterpret_cast<INT_PTR>(ret) > 32;
+}
+
 QString fromHString(const winrt::hstring &s) {
   return QString::fromWCharArray(s.c_str(), static_cast<int>(s.size()));
 }
@@ -570,6 +577,9 @@ std::vector<fs::path> WindowsAppDatabase::defaultSearchPaths() const {
 
 void WindowsAppDatabase::addApp(std::shared_ptr<WindowsApplication> app) {
   if (!app || m_appsById.contains(app->id())) return;
+  for (const auto &action : app->actions()) {
+    m_appsById.emplace(action->id(), std::static_pointer_cast<WindowsApplication>(action));
+  }
   m_appsById.emplace(app->id(), app);
   m_apps.emplace_back(std::move(app));
 }
@@ -784,6 +794,10 @@ bool WindowsAppDatabase::launch(const AbstractApplication &app, const std::vecto
         return ok;
       },
       [&](const PackagedApp &packaged) {
+        if (winApp->elevated()) {
+          qInfo() << "Launching elevated" << winApp->shellParsingName();
+          return launchElevated(winApp->shellParsingName().toStdWString(), {}, {});
+        }
         if (args.empty()) {
           qInfo() << "Launching" << winApp->shellParsingName();
           return shellExecuteOpen(winApp->shellParsingName().toStdWString());
@@ -799,6 +813,10 @@ bool WindowsAppDatabase::launch(const AbstractApplication &app, const std::vecto
       },
       [&](const Win32ExeApp &exe) {
         const QString exeStr = toQString(exe.exe);
+        if (winApp->elevated()) {
+          qInfo() << "Launching elevated" << exeStr;
+          return launchElevated(exe.exe.wstring(), joinArgs(args), {});
+        }
         if (!args.empty() && !exe.openerExtension.isEmpty() &&
             invokeAssocHandler(exe.openerExtension.toStdWString(), exeStr, args)) {
           qInfo() << "Invoked assoc handler" << exeStr << "with" << args;
@@ -814,14 +832,23 @@ bool WindowsAppDatabase::launch(const AbstractApplication &app, const std::vecto
       },
       [&](const Win32ShortcutApp &shortcut) {
         // ShellExecute ignores lpParameters for .lnk targets
-        if (!args.empty() && !shortcut.program.isEmpty()) {
+        if (!shortcut.program.isEmpty() && (!args.empty() || winApp->elevated())) {
           std::wstring combined = shortcut.arguments.toStdWString();
-          if (!combined.empty()) combined += L' ';
-          combined += joinArgs(args);
+          if (const std::wstring extra = joinArgs(args); !extra.empty()) {
+            if (!combined.empty()) combined += L' ';
+            combined += extra;
+          }
           const std::wstring workdir = shortcut.workingDirectory.toStdWString();
           qInfo() << "Launching" << shortcut.program << "args" << QString::fromStdWString(combined);
+          if (winApp->elevated()) {
+            return launchElevated(shortcut.program.toStdWString(), combined, workdir);
+          }
           return shellExecuteOpen(shortcut.program.toStdWString(), combined.c_str(),
                                   workdir.empty() ? nullptr : workdir.c_str());
+        }
+        if (winApp->elevated()) {
+          qInfo() << "Launching elevated" << toQString(shortcut.shortcut);
+          return launchElevated(shortcut.shortcut.wstring(), {}, {});
         }
         const std::wstring params = joinArgs(args);
         qInfo() << "Launching" << toQString(shortcut.shortcut) << "args" << QString::fromStdWString(params);

--- a/src/server/src/services/app-service/windows/win-app-database.cpp
+++ b/src/server/src/services/app-service/windows/win-app-database.cpp
@@ -145,7 +145,7 @@ QString win32AppId(const QString &program, const QString &arguments = {}, const 
   return QStringLiteral("win32:") + QString::fromStdWString(shortcut.wstring()).toLower();
 }
 
-QString uwpAppId(const QString &aumid) { return QStringLiteral("uwp:") + aumid; }
+QString uwpAppId(const QString &aumid) { return QStringLiteral("uwp:") + aumid.toLower(); }
 
 QString readUrlTarget(const fs::path &url) {
   wchar_t buf[2048] = {};

--- a/src/server/src/services/app-service/windows/win-app-database.cpp
+++ b/src/server/src/services/app-service/windows/win-app-database.cpp
@@ -163,18 +163,24 @@ QString shellDisplayName(const fs::path &file) {
   return result;
 }
 
-QString win32AppId(const QString &program, const QString &arguments = {}, const QString &aumid = {},
-                   const fs::path &shortcut = {}) {
-  if (!aumid.isEmpty()) return QStringLiteral("win32:aumid:") + aumid.toLower();
-  if (!program.isEmpty()) {
-    QString id = QStringLiteral("win32:") + program.toLower();
-    if (!arguments.isEmpty()) id += QLatin1Char(' ') + arguments.toLower();
+QString appId(const Win32ShortcutApp &app) {
+  if (!app.aumid.isEmpty()) return QStringLiteral("win32:aumid:") + app.aumid.toLower();
+  if (!app.program.isEmpty()) {
+    QString id = QStringLiteral("win32:") + app.program.toLower();
+    if (!app.arguments.isEmpty()) id += QLatin1Char(' ') + app.arguments.toLower();
     return id;
   }
-  return QStringLiteral("win32:") + toQString(shortcut).toLower();
+  return QStringLiteral("win32:") + toQString(app.shortcut).toLower();
 }
 
-QString uwpAppId(const QString &aumid) { return QStringLiteral("uwp:") + aumid.toLower(); }
+QString appId(const UrlShortcutApp &app) {
+  if (!app.url.isEmpty()) return QStringLiteral("win32:") + app.url.toLower();
+  return QStringLiteral("win32:") + toQString(app.shortcut).toLower();
+}
+
+QString appId(const Win32ExeApp &app) { return QStringLiteral("win32:") + toQString(app.exe).toLower(); }
+
+QString appId(const PackagedApp &app) { return QStringLiteral("uwp:") + app.aumid.toLower(); }
 
 QString readUrlTarget(const fs::path &url) {
   wchar_t buf[2048] = {};
@@ -353,24 +359,24 @@ std::wstring joinArgs(const std::vector<QString> &args) {
   return out;
 }
 
-enum class AssocKind { None, Protocol, Extension, Directory };
+enum class AssocKind { Protocol, Extension, Directory };
 struct Assoc {
-  AssocKind kind = AssocKind::None;
+  AssocKind kind;
   std::wstring value; // "http" for a protocol, ".txt" for an extension, "Directory" for a folder
 };
 
-Assoc classifyTarget(const QString &target) {
-  if (target.isEmpty()) return {};
+std::optional<Assoc> classifyTarget(const QString &target) {
+  if (target.isEmpty()) return std::nullopt;
 
   const int schemeSep = target.indexOf(QStringLiteral("://"));
   const bool driveLetter = target.size() >= 2 && target[1] == QLatin1Char(':') && target[0].isLetter();
 
   if (schemeSep > 0) {
     QString scheme = target.left(schemeSep).toLower();
-    if (scheme != QStringLiteral("file")) return {AssocKind::Protocol, scheme.toStdWString()};
+    if (scheme != QStringLiteral("file")) return Assoc{AssocKind::Protocol, scheme.toStdWString()};
   } else if (!driveLetter) {
     if (const int colon = target.indexOf(QLatin1Char(':')); colon > 1) {
-      return {AssocKind::Protocol, target.left(colon).toLower().toStdWString()};
+      return Assoc{AssocKind::Protocol, target.left(colon).toLower().toStdWString()};
     }
   }
 
@@ -379,12 +385,12 @@ Assoc classifyTarget(const QString &target) {
   // a dead UNC host can block for seconds
   std::error_code ec;
   if (!target.startsWith(QLatin1String("\\\\")) && fs::is_directory(path, ec)) {
-    return {AssocKind::Directory, L"Directory"};
+    return Assoc{AssocKind::Directory, L"Directory"};
   }
 
   std::wstring ext = lowerExtension(path);
-  if (ext.empty()) return {};
-  return {AssocKind::Extension, std::move(ext)};
+  if (ext.empty()) return std::nullopt;
+  return Assoc{AssocKind::Extension, std::move(ext)};
 }
 
 std::optional<std::wstring> assocQueryString(ASSOCSTR type, const std::wstring &assoc) {
@@ -461,8 +467,10 @@ bool invokeAssocHandler(const std::wstring &ext, const QString &handlerName,
   ULONG fetched = 0;
   while (handlers->Next(1, &handler, &fetched) == S_OK && fetched == 1) {
     LPWSTR name = nullptr;
-    const bool match = SUCCEEDED(handler->GetName(&name)) && name &&
-                       handlerName.compare(QString::fromWCharArray(name), Qt::CaseInsensitive) == 0;
+    // normalized: we store normalized paths, GetName returns the raw registry value
+    const bool match =
+        SUCCEEDED(handler->GetName(&name)) && name &&
+        handlerName.compare(toQString(fs::path(name).lexically_normal()), Qt::CaseInsensitive) == 0;
     if (name) CoTaskMemFree(name);
     if (!match) continue;
 
@@ -583,44 +591,37 @@ void WindowsAppDatabase::addApp(std::shared_ptr<WindowsApplication> app) {
 
 void WindowsAppDatabase::addShortcut(const fs::path &file) {
   const std::wstring ext = lowerExtension(file);
-  const bool isLnk = ext == L".lnk";
-  const bool isUrl = ext == L".url";
-  const bool isAppRef = ext == L".appref-ms";
-  if (!isLnk && !isUrl && !isAppRef) return;
-
+  if (ext != L".lnk" && ext != L".url" && ext != L".appref-ms") return;
   if (looksLikeUninstaller(file)) return;
 
-  ShortcutInfo info;
-  QString program;
-  if (isLnk) {
-    info = readShortcutInfo(file);
-    if (info.target && looksLikeUninstaller(*info.target)) return;
-    if (isMsiUninstall(info.target, info.arguments)) return;
-    if (!info.aumid.isEmpty() && m_appsById.contains(uwpAppId(info.aumid))) return;
-    if (info.target) program = toQString(*info.target);
-  } else if (isUrl) {
-    program = readUrlTarget(file);
+  WindowsApplication::Data data;
+
+  if (ext == L".url") {
+    UrlShortcutApp link{file, readUrlTarget(file)};
+    data.id = appId(link);
+    if (isGameLauncherUrl(link.url)) {
+      data.category = QStringLiteral("Game");
+    } else if (link.url.startsWith(QLatin1String("http://"), Qt::CaseInsensitive) ||
+               link.url.startsWith(QLatin1String("https://"), Qt::CaseInsensitive)) {
+      data.category = QStringLiteral("Link");
+    }
+    data.kind = std::move(link);
+  } else {
+    ShortcutInfo info;
+    if (ext == L".lnk") {
+      info = readShortcutInfo(file);
+      if (info.target && looksLikeUninstaller(*info.target)) return;
+      if (isMsiUninstall(info.target, info.arguments)) return;
+      if (!info.aumid.isEmpty() && m_appsById.contains(appId(PackagedApp{info.aumid}))) return;
+    }
+    const QString program = info.target ? toQString(*info.target) : QString();
+    Win32ShortcutApp shortcut{file, program, info.arguments, info.workingDirectory, info.aumid};
+    data.id = appId(shortcut);
+    data.kind = std::move(shortcut);
   }
 
   const QString display = shellDisplayName(file);
-
-  WindowsApplication::Data data;
-  data.id = win32AppId(program, info.arguments, info.aumid, file);
   data.displayName = display.isEmpty() ? toQString(file.stem()) : display;
-  data.program = program;
-  data.arguments = info.arguments;
-  data.workingDirectory = info.workingDirectory;
-  data.path = file;
-  data.shellParsingName = toQString(file);
-  data.packaged = false;
-  if (isUrl) {
-    if (isGameLauncherUrl(program)) {
-      data.category = QStringLiteral("Game");
-    } else if (program.startsWith(QLatin1String("http://"), Qt::CaseInsensitive) ||
-               program.startsWith(QLatin1String("https://"), Qt::CaseInsensitive)) {
-      data.category = QStringLiteral("Link");
-    }
-  }
 
   addApp(std::make_shared<WindowsApplication>(std::move(data)));
 }
@@ -687,15 +688,12 @@ void WindowsAppDatabase::scanAppPaths() {
     const QString description = exeFileDescription(exe);
     if (description.isEmpty()) continue;
 
-    const QString exeStr = toQString(exe);
+    Win32ExeApp exeApp{exe};
 
     WindowsApplication::Data data;
-    data.id = win32AppId(exeStr);
+    data.id = appId(exeApp);
     data.displayName = description;
-    data.program = exeStr;
-    data.path = exe;
-    data.shellParsingName = exeStr;
-    data.packaged = false;
+    data.kind = std::move(exeApp);
 
     addApp(std::make_shared<WindowsApplication>(std::move(data)));
   }
@@ -747,13 +745,12 @@ void WindowsAppDatabase::refreshUwpCache() {
         } catch (const winrt::hresult_error &) {}
         if (name.isEmpty()) continue;
 
+        PackagedApp packaged{aumid, installPath};
+
         WindowsApplication::Data data;
-        data.id = uwpAppId(aumid);
+        data.id = appId(packaged);
         data.displayName = name;
-        data.program = aumid;
-        data.path = installPath;
-        data.shellParsingName = QStringLiteral("shell:AppsFolder\\") + aumid;
-        data.packaged = true;
+        data.kind = std::move(packaged);
 
         m_uwpCache.push_back(std::make_shared<WindowsApplication>(std::move(data)));
       }
@@ -789,54 +786,67 @@ bool WindowsAppDatabase::launch(const AbstractApplication &app, const std::vecto
 
   ScopedCom com;
 
-  // only way to open a target whose default handler is a UWP app with no exe
-  if (winApp->opensViaShell()) {
-    if (args.empty()) return false;
-    bool ok = true;
-    for (const auto &target : args) {
-      qInfo() << "Shell-opening" << target;
-      ok = shellExecuteOpen(target.toStdWString()) && ok;
-    }
-    return ok;
-  }
-
-  if (winApp->isPackaged() && !args.empty()) {
-    std::vector<QString> files;
-    std::vector<QString> uris;
-    for (const auto &arg : args) {
-      (classifyTarget(arg).kind == AssocKind::Protocol ? uris : files).emplace_back(arg);
-    }
-    qInfo() << "Activating packaged app" << winApp->program() << "files" << files << "uris" << uris;
-    return activatePackaged(winApp->program().toStdWString(), files, uris);
-  }
-
-  if (!args.empty() && !winApp->openerExtension().isEmpty() &&
-      invokeAssocHandler(winApp->openerExtension().toStdWString(), winApp->program(), args)) {
-    qInfo() << "Invoked assoc handler" << winApp->program() << "with" << args;
-    return true;
-  }
-
-  const std::wstring params = joinArgs(args);
-
-  // ShellExecute ignores lpParameters for .lnk targets
-  if (!args.empty() && !winApp->program().isEmpty() &&
-      classifyTarget(winApp->program()).kind != AssocKind::Protocol) {
-    std::wstring combined = winApp->arguments().toStdWString();
-    if (!combined.empty()) combined += L' ';
-    combined += params;
-    const std::wstring workdir = winApp->workingDirectory().toStdWString();
-    qInfo() << "Launching" << winApp->program() << "args" << QString::fromStdWString(combined);
-    return shellExecuteOpen(winApp->program().toStdWString(), combined.c_str(),
-                            workdir.empty() ? nullptr : workdir.c_str());
-  }
-
-  qInfo() << "Launching" << winApp->shellParsingName() << "args" << QString::fromStdWString(params);
-  if (!shellExecuteOpen(winApp->shellParsingName().toStdWString(),
-                        params.empty() ? nullptr : params.c_str())) {
-    qWarning() << "Failed to launch" << winApp->displayName();
-    return false;
-  }
-  return true;
+  return match(
+      winApp->kind(),
+      // only way to open a target whose default handler is a UWP app with no exe
+      [&](const ShellOpenApp &) {
+        if (args.empty()) return false;
+        bool ok = true;
+        for (const auto &target : args) {
+          qInfo() << "Shell-opening" << target;
+          ok = shellExecuteOpen(target.toStdWString()) && ok;
+        }
+        return ok;
+      },
+      [&](const PackagedApp &packaged) {
+        if (args.empty()) {
+          qInfo() << "Launching" << winApp->shellParsingName();
+          return shellExecuteOpen(winApp->shellParsingName().toStdWString());
+        }
+        std::vector<QString> files;
+        std::vector<QString> uris;
+        for (const auto &arg : args) {
+          const auto assoc = classifyTarget(arg);
+          (assoc && assoc->kind == AssocKind::Protocol ? uris : files).emplace_back(arg);
+        }
+        qInfo() << "Activating packaged app" << packaged.aumid << "files" << files << "uris" << uris;
+        return activatePackaged(packaged.aumid.toStdWString(), files, uris);
+      },
+      [&](const Win32ExeApp &exe) {
+        const QString exeStr = toQString(exe.exe);
+        if (!args.empty() && !exe.openerExtension.isEmpty() &&
+            invokeAssocHandler(exe.openerExtension.toStdWString(), exeStr, args)) {
+          qInfo() << "Invoked assoc handler" << exeStr << "with" << args;
+          return true;
+        }
+        const std::wstring params = joinArgs(args);
+        qInfo() << "Launching" << exeStr << "args" << QString::fromStdWString(params);
+        return shellExecuteOpen(exe.exe.wstring(), params.empty() ? nullptr : params.c_str());
+      },
+      [&](const UrlShortcutApp &link) {
+        qInfo() << "Launching" << toQString(link.shortcut);
+        return shellExecuteOpen(link.shortcut.wstring());
+      },
+      [&](const Win32ShortcutApp &shortcut) {
+        // ShellExecute ignores lpParameters for .lnk targets
+        if (!args.empty() && !shortcut.program.isEmpty()) {
+          std::wstring combined = shortcut.arguments.toStdWString();
+          if (!combined.empty()) combined += L' ';
+          combined += joinArgs(args);
+          const std::wstring workdir = shortcut.workingDirectory.toStdWString();
+          qInfo() << "Launching" << shortcut.program << "args" << QString::fromStdWString(combined);
+          return shellExecuteOpen(shortcut.program.toStdWString(), combined.c_str(),
+                                  workdir.empty() ? nullptr : workdir.c_str());
+        }
+        const std::wstring params = joinArgs(args);
+        qInfo() << "Launching" << toQString(shortcut.shortcut) << "args"
+                << QString::fromStdWString(params);
+        if (!shellExecuteOpen(shortcut.shortcut.wstring(), params.empty() ? nullptr : params.c_str())) {
+          qWarning() << "Failed to launch" << winApp->displayName();
+          return false;
+        }
+        return true;
+      });
 }
 
 bool WindowsAppDatabase::launchTerminalCommand(const std::vector<QString> &cmdline,
@@ -864,56 +874,52 @@ WindowsAppDatabase::AppPtr WindowsAppDatabase::resolveExecutable(const fs::path 
                                                                  const QString &openerExtension) const {
   // registry handler paths can contain doubled separators
   const fs::path normalized = exe.lexically_normal();
-  const auto it = m_appsById.find(win32AppId(toQString(normalized)));
+  const auto it = m_appsById.find(appId(Win32ExeApp{normalized}));
   if (it != m_appsById.end()) return it->second;
   return appForExecutable(normalized, name, openerExtension);
 }
 
 WindowsAppDatabase::AppPtr WindowsAppDatabase::appForExecutable(const fs::path &exe, const QString &name,
                                                                 const QString &openerExtension) const {
-  const QString exeStr = toQString(exe);
+  Win32ExeApp exeApp{exe, openerExtension};
 
   WindowsApplication::Data data;
-  data.id = win32AppId(exeStr);
+  data.id = appId(exeApp);
   data.displayName = name.isEmpty() ? toQString(exe.stem()) : name;
-  data.program = exeStr;
-  data.path = exe;
-  data.shellParsingName = exeStr;
-  data.openerExtension = openerExtension;
-  data.packaged = false;
+  data.kind = std::move(exeApp);
   return std::make_shared<WindowsApplication>(std::move(data));
 }
 
 WindowsAppDatabase::AppPtr WindowsAppDatabase::makeShellOpenApp(const QString &target) const {
-  const Assoc assoc = classifyTarget(target);
+  const auto assoc = classifyTarget(target);
+  const QString assocValue = assoc ? QString::fromStdWString(assoc->value) : QString();
+  const QString friendly = assoc ? friendlyAppName(assoc->value) : QString();
 
   WindowsApplication::Data data;
-  const QString friendly = assoc.kind == AssocKind::None ? QString() : friendlyAppName(assoc.value);
-  data.id = QStringLiteral("shell-open:") + QString::fromStdWString(assoc.value);
+  data.id = QStringLiteral("shell-open:") + assocValue;
   data.displayName = friendly.isEmpty() ? QStringLiteral("Open") : friendly;
-  data.shellParsingName = target;
-  data.shellOpen = true;
+  data.kind = ShellOpenApp{target};
   return std::make_shared<WindowsApplication>(std::move(data));
 }
 
 std::vector<WindowsAppDatabase::AppPtr> WindowsAppDatabase::findOpeners(const Target &target) const {
-  const Assoc assoc = classifyTarget(target);
-  if (assoc.kind == AssocKind::None) return {};
+  const auto assoc = classifyTarget(target);
+  if (!assoc) return {};
 
   ScopedCom com;
   std::vector<AppPtr> result;
 
-  if (assoc.kind == AssocKind::Extension) {
-    const QString ext = QString::fromStdWString(assoc.value);
-    for (auto &[exe, display] : enumExtensionHandlers(assoc.value, ASSOC_FILTER_RECOMMENDED)) {
+  if (assoc->kind == AssocKind::Extension) {
+    const QString ext = QString::fromStdWString(assoc->value);
+    for (auto &[exe, display] : enumExtensionHandlers(assoc->value, ASSOC_FILTER_RECOMMENDED)) {
       result.emplace_back(resolveExecutable(exe, display, ext));
     }
   }
 
-  if (assoc.kind == AssocKind::Directory) {
+  if (assoc->kind == AssocKind::Directory) {
     if (auto browser = fileBrowser()) result.emplace_back(std::move(browser));
-    for (auto &[exe, display] : enumExtensionHandlers(assoc.value, ASSOC_FILTER_NONE)) {
-      auto app = resolveExecutable(exe, display, QString::fromStdWString(assoc.value));
+    for (auto &[exe, display] : enumExtensionHandlers(assoc->value, ASSOC_FILTER_NONE)) {
+      auto app = resolveExecutable(exe, display, QString::fromStdWString(assoc->value));
       const bool dup = std::ranges::any_of(result, [&](const AppPtr &r) { return r->id() == app->id(); });
       if (!dup) result.emplace_back(std::move(app));
     }
@@ -921,8 +927,8 @@ std::vector<WindowsAppDatabase::AppPtr> WindowsAppDatabase::findOpeners(const Ta
 
   // Protocols have no handler enumeration, and UWP handlers expose no exe.
   if (result.empty()) {
-    if (auto exe = defaultHandlerExe(assoc.value))
-      result.emplace_back(resolveExecutable(*exe, friendlyAppName(assoc.value)));
+    if (auto exe = defaultHandlerExe(assoc->value))
+      result.emplace_back(resolveExecutable(*exe, friendlyAppName(assoc->value)));
     else
       result.emplace_back(makeShellOpenApp(target));
   }
@@ -931,12 +937,12 @@ std::vector<WindowsAppDatabase::AppPtr> WindowsAppDatabase::findOpeners(const Ta
 }
 
 WindowsAppDatabase::AppPtr WindowsAppDatabase::findDefaultOpener(const Target &target) const {
-  const Assoc assoc = classifyTarget(target);
-  if (assoc.kind == AssocKind::None) return nullptr;
-  if (assoc.kind == AssocKind::Directory) return fileBrowser();
+  const auto assoc = classifyTarget(target);
+  if (!assoc) return nullptr;
+  if (assoc->kind == AssocKind::Directory) return fileBrowser();
 
   ScopedCom com;
-  if (auto exe = defaultHandlerExe(assoc.value)) return resolveExecutable(*exe, friendlyAppName(assoc.value));
+  if (auto exe = defaultHandlerExe(assoc->value)) return resolveExecutable(*exe, friendlyAppName(assoc->value));
   return makeShellOpenApp(target); // UWP handler: defer to the shell
 }
 

--- a/src/server/src/services/app-service/windows/win-app-database.cpp
+++ b/src/server/src/services/app-service/windows/win-app-database.cpp
@@ -1,0 +1,686 @@
+#include "win-app-database.hpp"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#include <shlobj.h>
+#include <shellapi.h>
+#include <shlwapi.h>
+#include <shobjidl_core.h>
+
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.Storage.h>
+#include <winrt/Windows.Management.Deployment.h>
+#include <winrt/Windows.ApplicationModel.h>
+#include <winrt/Windows.ApplicationModel.Core.h>
+
+#include <QDebug>
+#include <array>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+// Tolerates Qt's existing COM init (S_FALSE) and a foreign apartment mode (RPC_E_CHANGED_MODE).
+class ScopedCom {
+public:
+  ScopedCom() {
+    const HRESULT hr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+    m_owns = hr == S_OK || hr == S_FALSE;
+  }
+  ~ScopedCom() {
+    if (m_owns) CoUninitialize();
+  }
+  ScopedCom(const ScopedCom &) = delete;
+  ScopedCom &operator=(const ScopedCom &) = delete;
+
+private:
+  bool m_owns = false;
+};
+
+std::optional<fs::path> knownFolder(REFKNOWNFOLDERID id) {
+  PWSTR raw = nullptr;
+  const HRESULT hr = SHGetKnownFolderPath(id, KF_FLAG_DEFAULT, nullptr, &raw);
+  std::optional<fs::path> result;
+  if (SUCCEEDED(hr) && raw) result = fs::path(raw);
+  if (raw) CoTaskMemFree(raw);
+  return result;
+}
+
+// Reads the stored target without IShellLink::Resolve, which can block on the network. Returns
+// nullopt for shortcuts backed by a PIDL rather than a filesystem path (AppsFolder, Control Panel).
+std::optional<fs::path> readShortcutTarget(const fs::path &lnk) {
+  IShellLinkW *link = nullptr;
+  if (FAILED(CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&link)))) {
+    return std::nullopt;
+  }
+
+  std::optional<fs::path> result;
+
+  IPersistFile *persist = nullptr;
+  if (SUCCEEDED(link->QueryInterface(IID_PPV_ARGS(&persist)))) {
+    if (SUCCEEDED(persist->Load(lnk.wstring().c_str(), STGM_READ))) {
+      wchar_t buf[MAX_PATH] = {};
+      WIN32_FIND_DATAW find = {};
+      if (SUCCEEDED(link->GetPath(buf, MAX_PATH, &find, 0)) && buf[0] != L'\0') {
+        result = fs::path(buf);
+      }
+    }
+    persist->Release();
+  }
+
+  link->Release();
+  return result;
+}
+
+QString readUrlTarget(const fs::path &url) {
+  wchar_t buf[2048] = {};
+  GetPrivateProfileStringW(L"InternetShortcut", L"URL", L"", buf, 2048, url.wstring().c_str());
+  return QString::fromWCharArray(buf);
+}
+
+bool isGameLauncherUrl(const QString &url) {
+  static constexpr std::array schemes = {"steam:",   "com.epicgames.launcher:",
+                                         "goggalaxy:", "uplay:",
+                                         "ubisoft:",  "battlenet:",
+                                         "origin:",   "link2ea:",
+                                         "amazon-games:"};
+  const QString lower = url.toLower();
+  return std::ranges::any_of(schemes,
+                             [&](const char *s) { return lower.startsWith(QLatin1String(s)); });
+}
+
+bool looksLikeUninstaller(const fs::path &target) {
+  auto name = target.filename().wstring();
+  for (auto &c : name)
+    c = static_cast<wchar_t>(::towlower(c));
+  return name.find(L"unins") != std::wstring::npos;
+}
+
+std::wstring lowerExtension(const fs::path &p) {
+  auto ext = p.extension().wstring();
+  for (auto &c : ext)
+    c = static_cast<wchar_t>(::towlower(c));
+  return ext;
+}
+
+std::optional<fs::path> readAppPathValue(HKEY appPathsKey, const std::wstring &subName) {
+  HKEY sub = nullptr;
+  if (RegOpenKeyExW(appPathsKey, subName.c_str(), 0, KEY_READ, &sub) != ERROR_SUCCESS) {
+    return std::nullopt;
+  }
+
+  std::optional<fs::path> result;
+  wchar_t buf[1024] = {};
+  DWORD cb = sizeof(buf);
+  DWORD type = 0;
+  if (RegQueryValueExW(sub, nullptr, nullptr, &type, reinterpret_cast<LPBYTE>(buf), &cb) ==
+          ERROR_SUCCESS &&
+      (type == REG_SZ || type == REG_EXPAND_SZ)) {
+    std::wstring value(buf, cb / sizeof(wchar_t));
+    while (!value.empty() && (value.back() == L'\0')) value.pop_back();
+    if (value.size() >= 2 && value.front() == L'"' && value.back() == L'"') {
+      value = value.substr(1, value.size() - 2);
+    }
+    if (!value.empty()) {
+      wchar_t expanded[1024] = {};
+      const DWORD n = ExpandEnvironmentStringsW(value.c_str(), expanded, 1024);
+      result = fs::path((n > 0 && n <= 1024) ? std::wstring(expanded, n - 1) : value);
+    }
+  }
+
+  RegCloseKey(sub);
+  return result;
+}
+
+std::vector<fs::path> enumerateAppPaths() {
+  std::vector<fs::path> result;
+  static constexpr const wchar_t *kSubKey =
+      L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths";
+
+  auto readHive = [&](HKEY root, REGSAM extraSam) {
+    HKEY key = nullptr;
+    if (RegOpenKeyExW(root, kSubKey, 0, KEY_READ | extraSam, &key) != ERROR_SUCCESS) return;
+
+    for (DWORD i = 0;; ++i) {
+      wchar_t nameBuf[256];
+      DWORD nameLen = 256;
+      const LONG r = RegEnumKeyExW(key, i, nameBuf, &nameLen, nullptr, nullptr, nullptr, nullptr);
+      if (r != ERROR_SUCCESS) break;
+      if (auto exe = readAppPathValue(key, std::wstring(nameBuf, nameLen))) {
+        result.emplace_back(std::move(*exe));
+      }
+    }
+
+    RegCloseKey(key);
+  };
+
+  readHive(HKEY_LOCAL_MACHINE, KEY_WOW64_64KEY);
+  readHive(HKEY_LOCAL_MACHINE, KEY_WOW64_32KEY);
+  readHive(HKEY_CURRENT_USER, 0);
+  return result;
+}
+
+bool shellExecuteOpen(const std::wstring &target, const wchar_t *params = nullptr) {
+  const HINSTANCE ret =
+      ShellExecuteW(nullptr, L"open", target.c_str(), params, nullptr, SW_SHOWNORMAL);
+  return reinterpret_cast<INT_PTR>(ret) > 32;
+}
+
+QString fromHString(const winrt::hstring &s) {
+  return QString::fromWCharArray(s.c_str(), static_cast<int>(s.size()));
+}
+
+std::wstring quoteArg(const QString &arg) {
+  std::wstring w = arg.toStdWString();
+  if (w.find_first_of(L" \t") == std::wstring::npos) return w;
+  return L"\"" + w + L"\"";
+}
+
+std::wstring joinArgs(const std::vector<QString> &args) {
+  std::wstring out;
+  for (size_t i = 0; i < args.size(); ++i) {
+    if (i) out += L' ';
+    out += quoteArg(args[i]);
+  }
+  return out;
+}
+
+enum class AssocKind { None, Protocol, Extension };
+struct Assoc {
+  AssocKind kind = AssocKind::None;
+  std::wstring value; // "http" for a protocol, ".txt" for an extension
+};
+
+Assoc classifyTarget(const QString &target) {
+  if (target.isEmpty()) return {};
+
+  const int schemeSep = target.indexOf(QStringLiteral("://"));
+  const bool driveLetter =
+      target.size() >= 2 && target[1] == QLatin1Char(':') && target[0].isLetter();
+
+  if (schemeSep > 0) {
+    QString scheme = target.left(schemeSep).toLower();
+    if (scheme != QStringLiteral("file")) return {AssocKind::Protocol, scheme.toStdWString()};
+  } else if (!driveLetter) {
+    if (const int colon = target.indexOf(QLatin1Char(':')); colon > 1) {
+      return {AssocKind::Protocol, target.left(colon).toLower().toStdWString()};
+    }
+  }
+
+  std::wstring ext = fs::path(target.toStdWString()).extension().wstring();
+  if (ext.empty()) return {};
+  for (auto &c : ext)
+    c = static_cast<wchar_t>(::towlower(c));
+  return {AssocKind::Extension, std::move(ext)};
+}
+
+QString friendlyAppName(const std::wstring &assoc) {
+  wchar_t buf[512];
+  DWORD len = 512;
+  if (SUCCEEDED(AssocQueryStringW(ASSOCF_NONE, ASSOCSTR_FRIENDLYAPPNAME, assoc.c_str(), nullptr, buf,
+                                  &len)) &&
+      len > 1) {
+    return QString::fromWCharArray(buf, len - 1);
+  }
+  return {};
+}
+
+std::optional<fs::path> defaultHandlerExe(const std::wstring &assoc) {
+  wchar_t buf[1024];
+  DWORD len = 1024;
+  const HRESULT hr =
+      AssocQueryStringW(ASSOCF_NONE, ASSOCSTR_EXECUTABLE, assoc.c_str(), nullptr, buf, &len);
+  if (SUCCEEDED(hr) && len > 1) return fs::path(std::wstring(buf, len - 1));
+  return std::nullopt;
+}
+
+std::vector<std::pair<fs::path, QString>> enumExtensionHandlers(const std::wstring &ext) {
+  std::vector<std::pair<fs::path, QString>> result;
+
+  IEnumAssocHandlers *handlers = nullptr;
+  if (FAILED(SHAssocEnumHandlers(ext.c_str(), ASSOC_FILTER_RECOMMENDED, &handlers)) || !handlers) {
+    return result;
+  }
+
+  IAssocHandler *handler = nullptr;
+  ULONG fetched = 0;
+  while (handlers->Next(1, &handler, &fetched) == S_OK && fetched == 1) {
+    LPWSTR path = nullptr;
+    LPWSTR ui = nullptr;
+    if (SUCCEEDED(handler->GetName(&path)) && path) {
+      QString display;
+      if (SUCCEEDED(handler->GetUIName(&ui)) && ui) display = QString::fromWCharArray(ui);
+      result.emplace_back(fs::path(path), display);
+    }
+    if (path) CoTaskMemFree(path);
+    if (ui) CoTaskMemFree(ui);
+    handler->Release();
+    handler = nullptr;
+  }
+
+  handlers->Release();
+  return result;
+}
+
+// Packaged apps never receive argv; a document is handed over through activation instead.
+bool activatePackagedForFiles(const std::wstring &aumid, const std::vector<QString> &files) {
+  IApplicationActivationManager *manager = nullptr;
+  if (FAILED(CoCreateInstance(CLSID_ApplicationActivationManager, nullptr, CLSCTX_INPROC_SERVER,
+                              IID_PPV_ARGS(&manager))) ||
+      !manager) {
+    return false;
+  }
+
+  std::vector<PIDLIST_ABSOLUTE> pidls;
+  for (const auto &file : files) {
+    IShellItem *item = nullptr;
+    if (SUCCEEDED(SHCreateItemFromParsingName(file.toStdWString().c_str(), nullptr,
+                                              IID_PPV_ARGS(&item))) &&
+        item) {
+      PIDLIST_ABSOLUTE pidl = nullptr;
+      if (SUCCEEDED(SHGetIDListFromObject(item, &pidl))) pidls.push_back(pidl);
+      item->Release();
+    }
+  }
+
+  bool ok = false;
+  IShellItemArray *array = nullptr;
+  if (!pidls.empty() &&
+      SUCCEEDED(SHCreateShellItemArrayFromIDLists(static_cast<UINT>(pidls.size()),
+                                                  const_cast<PCIDLIST_ABSOLUTE *>(pidls.data()),
+                                                  &array))) {
+    DWORD pid = 0;
+    ok = SUCCEEDED(manager->ActivateForFile(aumid.c_str(), array, L"open", &pid));
+    array->Release();
+  }
+
+  for (auto *pidl : pidls)
+    CoTaskMemFree(pidl);
+  manager->Release();
+  return ok;
+}
+
+// SearchPathW also resolves App Execution Aliases such as wt.exe.
+std::optional<fs::path> searchExecutable(const wchar_t *name) {
+  wchar_t buf[MAX_PATH];
+  const DWORD n = SearchPathW(nullptr, name, nullptr, MAX_PATH, buf, nullptr);
+  if (n > 0 && n < MAX_PATH) return fs::path(std::wstring(buf, n));
+  return std::nullopt;
+}
+
+} // namespace
+
+WindowsAppDatabase::WindowsAppDatabase() { scan(defaultSearchPaths()); }
+
+std::vector<fs::path> WindowsAppDatabase::defaultSearchPaths() const {
+  std::vector<fs::path> paths;
+  if (auto common = knownFolder(FOLDERID_CommonPrograms)) paths.emplace_back(std::move(*common));
+  if (auto user = knownFolder(FOLDERID_Programs)) paths.emplace_back(std::move(*user));
+  return paths;
+}
+
+void WindowsAppDatabase::addApp(std::shared_ptr<WindowsApplication> app) {
+  if (!app || m_appsById.contains(app->id())) return;
+  m_appsById.emplace(app->id(), app);
+  m_apps.emplace_back(std::move(app));
+}
+
+void WindowsAppDatabase::addShortcut(const fs::path &file) {
+  const std::wstring ext = lowerExtension(file);
+  const bool isLnk = ext == L".lnk";
+  const bool isUrl = ext == L".url";
+  const bool isAppRef = ext == L".appref-ms";
+  if (!isLnk && !isUrl && !isAppRef) return;
+
+  QString program; // .lnk: target exe. .url: target URL.
+  if (isLnk) {
+    auto target = readShortcutTarget(file);
+    if (target && looksLikeUninstaller(*target)) return;
+    if (target) program = QString::fromStdWString(target->wstring());
+  } else if (isUrl) {
+    program = readUrlTarget(file);
+  }
+
+  // Key on the target when known so the same app in Start Menu + Desktop collapses; otherwise
+  // fall back to the shortcut path.
+  const QString idBase = program.isEmpty() ? QString::fromStdWString(file.wstring()) : program;
+
+  WindowsApplication::Data data;
+  data.id = QStringLiteral("win32:") + idBase.toLower();
+  data.displayName = QString::fromStdWString(file.stem().wstring());
+  data.program = program;
+  data.path = file;
+  data.shellParsingName = QString::fromStdWString(file.wstring());
+  data.packaged = false;
+  data.game = isUrl && isGameLauncherUrl(program);
+
+  addApp(std::make_shared<WindowsApplication>(std::move(data)));
+}
+
+void WindowsAppDatabase::scanWin32(const std::vector<fs::path> &paths) {
+  for (const auto &root : paths) {
+    std::error_code ec;
+    if (!fs::is_directory(root, ec)) continue;
+
+    fs::recursive_directory_iterator it(root, fs::directory_options::skip_permission_denied, ec);
+    const fs::recursive_directory_iterator end;
+    if (ec) continue;
+
+    for (; it != end; it.increment(ec)) {
+      if (ec) {
+        ec.clear();
+        continue;
+      }
+      if (it->is_regular_file(ec)) addShortcut(it->path());
+    }
+  }
+}
+
+void WindowsAppDatabase::scanDesktop() {
+  std::vector<fs::path> roots;
+  if (auto user = knownFolder(FOLDERID_Desktop)) roots.emplace_back(std::move(*user));
+  if (auto common = knownFolder(FOLDERID_PublicDesktop)) roots.emplace_back(std::move(*common));
+
+  // Non-recursive: we want top-level shortcuts, not to descend into folders sitting on the Desktop.
+  for (const auto &root : roots) {
+    std::error_code ec;
+    if (!fs::is_directory(root, ec)) continue;
+
+    fs::directory_iterator it(root, fs::directory_options::skip_permission_denied, ec);
+    const fs::directory_iterator end;
+    if (ec) continue;
+
+    for (; it != end; it.increment(ec)) {
+      if (ec) {
+        ec.clear();
+        continue;
+      }
+      if (it->is_regular_file(ec)) addShortcut(it->path());
+    }
+  }
+}
+
+void WindowsAppDatabase::scanAppPaths() {
+  for (const auto &exe : enumerateAppPaths()) {
+    std::error_code ec;
+    if (!fs::exists(exe, ec) || looksLikeUninstaller(exe)) continue;
+
+    WindowsApplication::Data data;
+    data.id = QStringLiteral("win32:") + QString::fromStdWString(exe.wstring()).toLower();
+    data.displayName = QString::fromStdWString(exe.stem().wstring());
+    data.program = QString::fromStdWString(exe.wstring());
+    data.path = exe;
+    data.shellParsingName = QString::fromStdWString(exe.wstring());
+    data.packaged = false;
+
+    // Deduped by id, so this only contributes apps without a Start Menu / Desktop shortcut.
+    addApp(std::make_shared<WindowsApplication>(std::move(data)));
+  }
+}
+
+void WindowsAppDatabase::scanUwp() {
+  using namespace winrt::Windows::Management::Deployment;
+  using namespace winrt::Windows::ApplicationModel;
+
+  PackageManager manager{nullptr};
+  winrt::Windows::Foundation::Collections::IIterable<Package> packages{nullptr};
+
+  try {
+    manager = PackageManager();
+    packages = manager.FindPackagesForUser(winrt::hstring{}); // empty SID = current user
+  } catch (const winrt::hresult_error &e) {
+    qWarning() << "[win-app-db] PackageManager query failed:" << fromHString(e.message());
+    return;
+  }
+
+  for (const auto &pkg : packages) {
+    try {
+      if (pkg.IsFramework() || pkg.IsResourcePackage()) continue;
+
+      fs::path installPath;
+      try {
+        installPath = fs::path(std::wstring(pkg.InstalledLocation().Path()));
+      } catch (const winrt::hresult_error &) {
+        // no accessible install location; not fatal
+      }
+
+      // GetAppListEntries yields exactly the launchable, user-visible entries.
+      for (const auto &entry : pkg.GetAppListEntries()) {
+        const QString aumid = fromHString(entry.AppUserModelId());
+        if (aumid.isEmpty()) continue;
+
+        QString name;
+        try {
+          name = fromHString(entry.DisplayInfo().DisplayName());
+        } catch (const winrt::hresult_error &) {
+        }
+        if (name.isEmpty()) continue;
+
+        WindowsApplication::Data data;
+        data.id = QStringLiteral("uwp:") + aumid;
+        data.displayName = name;
+        data.program = aumid;
+        data.path = installPath;
+        data.shellParsingName = QStringLiteral("shell:AppsFolder\\") + aumid;
+        data.packaged = true;
+
+        addApp(std::make_shared<WindowsApplication>(std::move(data)));
+      }
+    } catch (const winrt::hresult_error &) {
+      // skip a single bad package rather than aborting the scan
+    }
+  }
+}
+
+bool WindowsAppDatabase::scan(const std::vector<fs::path> &paths) {
+  m_apps.clear();
+  m_appsById.clear();
+
+  ScopedCom com;
+  scanWin32(paths);
+  scanDesktop();
+  scanAppPaths();
+  scanUwp();
+
+  return !m_apps.empty();
+}
+
+bool WindowsAppDatabase::launch(const AbstractApplication &app, const std::vector<QString> &args) const {
+  const auto *winApp = dynamic_cast<const WindowsApplication *>(&app);
+  if (!winApp) return false;
+
+  ScopedCom com;
+
+  // Let the shell pick the default handler; the only way to open a target whose handler is a pure
+  // UWP app (e.g. Photos for images), which exposes no executable.
+  if (winApp->opensViaShell()) {
+    if (args.empty()) return false;
+    bool ok = true;
+    for (const auto &target : args)
+      ok = shellExecuteOpen(target.toStdWString()) && ok;
+    return ok;
+  }
+
+  if (winApp->isPackaged() && !args.empty()) {
+    const bool allFiles = std::ranges::none_of(
+        args, [](const QString &a) { return a.contains(QStringLiteral("://")); });
+    if (allFiles) {
+      if (activatePackagedForFiles(winApp->program().toStdWString(), args)) return true;
+      bool ok = true;
+      for (const auto &target : args)
+        ok = shellExecuteOpen(target.toStdWString()) && ok;
+      return ok;
+    }
+  }
+
+  const std::wstring params = joinArgs(args);
+  if (!shellExecuteOpen(winApp->shellParsingName().toStdWString(),
+                        params.empty() ? nullptr : params.c_str())) {
+    qWarning() << "Failed to launch" << winApp->displayName();
+    return false;
+  }
+  return true;
+}
+
+bool WindowsAppDatabase::launchTerminalCommand(const std::vector<QString> &cmdline,
+                                               const LaunchTerminalCommandOptions &opts) const {
+  if (cmdline.empty()) return false;
+
+  // cmd.exe is always present and gives us /k (hold) vs /c plus a working directory.
+  std::wstring comspec = L"cmd.exe";
+  if (const wchar_t *env = _wgetenv(L"ComSpec"); env && *env) comspec = env;
+
+  std::wstring inner;
+  if (opts.title) inner += L"title " + opts.title->toStdWString() + L" & ";
+  inner += joinArgs(cmdline);
+
+  const std::wstring params = (opts.hold ? L"/k " : L"/c ") + inner;
+  const std::wstring workdir =
+      opts.workingDirectory ? opts.workingDirectory->toStdWString() : std::wstring();
+
+  ScopedCom com;
+  const HINSTANCE ret = ShellExecuteW(nullptr, L"open", comspec.c_str(), params.c_str(),
+                                      workdir.empty() ? nullptr : workdir.c_str(), SW_SHOWNORMAL);
+  return reinterpret_cast<INT_PTR>(ret) > 32;
+}
+
+WindowsAppDatabase::AppPtr WindowsAppDatabase::appForExecutable(const fs::path &exe,
+                                                               const QString &name) const {
+  const QString exeStr = QString::fromStdWString(exe.wstring());
+
+  WindowsApplication::Data data;
+  data.id = QStringLiteral("win32:") + exeStr.toLower();
+  data.displayName = name.isEmpty() ? QString::fromStdWString(exe.stem().wstring()) : name;
+  data.program = exeStr;
+  data.path = exe;
+  data.shellParsingName = exeStr;
+  data.packaged = false;
+  return std::make_shared<WindowsApplication>(std::move(data));
+}
+
+WindowsAppDatabase::AppPtr WindowsAppDatabase::makeShellOpenApp(const QString &target) const {
+  const Assoc assoc = classifyTarget(target);
+
+  WindowsApplication::Data data;
+  const QString friendly = assoc.kind == AssocKind::None ? QString() : friendlyAppName(assoc.value);
+  data.id = QStringLiteral("shell-open:") + QString::fromStdWString(assoc.value);
+  data.displayName = friendly.isEmpty() ? QStringLiteral("Open") : friendly;
+  data.shellParsingName = target; // icon resolves to the target's type icon
+  data.shellOpen = true;
+  return std::make_shared<WindowsApplication>(std::move(data));
+}
+
+std::vector<WindowsAppDatabase::AppPtr> WindowsAppDatabase::findOpeners(const Target &target) const {
+  const Assoc assoc = classifyTarget(target);
+  if (assoc.kind == AssocKind::None) return {};
+
+  ScopedCom com;
+  std::vector<AppPtr> result;
+
+  if (assoc.kind == AssocKind::Extension) {
+    for (auto &[exe, display] : enumExtensionHandlers(assoc.value)) {
+      result.emplace_back(appForExecutable(exe, display));
+    }
+  }
+
+  // Protocols have no handler enumeration, and UWP handlers expose no exe.
+  if (result.empty()) {
+    if (auto exe = defaultHandlerExe(assoc.value))
+      result.emplace_back(appForExecutable(*exe, friendlyAppName(assoc.value)));
+    else
+      result.emplace_back(makeShellOpenApp(target));
+  }
+
+  return result;
+}
+
+WindowsAppDatabase::AppPtr WindowsAppDatabase::findDefaultOpener(const Target &target) const {
+  const Assoc assoc = classifyTarget(target);
+  if (assoc.kind == AssocKind::None) return nullptr;
+
+  ScopedCom com;
+  if (auto exe = defaultHandlerExe(assoc.value))
+    return appForExecutable(*exe, friendlyAppName(assoc.value));
+  return makeShellOpenApp(target); // UWP handler: defer to the shell
+}
+
+WindowsAppDatabase::AppPtr WindowsAppDatabase::findById(const QString &id) const {
+  if (auto it = m_appsById.find(id); it != m_appsById.end()) return it->second;
+  return nullptr;
+}
+
+std::vector<WindowsAppDatabase::AppPtr> WindowsAppDatabase::list() const {
+  return {m_apps.begin(), m_apps.end()};
+}
+
+WindowsAppDatabase::AppPtr WindowsAppDatabase::findByClass(const QString &) const { return nullptr; }
+
+WindowsAppDatabase::AppPtr WindowsAppDatabase::fileBrowser() const {
+  ScopedCom com;
+  fs::path explorer;
+  if (const wchar_t *windir = _wgetenv(L"WINDIR"); windir && *windir) {
+    explorer = fs::path(windir) / L"explorer.exe";
+  } else if (auto found = searchExecutable(L"explorer.exe")) {
+    explorer = *found;
+  } else {
+    return nullptr;
+  }
+  return appForExecutable(explorer, QStringLiteral("File Explorer"));
+}
+
+WindowsAppDatabase::AppPtr WindowsAppDatabase::genericTextEditor() const {
+  ScopedCom com;
+  if (auto exe = defaultHandlerExe(L".txt")) return appForExecutable(*exe, friendlyAppName(L".txt"));
+  if (auto notepad = searchExecutable(L"notepad.exe")) return appForExecutable(*notepad, {});
+  return nullptr;
+}
+
+WindowsAppDatabase::AppPtr WindowsAppDatabase::webBrowser() const {
+  ScopedCom com;
+  if (auto exe = defaultHandlerExe(L"http")) return appForExecutable(*exe, friendlyAppName(L"http"));
+  return nullptr;
+}
+
+WindowsAppDatabase::AppPtr WindowsAppDatabase::terminalEmulator() const {
+  ScopedCom com;
+  if (auto wt = searchExecutable(L"wt.exe")) return appForExecutable(*wt, QStringLiteral("Terminal"));
+  fs::path comspec = L"cmd.exe";
+  if (const wchar_t *env = _wgetenv(L"ComSpec"); env && *env) comspec = env;
+  return appForExecutable(comspec, QStringLiteral("Command Prompt"));
+}
+
+bool WindowsAppDatabase::showInFileBrowser(const fs::path &path, bool select) const {
+  std::error_code ec;
+  fs::path target = path;
+  bool reveal = select;
+
+  if (!fs::exists(target, ec)) {
+    target = target.parent_path();
+    reveal = false;
+    if (target.empty()) return false;
+  }
+
+  ScopedCom com;
+
+  if (reveal) {
+    const std::wstring params = L"/select,\"" + target.wstring() + L"\"";
+    return shellExecuteOpen(L"explorer.exe", params.c_str());
+  }
+
+  return shellExecuteOpen(target.wstring());
+}
+
+bool WindowsAppDatabase::openLocation(const AbstractApplication &app) const {
+  return showInFileBrowser(app.path(), true);
+}
+
+WindowsAppDatabase::AppPtr WindowsAppDatabase::locationOpener(const AbstractApplication &) const {
+  return nullptr;
+}

--- a/src/server/src/services/app-service/windows/win-app-database.hpp
+++ b/src/server/src/services/app-service/windows/win-app-database.hpp
@@ -3,8 +3,11 @@
 #include "win-app.hpp"
 #include <QFileSystemWatcher>
 #include <QString>
+#include <QTimer>
+#include <atomic>
 #include <memory>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 struct UwpPackageWatcher;
@@ -41,6 +44,8 @@ private:
   void scanDesktop();                                              // non-recursive
   void scanAppPaths();
   void scanUwp();
+  void refreshUwpCache();
+  void installWatches();
   void addShortcut(const std::filesystem::path &file);
   void addApp(std::shared_ptr<WindowsApplication> app);
 
@@ -54,5 +59,10 @@ private:
   std::vector<std::shared_ptr<WindowsApplication>> m_apps;
   std::unordered_map<QString, std::shared_ptr<WindowsApplication>> m_appsById;
   std::unique_ptr<UwpPackageWatcher> m_uwpWatcher;
-  QFileSystemWatcher m_desktopWatcher;
+  std::vector<std::shared_ptr<WindowsApplication>> m_uwpCache;
+  std::atomic<bool> m_uwpDirty = true; // set from WinRT event threads
+  std::unordered_set<QString> m_watchDirs;
+  QFileSystemWatcher m_watcher;
+  QTimer m_rescanTimer; // App Paths (registry) has no watcher
+
 };

--- a/src/server/src/services/app-service/windows/win-app-database.hpp
+++ b/src/server/src/services/app-service/windows/win-app-database.hpp
@@ -1,0 +1,48 @@
+#pragma once
+#include "services/app-service/abstract-app-db.hpp"
+#include "win-app.hpp"
+#include <QString>
+#include <unordered_map>
+#include <vector>
+
+// App provider merging two tracks: Win32 shortcuts/registry and packaged apps (WinRT PackageManager).
+class WindowsAppDatabase : public AbstractAppDatabase {
+public:
+  WindowsAppDatabase();
+
+  std::vector<std::filesystem::path> defaultSearchPaths() const override;
+  bool scan(const std::vector<std::filesystem::path> &paths) override;
+
+  bool launch(const AbstractApplication &exec, const std::vector<QString> &args = {}) const override;
+  bool launchTerminalCommand(const std::vector<QString> &cmdline,
+                             const LaunchTerminalCommandOptions &opts = {}) const override;
+
+  std::vector<AppPtr> findOpeners(const Target &target) const override;
+  AppPtr findDefaultOpener(const Target &target) const override;
+  AppPtr findById(const QString &id) const override;
+  std::vector<AppPtr> list() const override;
+  AppPtr findByClass(const QString &name) const override;
+
+  AppPtr fileBrowser() const override;
+  AppPtr genericTextEditor() const override;
+  AppPtr webBrowser() const override;
+  AppPtr terminalEmulator() const override;
+  bool showInFileBrowser(const std::filesystem::path &path, bool select) const override;
+  bool openLocation(const AbstractApplication &app) const override;
+  AppPtr locationOpener(const AbstractApplication &app) const override;
+
+private:
+  void scanWin32(const std::vector<std::filesystem::path> &paths); // recursive
+  void scanDesktop();                                              // non-recursive
+  void scanAppPaths();
+  void scanUwp();
+  void addShortcut(const std::filesystem::path &file);
+  void addApp(std::shared_ptr<WindowsApplication> app);
+
+  AppPtr appForExecutable(const std::filesystem::path &exe, const QString &name) const;
+
+  AppPtr makeShellOpenApp(const QString &target) const;
+
+  std::vector<std::shared_ptr<WindowsApplication>> m_apps;
+  std::unordered_map<QString, std::shared_ptr<WindowsApplication>> m_appsById;
+};

--- a/src/server/src/services/app-service/windows/win-app-database.hpp
+++ b/src/server/src/services/app-service/windows/win-app-database.hpp
@@ -64,5 +64,4 @@ private:
   std::unordered_set<QString> m_watchDirs;
   QFileSystemWatcher m_watcher;
   QTimer m_rescanTimer;
-
 };

--- a/src/server/src/services/app-service/windows/win-app-database.hpp
+++ b/src/server/src/services/app-service/windows/win-app-database.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "services/app-service/abstract-app-db.hpp"
 #include "win-app.hpp"
+#include <QFileSystemWatcher>
 #include <QString>
 #include <memory>
 #include <unordered_map>
@@ -53,4 +54,5 @@ private:
   std::vector<std::shared_ptr<WindowsApplication>> m_apps;
   std::unordered_map<QString, std::shared_ptr<WindowsApplication>> m_appsById;
   std::unique_ptr<UwpPackageWatcher> m_uwpWatcher;
+  QFileSystemWatcher m_desktopWatcher;
 };

--- a/src/server/src/services/app-service/windows/win-app-database.hpp
+++ b/src/server/src/services/app-service/windows/win-app-database.hpp
@@ -2,13 +2,17 @@
 #include "services/app-service/abstract-app-db.hpp"
 #include "win-app.hpp"
 #include <QString>
+#include <memory>
 #include <unordered_map>
 #include <vector>
+
+struct UwpPackageWatcher;
 
 // App provider merging two tracks: Win32 shortcuts/registry and packaged apps (WinRT PackageManager).
 class WindowsAppDatabase : public AbstractAppDatabase {
 public:
   WindowsAppDatabase();
+  ~WindowsAppDatabase() override;
 
   std::vector<std::filesystem::path> defaultSearchPaths() const override;
   bool scan(const std::vector<std::filesystem::path> &paths) override;
@@ -45,4 +49,5 @@ private:
 
   std::vector<std::shared_ptr<WindowsApplication>> m_apps;
   std::unordered_map<QString, std::shared_ptr<WindowsApplication>> m_appsById;
+  std::unique_ptr<UwpPackageWatcher> m_uwpWatcher;
 };

--- a/src/server/src/services/app-service/windows/win-app-database.hpp
+++ b/src/server/src/services/app-service/windows/win-app-database.hpp
@@ -43,7 +43,10 @@ private:
   void addShortcut(const std::filesystem::path &file);
   void addApp(std::shared_ptr<WindowsApplication> app);
 
-  AppPtr appForExecutable(const std::filesystem::path &exe, const QString &name) const;
+  AppPtr appForExecutable(const std::filesystem::path &exe, const QString &name,
+                          const QString &openerExtension = {}) const;
+  AppPtr resolveExecutable(const std::filesystem::path &exe, const QString &name,
+                           const QString &openerExtension = {}) const;
 
   AppPtr makeShellOpenApp(const QString &target) const;
 

--- a/src/server/src/services/app-service/windows/win-app-database.hpp
+++ b/src/server/src/services/app-service/windows/win-app-database.hpp
@@ -63,6 +63,6 @@ private:
   std::atomic<bool> m_uwpDirty = true; // set from WinRT event threads
   std::unordered_set<QString> m_watchDirs;
   QFileSystemWatcher m_watcher;
-  QTimer m_rescanTimer; // App Paths (registry) has no watcher
+  QTimer m_rescanTimer;
 
 };

--- a/src/server/src/services/app-service/windows/win-app.hpp
+++ b/src/server/src/services/app-service/windows/win-app.hpp
@@ -34,8 +34,7 @@ struct ShellOpenApp {
   QString target;
 };
 
-using WindowsAppKind =
-    std::variant<Win32ShortcutApp, UrlShortcutApp, Win32ExeApp, PackagedApp, ShellOpenApp>;
+using WindowsAppKind = std::variant<Win32ShortcutApp, UrlShortcutApp, Win32ExeApp, PackagedApp, ShellOpenApp>;
 
 class WindowsApplication : public AbstractApplication {
 public:
@@ -66,16 +65,14 @@ public:
   std::filesystem::path path() const override {
     return match(
         m_data.kind, [](const Win32ShortcutApp &s) { return s.shortcut; },
-        [](const UrlShortcutApp &u) { return u.shortcut; },
-        [](const Win32ExeApp &e) { return e.exe; },
+        [](const UrlShortcutApp &u) { return u.shortcut; }, [](const Win32ExeApp &e) { return e.exe; },
         [](const PackagedApp &p) { return p.installLocation; },
         [](const ShellOpenApp &) { return std::filesystem::path(); });
   }
 
   QString shellParsingName() const {
     return match(
-        m_data.kind,
-        [](const Win32ShortcutApp &s) { return QString::fromStdWString(s.shortcut.wstring()); },
+        m_data.kind, [](const Win32ShortcutApp &s) { return QString::fromStdWString(s.shortcut.wstring()); },
         [](const UrlShortcutApp &u) { return QString::fromStdWString(u.shortcut.wstring()); },
         [](const Win32ExeApp &e) { return QString::fromStdWString(e.exe.wstring()); },
         [](const PackagedApp &p) { return QStringLiteral("shell:AppsFolder\\") + p.aumid; },

--- a/src/server/src/services/app-service/windows/win-app.hpp
+++ b/src/server/src/services/app-service/windows/win-app.hpp
@@ -11,11 +11,14 @@ public:
     QString id;
     QString displayName;
     QString program;              // Win32: target exe. Packaged: AppUserModelID.
+    QString arguments;
+    QString workingDirectory;
     std::filesystem::path path;   // Win32: the .lnk. Packaged: install location.
     QString shellParsingName;     // Win32: the .lnk. Packaged: shell:AppsFolder\<AUMID>.
+    QString openerExtension;      // set on openers from the assoc-handler enumeration
+    QString category;             // "Game", "Link", or empty for a regular application
     bool packaged = false;
     bool shellOpen = false;       // opener that defers to the shell's default handler for the target
-    bool game = false;
   };
 
   explicit WindowsApplication(Data data) : m_data(std::move(data)) {}
@@ -27,13 +30,16 @@ public:
   QString program() const override { return m_data.program; }
   std::filesystem::path path() const override { return m_data.path; }
   QString description() const override { return {}; }
-  QString category() const override { return m_data.game ? QStringLiteral("Game") : QString(); }
+  QString category() const override { return m_data.category; }
 
   ImageURL iconUrl() const override { return ImageURL::winShellIcon(m_data.shellParsingName); }
 
   bool isPackaged() const { return m_data.packaged; }
   bool opensViaShell() const { return m_data.shellOpen; }
   const QString &shellParsingName() const { return m_data.shellParsingName; }
+  const QString &arguments() const { return m_data.arguments; }
+  const QString &workingDirectory() const { return m_data.workingDirectory; }
+  const QString &openerExtension() const { return m_data.openerExtension; }
 
 private:
   Data m_data;

--- a/src/server/src/services/app-service/windows/win-app.hpp
+++ b/src/server/src/services/app-service/windows/win-app.hpp
@@ -1,0 +1,40 @@
+#pragma once
+#include "services/app-service/abstract-app-db.hpp"
+#include "ui/image/url.hpp"
+#include <QString>
+#include <filesystem>
+
+// A launchable Windows app, from either the Win32 (shortcut) or packaged (UWP) track.
+class WindowsApplication : public AbstractApplication {
+public:
+  struct Data {
+    QString id;
+    QString displayName;
+    QString program;              // Win32: target exe. Packaged: AppUserModelID.
+    std::filesystem::path path;   // Win32: the .lnk. Packaged: install location.
+    QString shellParsingName;     // Win32: the .lnk. Packaged: shell:AppsFolder\<AUMID>.
+    bool packaged = false;
+    bool shellOpen = false;       // opener that defers to the shell's default handler for the target
+    bool game = false;
+  };
+
+  explicit WindowsApplication(Data data) : m_data(std::move(data)) {}
+
+  QString id() const override { return m_data.id; }
+  QString displayName() const override { return m_data.displayName; }
+  bool displayable() const override { return true; }
+  bool isTerminalApp() const override { return false; }
+  QString program() const override { return m_data.program; }
+  std::filesystem::path path() const override { return m_data.path; }
+  QString description() const override { return {}; }
+  QString category() const override { return m_data.game ? QStringLiteral("Game") : QString(); }
+
+  ImageURL iconUrl() const override { return ImageURL::winShellIcon(m_data.shellParsingName); }
+
+  bool isPackaged() const { return m_data.packaged; }
+  bool opensViaShell() const { return m_data.shellOpen; }
+  const QString &shellParsingName() const { return m_data.shellParsingName; }
+
+private:
+  Data m_data;
+};

--- a/src/server/src/services/app-service/windows/win-app.hpp
+++ b/src/server/src/services/app-service/windows/win-app.hpp
@@ -10,15 +10,15 @@ public:
   struct Data {
     QString id;
     QString displayName;
-    QString program;              // Win32: target exe. Packaged: AppUserModelID.
+    QString program; // Win32: target exe. Packaged: AppUserModelID.
     QString arguments;
     QString workingDirectory;
-    std::filesystem::path path;   // Win32: the .lnk. Packaged: install location.
-    QString shellParsingName;     // Win32: the .lnk. Packaged: shell:AppsFolder\<AUMID>.
-    QString openerExtension;      // set on openers from the assoc-handler enumeration
-    QString category;             // "Game", "Link", or empty for a regular application
+    std::filesystem::path path; // Win32: the .lnk. Packaged: install location.
+    QString shellParsingName;   // Win32: the .lnk. Packaged: shell:AppsFolder\<AUMID>.
+    QString openerExtension;    // set on openers from the assoc-handler enumeration
+    QString category;           // "Game", "Link", or empty for a regular application
     bool packaged = false;
-    bool shellOpen = false;       // opener that defers to the shell's default handler for the target
+    bool shellOpen = false; // opener that defers to the shell's default handler for the target
   };
 
   explicit WindowsApplication(Data data) : m_data(std::move(data)) {}

--- a/src/server/src/services/app-service/windows/win-app.hpp
+++ b/src/server/src/services/app-service/windows/win-app.hpp
@@ -41,7 +41,9 @@ public:
   struct Data {
     QString id;
     QString displayName;
+    QString fullyQualifiedName;
     QString category; // "Game", "Link", or empty
+    bool elevated = false;
     WindowsAppKind kind;
   };
 
@@ -49,10 +51,24 @@ public:
 
   QString id() const override { return m_data.id; }
   QString displayName() const override { return m_data.displayName; }
+  QString fullyQualifiedName() const override {
+    return m_data.fullyQualifiedName.isEmpty() ? m_data.displayName : m_data.fullyQualifiedName;
+  }
   bool displayable() const override { return true; }
   bool isTerminalApp() const override { return false; }
+  bool isAction() const override { return m_data.elevated; }
   QString description() const override { return {}; }
   QString category() const override { return m_data.category; }
+
+  std::vector<std::shared_ptr<AbstractApplication>> actions() const override {
+    if (m_data.elevated || !supportsElevation()) return {};
+    Data data = m_data;
+    data.id += QStringLiteral(":runas");
+    data.fullyQualifiedName = m_data.displayName + QStringLiteral(": Run as Administrator");
+    data.displayName = QStringLiteral("Run as Administrator");
+    data.elevated = true;
+    return {std::make_shared<WindowsApplication>(std::move(data))};
+  }
 
   QString program() const override {
     return match(
@@ -79,12 +95,24 @@ public:
         [](const ShellOpenApp &s) { return s.target; });
   }
 
-  ImageURL iconUrl() const override { return ImageURL::winShellIcon(shellParsingName()); }
+  ImageURL iconUrl() const override {
+    constexpr int SIID_SHIELD_ID = 77; // SIID_SHIELD
+    if (m_data.elevated) return ImageURL::winStockIcon(SIID_SHIELD_ID);
+    return ImageURL::winShellIcon(shellParsingName());
+  }
 
   const WindowsAppKind &kind() const { return m_data.kind; }
   bool isPackaged() const { return std::holds_alternative<PackagedApp>(m_data.kind); }
   bool opensViaShell() const { return std::holds_alternative<ShellOpenApp>(m_data.kind); }
+  bool elevated() const { return m_data.elevated; }
 
 private:
+  bool supportsElevation() const {
+    return match(
+        m_data.kind, [](const Win32ShortcutApp &) { return true; },
+        [](const UrlShortcutApp &) { return false; }, [](const Win32ExeApp &) { return true; },
+        [](const PackagedApp &) { return true; }, [](const ShellOpenApp &) { return false; });
+  }
+
   Data m_data;
 };

--- a/src/server/src/services/app-service/windows/win-app.hpp
+++ b/src/server/src/services/app-service/windows/win-app.hpp
@@ -1,24 +1,49 @@
 #pragma once
+#include "common/types.hpp"
 #include "services/app-service/abstract-app-db.hpp"
 #include "ui/image/url.hpp"
 #include <QString>
 #include <filesystem>
+#include <variant>
 
-// A launchable Windows app, from either the Win32 (shortcut) or packaged (UWP) track.
+struct Win32ShortcutApp {
+  std::filesystem::path shortcut; // .lnk or .appref-ms
+  QString program;                // target exe; empty when only a shell PIDL is stored
+  QString arguments;
+  QString workingDirectory;
+  QString aumid; // from the .lnk property store, when set
+};
+
+struct UrlShortcutApp {
+  std::filesystem::path shortcut; // the .url file
+  QString url;
+};
+
+struct Win32ExeApp {
+  std::filesystem::path exe;
+  QString openerExtension; // assoc string to re-resolve the handler through, when known
+};
+
+struct PackagedApp {
+  QString aumid;
+  std::filesystem::path installLocation;
+};
+
+// defers to the shell's default handler for the target
+struct ShellOpenApp {
+  QString target;
+};
+
+using WindowsAppKind =
+    std::variant<Win32ShortcutApp, UrlShortcutApp, Win32ExeApp, PackagedApp, ShellOpenApp>;
+
 class WindowsApplication : public AbstractApplication {
 public:
   struct Data {
     QString id;
     QString displayName;
-    QString program; // Win32: target exe. Packaged: AppUserModelID.
-    QString arguments;
-    QString workingDirectory;
-    std::filesystem::path path; // Win32: the .lnk. Packaged: install location.
-    QString shellParsingName;   // Win32: the .lnk. Packaged: shell:AppsFolder\<AUMID>.
-    QString openerExtension;    // set on openers from the assoc-handler enumeration
-    QString category;           // "Game", "Link", or empty for a regular application
-    bool packaged = false;
-    bool shellOpen = false; // opener that defers to the shell's default handler for the target
+    QString category; // "Game", "Link", or empty
+    WindowsAppKind kind;
   };
 
   explicit WindowsApplication(Data data) : m_data(std::move(data)) {}
@@ -27,19 +52,41 @@ public:
   QString displayName() const override { return m_data.displayName; }
   bool displayable() const override { return true; }
   bool isTerminalApp() const override { return false; }
-  QString program() const override { return m_data.program; }
-  std::filesystem::path path() const override { return m_data.path; }
   QString description() const override { return {}; }
   QString category() const override { return m_data.category; }
 
-  ImageURL iconUrl() const override { return ImageURL::winShellIcon(m_data.shellParsingName); }
+  QString program() const override {
+    return match(
+        m_data.kind, [](const Win32ShortcutApp &s) { return s.program; },
+        [](const UrlShortcutApp &u) { return u.url; },
+        [](const Win32ExeApp &e) { return QString::fromStdWString(e.exe.wstring()); },
+        [](const PackagedApp &p) { return p.aumid; }, [](const ShellOpenApp &) { return QString(); });
+  }
 
-  bool isPackaged() const { return m_data.packaged; }
-  bool opensViaShell() const { return m_data.shellOpen; }
-  const QString &shellParsingName() const { return m_data.shellParsingName; }
-  const QString &arguments() const { return m_data.arguments; }
-  const QString &workingDirectory() const { return m_data.workingDirectory; }
-  const QString &openerExtension() const { return m_data.openerExtension; }
+  std::filesystem::path path() const override {
+    return match(
+        m_data.kind, [](const Win32ShortcutApp &s) { return s.shortcut; },
+        [](const UrlShortcutApp &u) { return u.shortcut; },
+        [](const Win32ExeApp &e) { return e.exe; },
+        [](const PackagedApp &p) { return p.installLocation; },
+        [](const ShellOpenApp &) { return std::filesystem::path(); });
+  }
+
+  QString shellParsingName() const {
+    return match(
+        m_data.kind,
+        [](const Win32ShortcutApp &s) { return QString::fromStdWString(s.shortcut.wstring()); },
+        [](const UrlShortcutApp &u) { return QString::fromStdWString(u.shortcut.wstring()); },
+        [](const Win32ExeApp &e) { return QString::fromStdWString(e.exe.wstring()); },
+        [](const PackagedApp &p) { return QStringLiteral("shell:AppsFolder\\") + p.aumid; },
+        [](const ShellOpenApp &s) { return s.target; });
+  }
+
+  ImageURL iconUrl() const override { return ImageURL::winShellIcon(shellParsingName()); }
+
+  const WindowsAppKind &kind() const { return m_data.kind; }
+  bool isPackaged() const { return std::holds_alternative<PackagedApp>(m_data.kind); }
+  bool opensViaShell() const { return std::holds_alternative<ShellOpenApp>(m_data.kind); }
 
 private:
   Data m_data;

--- a/src/server/src/ui/image/image-renderer.cpp
+++ b/src/server/src/ui/image/image-renderer.cpp
@@ -10,6 +10,9 @@
 #ifdef Q_OS_MACOS
 #include "ui/image/mac-file-icon-loader.hpp"
 #endif
+#ifdef Q_OS_WIN
+#include "ui/image/win-file-icon-loader.hpp"
+#endif
 #include <QBuffer>
 #include <QCoreApplication>
 #include <QFontMetricsF>
@@ -195,6 +198,11 @@ QImage renderFileIcon(const QString &path, const QSize &size, const QColor &fg, 
 #ifdef Q_OS_MACOS
   if (!fg.isValid()) {
     if (QImage native = renderMacFileIcon(path, size); !native.isNull()) { return native; }
+  }
+#endif
+#ifdef Q_OS_WIN
+  if (!fg.isValid()) {
+    if (QImage native = renderWinShellIcon(path, size); !native.isNull()) { return native; }
   }
 #endif
 

--- a/src/server/src/ui/image/image-stream.cpp
+++ b/src/server/src/ui/image/image-stream.cpp
@@ -7,6 +7,9 @@
 #ifdef Q_OS_MACOS
 #include "ui/image/mac-file-icon-loader.hpp"
 #endif
+#ifdef Q_OS_WIN
+#include "ui/image/win-file-icon-loader.hpp"
+#endif
 #include <QBuffer>
 #include <QCache>
 #include <QFutureWatcher>
@@ -182,6 +185,11 @@ void ImageStream::startStatic() {
 #ifdef Q_OS_MACOS
   case ImageURLType::MacBundle:
     runInPool([name, size = m_size]() { return renderMacFileIcon(name, size); }, m_fg);
+    break;
+#endif
+#ifdef Q_OS_WIN
+  case ImageURLType::WinShellIcon:
+    runInPool([name, size = m_size]() { return renderWinShellIcon(name, size); }, m_fg);
     break;
 #endif
   case ImageURLType::FileIcon:

--- a/src/server/src/ui/image/image-stream.cpp
+++ b/src/server/src/ui/image/image-stream.cpp
@@ -191,6 +191,9 @@ void ImageStream::startStatic() {
   case ImageURLType::WinShellIcon:
     runInPool([name, size = m_size]() { return renderWinShellIcon(name, size); }, m_fg);
     break;
+  case ImageURLType::WinStockIcon:
+    runInPool([name, size = m_size]() { return renderWinStockIcon(name.toInt(), size); }, m_fg);
+    break;
 #endif
   case ImageURLType::FileIcon:
     runInPool(

--- a/src/server/src/ui/image/url.cpp
+++ b/src/server/src/ui/image/url.cpp
@@ -270,6 +270,15 @@ ImageURL ImageURL::macBundle(const std::filesystem::path &bundlePath) {
   return url;
 }
 
+ImageURL ImageURL::winShellIcon(const QString &parsingName) {
+  ImageURL url;
+
+  url.setType(ImageURLType::WinShellIcon);
+  url.setName(parsingName);
+
+  return url;
+}
+
 ImageURL ImageURL::http(const QUrl &httpUrl) {
   ImageURL url;
 

--- a/src/server/src/ui/image/url.cpp
+++ b/src/server/src/ui/image/url.cpp
@@ -279,6 +279,15 @@ ImageURL ImageURL::winShellIcon(const QString &parsingName) {
   return url;
 }
 
+ImageURL ImageURL::winStockIcon(int stockIconId) {
+  ImageURL url;
+
+  url.setType(ImageURLType::WinStockIcon);
+  url.setName(QString::number(stockIconId));
+
+  return url;
+}
+
 ImageURL ImageURL::http(const QUrl &httpUrl) {
   ImageURL url;
 

--- a/src/server/src/ui/image/url.hpp
+++ b/src/server/src/ui/image/url.hpp
@@ -25,7 +25,8 @@ enum ImageURLType : std::uint8_t {
   MacBundle,
   FileIcon,
   FontPreview,
-  WinShellIcon
+  WinShellIcon,
+  WinStockIcon
 };
 
 static std::vector<std::pair<QString, ImageURLType>> iconTypes = {
@@ -38,6 +39,7 @@ static std::vector<std::pair<QString, ImageURLType>> iconTypes = {
     {"local", Local},
     {"bundle", MacBundle},
     {"win-shell", WinShellIcon},
+    {"win-stock", WinStockIcon},
     {"file-icon", FileIcon},
     {"emoji", Emoji},
     {"symbol", Symbol},
@@ -143,6 +145,7 @@ public:
   static ImageURL local(const std::filesystem::path &path);
   static ImageURL macBundle(const std::filesystem::path &bundlePath);
   static ImageURL winShellIcon(const QString &parsingName);
+  static ImageURL winStockIcon(int stockIconId); // SHSTOCKICONID
   static ImageURL http(const QUrl &httpUrl);
   static ImageURL emoji(const QString &emoji);
   static ImageURL symbol(const QString &symbol);

--- a/src/server/src/ui/image/url.hpp
+++ b/src/server/src/ui/image/url.hpp
@@ -24,7 +24,8 @@ enum ImageURLType : std::uint8_t {
   DataURI,
   MacBundle,
   FileIcon,
-  FontPreview
+  FontPreview,
+  WinShellIcon
 };
 
 static std::vector<std::pair<QString, ImageURLType>> iconTypes = {
@@ -36,6 +37,7 @@ static std::vector<std::pair<QString, ImageURLType>> iconTypes = {
     {"https", Http},
     {"local", Local},
     {"bundle", MacBundle},
+    {"win-shell", WinShellIcon},
     {"file-icon", FileIcon},
     {"emoji", Emoji},
     {"symbol", Symbol},
@@ -140,6 +142,7 @@ public:
   static ImageURL local(const QString &path);
   static ImageURL local(const std::filesystem::path &path);
   static ImageURL macBundle(const std::filesystem::path &bundlePath);
+  static ImageURL winShellIcon(const QString &parsingName);
   static ImageURL http(const QUrl &httpUrl);
   static ImageURL emoji(const QString &emoji);
   static ImageURL symbol(const QString &symbol);

--- a/src/server/src/ui/image/win-file-icon-loader.cpp
+++ b/src/server/src/ui/image/win-file-icon-loader.cpp
@@ -8,11 +8,13 @@
 #endif
 #include <windows.h>
 #include <shlobj.h>
+#include <shellapi.h>
 #include <shobjidl_core.h>
 #include <wrl/client.h>
 
 #include "utils/scoped-com.hpp"
 
+#include <algorithm>
 #include <string>
 
 namespace {
@@ -90,5 +92,23 @@ QImage renderWinShellIcon(const QString &parsingName, const QSize &size) {
     }
   }
 
+  return result;
+}
+
+QImage renderWinStockIcon(int stockIconId, const QSize &size) {
+  if (size.isEmpty()) return {};
+
+  SHSTOCKICONINFO info{};
+  info.cbSize = sizeof(info);
+  if (FAILED(SHGetStockIconInfo(static_cast<SHSTOCKICONID>(stockIconId), SHGSI_ICONLOCATION, &info))) {
+    return {};
+  }
+
+  const UINT dim = static_cast<UINT>(std::max(size.width(), size.height()));
+  HICON icon = nullptr;
+  if (FAILED(SHDefExtractIconW(info.szPath, info.iIcon, 0, &icon, nullptr, dim)) || !icon) return {};
+
+  QImage result = QImage::fromHICON(icon);
+  DestroyIcon(icon);
   return result;
 }

--- a/src/server/src/ui/image/win-file-icon-loader.cpp
+++ b/src/server/src/ui/image/win-file-icon-loader.cpp
@@ -69,7 +69,7 @@ QImage renderWinShellIcon(const QString &parsingName, const QSize &size) {
   if (parsingName.isEmpty() || size.isEmpty()) return {};
 
   // Decoding-pool threads aren't COM-initialized by default.
-  const HRESULT coInit = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+  const HRESULT coInit = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
   const bool ownsCom = coInit == S_OK || coInit == S_FALSE;
 
   QImage result;

--- a/src/server/src/ui/image/win-file-icon-loader.cpp
+++ b/src/server/src/ui/image/win-file-icon-loader.cpp
@@ -1,0 +1,95 @@
+#include "win-file-icon-loader.hpp"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#include <shlobj.h>
+#include <shobjidl_core.h>
+
+#include <string>
+
+namespace {
+
+// Some icons come back with an all-zero alpha channel (stored without alpha); force those opaque.
+QImage imageFromHBITMAP(HBITMAP bitmap) {
+  BITMAP bm{};
+  if (GetObject(bitmap, sizeof(bm), &bm) == 0) return {};
+
+  const int w = bm.bmWidth;
+  const int h = bm.bmHeight;
+  if (w <= 0 || h <= 0) return {};
+
+  BITMAPINFO bmi{};
+  bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+  bmi.bmiHeader.biWidth = w;
+  bmi.bmiHeader.biHeight = -h; // negative: top-down
+  bmi.bmiHeader.biPlanes = 1;
+  bmi.bmiHeader.biBitCount = 32;
+  bmi.bmiHeader.biCompression = BI_RGB;
+
+  QImage image(w, h, QImage::Format_ARGB32);
+  if (image.isNull()) return {};
+
+  HDC hdc = GetDC(nullptr);
+  if (!hdc) return {};
+  const int lines = GetDIBits(hdc, bitmap, 0, static_cast<UINT>(h), image.bits(), &bmi, DIB_RGB_COLORS);
+  ReleaseDC(nullptr, hdc);
+  if (lines == 0) return {};
+
+  bool hasAlpha = false;
+  for (int y = 0; y < h && !hasAlpha; ++y) {
+    const auto *row = reinterpret_cast<const QRgb *>(image.constScanLine(y));
+    for (int x = 0; x < w; ++x) {
+      if (qAlpha(row[x]) != 0) {
+        hasAlpha = true;
+        break;
+      }
+    }
+  }
+
+  if (!hasAlpha) {
+    for (int y = 0; y < h; ++y) {
+      auto *row = reinterpret_cast<QRgb *>(image.scanLine(y));
+      for (int x = 0; x < w; ++x) {
+        row[x] |= 0xFF000000;
+      }
+    }
+  }
+
+  return image;
+}
+
+} // namespace
+
+QImage renderWinShellIcon(const QString &parsingName, const QSize &size) {
+  if (parsingName.isEmpty() || size.isEmpty()) return {};
+
+  // Decoding-pool threads aren't COM-initialized by default.
+  const HRESULT coInit = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+  const bool ownsCom = coInit == S_OK || coInit == S_FALSE;
+
+  QImage result;
+
+  IShellItemImageFactory *factory = nullptr;
+  const std::wstring wname = parsingName.toStdWString();
+  HRESULT hr = SHCreateItemFromParsingName(wname.c_str(), nullptr, IID_PPV_ARGS(&factory));
+  if (SUCCEEDED(hr) && factory) {
+    const SIZE requested{size.width(), size.height()};
+    HBITMAP bitmap = nullptr;
+    // ICONONLY: never a document thumbnail. BIGGERSIZEOK: allow upscaling for sharpness.
+    hr = factory->GetImage(requested, SIIGBF_ICONONLY | SIIGBF_BIGGERSIZEOK, &bitmap);
+    if (SUCCEEDED(hr) && bitmap) {
+      result = imageFromHBITMAP(bitmap);
+      DeleteObject(bitmap);
+    }
+    factory->Release();
+  }
+
+  if (ownsCom) CoUninitialize();
+
+  return result;
+}

--- a/src/server/src/ui/image/win-file-icon-loader.cpp
+++ b/src/server/src/ui/image/win-file-icon-loader.cpp
@@ -11,6 +11,8 @@
 #include <shobjidl_core.h>
 #include <wrl/client.h>
 
+#include "utils/scoped-com.hpp"
+
 #include <string>
 
 namespace {
@@ -70,29 +72,23 @@ QImage renderWinShellIcon(const QString &parsingName, const QSize &size) {
   if (parsingName.isEmpty() || size.isEmpty()) return {};
 
   // STA required: from an MTA thread GetImage returns E_PENDING for icons not yet in the shell cache
-  const HRESULT coInit = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
-  const bool ownsCom = coInit == S_OK || coInit == S_FALSE;
+  ScopedCom com;
 
   QImage result;
 
-  // scoped so the factory is released before CoUninitialize
-  {
-    Microsoft::WRL::ComPtr<IShellItemImageFactory> factory;
-    const std::wstring wname = parsingName.toStdWString();
-    HRESULT hr = SHCreateItemFromParsingName(wname.c_str(), nullptr, IID_PPV_ARGS(&factory));
-    if (SUCCEEDED(hr) && factory) {
-      const SIZE requested{size.width(), size.height()};
-      HBITMAP bitmap = nullptr;
-      // ICONONLY: never a document thumbnail. BIGGERSIZEOK: allow upscaling for sharpness.
-      hr = factory->GetImage(requested, SIIGBF_ICONONLY | SIIGBF_BIGGERSIZEOK, &bitmap);
-      if (SUCCEEDED(hr) && bitmap) {
-        result = imageFromHBITMAP(bitmap);
-        DeleteObject(bitmap);
-      }
+  Microsoft::WRL::ComPtr<IShellItemImageFactory> factory;
+  const std::wstring wname = parsingName.toStdWString();
+  HRESULT hr = SHCreateItemFromParsingName(wname.c_str(), nullptr, IID_PPV_ARGS(&factory));
+  if (SUCCEEDED(hr) && factory) {
+    const SIZE requested{size.width(), size.height()};
+    HBITMAP bitmap = nullptr;
+    // ICONONLY: never a document thumbnail. BIGGERSIZEOK: allow upscaling for sharpness.
+    hr = factory->GetImage(requested, SIIGBF_ICONONLY | SIIGBF_BIGGERSIZEOK, &bitmap);
+    if (SUCCEEDED(hr) && bitmap) {
+      result = imageFromHBITMAP(bitmap);
+      DeleteObject(bitmap);
     }
   }
-
-  if (ownsCom) CoUninitialize();
 
   return result;
 }

--- a/src/server/src/ui/image/win-file-icon-loader.cpp
+++ b/src/server/src/ui/image/win-file-icon-loader.cpp
@@ -9,6 +9,7 @@
 #include <windows.h>
 #include <shlobj.h>
 #include <shobjidl_core.h>
+#include <wrl/client.h>
 
 #include <string>
 
@@ -68,25 +69,27 @@ QImage imageFromHBITMAP(HBITMAP bitmap) {
 QImage renderWinShellIcon(const QString &parsingName, const QSize &size) {
   if (parsingName.isEmpty() || size.isEmpty()) return {};
 
-  // Decoding-pool threads aren't COM-initialized by default.
-  const HRESULT coInit = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+  // STA required: from an MTA thread GetImage returns E_PENDING for icons not yet in the shell cache
+  const HRESULT coInit = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
   const bool ownsCom = coInit == S_OK || coInit == S_FALSE;
 
   QImage result;
 
-  IShellItemImageFactory *factory = nullptr;
-  const std::wstring wname = parsingName.toStdWString();
-  HRESULT hr = SHCreateItemFromParsingName(wname.c_str(), nullptr, IID_PPV_ARGS(&factory));
-  if (SUCCEEDED(hr) && factory) {
-    const SIZE requested{size.width(), size.height()};
-    HBITMAP bitmap = nullptr;
-    // ICONONLY: never a document thumbnail. BIGGERSIZEOK: allow upscaling for sharpness.
-    hr = factory->GetImage(requested, SIIGBF_ICONONLY | SIIGBF_BIGGERSIZEOK, &bitmap);
-    if (SUCCEEDED(hr) && bitmap) {
-      result = imageFromHBITMAP(bitmap);
-      DeleteObject(bitmap);
+  // scoped so the factory is released before CoUninitialize
+  {
+    Microsoft::WRL::ComPtr<IShellItemImageFactory> factory;
+    const std::wstring wname = parsingName.toStdWString();
+    HRESULT hr = SHCreateItemFromParsingName(wname.c_str(), nullptr, IID_PPV_ARGS(&factory));
+    if (SUCCEEDED(hr) && factory) {
+      const SIZE requested{size.width(), size.height()};
+      HBITMAP bitmap = nullptr;
+      // ICONONLY: never a document thumbnail. BIGGERSIZEOK: allow upscaling for sharpness.
+      hr = factory->GetImage(requested, SIIGBF_ICONONLY | SIIGBF_BIGGERSIZEOK, &bitmap);
+      if (SUCCEEDED(hr) && bitmap) {
+        result = imageFromHBITMAP(bitmap);
+        DeleteObject(bitmap);
+      }
     }
-    factory->Release();
   }
 
   if (ownsCom) CoUninitialize();

--- a/src/server/src/ui/image/win-file-icon-loader.hpp
+++ b/src/server/src/ui/image/win-file-icon-loader.hpp
@@ -1,0 +1,8 @@
+#pragma once
+#include <QImage>
+#include <QSize>
+#include <QString>
+
+// Native icon for a shell parsing name (a path, .lnk, or shell:AppsFolder\<AUMID>) via
+// IShellItemImageFactory. Self-initializes COM, so it is safe to call from the decoding pool.
+QImage renderWinShellIcon(const QString &parsingName, const QSize &size);

--- a/src/server/src/ui/image/win-file-icon-loader.hpp
+++ b/src/server/src/ui/image/win-file-icon-loader.hpp
@@ -6,3 +6,5 @@
 // Native icon for a shell parsing name (a path, .lnk, or shell:AppsFolder\<AUMID>) via
 // IShellItemImageFactory. Self-initializes COM, so it is safe to call from the decoding pool.
 QImage renderWinShellIcon(const QString &parsingName, const QSize &size);
+
+QImage renderWinStockIcon(int stockIconId, const QSize &size);

--- a/src/server/src/utils/scoped-com.hpp
+++ b/src/server/src/utils/scoped-com.hpp
@@ -1,0 +1,20 @@
+#pragma once
+#include <objbase.h>
+
+// Tolerates an existing COM init (S_FALSE) and a foreign apartment mode (RPC_E_CHANGED_MODE).
+// Declare before any ComPtr so interfaces are released before the apartment closes.
+class ScopedCom {
+public:
+  explicit ScopedCom(DWORD model = COINIT_APARTMENTTHREADED) {
+    const HRESULT hr = CoInitializeEx(nullptr, model);
+    m_owns = hr == S_OK || hr == S_FALSE;
+  }
+  ~ScopedCom() {
+    if (m_owns) CoUninitialize();
+  }
+  ScopedCom(const ScopedCom &) = delete;
+  ScopedCom &operator=(const ScopedCom &) = delete;
+
+private:
+  bool m_owns = false;
+};


### PR DESCRIPTION
Implements `AbstractAppDatabase` for Windows systems.
Use common app locations to source available apps on the system (start menu, desktop shortcuts, package managed apps)

We also index `.lnk` files that link to URLs, commonly used to install web shortcuts.