### PR TITLE
feat: windows clipboard history

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 * text=auto eol=lf
+*.ts text eol=lf
 *.bat text eol=crlf
 *.cmd text eol=crlf
 

--- a/src/lib/common/include/common/clipboard-formats.hpp
+++ b/src/lib/common/include/common/clipboard-formats.hpp
@@ -5,4 +5,15 @@ namespace Clipboard {
 inline constexpr const char *CONCEALED_MIME_TYPE = "vicinae/concealed";
 inline constexpr const char *PASSWORD_HINT_MIME_TYPE = "x-kde-passwordManagerHint";
 
+// Qt wraps native Windows clipboard formats it has no mime mapping for
+inline constexpr const char *WIN_NATIVE_MIME_PREFIX = "application/x-qt-windows-mime";
+inline constexpr const char *WIN_EXCLUDE_FMT =
+    R"(application/x-qt-windows-mime;value="ExcludeClipboardContentFromMonitorProcessing")";
+inline constexpr const char *WIN_HISTORY_FMT =
+    R"(application/x-qt-windows-mime;value="CanIncludeInClipboardHistory")";
+inline constexpr const char *WIN_CLOUD_FMT =
+    R"(application/x-qt-windows-mime;value="CanUploadToCloudClipboard")";
+inline constexpr const char *WIN_LEGACY_IGNORE_FMT =
+    R"(application/x-qt-windows-mime;value="Clipboard Viewer Ignore")";
+
 } // namespace Clipboard

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -702,6 +702,8 @@ elseif (WIN32)
 		src/services/app-service/windows/win-app-database.cpp
 		src/services/global-shortcuts/windows-global-shortcut-backend.hpp
 		src/services/global-shortcuts/windows-global-shortcut-backend.cpp
+		src/services/clipboard/windows/windows-clipboard-server.hpp
+		src/services/clipboard/windows/windows-clipboard-server.cpp
 	)
 	list(APPEND LIBS shell32 ole32 shlwapi user32 gdi32 advapi32 version windowsapp dwmapi comctl32)
 else()

