### PR TITLE
feat(settings): expose automatic window material

### DIFF
--- a/extra/config.jsonc
+++ b/extra/config.jsonc
@@ -108,7 +108,7 @@
 		},
 
 		// "none", "blur", "liquid_glass", or "auto" (liquid_glass when available, else blur).
-		// Needs window opacity < 1 to be visible.
+		// When opacity is unset, liquid glass uses a translucent default automatically.
 		"material": "auto",
 
 		// Corner radius of the launcher window, in pixels.

--- a/src/server/src/qml/general-settings-model.cpp
+++ b/src/server/src/qml/general-settings-model.cpp
@@ -168,6 +168,7 @@ static QVariantList wrapSection(const QString &title, const QVariantList &items)
 
 QVariantList GeneralSettingsModel::windowMaterialItems() const {
   QVariantList items;
+  items.append(makeDropdownItem(QStringLiteral("auto"), QStringLiteral("Automatic")));
   items.append(makeDropdownItem(QStringLiteral("none"), QStringLiteral("None")));
   items.append(makeDropdownItem(QStringLiteral("blur"), QStringLiteral("Blurred")));
   if (platform::supports(platform::Capability::LiquidGlass))
@@ -176,6 +177,10 @@ QVariantList GeneralSettingsModel::windowMaterialItems() const {
 }
 
 QVariant GeneralSettingsModel::currentWindowMaterial() const {
+  if (cfg().launcherWindow.material == "auto") {
+    return makeDropdownItem(QStringLiteral("auto"), QStringLiteral("Automatic"));
+  }
+
   auto id = QString::fromStdString(
       cfg().launcherWindow.resolvedMaterial(platform::supports(platform::Capability::LiquidGlass),
                                             platform::supports(platform::Capability::WindowMaterial)));

--- a/src/server/src/qml/qml/AppearanceSettingsPage.qml
+++ b/src/server/src/qml/qml/AppearanceSettingsPage.qml
@@ -89,7 +89,7 @@ Flickable {
             SettingsRow {
                 visible: Platform.supports("windowMaterial")
                 label: "Window material"
-                description: "Background material applied to the launcher window. Lower the window opacity to see it."
+                description: "Background material applied to the launcher window. Automatic uses Liquid Glass when available, then falls back to blur."
                 SearchableDropdown {
                     width: parent.width
                     items: root.model.windowMaterialItems


### PR DESCRIPTION
## Summary

- add **Automatic** to the window material picker
- show the configured automatic state instead of its resolved material
- clarify that automatic prefers Liquid Glass and falls back to blur

## Why

Selecting an explicit window material currently removes the only UI path back to the capability-aware `auto` behavior. This restores that option without changing existing defaults.

## Checks

- `cmake --preset macos-debug`
- `cmake --build --preset macos-debug`
- `make check-format`
- `scriptcommand-tests` (256 assertions)
- `vicinae-crypto-tests` (36 assertions)
- `vicinae-fuzzy-tests` (53 assertions)
- `vicinae-glyph-tests` (1,980 assertions)
- `xdgpp-tests` (257 assertions)

Prepared with Codex; locally reviewed and tested.