### PR TITLE
Adds new cmd verb to cli and attaches cwd to extension launch from it

### DIFF
--- a/figura/ipc.fig
+++ b/figura/ipc.fig
@@ -40,8 +40,12 @@ struct LaunchCommandResponse {
   error?: string;
 };
 
+struct CommandInfo {
+  id: string;
+};
+
 struct ListCommandsResponse {
-  commands: string[];
+  commands: CommandInfo[];
 };
 
 struct DMenuRequest {

--- a/figura/ipc.fig
+++ b/figura/ipc.fig
@@ -43,6 +43,7 @@ struct LaunchCommandResponse {
 
 struct CommandInfo {
   id: string;
+  name: string;
 };
 
 struct ListCommandsResponse {

--- a/figura/ipc.fig
+++ b/figura/ipc.fig
@@ -34,6 +34,7 @@ struct LaunchCommandRequest {
   entrypoint: string;
   args: string[];
   cwd?: string;
+  query?: string;
 };
 
 struct LaunchCommandResponse {

--- a/figura/ipc.fig
+++ b/figura/ipc.fig
@@ -30,6 +30,20 @@ struct LaunchAppResponse {
   focusedWindowTitle: string;
 };
 
+struct LaunchCommandRequest {
+  entrypoint: string;
+  args: string[];
+  cwd?: string;
+};
+
+struct LaunchCommandResponse {
+  error?: string;
+};
+
+struct ListCommandsResponse {
+  commands: string[];
+};
+
 struct DMenuRequest {
   rawContent: string;
   navigationTitle?: string;
@@ -90,6 +104,8 @@ service Ipc {
   fn deeplink(req: DeeplinkRequest) => DeeplinkResponse;
   fn describe() => DescribeResponse;
   fn launchApp(req: LaunchAppRequest) => LaunchAppResponse;
+  fn listCommands() => ListCommandsResponse;
+  fn launchCommand(req: LaunchCommandRequest) => LaunchCommandResponse;
   fn dmenu(req: DMenuRequest) => DMenuResponse;
   fn browserInit(req: BrowserInitRequest) => void;
   fn browserTabsChanged(tabs: BrowserTabInfo[]) => void;

--- a/figura/manager-extension.fig
+++ b/figura/manager-extension.fig
@@ -38,7 +38,7 @@ struct LaunchEventData {
   owner_or_author_name: string;
   launch_type: LaunchType;
   capabilities: Capabilities;
-  cwd: string;
+  cwd?: string;
 };
 
 service Lifecycle {

--- a/figura/manager-extension.fig
+++ b/figura/manager-extension.fig
@@ -33,6 +33,7 @@ struct LaunchEventData {
   support_path: string;
   preferenceValues: any;
   argumentValues: any;
+  launch_context: any;
   is_raycast: bool;
   owner_or_author_name: string;
   launch_type: LaunchType;

--- a/figura/manager-extension.fig
+++ b/figura/manager-extension.fig
@@ -38,6 +38,7 @@ struct LaunchEventData {
   owner_or_author_name: string;
   launch_type: LaunchType;
   capabilities: Capabilities;
+  fallbackText?: string;
   cwd?: string;
 };
 

--- a/figura/manager-extension.fig
+++ b/figura/manager-extension.fig
@@ -1,7 +1,6 @@
 // manager (client) to extension (server)
 // the worker is already provisioned but waiting for the manager to initialize it with extension info (to avoid cold starts)
 
-
 enum CommandMode {
   View,
   NoView
@@ -14,7 +13,8 @@ enum CommandEnv {
 
 enum LaunchType {
   User,
-  Background
+  Background,
+  CommandLine
 };
 
 struct Capabilities {
@@ -38,6 +38,7 @@ struct LaunchEventData {
   owner_or_author_name: string;
   launch_type: LaunchType;
   capabilities: Capabilities;
+  cwd: string;
 };
 
 service Lifecycle {

--- a/figura/manager.fig
+++ b/figura/manager.fig
@@ -42,6 +42,7 @@ struct LoadOptions {
   launch_context: any;
   launch_type: LaunchType;
   capabilities: Capabilities;
+  fallbackText?: string;
   cwd?: string;
 };
 

--- a/figura/manager.fig
+++ b/figura/manager.fig
@@ -16,7 +16,8 @@ enum CommandEnv {
 
 enum LaunchType {
   User,
-  Background
+  Background,
+  CommandLine
 };
 
 struct Capabilities {
@@ -41,6 +42,7 @@ struct LoadOptions {
   launch_context: any;
   launch_type: LaunchType;
   capabilities: Capabilities;
+  cwd: string;
 };
 
 struct LoadResponse {

--- a/figura/manager.fig
+++ b/figura/manager.fig
@@ -42,7 +42,7 @@ struct LoadOptions {
   launch_context: any;
   launch_type: LaunchType;
   capabilities: Capabilities;
-  cwd: string;
+  cwd?: string;
 };
 
 struct LoadResponse {

--- a/figura/manager.fig
+++ b/figura/manager.fig
@@ -38,6 +38,7 @@ struct LoadOptions {
   owner_or_author_name: string;
   arguments: any;
   preferences: any;
+  launch_context: any;
   launch_type: LaunchType;
   capabilities: Capabilities;
 };

--- a/src/cli/src/cli.cpp
+++ b/src/cli/src/cli.cpp
@@ -1,4 +1,6 @@
 #include <filesystem>
+#include <glaze/core/opts.hpp>
+#include <glaze/core/reflect.hpp>
 #include <system_error>
 #include "cli.hpp"
 #include "config.hpp"
@@ -174,9 +176,11 @@ public:
   AppCommand() { registerCommand<LaunchAppCommand>(); }
 };
 
-class ListCommandsCommand : public AbstractCommandLineCommand {
+struct ListCommandsCommand : public AbstractCommandLineCommand {
   std::string id() const override { return "ls"; }
   std::string description() const override { return "List loaded commands"; }
+
+  void setup(CLI::App *app) override { app->add_flag("--json,-j", m_json, "Output command list as json"); }
 
   bool run(CLI::App *) override {
     auto res =
@@ -187,12 +191,27 @@ class ListCommandsCommand : public AbstractCommandLineCommand {
       return false;
     }
 
-    for (const auto &command : res->commands) {
-      std::println(std::cout, "{}", command);
+    if (m_json) {
+      std::string buf;
+
+      if (auto error =
+              glz::write<glz::opts{.format = glz::JSON, .prettify = true}>(res.value().commands, buf)) {
+        std::println(std::cerr, "Failed to serialize json: {}", glz::format_error(error));
+        return false;
+      }
+
+      std::cout << buf << std::endl;
+    } else {
+      for (const auto &command : res->commands) {
+        std::cout << command.id << "\n";
+      }
     }
 
     return true;
   }
+
+private:
+  bool m_json;
 };
 
 class LaunchCommandCommand : public AbstractCommandLineCommand {

--- a/src/cli/src/cli.cpp
+++ b/src/cli/src/cli.cpp
@@ -180,7 +180,10 @@ struct ListCommandsCommand : public AbstractCommandLineCommand {
   std::string id() const override { return "ls"; }
   std::string description() const override { return "List loaded commands"; }
 
-  void setup(CLI::App *app) override { app->add_flag("--json,-j", m_json, "Output command list as json"); }
+  void setup(CLI::App *app) override {
+    app->alias("list");
+    app->add_flag("--json,-j", m_json, "Output command list as json");
+  }
 
   bool run(CLI::App *) override {
     auto res =
@@ -220,9 +223,9 @@ class LaunchCommandCommand : public AbstractCommandLineCommand {
 
   void setup(CLI::App *app) override {
     app->add_option("entrypoint", m_entrypoint, "The command entrypoint ID to launch")->required();
+    app->add_option("args", m_args, "Arguments to pass to the command");
     app->add_option("--cwd", m_cwd, "Working directory forwarded to the command");
     app->add_option("--query,-q", m_query, "");
-    app->add_option("args", m_args, "Arguments to pass to the command");
   }
 
   bool run(CLI::App *) override {
@@ -255,6 +258,7 @@ private:
 class CommandCommand : public AbstractCommandLineCommand {
   std::string id() const override { return "cmd"; }
   std::string description() const override { return "Command utilities"; }
+  void setup(CLI::App *app) override { app->alias("command"); }
 
 public:
   CommandCommand() {

--- a/src/cli/src/cli.cpp
+++ b/src/cli/src/cli.cpp
@@ -1,3 +1,5 @@
+#include <filesystem>
+#include <system_error>
 #include "cli.hpp"
 #include "config.hpp"
 #include "fs.hpp"
@@ -170,6 +172,74 @@ class AppCommand : public AbstractCommandLineCommand {
 
 public:
   AppCommand() { registerCommand<LaunchAppCommand>(); }
+};
+
+class ListCommandsCommand : public AbstractCommandLineCommand {
+  std::string id() const override { return "ls"; }
+  std::string description() const override { return "List loaded commands"; }
+
+  bool run(CLI::App *) override {
+    auto res =
+        cli::IpcClient::connect().and_then([](cli::IpcClient client) { return client.listCommands(); });
+
+    if (!res) {
+      std::println(std::cerr, "Failed to list commands: {}", res.error());
+      return false;
+    }
+
+    for (const auto &command : res->commands) {
+      std::println(std::cout, "{}", command);
+    }
+
+    return true;
+  }
+};
+
+class LaunchCommandCommand : public AbstractCommandLineCommand {
+  std::string id() const override { return "launch"; }
+  std::string description() const override { return "Launch a command"; }
+
+  void setup(CLI::App *app) override {
+    app->add_option("entrypoint", m_entrypoint, "The command entrypoint ID to launch")->required();
+    app->add_option("--cwd", m_cwd, "Working directory forwarded to the command");
+    app->add_option("args", m_args, "Arguments to pass to the command");
+  }
+
+  bool run(CLI::App *) override {
+    auto cwd = m_cwd;
+    std::error_code ec;
+
+    if (!cwd) {
+      if (auto path = std::filesystem::current_path(ec); !ec) { cwd = path.generic_string(); }
+    }
+
+    auto res = cli::IpcClient::connect().and_then([&](cli::IpcClient client) {
+      return client.launchCommand({.entrypoint = m_entrypoint, .args = m_args, .cwd = cwd});
+    });
+
+    if (!res) {
+      std::println(std::cerr, "Failed to launch command: {}", res.error());
+      return false;
+    }
+
+    return true;
+  }
+
+private:
+  std::string m_entrypoint;
+  std::optional<std::string> m_cwd;
+  std::vector<std::string> m_args;
+};
+
+class CommandCommand : public AbstractCommandLineCommand {
+  std::string id() const override { return "cmd"; }
+  std::string description() const override { return "Command utilities"; }
+
+public:
+  CommandCommand() {
+    registerCommand<ListCommandsCommand>();
+    registerCommand<LaunchCommandCommand>();
+  }
 };
 
 class CliPing : public AbstractCommandLineCommand {
@@ -387,6 +457,7 @@ int CommandLineInterface::execute(int ac, char **av) {
   app.registerCommand<ToggleCommand>();
   app.registerCommand<OpenCommand>();
   app.registerCommand<CloseCommand>();
+  app.registerCommand<CommandCommand>();
   app.registerCommand<DeeplinkCommand>();
   app.registerCommand<DMenuCommand>();
   app.registerCommand<ThemeCommand>();

--- a/src/cli/src/cli.cpp
+++ b/src/cli/src/cli.cpp
@@ -221,6 +221,7 @@ class LaunchCommandCommand : public AbstractCommandLineCommand {
   void setup(CLI::App *app) override {
     app->add_option("entrypoint", m_entrypoint, "The command entrypoint ID to launch")->required();
     app->add_option("--cwd", m_cwd, "Working directory forwarded to the command");
+    app->add_option("--query,-q", m_query, "");
     app->add_option("args", m_args, "Arguments to pass to the command");
   }
 
@@ -233,7 +234,7 @@ class LaunchCommandCommand : public AbstractCommandLineCommand {
     }
 
     auto res = cli::IpcClient::connect().and_then([&](cli::IpcClient client) {
-      return client.launchCommand({.entrypoint = m_entrypoint, .args = m_args, .cwd = cwd});
+      return client.launchCommand({.entrypoint = m_entrypoint, .args = m_args, .cwd = cwd, .query = m_query});
     });
 
     if (!res) {
@@ -247,6 +248,7 @@ class LaunchCommandCommand : public AbstractCommandLineCommand {
 private:
   std::string m_entrypoint;
   std::optional<std::string> m_cwd;
+  std::optional<std::string> m_query;
   std::vector<std::string> m_args;
 };
 

--- a/src/cli/src/ipc-client.hpp
+++ b/src/cli/src/ipc-client.hpp
@@ -52,6 +52,15 @@ public:
     return call<ipc::LaunchAppResponse>([&](auto cb) { m_client.ipc().launchApp(req, std::move(cb)); });
   }
 
+  std::expected<ipc::ListCommandsResponse, std::string> listCommands() {
+    return call<ipc::ListCommandsResponse>([&](auto cb) { m_client.ipc().listCommands(std::move(cb)); });
+  }
+
+  std::expected<ipc::LaunchCommandResponse, std::string> launchCommand(ipc::LaunchCommandRequest req) {
+    return call<ipc::LaunchCommandResponse>(
+        [&](auto cb) { m_client.ipc().launchCommand(req, std::move(cb)); });
+  }
+
   std::expected<std::vector<ipc::FileResult>, std::string> fsQuery(std::string_view query, int limit = 100,
                                                                    std::optional<std::string> category = {}) {
     ipc::FsQueryParams params{

--- a/src/server/src/command-actions.cpp
+++ b/src/server/src/command-actions.cpp
@@ -4,7 +4,10 @@
 void OpenBuiltinCommandAction::execute(ApplicationContext *context) {
   QString const searchText = context->navigation->searchText();
 
-  context->navigation->launch(cmd);
-
-  if (m_forwardSearchText) { context->navigation->setSearchText(searchText); }
+  if (m_forwardSearchText && !searchText.isEmpty()) {
+    context->navigation->launch(cmd, LaunchProps{.fallbackText = searchText});
+    context->navigation->setSearchText(searchText);
+  } else {
+    context->navigation->launch(cmd);
+  }
 }

--- a/src/server/src/common.hpp
+++ b/src/server/src/common.hpp
@@ -12,6 +12,7 @@ struct LaunchProps {
   QString query;
   std::vector<std::pair<QString, QString>> arguments;
   std::optional<LaunchContext> launchContext;
+  std::optional<QString> cwd;
 };
 
 enum CommandMode : std::uint8_t {

--- a/src/server/src/common.hpp
+++ b/src/server/src/common.hpp
@@ -1,12 +1,17 @@
 #pragma once
 #include <QString>
 #include <cstdint>
+#include <optional>
+#include <qjsonobject.h>
 
 class CommandContext;
+
+using LaunchContext = QJsonObject;
 
 struct LaunchProps {
   QString query;
   std::vector<std::pair<QString, QString>> arguments;
+  std::optional<LaunchContext> launchContext;
 };
 
 enum CommandMode : std::uint8_t {

--- a/src/server/src/common.hpp
+++ b/src/server/src/common.hpp
@@ -12,6 +12,7 @@ struct LaunchProps {
   QString query;
   std::vector<std::pair<QString, QString>> arguments;
   std::optional<LaunchContext> launchContext;
+  std::optional<QString> fallbackText;
   std::optional<QString> cwd;
 };
 

--- a/src/server/src/common/entrypoint.hpp
+++ b/src/server/src/common/entrypoint.hpp
@@ -20,6 +20,8 @@ struct EntrypointId {
     return s;
   }
 
+  bool isValid() const { return !provider.empty() && !entrypoint.empty(); }
+
   static EntrypointId fromSerialized(std::string_view s) {
     auto pos = s.find(':');
     if (pos == std::string::npos) return {};

--- a/src/server/src/extension/extension-command-runtime.cpp
+++ b/src/server/src/extension/extension-command-runtime.cpp
@@ -91,7 +91,7 @@ void ExtensionCommandRuntime::load(const LaunchProps &props) {
   opts.mode = m_command->mode() == CommandMode::CommandModeView ? manager::CommandMode::View
                                                                 : manager::CommandMode::NoView;
 
-  opts.cwd = props.cwd.value_or(QDir::currentPath()).toStdString();
+  opts.cwd = props.cwd.transform([](const QString &s) { return s.toStdString(); });
   opts.extension_id = m_command->extensionId().toStdString();
   opts.vicinae_path = Omnicast::dataDir().string();
   opts.command_name = m_command->commandId().toStdString();

--- a/src/server/src/extension/extension-command-runtime.cpp
+++ b/src/server/src/extension/extension-command-runtime.cpp
@@ -90,6 +90,8 @@ void ExtensionCommandRuntime::load(const LaunchProps &props) {
   opts.entrypoint = m_command->manifest().entrypoint.string();
   opts.mode = m_command->mode() == CommandMode::CommandModeView ? manager::CommandMode::View
                                                                 : manager::CommandMode::NoView;
+
+  opts.cwd = props.cwd.value_or(QDir::currentPath()).toStdString();
   opts.extension_id = m_command->extensionId().toStdString();
   opts.vicinae_path = Omnicast::dataDir().string();
   opts.command_name = m_command->commandId().toStdString();
@@ -110,7 +112,12 @@ void ExtensionCommandRuntime::load(const LaunchProps &props) {
   opts.capabilities.wallpaper = context()->services->wallpaperManager()->canSetWallpaper();
   opts.capabilities.fileSearch = context()->services->fileService()->isAvailable();
 
-  if (m_headless) {
+  // FIXME: relying on the presence of props.cwd to infer CommandLine mode is not
+  // very accurate and could break in the future, we probably want to pass the activation
+  // mode in the props at some point and map them to the figura types.
+  if (props.cwd) {
+    opts.launch_type = manager::LaunchType::CommandLine;
+  } else if (m_headless) {
     opts.launch_type = manager::LaunchType::Background;
   } else {
     opts.launch_type = manager::LaunchType::User;

--- a/src/server/src/extension/extension-command-runtime.cpp
+++ b/src/server/src/extension/extension-command-runtime.cpp
@@ -97,6 +97,8 @@ void ExtensionCommandRuntime::load(const LaunchProps &props) {
   opts.owner_or_author_name = m_command->author().toStdString();
   opts.is_raycast = m_command->isRaycast();
   opts.preferences = qJsonObjectToGlazeGeneric(preferenceValues);
+  opts.launch_context =
+      props.launchContext ? qJsonObjectToGlazeGeneric(*props.launchContext) : glz::generic{};
   opts.arguments = props.arguments |
                    std::views::transform([](auto &&pair) -> std::pair<std::string, std::string> {
                      return {pair.first.toStdString(), pair.second.toStdString()};

--- a/src/server/src/extension/extension-command-runtime.cpp
+++ b/src/server/src/extension/extension-command-runtime.cpp
@@ -92,6 +92,7 @@ void ExtensionCommandRuntime::load(const LaunchProps &props) {
                                                                 : manager::CommandMode::NoView;
 
   opts.cwd = props.cwd.transform([](const QString &s) { return s.toStdString(); });
+  opts.fallbackText = props.fallbackText.transform([](const QString &s) { return s.toStdString(); });
   opts.extension_id = m_command->extensionId().toStdString();
   opts.vicinae_path = Omnicast::dataDir().string();
   opts.command_name = m_command->commandId().toStdString();

--- a/src/server/src/ipc-command-handler.cpp
+++ b/src/server/src/ipc-command-handler.cpp
@@ -172,10 +172,10 @@ std::expected<void, std::string> IpcCommandHandler::handleUrl(const QUrl &url) {
       }
     }
 
-    LaunchProps props{.arguments = std::move(arguments)};
+    LaunchProps props{.arguments = std::move(arguments),
+                      .fallbackText = query.queryItemValue("fallbackText")};
 
-    if (!m_ctx.navigation->activateEntrypoint(
-            id, {.props = props, .fallbackText = query.queryItemValue("fallbackText")})) {
+    if (!m_ctx.navigation->activateEntrypoint(id, {.props = props})) {
       return std::unexpected("No primary action for this root item");
     }
 

--- a/src/server/src/ipc-command-handler.cpp
+++ b/src/server/src/ipc-command-handler.cpp
@@ -172,8 +172,10 @@ std::expected<void, std::string> IpcCommandHandler::handleUrl(const QUrl &url) {
       }
     }
 
+    LaunchProps props{.arguments = std::move(arguments)};
+
     if (!m_ctx.navigation->activateEntrypoint(
-            id, {.arguments = std::move(arguments), .fallbackText = query.queryItemValue("fallbackText")})) {
+            id, {.props = props, .fallbackText = query.queryItemValue("fallbackText")})) {
       return std::unexpected("No primary action for this root item");
     }
 

--- a/src/server/src/ipc-command-server.cpp
+++ b/src/server/src/ipc-command-server.cpp
@@ -1,4 +1,5 @@
 #include "ipc-command-server.hpp"
+#include "common.hpp"
 #include "generated/ipc-server.hpp"
 #include "ipc-command-handler.hpp"
 #include "config/config.hpp"
@@ -122,14 +123,7 @@ std::expected<ArgumentValues, std::string> buildLaunchArguments(const ArgumentLi
   return arguments;
 }
 
-std::optional<LaunchContext> makeLaunchContext(const ipc_gen::LaunchCommandRequest &req) {
-  if (!req.cwd) return std::nullopt;
-
-  LaunchContext context;
-
-  context.insert("cwd", QString::fromStdString(*req.cwd));
-  return context;
-}
+LaunchContext makeLaunchContext(const ipc_gen::LaunchCommandRequest &req) { return LaunchContext{}; }
 
 } // namespace
 
@@ -242,9 +236,13 @@ IpcService::launchCommand(ipc_gen::LaunchCommandRequest req) {
 
   if (!arguments) return ipc_gen::Result<ipc_gen::LaunchCommandResponse>::fail(arguments.error());
 
-  if (!m_ctx.navigation->activateEntrypoint(id, {.arguments = std::move(*arguments),
-                                                 .launchContext = makeLaunchContext(req),
-                                                 .toggleIfAlreadyActive = false})) {
+  LaunchProps props{
+      .arguments = std::move(*arguments),
+      .launchContext = makeLaunchContext(req),
+      .cwd = req.cwd.transform(QString::fromStdString),
+  };
+
+  if (!m_ctx.navigation->activateEntrypoint(id, {.props = props, .toggleIfAlreadyActive = false})) {
     return ipc_gen::Result<ipc_gen::LaunchCommandResponse>::fail("Failed to launch command");
   }
 

--- a/src/server/src/ipc-command-server.cpp
+++ b/src/server/src/ipc-command-server.cpp
@@ -8,6 +8,8 @@
 #include "services/files-service/file-service.hpp"
 #include "qml/dmenu-view-host.hpp"
 #include "utils.hpp"
+#include "root-search/extensions/extension-root-provider.hpp"
+#include <algorithm>
 #include <cstdint>
 #include <optional>
 #include <qfuture.h>
@@ -82,6 +84,51 @@ std::string_view fileCategoryToString(vicinae::FileCategory category) {
     if (definition.category == category) return definition.name;
   }
   return "other";
+}
+
+std::expected<ArgumentValues, std::string> buildLaunchArguments(const ArgumentList &manifestArgs,
+                                                                const std::vector<std::string> &values) {
+  if (values.size() > manifestArgs.size()) {
+    return std::unexpected(
+        std::format("Too many arguments: expected at most {}, got {}", manifestArgs.size(), values.size()));
+  }
+
+  ArgumentValues arguments;
+  arguments.reserve(values.size());
+
+  for (size_t idx = 0; idx != values.size(); ++idx) {
+    const auto &value = values.at(idx);
+    const auto &arg = manifestArgs.at(idx);
+    const QString qvalue = QString::fromStdString(value);
+
+    if (arg.type == CommandArgument::Dropdown && arg.data) {
+      auto matchesValue = [&](const CommandArgument::DropdownData &option) { return option.value == qvalue; };
+      if (!std::ranges::any_of(*arg.data, matchesValue)) {
+        return std::unexpected(
+            std::format("Invalid value '{}' for argument '{}'", value, arg.name.toStdString()));
+      }
+    }
+
+    arguments.emplace_back(arg.name, qvalue);
+  }
+
+  for (size_t idx = values.size(); idx != manifestArgs.size(); ++idx) {
+    const auto &arg = manifestArgs.at(idx);
+    if (arg.required) {
+      return std::unexpected(std::format("Missing required argument '{}'", arg.name.toStdString()));
+    }
+  }
+
+  return arguments;
+}
+
+std::optional<LaunchContext> makeLaunchContext(const ipc_gen::LaunchCommandRequest &req) {
+  if (!req.cwd) return std::nullopt;
+
+  LaunchContext context;
+
+  context.insert("cwd", QString::fromStdString(*req.cwd));
+  return context;
 }
 
 } // namespace
@@ -160,6 +207,61 @@ ipc_gen::Result<ipc_gen::LaunchAppResponse>::Future IpcService::launchApp(ipc_ge
         std::format("Failed to launch app with id {}", req.appId));
 
   return ipc_gen::Result<ipc_gen::LaunchAppResponse>::ok({});
+}
+
+ipc_gen::Result<ipc_gen::ListCommandsResponse>::Future IpcService::listCommands() {
+  std::vector<std::string> commands;
+  auto root = m_ctx.services->rootItemManager();
+  auto items = root->allItems();
+
+  commands.reserve(items.size());
+
+  for (const auto &item : items) {
+    if (!item.item) continue;
+
+    auto *commandItem = dynamic_cast<CommandRootItem *>(item.item.get());
+    if (!commandItem) continue;
+
+    auto command = commandItem->command();
+    commands.emplace_back(std::string{command->uniqueId()});
+  }
+
+  std::ranges::sort(commands);
+  return ipc_gen::Result<ipc_gen::ListCommandsResponse>::ok({.commands = std::move(commands)});
+}
+
+ipc_gen::Result<ipc_gen::LaunchCommandResponse>::Future
+IpcService::launchCommand(ipc_gen::LaunchCommandRequest req) {
+  auto id = EntrypointId::fromSerialized(req.entrypoint);
+  if (id.provider.empty() || id.entrypoint.empty()) {
+    return ipc_gen::Result<ipc_gen::LaunchCommandResponse>::fail(
+        std::format("Invalid command entrypoint: {}", req.entrypoint));
+  }
+
+  auto root = m_ctx.services->rootItemManager();
+  auto *item = root->findItemById(id);
+
+  if (!item) {
+    return ipc_gen::Result<ipc_gen::LaunchCommandResponse>::fail(
+        std::format("Unknown command entrypoint: {}", req.entrypoint));
+  }
+
+  auto *commandItem = dynamic_cast<CommandRootItem *>(item);
+  if (!commandItem) {
+    return ipc_gen::Result<ipc_gen::LaunchCommandResponse>::fail("Target is not a command");
+  }
+
+  auto command = commandItem->command();
+  auto arguments = buildLaunchArguments(command->arguments(), req.args);
+  if (!arguments) return ipc_gen::Result<ipc_gen::LaunchCommandResponse>::fail(arguments.error());
+
+  if (!m_ctx.navigation->activateEntrypoint(id, {.arguments = std::move(*arguments),
+                                                 .launchContext = makeLaunchContext(req),
+                                                 .toggleIfAlreadyActive = false})) {
+    return ipc_gen::Result<ipc_gen::LaunchCommandResponse>::fail("Failed to launch command");
+  }
+
+  return ipc_gen::Result<ipc_gen::LaunchCommandResponse>::ok({});
 }
 
 ipc_gen::Result<ipc_gen::DMenuResponse>::Future IpcService::dmenu(ipc_gen::DMenuRequest request) {

--- a/src/server/src/ipc-command-server.cpp
+++ b/src/server/src/ipc-command-server.cpp
@@ -252,7 +252,7 @@ IpcService::launchCommand(ipc_gen::LaunchCommandRequest req) {
   if (!arguments) return ipc_gen::Result<ipc_gen::LaunchCommandResponse>::fail(arguments.error());
 
   LaunchProps props{
-      .arguments = std::move(*arguments),
+      .arguments = std::move(arguments).value(),
       .launchContext = makeLaunchContext(req),
       .fallbackText = req.query.transform(QString::fromStdString),
       .cwd = req.cwd.transform(QString::fromStdString),

--- a/src/server/src/ipc-command-server.cpp
+++ b/src/server/src/ipc-command-server.cpp
@@ -239,6 +239,7 @@ IpcService::launchCommand(ipc_gen::LaunchCommandRequest req) {
   LaunchProps props{
       .arguments = std::move(*arguments),
       .launchContext = makeLaunchContext(req),
+      .fallbackText = req.query.transform(QString::fromStdString),
       .cwd = req.cwd.transform(QString::fromStdString),
   };
 

--- a/src/server/src/ipc-command-server.cpp
+++ b/src/server/src/ipc-command-server.cpp
@@ -210,32 +210,24 @@ ipc_gen::Result<ipc_gen::LaunchAppResponse>::Future IpcService::launchApp(ipc_ge
 }
 
 ipc_gen::Result<ipc_gen::ListCommandsResponse>::Future IpcService::listCommands() {
-  std::vector<std::string> commands;
   auto root = m_ctx.services->rootItemManager();
-  auto items = root->allItems();
+  auto commands =
+      root->allItems() |
+      std::views::transform([](auto &&item) { return ipc_gen::CommandInfo{.id = item.item->uniqueId()}; }) |
+      std::ranges::to<std::vector>();
 
-  commands.reserve(items.size());
+  std::ranges::sort(commands, [](const auto &a, const auto &b) { return a.id < b.id; });
 
-  for (const auto &item : items) {
-    if (!item.item) continue;
-
-    auto *commandItem = dynamic_cast<CommandRootItem *>(item.item.get());
-    if (!commandItem) continue;
-
-    auto command = commandItem->command();
-    commands.emplace_back(std::string{command->uniqueId()});
-  }
-
-  std::ranges::sort(commands);
   return ipc_gen::Result<ipc_gen::ListCommandsResponse>::ok({.commands = std::move(commands)});
 }
 
 ipc_gen::Result<ipc_gen::LaunchCommandResponse>::Future
 IpcService::launchCommand(ipc_gen::LaunchCommandRequest req) {
   auto id = EntrypointId::fromSerialized(req.entrypoint);
-  if (id.provider.empty() || id.entrypoint.empty()) {
+
+  if (!id.isValid()) {
     return ipc_gen::Result<ipc_gen::LaunchCommandResponse>::fail(
-        std::format("Invalid command entrypoint: {}", req.entrypoint));
+        std::format("Ill-formed command entrypoint: {}", req.entrypoint));
   }
 
   auto root = m_ctx.services->rootItemManager();
@@ -246,13 +238,8 @@ IpcService::launchCommand(ipc_gen::LaunchCommandRequest req) {
         std::format("Unknown command entrypoint: {}", req.entrypoint));
   }
 
-  auto *commandItem = dynamic_cast<CommandRootItem *>(item);
-  if (!commandItem) {
-    return ipc_gen::Result<ipc_gen::LaunchCommandResponse>::fail("Target is not a command");
-  }
+  auto arguments = buildLaunchArguments(item->arguments(), req.args);
 
-  auto command = commandItem->command();
-  auto arguments = buildLaunchArguments(command->arguments(), req.args);
   if (!arguments) return ipc_gen::Result<ipc_gen::LaunchCommandResponse>::fail(arguments.error());
 
   if (!m_ctx.navigation->activateEntrypoint(id, {.arguments = std::move(*arguments),

--- a/src/server/src/ipc-command-server.cpp
+++ b/src/server/src/ipc-command-server.cpp
@@ -1,5 +1,8 @@
 #include "ipc-command-server.hpp"
+#include "argument.hpp"
 #include "common.hpp"
+#include "common/entrypoint.hpp"
+#include "common/enumerate.hpp"
 #include "generated/ipc-server.hpp"
 #include "ipc-command-handler.hpp"
 #include "config/config.hpp"
@@ -16,6 +19,7 @@
 #include <qfuture.h>
 #include <qlogging.h>
 #include <ranges>
+#include <sstream>
 #include <string_view>
 #include <utility>
 #include "services/app-service/app-service.hpp"
@@ -62,7 +66,7 @@ struct FileCategoryDefinition {
   vicinae::FileCategory category;
 };
 
-static constexpr FileCategoryDefinition FILE_CATEGORIES[] = {
+constexpr FileCategoryDefinition FILE_CATEGORIES[] = {
     {.name = "other", .category = vicinae::FileCategory::Other},
     {.name = "directory", .category = vicinae::FileCategory::Directory},
     {.name = "image", .category = vicinae::FileCategory::Image},
@@ -87,26 +91,39 @@ std::string_view fileCategoryToString(vicinae::FileCategory category) {
   return "other";
 }
 
-std::expected<ArgumentValues, std::string> buildLaunchArguments(const ArgumentList &manifestArgs,
+std::expected<ArgumentValues, std::string> buildLaunchArguments(const EntrypointId &id,
+                                                                const ArgumentList &manifestArgs,
                                                                 const std::vector<std::string> &values) {
+  const auto fail = [&](auto &&message) {
+    std::ostringstream oss;
+
+    oss << message << "\n" << "Usage: vicinae cmd launch " << std::string{id};
+
+    for (const auto &[idx, arg] : manifestArgs | vicinae::enumerate) {
+      auto openChar = arg.required ? '<' : '[';
+      auto closeChar = arg.required ? '>' : ']';
+      oss << " " << openChar << arg.name.toStdString() << closeChar;
+    }
+
+    return std::unexpected(oss.str());
+  };
+
   if (values.size() > manifestArgs.size()) {
-    return std::unexpected(
+    return fail(
         std::format("Too many arguments: expected at most {}, got {}", manifestArgs.size(), values.size()));
   }
 
   ArgumentValues arguments;
   arguments.reserve(values.size());
 
-  for (size_t idx = 0; idx != values.size(); ++idx) {
-    const auto &value = values.at(idx);
+  for (const auto [idx, value] : values | vicinae::enumerate) {
     const auto &arg = manifestArgs.at(idx);
     const QString qvalue = QString::fromStdString(value);
 
     if (arg.type == CommandArgument::Dropdown && arg.data) {
       auto matchesValue = [&](const CommandArgument::DropdownData &option) { return option.value == qvalue; };
       if (!std::ranges::any_of(*arg.data, matchesValue)) {
-        return std::unexpected(
-            std::format("Invalid value '{}' for argument '{}'", value, arg.name.toStdString()));
+        return fail(std::format("Invalid value '{}' for argument '{}'", value, arg.name.toStdString()));
       }
     }
 
@@ -115,9 +132,7 @@ std::expected<ArgumentValues, std::string> buildLaunchArguments(const ArgumentLi
 
   for (size_t idx = values.size(); idx != manifestArgs.size(); ++idx) {
     const auto &arg = manifestArgs.at(idx);
-    if (arg.required) {
-      return std::unexpected(std::format("Missing required argument '{}'", arg.name.toStdString()));
-    }
+    if (arg.required) { return fail(std::format("Missing required argument '{}'", arg.name.toStdString())); }
   }
 
   return arguments;
@@ -232,7 +247,7 @@ IpcService::launchCommand(ipc_gen::LaunchCommandRequest req) {
         std::format("Unknown command entrypoint: {}", req.entrypoint));
   }
 
-  auto arguments = buildLaunchArguments(item->arguments(), req.args);
+  auto arguments = buildLaunchArguments(id, item->arguments(), req.args);
 
   if (!arguments) return ipc_gen::Result<ipc_gen::LaunchCommandResponse>::fail(arguments.error());
 

--- a/src/server/src/ipc-command-server.cpp
+++ b/src/server/src/ipc-command-server.cpp
@@ -221,8 +221,9 @@ ipc_gen::Result<ipc_gen::LaunchAppResponse>::Future IpcService::launchApp(ipc_ge
 ipc_gen::Result<ipc_gen::ListCommandsResponse>::Future IpcService::listCommands() {
   auto root = m_ctx.services->rootItemManager();
   auto commands =
-      root->allItems() |
-      std::views::transform([](auto &&item) { return ipc_gen::CommandInfo{.id = item.item->uniqueId()}; }) |
+      root->allItems() | std::views::transform([](auto &&item) {
+        return ipc_gen::CommandInfo{.id = item.item->uniqueId(), .name = item.item->title().toStdString()};
+      }) |
       std::ranges::to<std::vector>();
 
   std::ranges::sort(commands, [](const auto &a, const auto &b) { return a.id < b.id; });

--- a/src/server/src/ipc-command-server.hpp
+++ b/src/server/src/ipc-command-server.hpp
@@ -28,6 +28,9 @@ public:
   ipc_gen::Result<ipc_gen::DeeplinkResponse>::Future deeplink(ipc_gen::DeeplinkRequest req) override;
   ipc_gen::Result<ipc_gen::DescribeResponse>::Future describe() override;
   ipc_gen::Result<ipc_gen::LaunchAppResponse>::Future launchApp(ipc_gen::LaunchAppRequest req) override;
+  ipc_gen::Result<ipc_gen::ListCommandsResponse>::Future listCommands() override;
+  ipc_gen::Result<ipc_gen::LaunchCommandResponse>::Future
+  launchCommand(ipc_gen::LaunchCommandRequest req) override;
   ipc_gen::Result<ipc_gen::DMenuResponse>::Future dmenu(ipc_gen::DMenuRequest req) override;
   ipc_gen::Result<void>::Future browserInit(ipc_gen::BrowserInitRequest req) override;
   ipc_gen::Result<void>::Future browserTabsChanged(std::vector<ipc_gen::BrowserTabInfo> tabs) override;

--- a/src/server/src/navigation-controller.cpp
+++ b/src/server/src/navigation-controller.cpp
@@ -591,7 +591,7 @@ bool NavigationController::activateEntrypoint(const EntrypointId &id,
 
   // FIXME: we need a unified interface for this
   if (auto *ext = dynamic_cast<const CommandRootItem *>(entrypoint)) {
-    launch(ext->command(), {.arguments = options.arguments, .launchContext = options.launchContext});
+    launch(ext->command(), options.props);
   } else {
     auto panel = entrypoint->newActionPanel(&m_ctx, root->itemMetadata(id));
     panel->finalize();

--- a/src/server/src/navigation-controller.cpp
+++ b/src/server/src/navigation-controller.cpp
@@ -603,7 +603,7 @@ bool NavigationController::activateEntrypoint(const EntrypointId &id,
     action->execute(&m_ctx);
   }
 
-  if (auto fallback = options.props.fallbackText; !fallback) { setSearchText(fallback.value()); }
+  if (auto fallback = options.props.fallbackText) { setSearchText(fallback.value()); }
 
   if (!isRootSearch() && !initialOpenState) {
     setInstantDismiss();

--- a/src/server/src/navigation-controller.cpp
+++ b/src/server/src/navigation-controller.cpp
@@ -581,7 +581,7 @@ bool NavigationController::activateEntrypoint(const EntrypointId &id,
   const bool isSameView = previouslyActive->uniqueId() == id && previouslyActive->isView();
 
   // toggle visibility if we are already showing
-  if (initialOpenState && isSameView) {
+  if (options.toggleIfAlreadyActive && initialOpenState && isSameView) {
     popToRoot({.clearSearch = false});
     m_ctx.navigation->closeWindow();
     return true;
@@ -591,7 +591,7 @@ bool NavigationController::activateEntrypoint(const EntrypointId &id,
 
   // FIXME: we need a unified interface for this
   if (auto *ext = dynamic_cast<const CommandRootItem *>(entrypoint)) {
-    launch(ext->command(), options.arguments);
+    launch(ext->command(), {.arguments = options.arguments, .launchContext = options.launchContext});
   } else {
     auto panel = entrypoint->newActionPanel(&m_ctx, root->itemMetadata(id));
     panel->finalize();
@@ -617,10 +617,14 @@ bool NavigationController::activateEntrypoint(const EntrypointId &id,
 }
 
 void NavigationController::launch(const std::shared_ptr<AbstractCmd> &cmd) {
-  launch(cmd, completionValues());
+  launch(cmd, LaunchProps{.arguments = completionValues()});
 }
 
 void NavigationController::launch(const std::shared_ptr<AbstractCmd> &cmd, const ArgumentValues &arguments) {
+  launch(cmd, LaunchProps{.arguments = arguments});
+}
+
+void NavigationController::launch(const std::shared_ptr<AbstractCmd> &cmd, const LaunchProps &props) {
   // unload stalled no-view command
   if (!m_frames.empty() && m_frames.back()->viewCount == 0) { m_frames.pop_back(); }
 
@@ -630,9 +634,6 @@ void NavigationController::launch(const std::shared_ptr<AbstractCmd> &cmd, const
   }
 
   bool const shouldCheckPreferences = cmd->type() == CommandType::CommandTypeExtension;
-  LaunchProps props;
-
-  props.arguments = arguments;
 
   if (shouldCheckPreferences) {
     auto itemId = cmd->uniqueId();

--- a/src/server/src/navigation-controller.cpp
+++ b/src/server/src/navigation-controller.cpp
@@ -603,9 +603,7 @@ bool NavigationController::activateEntrypoint(const EntrypointId &id,
     action->execute(&m_ctx);
   }
 
-  if (!options.fallbackText.isEmpty()) { setSearchText(options.fallbackText); }
-
-  auto *active = activeCommand();
+  if (auto fallback = options.props.fallbackText; !fallback) { setSearchText(fallback.value()); }
 
   if (!isRootSearch() && !initialOpenState) {
     setInstantDismiss();

--- a/src/server/src/navigation-controller.cpp
+++ b/src/server/src/navigation-controller.cpp
@@ -593,6 +593,10 @@ bool NavigationController::activateEntrypoint(const EntrypointId &id,
   if (auto *ext = dynamic_cast<const CommandRootItem *>(entrypoint)) {
     launch(ext->command(), options.props);
   } else {
+    // FIXME: hacky, again we need a proper unified interface for this
+    createCompletion(entrypoint->arguments(), entrypoint->iconUrl());
+    setCompletionValues(options.props.arguments);
+
     auto panel = entrypoint->newActionPanel(&m_ctx, root->itemMetadata(id));
     panel->finalize();
     auto *action = panel->primaryAction();

--- a/src/server/src/navigation-controller.hpp
+++ b/src/server/src/navigation-controller.hpp
@@ -38,9 +38,8 @@ struct PopToRootOptions {
 using ArgumentValues = std::vector<std::pair<QString, QString>>;
 
 struct ActivateEntrypointOptions {
-  ArgumentValues arguments;
+  LaunchProps props;
   QString fallbackText;
-  std::optional<LaunchContext> launchContext;
   bool toggleIfAlreadyActive = true;
 };
 

--- a/src/server/src/navigation-controller.hpp
+++ b/src/server/src/navigation-controller.hpp
@@ -40,6 +40,8 @@ using ArgumentValues = std::vector<std::pair<QString, QString>>;
 struct ActivateEntrypointOptions {
   ArgumentValues arguments;
   QString fallbackText;
+  std::optional<LaunchContext> launchContext;
+  bool toggleIfAlreadyActive = true;
 };
 
 struct CompleterState {
@@ -214,6 +216,7 @@ public:
 
   void launch(const std::shared_ptr<AbstractCmd> &cmd);
   void launch(const std::shared_ptr<AbstractCmd> &cmd, const ArgumentValues &arguments);
+  void launch(const std::shared_ptr<AbstractCmd> &cmd, const LaunchProps &props);
   bool activateEntrypoint(const EntrypointId &id, const ActivateEntrypointOptions &options = {});
 
   const AbstractCmd *activeCommand() const;

--- a/src/server/src/navigation-controller.hpp
+++ b/src/server/src/navigation-controller.hpp
@@ -39,7 +39,6 @@ using ArgumentValues = std::vector<std::pair<QString, QString>>;
 
 struct ActivateEntrypointOptions {
   LaunchProps props;
-  QString fallbackText;
   bool toggleIfAlreadyActive = true;
 };
 

--- a/src/server/src/root-search/shortcuts/shortcut-root-provider.cpp
+++ b/src/server/src/root-search/shortcuts/shortcut-root-provider.cpp
@@ -87,6 +87,7 @@ ArgumentList RootShortcutItem::arguments() const {
     CommandArgument cmdArg;
 
     cmdArg.type = CommandArgument::Text;
+    cmdArg.name = arg.name;
     cmdArg.required = arg.defaultValue.isEmpty();
     cmdArg.placeholder = arg.name;
     args.emplace_back(cmdArg);

--- a/src/typescript/api/src/api/environment.ts
+++ b/src/typescript/api/src/api/environment.ts
@@ -6,6 +6,7 @@ import type { Wallpaper } from "./wallpaper";
 import type { WindowManagement } from "./window-management";
 
 export interface LaunchContext {
+	cwd: string;
 	[item: string]: any;
 }
 

--- a/src/typescript/api/src/api/environment.ts
+++ b/src/typescript/api/src/api/environment.ts
@@ -6,7 +6,6 @@ import type { Wallpaper } from "./wallpaper";
 import type { WindowManagement } from "./window-management";
 
 export interface LaunchContext {
-	cwd: string;
 	[item: string]: any;
 }
 
@@ -53,10 +52,18 @@ export enum LaunchType {
 	 * A regular launch through user interaction
 	 */
 	UserInitiated = "userInitiated",
+
 	/**
 	 * Scheduled through an interval and launched from background
 	 */
 	Background = "background",
+
+	/**
+	 * The command was started from the command line, using e.g
+	 * `vicinae cmd launch`. `process.cwd()` can be called to get the
+	 * working directory in which the command was issued.
+	 */
+	CommandLine = "commandLine",
 }
 
 // every API we can check availability for using environment.canAccess

--- a/src/typescript/api/src/api/environment.ts
+++ b/src/typescript/api/src/api/environment.ts
@@ -45,6 +45,11 @@ export declare type LaunchProps<
 	 * When the command is launched as a fallback command, this string contains the text of the root search.
 	 */
 	fallbackText?: string;
+
+	/**
+	 * Set when the command is launched from the command line using `vicinae cmd launch`.
+	 */
+	cwd?: string;
 };
 
 export enum LaunchType {

--- a/src/typescript/api/src/proto/ipc.ts
+++ b/src/typescript/api/src/proto/ipc.ts
@@ -107,6 +107,20 @@ export type LaunchAppResponse = {
 	focusedWindowTitle: string;
 }
 
+export type LaunchCommandRequest = {
+	entrypoint: string;
+	args: string[];
+	cwd?: string;
+}
+
+export type LaunchCommandResponse = {
+	error?: string;
+}
+
+export type ListCommandsResponse = {
+	commands: string[];
+}
+
 export type DMenuRequest = {
 	rawContent: string;
 	navigationTitle?: string;
@@ -179,6 +193,14 @@ class IpcService {
 
 	launchApp(req: LaunchAppRequest): Promise<LaunchAppResponse> {
 		return this.transport.request("Ipc/launchApp", { req});	
+	}
+
+	listCommands(): Promise<ListCommandsResponse> {
+		return this.transport.request("Ipc/listCommands", { });	
+	}
+
+	launchCommand(req: LaunchCommandRequest): Promise<LaunchCommandResponse> {
+		return this.transport.request("Ipc/launchCommand", { req});	
 	}
 
 	dmenu(req: DMenuRequest): Promise<DMenuResponse> {

--- a/src/typescript/api/src/proto/ipc.ts
+++ b/src/typescript/api/src/proto/ipc.ts
@@ -111,6 +111,7 @@ export type LaunchCommandRequest = {
 	entrypoint: string;
 	args: string[];
 	cwd?: string;
+	query?: string;
 }
 
 export type LaunchCommandResponse = {

--- a/src/typescript/api/src/proto/ipc.ts
+++ b/src/typescript/api/src/proto/ipc.ts
@@ -120,6 +120,7 @@ export type LaunchCommandResponse = {
 
 export type CommandInfo = {
 	id: string;
+	name: string;
 }
 
 export type ListCommandsResponse = {

--- a/src/typescript/api/src/proto/ipc.ts
+++ b/src/typescript/api/src/proto/ipc.ts
@@ -117,8 +117,12 @@ export type LaunchCommandResponse = {
 	error?: string;
 }
 
+export type CommandInfo = {
+	id: string;
+}
+
 export type ListCommandsResponse = {
-	commands: string[];
+	commands: CommandInfo[];
 }
 
 export type DMenuRequest = {

--- a/src/typescript/extension-manager/src/index.ts
+++ b/src/typescript/extension-manager/src/index.ts
@@ -104,6 +104,7 @@ class ExtensionManager extends manager.ManagerService {
 				command_name: load.command_name,
 				launch_type: load.launch_type,
 				capabilities: load.capabilities,
+				cwd: load.cwd,
 			},
 		};
 

--- a/src/typescript/extension-manager/src/index.ts
+++ b/src/typescript/extension-manager/src/index.ts
@@ -94,6 +94,7 @@ class ExtensionManager extends manager.ManagerService {
 				entrypoint: load.entrypoint,
 				argumentValues: load.arguments,
 				preferenceValues: load.preferences,
+				launch_context: load.launch_context,
 				mode: load.mode,
 				support_path: supportPath,
 				asset_path: assetsPath,

--- a/src/typescript/extension-manager/src/index.ts
+++ b/src/typescript/extension-manager/src/index.ts
@@ -135,7 +135,7 @@ class ExtensionManager extends manager.ManagerService {
 			logger.error(`worker error: ${error}`);
 		});
 
-		worker.on("online", () => { });
+		worker.on("online", () => {});
 
 		const stdoutStream = fs.createWriteStream(stdoutLog);
 		const stderrStream = fs.createWriteStream(stderrLog);

--- a/src/typescript/extension-manager/src/index.ts
+++ b/src/typescript/extension-manager/src/index.ts
@@ -105,6 +105,7 @@ class ExtensionManager extends manager.ManagerService {
 				launch_type: load.launch_type,
 				capabilities: load.capabilities,
 				cwd: load.cwd,
+				fallbackText: load.fallbackText,
 			},
 		};
 
@@ -134,7 +135,7 @@ class ExtensionManager extends manager.ManagerService {
 			logger.error(`worker error: ${error}`);
 		});
 
-		worker.on("online", () => {});
+		worker.on("online", () => { });
 
 		const stdoutStream = fs.createWriteStream(stdoutLog);
 		const stderrStream = fs.createWriteStream(stderrLog);

--- a/src/typescript/extension-manager/src/loaders/load-no-view-command.ts
+++ b/src/typescript/extension-manager/src/loaders/load-no-view-command.ts
@@ -11,5 +11,8 @@ export default async (data: LaunchEventData) => {
 		);
 	}
 
-	await entrypoint({ arguments: data.argumentValues });
+	await entrypoint({
+		arguments: data.argumentValues,
+		launchContext: data.launch_context,
+	});
 };

--- a/src/typescript/extension-manager/src/loaders/load-no-view-command.ts
+++ b/src/typescript/extension-manager/src/loaders/load-no-view-command.ts
@@ -1,3 +1,4 @@
+import { environment, type LaunchProps } from "@vicinae/api";
 import type { LaunchEventData } from "../proto/extension-manager";
 import { pathToFileURL } from "node:url";
 
@@ -12,7 +13,10 @@ export default async (data: LaunchEventData) => {
 	}
 
 	await entrypoint({
+		launchType: environment.launchType,
 		arguments: data.argumentValues,
 		launchContext: data.launch_context,
-	});
+		cwd: data.cwd,
+		fallbackText: data.fallbackText,
+	} as LaunchProps);
 };

--- a/src/typescript/extension-manager/src/loaders/load-view-command.tsx
+++ b/src/typescript/extension-manager/src/loaders/load-view-command.tsx
@@ -46,7 +46,7 @@ const App: React.FC<{ component: ComponentType; launchProps: LaunchProps }> = ({
 	);
 };
 
-export default async function(data: extensionServer.LaunchEventData) {
+export default async function (data: extensionServer.LaunchEventData) {
 	const module = await import(pathToFileURL(data.entrypoint).href);
 	const Component = module.default.default;
 	const sendRender = (views: ViewData[]) => {

--- a/src/typescript/extension-manager/src/loaders/load-view-command.tsx
+++ b/src/typescript/extension-manager/src/loaders/load-view-command.tsx
@@ -57,7 +57,10 @@ export default async function (data: extensionServer.LaunchEventData) {
 
 	renderer.render(
 		<App
-			launchProps={{ arguments: data.argumentValues }}
+			launchProps={{
+				arguments: data.argumentValues,
+				launchContext: data.launch_context,
+			}}
 			component={Component}
 		/>,
 	);

--- a/src/typescript/extension-manager/src/loaders/load-view-command.tsx
+++ b/src/typescript/extension-manager/src/loaders/load-view-command.tsx
@@ -46,7 +46,7 @@ const App: React.FC<{ component: ComponentType; launchProps: LaunchProps }> = ({
 	);
 };
 
-export default async function (data: extensionServer.LaunchEventData) {
+export default async function(data: extensionServer.LaunchEventData) {
 	const module = await import(pathToFileURL(data.entrypoint).href);
 	const Component = module.default.default;
 	const sendRender = (views: ViewData[]) => {
@@ -64,6 +64,7 @@ export default async function (data: extensionServer.LaunchEventData) {
 				launchType: environment.launchType,
 				arguments: data.argumentValues,
 				launchContext: data.launch_context,
+				fallbackText: data.fallbackText,
 				cwd: data.cwd,
 			}}
 			component={Component}

--- a/src/typescript/extension-manager/src/loaders/load-view-command.tsx
+++ b/src/typescript/extension-manager/src/loaders/load-view-command.tsx
@@ -1,3 +1,4 @@
+import { environment, type LaunchProps } from "@vicinae/api";
 import { createRenderer, type ViewData } from "../reconciler";
 import { type ComponentType, Suspense } from "react";
 import * as React from "react";
@@ -30,14 +31,16 @@ class ErrorBoundary extends React.Component<
 	}
 }
 
-const App: React.FC<{ component: ComponentType; launchProps: any }> = ({
+const App: React.FC<{ component: ComponentType; launchProps: LaunchProps }> = ({
 	component: Component,
 	launchProps,
 }) => {
 	return (
 		<ErrorBoundary>
 			<Suspense fallback={null}>
-				<NavigationProvider root={<Component {...launchProps} />} />
+				<NavigationProvider
+					root={<Component {...(launchProps as Record<string, unknown>)} />}
+				/>
 			</Suspense>
 		</ErrorBoundary>
 	);
@@ -58,8 +61,10 @@ export default async function (data: extensionServer.LaunchEventData) {
 	renderer.render(
 		<App
 			launchProps={{
+				launchType: environment.launchType,
 				arguments: data.argumentValues,
 				launchContext: data.launch_context,
+				cwd: data.cwd,
 			}}
 			component={Component}
 		/>,

--- a/src/typescript/extension-manager/src/worker.tsx
+++ b/src/typescript/extension-manager/src/worker.tsx
@@ -21,6 +21,8 @@ class Lifecycle extends extensionServer.LifecycleService {
 	async launch(data: extensionServer.LaunchEventData): Promise<boolean> {
 		const { environment } = workerData as { environment: EnvironmentType };
 
+		process.chdir(data.cwd);
+
 		// raycast compat captures preference values at load time: keep before patchRequire
 		loadEnviron(environment, data);
 		patchRequire(environment);

--- a/src/typescript/extension-manager/src/worker.tsx
+++ b/src/typescript/extension-manager/src/worker.tsx
@@ -21,8 +21,6 @@ class Lifecycle extends extensionServer.LifecycleService {
 	async launch(data: extensionServer.LaunchEventData): Promise<boolean> {
 		const { environment } = workerData as { environment: EnvironmentType };
 
-		process.chdir(data.cwd);
-
 		// raycast compat captures preference values at load time: keep before patchRequire
 		loadEnviron(environment, data);
 		patchRequire(environment);
@@ -73,6 +71,17 @@ client.EventCore.handlerActivated((id, data) => {
 	callbackManager.activateHandler(id, data);
 });
 
+const mapLaunchType = (t: extensionServer.LaunchType) => {
+	switch (t) {
+		case "User":
+			return LaunchType.UserInitiated;
+		case "Background":
+			return LaunchType.Background;
+		case "CommandLine":
+			return LaunchType.CommandLine;
+	}
+};
+
 const loadEnviron = (
 	environment: EnvironmentType,
 	data: extensionServer.LaunchEventData,
@@ -98,10 +107,7 @@ const loadEnviron = (
 		supportPath: data.support_path,
 		assetsPath: data.asset_path,
 		raycastVersion: "1.0.0", // provided for compatibility only, not meaningful
-		launchType:
-			data.launch_type === "User"
-				? LaunchType.UserInitiated
-				: LaunchType.Background,
+		launchType: mapLaunchType(data.launch_type),
 		extensionName: data.extension_name,
 		ownerOrAuthorName: data.owner_or_author_name,
 		vicinaeVersion: {


### PR DESCRIPTION
This PR adds a new `cmd` cli verb that lets the user launch a command from the cli easier. It also attaches the cwd to the a new launchContext for extensions.

<img width="840" height="495" alt="image" src="https://github.com/user-attachments/assets/4478829b-c2e1-4b04-8168-b855255d52df" />
<img width="893" height="303" alt="image" src="https://github.com/user-attachments/assets/c5baf305-9f2d-4814-b1b4-ca80c64ae730" />
<img width="952" height="256" alt="image" src="https://github.com/user-attachments/assets/22d506d8-0509-40af-b18a-46490b7cb4a0" />

Fixes #1657