--- a/src/server/src/qml/clipboard-history-view-host.cpp
+++ b/src/server/src/qml/clipboard-history-view-host.cpp
@@ -238,9 +238,9 @@ void ClipboardHistoryViewHost::loadDetail(const ClipboardHistoryEntry &entry) {
     auto paths = text.split("\r\n", Qt::SkipEmptyParts);
     if (paths.size() == 1) {
       QUrl const url(paths.at(0));
-      if (url.scheme() == "file") {
+      if (url.isLocalFile()) {
         std::error_code ec;
-        std::filesystem::path const path = url.path().toStdString();
+        std::filesystem::path const path = url.toLocalFile().toStdString();
         if (std::filesystem::is_regular_file(path, ec)) {
           auto preview = qml::resolveFilePreview(path, m_mimeDb);
           m_detailImageSource = preview.imageSource;

--- a/src/server/src/services/app-service/windows/win-app-database.cpp
+++ b/src/server/src/services/app-service/windows/win-app-database.cpp
@@ -581,7 +581,22 @@ void WindowsAppDatabase::addApp(std::shared_ptr<WindowsApplication> app) {
     m_appsById.emplace(action->id(), std::static_pointer_cast<WindowsApplication>(action));
   }
   m_appsById.emplace(app->id(), app);
+  indexAliases(app);
   m_apps.emplace_back(std::move(app));
+}
+
+void WindowsAppDatabase::indexAliases(const std::shared_ptr<WindowsApplication> &app) {
+  auto add = [&](const QString &alias) {
+    if (!alias.isEmpty()) m_appsByAlias.try_emplace(alias.toLower(), app);
+  };
+  match(
+      app->kind(),
+      [&](const Win32ShortcutApp &s) {
+        add(s.aumid);
+        add(s.program);
+      },
+      [&](const Win32ExeApp &e) { add(toQString(e.exe)); },
+      [&](const PackagedApp &p) { add(p.aumid); }, [](const auto &) {});
 }
 
 void WindowsAppDatabase::addShortcut(const fs::path &file) {
@@ -758,6 +773,7 @@ void WindowsAppDatabase::refreshUwpCache() {
 bool WindowsAppDatabase::scan(const std::vector<fs::path> &paths) {
   m_apps.clear();
   m_appsById.clear();
+  m_appsByAlias.clear();
   m_watchDirs.clear();
 
   ScopedCom com;
@@ -967,7 +983,10 @@ std::vector<WindowsAppDatabase::AppPtr> WindowsAppDatabase::list() const {
   return {m_apps.begin(), m_apps.end()};
 }
 
-WindowsAppDatabase::AppPtr WindowsAppDatabase::findByClass(const QString &) const { return nullptr; }
+WindowsAppDatabase::AppPtr WindowsAppDatabase::findByClass(const QString &name) const {
+  if (auto it = m_appsByAlias.find(name.toLower()); it != m_appsByAlias.end()) return it->second;
+  return nullptr;
+}
 
 WindowsAppDatabase::AppPtr WindowsAppDatabase::fileBrowser() const {
   ScopedCom com;

--- a/src/server/src/services/app-service/windows/win-app-database.cpp
+++ b/src/server/src/services/app-service/windows/win-app-database.cpp
@@ -595,8 +595,8 @@ void WindowsAppDatabase::indexAliases(const std::shared_ptr<WindowsApplication> 
         add(s.aumid);
         add(s.program);
       },
-      [&](const Win32ExeApp &e) { add(toQString(e.exe)); },
-      [&](const PackagedApp &p) { add(p.aumid); }, [](const auto &) {});
+      [&](const Win32ExeApp &e) { add(toQString(e.exe)); }, [&](const PackagedApp &p) { add(p.aumid); },
+      [](const auto &) {});
 }
 
 void WindowsAppDatabase::addShortcut(const fs::path &file) {

--- a/src/server/src/services/app-service/windows/win-app-database.hpp
+++ b/src/server/src/services/app-service/windows/win-app-database.hpp
@@ -48,6 +48,7 @@ private:
   void installWatches();
   void addShortcut(const std::filesystem::path &file);
   void addApp(std::shared_ptr<WindowsApplication> app);
+  void indexAliases(const std::shared_ptr<WindowsApplication> &app);
 
   AppPtr appForExecutable(const std::filesystem::path &exe, const QString &name,
                           const QString &openerExtension = {}) const;
@@ -58,6 +59,8 @@ private:
 
   std::vector<std::shared_ptr<WindowsApplication>> m_apps;
   std::unordered_map<QString, std::shared_ptr<WindowsApplication>> m_appsById;
+  // lowercased exe target paths and AUMIDs, for findByClass
+  std::unordered_map<QString, std::shared_ptr<WindowsApplication>> m_appsByAlias;
   std::unique_ptr<UwpPackageWatcher> m_uwpWatcher;
   std::vector<std::shared_ptr<WindowsApplication>> m_uwpCache;
   std::atomic<bool> m_uwpDirty = true; // set from WinRT event threads

--- a/src/server/src/services/clipboard/clipboard-mime.cpp
+++ b/src/server/src/services/clipboard/clipboard-mime.cpp
@@ -88,6 +88,12 @@ std::optional<ClipboardSelection> selectionFromMimeData(const QMimeData *mimeDat
   // We also want to index other formats that are not text, image, or legacy X11 target types.
 
   auto isIndexableFormat = [](const QString &fmt) {
+#ifdef Q_OS_WIN
+    // Unmapped native formats; reading one forces delayed rendering in the source app
+    if (fmt.startsWith("application/x-qt-windows-mime")) return false;
+#endif
+    // Qt-internal synthetic format
+    if (fmt == "application/x-qt-image") return false;
     return !isLegacyContentType(fmt) && !fmt.startsWith("text/") && !fmt.startsWith("image/") &&
            fmt != Clipboard::PASSWORD_HINT_MIME_TYPE;
   };

--- a/src/server/src/services/clipboard/clipboard-mime.cpp
+++ b/src/server/src/services/clipboard/clipboard-mime.cpp
@@ -90,7 +90,7 @@ std::optional<ClipboardSelection> selectionFromMimeData(const QMimeData *mimeDat
   auto isIndexableFormat = [](const QString &fmt) {
 #ifdef Q_OS_WIN
     // Unmapped native formats; reading one forces delayed rendering in the source app
-    if (fmt.startsWith("application/x-qt-windows-mime")) return false;
+    if (fmt.startsWith(Clipboard::WIN_NATIVE_MIME_PREFIX)) return false;
 #endif
     // Qt-internal synthetic format
     if (fmt == "application/x-qt-image") return false;

--- a/src/server/src/services/clipboard/clipboard-service.cpp
+++ b/src/server/src/services/clipboard/clipboard-service.cpp
@@ -34,6 +34,9 @@
 #ifdef Q_OS_MACOS
 #include "macos/macos-clipboard-server.hpp"
 #endif
+#ifdef Q_OS_WIN
+#include "windows/windows-clipboard-server.hpp"
+#endif
 
 namespace fs = std::filesystem;
 
@@ -621,6 +624,9 @@ ClipboardService::ClipboardService(const std::filesystem::path &path, std::optio
 #endif
 #ifdef Q_OS_MACOS
     factory.registerServer<MacosClipboardServer>();
+#endif
+#ifdef Q_OS_WIN
+    factory.registerServer<WindowsClipboardServer>();
 #endif
     m_clipboardServer = factory.createFirstActivatable();
     qInfo() << "Activated clipboard server" << m_clipboardServer->id();

--- a/src/server/src/services/clipboard/clipboard-service.cpp
+++ b/src/server/src/services/clipboard/clipboard-service.cpp
@@ -194,18 +194,32 @@ ClipboardOfferKind ClipboardService::getKind(const ClipboardDataOffer &offer) {
 
 QString ClipboardService::getSelectionPreferredMimeType(const ClipboardSelection &selection) {
   static const std::vector<QString> plainTextMimeTypes = {
-      "text/uri-list", "text/plain;charset=utf-8", "text/plain", "UTF8_STRING", "STRING", "TEXT",
-      "COMPOUND_TEXT"};
+      "text/plain;charset=utf-8", "text/plain", "UTF8_STRING", "STRING", "TEXT", "COMPOUND_TEXT"};
 
-  for (const auto &mime : plainTextMimeTypes) {
-    auto it = std::ranges::find_if(
-        selection.offers, [&](const auto &offer) { return offer.mimeType == mime && !offer.data.isEmpty(); });
-    if (it != selection.offers.end()) return it->mimeType;
+  auto uriIt = std::ranges::find_if(selection.offers, [](const auto &offer) {
+    return offer.mimeType == "text/uri-list" && !offer.data.isEmpty();
+  });
+  if (uriIt != selection.offers.end() && getKind(*uriIt) == ClipboardOfferKind::File) {
+    return uriIt->mimeType;
   }
 
   auto imageIt = std::ranges::find_if(selection.offers, [](const auto &offer) {
     return offer.mimeType.startsWith("image/") && !offer.data.isEmpty();
   });
+
+  auto isRemoteUrl = [](const QByteArray &data) {
+    auto url = QUrl::fromEncoded(data.trimmed(), QUrl::StrictMode);
+    return url.scheme().length() > 1 && !url.isLocalFile();
+  };
+
+  for (const auto &mime : plainTextMimeTypes) {
+    auto it = std::ranges::find_if(
+        selection.offers, [&](const auto &offer) { return offer.mimeType == mime && !offer.data.isEmpty(); });
+    if (it == selection.offers.end()) continue;
+    if (imageIt != selection.offers.end() && isRemoteUrl(it->data)) break;
+    return it->mimeType;
+  }
+
   if (imageIt != selection.offers.end()) return imageIt->mimeType;
 
   auto htmlIt = std::ranges::find_if(selection.offers, [](const auto &offer) {

--- a/src/server/src/services/clipboard/windows/windows-clipboard-server.cpp
+++ b/src/server/src/services/clipboard/windows/windows-clipboard-server.cpp
@@ -1,0 +1,110 @@
+#include <QTimer>
+#include <qendian.h>
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#include <appmodel.h>
+
+#include "windows-clipboard-server.hpp"
+#include "services/clipboard/clipboard-mime.hpp"
+
+namespace {
+constexpr const char *EXCLUDE_FMT =
+    R"(application/x-qt-windows-mime;value="ExcludeClipboardContentFromMonitorProcessing")";
+constexpr const char *HISTORY_FMT = R"(application/x-qt-windows-mime;value="CanIncludeInClipboardHistory")";
+constexpr const char *CLOUD_FMT = R"(application/x-qt-windows-mime;value="CanUploadToCloudClipboard")";
+constexpr const char *LEGACY_IGNORE_FMT = R"(application/x-qt-windows-mime;value="Clipboard Viewer Ignore")";
+
+bool isDwordZero(const QByteArray &data) {
+  return data.size() >= 4 && qFromLittleEndian<quint32>(data.constData()) == 0;
+}
+} // namespace
+
+bool WindowsClipboardServer::start() {
+  connect(QGuiApplication::clipboard(), &QClipboard::dataChanged, this, [this]() { handleChange(false); });
+  return true;
+}
+
+bool WindowsClipboardServer::stop() {
+  disconnect(QGuiApplication::clipboard(), nullptr, this, nullptr);
+  return true;
+}
+
+void WindowsClipboardServer::handleChange(bool isRetry) {
+  const QMimeData *mime = QGuiApplication::clipboard()->mimeData();
+  // each formats()/hasFormat() call re-enumerates the clipboard
+  const QStringList formats = mime ? mime->formats() : QStringList();
+
+  // another process may still hold the clipboard open
+  if (formats.isEmpty()) {
+    if (!isRetry) {
+      QTimer::singleShot(RETRY_DELAY_MS, this, [this]() { handleChange(true); });
+    } else {
+      qWarning() << "Windows: clipboard still unreadable after retry, selection lost";
+    }
+    return;
+  }
+
+  if (formats.contains(EXCLUDE_FMT) || formats.contains(LEGACY_IGNORE_FMT)) {
+    qInfo() << "Windows: dropping selection excluded from monitoring";
+    return;
+  }
+  // CanUploadToCloudClipboard=0 only opts out of cloud sync
+  if (formats.contains(HISTORY_FMT) && isDwordZero(mime->data(HISTORY_FMT))) {
+    qInfo() << "Windows: dropping selection excluded from clipboard history";
+    return;
+  }
+
+  auto selection = Clipboard::selectionFromMimeData(mime);
+  if (!selection) return;
+
+  selection->sourceApp = clipboardOwnerApp();
+  emit selectionAdded(*selection);
+}
+
+bool WindowsClipboardServer::writeClipboard(QMimeData *data, const Clipboard::CopyOptions &options) {
+  if (options.concealed || options.transient) {
+    QByteArray const zero(4, '\0');
+    data->setData(EXCLUDE_FMT, zero);
+    data->setData(HISTORY_FMT, zero);
+    data->setData(CLOUD_FMT, zero);
+  }
+  return AbstractClipboardServer::writeClipboard(data, options);
+}
+
+std::optional<QString> WindowsClipboardServer::clipboardOwnerApp() const {
+  // OLE clipboard writes often have no owner window
+  HWND hwnd = GetClipboardOwner();
+  if (!hwnd) hwnd = GetForegroundWindow();
+  if (!hwnd) return std::nullopt;
+
+  DWORD pid = 0;
+  GetWindowThreadProcessId(hwnd, &pid);
+  if (!pid) return std::nullopt;
+
+  HANDLE process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+  if (!process) return std::nullopt;
+
+  std::optional<QString> result;
+  wchar_t aumid[APPLICATION_USER_MODEL_ID_MAX_LENGTH];
+  UINT32 aumidSize = APPLICATION_USER_MODEL_ID_MAX_LENGTH;
+
+  if (GetApplicationUserModelId(process, &aumidSize, aumid) == ERROR_SUCCESS && aumidSize > 1) {
+    result = QString::fromWCharArray(aumid, aumidSize - 1);
+  } else {
+    constexpr DWORD PATH_BUFFER_LEN = 8192;
+    wchar_t path[PATH_BUFFER_LEN];
+    DWORD size = PATH_BUFFER_LEN;
+    if (QueryFullProcessImageNameW(process, 0, path, &size) && size > 0) {
+      result = QString::fromWCharArray(path, size);
+    }
+  }
+
+  CloseHandle(process);
+  return result;
+}

--- a/src/server/src/services/clipboard/windows/windows-clipboard-server.cpp
+++ b/src/server/src/services/clipboard/windows/windows-clipboard-server.cpp
@@ -1,4 +1,4 @@
-#include <QTimer>
+﻿#include <QTimer>
 #include <qendian.h>
 
 #ifndef WIN32_LEAN_AND_MEAN
@@ -14,11 +14,10 @@
 #include "services/clipboard/clipboard-mime.hpp"
 
 namespace {
-constexpr const char *EXCLUDE_FMT =
-    R"(application/x-qt-windows-mime;value="ExcludeClipboardContentFromMonitorProcessing")";
-constexpr const char *HISTORY_FMT = R"(application/x-qt-windows-mime;value="CanIncludeInClipboardHistory")";
-constexpr const char *CLOUD_FMT = R"(application/x-qt-windows-mime;value="CanUploadToCloudClipboard")";
-constexpr const char *LEGACY_IGNORE_FMT = R"(application/x-qt-windows-mime;value="Clipboard Viewer Ignore")";
+using Clipboard::WIN_CLOUD_FMT;
+using Clipboard::WIN_EXCLUDE_FMT;
+using Clipboard::WIN_HISTORY_FMT;
+using Clipboard::WIN_LEGACY_IGNORE_FMT;
 
 bool isDwordZero(const QByteArray &data) {
   return data.size() >= 4 && qFromLittleEndian<quint32>(data.constData()) == 0;
@@ -50,12 +49,12 @@ void WindowsClipboardServer::handleChange(bool isRetry) {
     return;
   }
 
-  if (formats.contains(EXCLUDE_FMT) || formats.contains(LEGACY_IGNORE_FMT)) {
+  if (formats.contains(WIN_EXCLUDE_FMT) || formats.contains(WIN_LEGACY_IGNORE_FMT)) {
     qInfo() << "Windows: dropping selection excluded from monitoring";
     return;
   }
   // CanUploadToCloudClipboard=0 only opts out of cloud sync
-  if (formats.contains(HISTORY_FMT) && isDwordZero(mime->data(HISTORY_FMT))) {
+  if (formats.contains(WIN_HISTORY_FMT) && isDwordZero(mime->data(WIN_HISTORY_FMT))) {
     qInfo() << "Windows: dropping selection excluded from clipboard history";
     return;
   }
@@ -70,9 +69,9 @@ void WindowsClipboardServer::handleChange(bool isRetry) {
 bool WindowsClipboardServer::writeClipboard(QMimeData *data, const Clipboard::CopyOptions &options) {
   if (options.concealed || options.transient) {
     QByteArray const zero(4, '\0');
-    data->setData(EXCLUDE_FMT, zero);
-    data->setData(HISTORY_FMT, zero);
-    data->setData(CLOUD_FMT, zero);
+    data->setData(WIN_EXCLUDE_FMT, zero);
+    data->setData(WIN_HISTORY_FMT, zero);
+    data->setData(WIN_CLOUD_FMT, zero);
   }
   return AbstractClipboardServer::writeClipboard(data, options);
 }

--- a/src/server/src/services/clipboard/windows/windows-clipboard-server.cpp
+++ b/src/server/src/services/clipboard/windows/windows-clipboard-server.cpp
@@ -1,12 +1,6 @@
 ﻿#include <QTimer>
 #include <qendian.h>
 
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
 #include <windows.h>
 #include <appmodel.h>
 

--- a/src/server/src/services/clipboard/windows/windows-clipboard-server.hpp
+++ b/src/server/src/services/clipboard/windows/windows-clipboard-server.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "services/clipboard/clipboard-server.hpp"
+
+class WindowsClipboardServer : public AbstractClipboardServer {
+  Q_OBJECT
+
+public:
+  QString id() const override { return "windows"; }
+  bool isActivatable() const override { return QGuiApplication::platformName() == "windows"; }
+  bool isAlive() const override { return true; }
+  bool start() override;
+  bool stop() override;
+
+private:
+  static constexpr int RETRY_DELAY_MS = 100;
+
+  bool writeClipboard(QMimeData *data, const Clipboard::CopyOptions &options) override;
+  void handleChange(bool isRetry);
+  std::optional<QString> clipboardOwnerApp() const;
+};


### PR DESCRIPTION
clipboard server implementation for Windows. Qt does most of the work here, plus we ignore/stamp selections with the appropriate types so that other apps ignore our transient clipboard selections.