### PR TITLE
feat: force utf8 active code page on windows

### DIFF
--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -6,3 +6,13 @@ function(get_cxx_compiler_name CXX_COMPILER_NAME)
 	endif()
 endfunction()
 
+# Embeds the UTF-8 activeCodePage manifest into an executable so it runs with a UTF-8
+# process code page (Windows 10 1903+). Pair with vicinae::enableUtf8() at runtime.
+# Added as a source so CMake merges it into the linker-generated manifest via mt.exe,
+# rather than embedding a second, conflicting MANIFEST resource.
+function(vicinae_enable_utf8 target)
+	if(WIN32)
+		target_sources(${target} PRIVATE "${CMAKE_SOURCE_DIR}/extra/windows/vicinae.manifest")
+	endif()
+endfunction()
+

--- a/extra/windows/vicinae.manifest
+++ b/extra/windows/vicinae.manifest
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <application>
+    <windowsSettings>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -22,6 +22,7 @@ if (NOT WIN32)
 endif()
 
 add_executable(${PROJECT_NAME} ${CLI_SOURCES})
+vicinae_enable_utf8(${PROJECT_NAME})
 target_include_directories(${PROJECT_NAME} PRIVATE src ${GENOUT})
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_23)
 include(EmbedFile)

--- a/src/cli/src/main.cpp
+++ b/src/cli/src/main.cpp
@@ -1,10 +1,12 @@
 #include "cli.hpp"
+#include "common/common.hpp"
 
 #ifdef _WIN32
 #include <windows.h>
 #endif
 
 int main(int ac, char **av) {
+  vicinae::enableUtf8();
 #ifdef _WIN32
   SetConsoleOutputCP(CP_UTF8);
 #endif

--- a/src/lib/common/include/common/common.hpp
+++ b/src/lib/common/include/common/common.hpp
@@ -8,6 +8,10 @@
 #include <vector>
 
 namespace vicinae {
+// Switches the CRT locale to UTF-8 on Windows so that we operate on UTF-8 rather
+// than the legacy ANSI code page. No-op elsewhere.
+void enableUtf8();
+
 std::filesystem::path selfPath();
 std::optional<std::filesystem::path> findHelperProgram(std::string_view program);
 std::vector<std::filesystem::path> helperProgramCandidates(std::string_view program);

--- a/src/lib/common/src/common.cpp
+++ b/src/lib/common/src/common.cpp
@@ -1,4 +1,5 @@
 #include "common/common.hpp"
+#include <clocale>
 #include <cstdlib>
 #include <filesystem>
 #include <sstream>
@@ -17,6 +18,12 @@
 namespace fs = std::filesystem;
 
 namespace vicinae {
+void enableUtf8() {
+#ifdef _WIN32
+  std::setlocale(LC_ALL, ".UTF-8");
+#endif
+}
+
 #ifdef __APPLE__
 fs::path selfPath() {
   char buf[PATH_MAX];

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -904,6 +904,8 @@ endif()
 
 qt_add_executable(${TARGET} ${SRCS})
 
+vicinae_enable_utf8(${TARGET})
+
 if(APPLE)
 	set(VICINAE_BUNDLE_EXECUTABLE "Vicinae")
 	set(VICINAE_BUNDLE_SHORT_VERSION "${VICINAE_GIT_TAG}")

--- a/src/server/src/main.cpp
+++ b/src/server/src/main.cpp
@@ -2,9 +2,12 @@
 #include <exception>
 #include <iostream>
 #include <glaze/glaze.hpp>
+#include "common/common.hpp"
 #include "server.hpp"
 
 int main(int argc, char **argv) {
+  vicinae::enableUtf8();
+
   std::set_terminate([] {
     if (auto e = std::current_exception()) {
       try {


### PR DESCRIPTION
Use Windows fusion manifest to give the vicinae executables a native UTF-8 codepage so that conversions to `std::string` always yield valid utf-8 and do not throw.

This is the modern way to deal with the UTF-8 problem on Windows apparently. Available since Win10 1903+ (2019)