### PR TITLE
feat: extension tooling on windows

### DIFF
--- a/nix/vicinae.nix
+++ b/nix/vicinae.nix
@@ -53,7 +53,7 @@ in
 
     apiDeps = fetchNpmDeps {
       src = "${finalAttrs.src}/src/typescript/api";
-      hash = "sha256-Im8fSG9sbaSynrN5gLsWVaPgH5g4Zp+x+FUPIBXrKjg=";
+      hash = "sha256-4FEaBDJK9abcgz+vptuL4wQ8zhp+wpLbbR4Y79BVhEg=";
     };
 
     extensionManagerDeps = fetchNpmDeps {

--- a/src/typescript/api/package-lock.json
+++ b/src/typescript/api/package-lock.json
@@ -13,6 +13,7 @@
 				"chokidar": "^4.0.3",
 				"esbuild": "^0.25.2",
 				"react": "19.1.1",
+				"typescript": "5.9.2",
 				"zod": "^4.0.17"
 			},
 			"bin": {
@@ -20,8 +21,7 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.3.2",
-				"@types/node": "24.3.0",
-				"typescript": "5.9.2"
+				"@types/node": "24.3.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -713,9 +713,7 @@
 			"version": "5.9.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
 			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"

--- a/src/typescript/api/package.json
+++ b/src/typescript/api/package.json
@@ -30,6 +30,7 @@
 		"chokidar": "^4.0.3",
 		"esbuild": "^0.25.2",
 		"react": "19.1.1",
+		"typescript": "5.9.2",
 		"zod": "^4.0.17"
 	},
 	"peerDependencies": {
@@ -37,8 +38,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.3.2",
-		"@types/node": "24.3.0",
-		"typescript": "5.9.2"
+		"@types/node": "24.3.0"
 	},
 	"repository": "vicinaehq/vicinae"
 }

--- a/src/typescript/api/src/commands/build/index.ts
+++ b/src/typescript/api/src/commands/build/index.ts
@@ -1,11 +1,11 @@
 import * as esbuild from "esbuild";
-import { spawnSync } from "node:child_process";
 import { cpSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { CommandDef } from "../../cli.js";
 import ManifestSchema from "../../schemas/manifest.js";
 import { updateExtensionTypes } from "../../utils/extension-types.js";
 import { Logger } from "../../utils/logger.js";
+import { typeCheck } from "../../utils/typecheck.js";
 import { extensionDataDir } from "../../utils/utils.js";
 
 const build: CommandDef = {
@@ -112,10 +112,10 @@ const build: CommandDef = {
 		updateExtensionTypes(manifest, src);
 
 		logger.logInfo("Checking types...");
-		const typeCheck = spawnSync("npx", ["tsc", "--noEmit"]);
+		const check = typeCheck(src);
 
-		if (typeCheck.error) {
-			logger.logError(`Type check failed: ${typeCheck.error}`);
+		if (!check.ok) {
+			logger.logError(`Type check failed:\n${check.output}`);
 			process.exit(1);
 		}
 

--- a/src/typescript/api/src/commands/develop/index.ts
+++ b/src/typescript/api/src/commands/develop/index.ts
@@ -1,6 +1,5 @@
 import * as chokidar from "chokidar";
 import * as esbuild from "esbuild";
-import { spawn } from "node:child_process";
 import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
@@ -9,16 +8,12 @@ import ManifestSchema from "../../schemas/manifest.js";
 import { updateExtensionTypes } from "../../utils/extension-types.js";
 import { Logger } from "../../utils/logger.js";
 import { Tail } from "../../utils/tail.js";
+import { typeCheck } from "../../utils/typecheck.js";
 import {
 	extensionDataDir,
 	extensionInternalSupportDir,
 } from "../../utils/utils.js";
 import { VicinaeClient } from "../../utils/vicinae.js";
-
-type TypeCheckResult = {
-	error: string;
-	ok: boolean;
-};
 
 const develop: CommandDef = {
 	description: "Start an extension development session",
@@ -60,21 +55,6 @@ const develop: CommandDef = {
 
 		logger.logInfo("Generating extension types...");
 		updateExtensionTypes(manifest, target);
-
-		const typeCheck = async (): Promise<TypeCheckResult> => {
-			const spawned = spawn("npx", ["tsc", "--noEmit"]);
-			let stderr = Buffer.from("");
-
-			return new Promise<TypeCheckResult>((resolve) => {
-				spawned.stderr.on("data", (buf) => {
-					stderr = Buffer.concat([stderr, buf]);
-				});
-
-				spawned.on("exit", (status) =>
-					resolve({ error: stderr.toString(), ok: status === 0 }),
-				);
-			});
-		};
 
 		const build = async (outDir: string) => {
 			const entryPoints = manifest.commands
@@ -153,6 +133,9 @@ const develop: CommandDef = {
 						`Failed to refresh dev session: ${error instanceof Error ? error.message : error}`,
 					);
 				});
+
+				const check = typeCheck(target);
+				if (!check.ok) logger.logError(`Type errors:\n${check.output}`);
 			} catch (error: unknown) {
 				if (error instanceof Error) {
 					logger.logError(`Failed to build extension: ${error.message}`);

--- a/src/typescript/api/src/utils/typecheck.ts
+++ b/src/typescript/api/src/utils/typecheck.ts
@@ -1,3 +1,4 @@
+import * as path from "node:path";
 import * as ts from "typescript";
 
 export type TypeCheckResult = {
@@ -5,18 +6,22 @@ export type TypeCheckResult = {
 	output: string;
 };
 
+const FORCED_OPTIONS: ts.CompilerOptions = {
+	noEmit: true,
+	jsx: ts.JsxEmit.ReactJSX,
+	esModuleInterop: true,
+	skipLibCheck: true,
+};
+
 const DEFAULT_CONFIG = {
 	compilerOptions: {
 		target: "ES2022",
 		module: "commonjs",
 		moduleResolution: "node",
-		jsx: "react-jsx",
 		strict: true,
-		esModuleInterop: true,
-		skipLibCheck: true,
 		resolveJsonModule: true,
 	},
-	include: ["src", "vicinae-env.d.ts"],
+	include: ["src"],
 };
 
 const parseConfig = (target: string): ts.ParsedCommandLine => {
@@ -43,9 +48,13 @@ const parseConfig = (target: string): ts.ParsedCommandLine => {
 
 export const typeCheck = (target: string): TypeCheckResult => {
 	const parsed = parseConfig(target);
-	const program = ts.createProgram(parsed.fileNames, {
+	const envFile = path.join(target, "vicinae-env.d.ts");
+	const rootNames = ts.sys.fileExists(envFile)
+		? [...parsed.fileNames, envFile]
+		: parsed.fileNames;
+	const program = ts.createProgram(rootNames, {
 		...parsed.options,
-		noEmit: true,
+		...FORCED_OPTIONS,
 	});
 	const diagnostics = [
 		...ts.getConfigFileParsingDiagnostics(parsed),

--- a/src/typescript/api/src/utils/typecheck.ts
+++ b/src/typescript/api/src/utils/typecheck.ts
@@ -1,0 +1,66 @@
+import * as ts from "typescript";
+
+export type TypeCheckResult = {
+	ok: boolean;
+	output: string;
+};
+
+const DEFAULT_CONFIG = {
+	compilerOptions: {
+		target: "ES2022",
+		module: "commonjs",
+		moduleResolution: "node",
+		jsx: "react-jsx",
+		strict: true,
+		esModuleInterop: true,
+		skipLibCheck: true,
+		resolveJsonModule: true,
+	},
+	include: ["src", "vicinae-env.d.ts"],
+};
+
+const parseConfig = (target: string): ts.ParsedCommandLine => {
+	const configPath = ts.findConfigFile(target, ts.sys.fileExists);
+
+	if (configPath) {
+		const parsed = ts.getParsedCommandLineOfConfigFile(
+			configPath,
+			{ noEmit: true },
+			{
+				...ts.sys,
+				onUnRecoverableConfigFileDiagnostic: (diagnostic) => {
+					throw new Error(
+						ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"),
+					);
+				},
+			},
+		);
+		if (parsed) return parsed;
+	}
+
+	return ts.parseJsonConfigFileContent(DEFAULT_CONFIG, ts.sys, target);
+};
+
+export const typeCheck = (target: string): TypeCheckResult => {
+	const parsed = parseConfig(target);
+	const program = ts.createProgram(parsed.fileNames, {
+		...parsed.options,
+		noEmit: true,
+	});
+	const diagnostics = [
+		...ts.getConfigFileParsingDiagnostics(parsed),
+		...ts.getPreEmitDiagnostics(program),
+	];
+	const output = ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+		getCurrentDirectory: () => target,
+		getCanonicalFileName: (fileName) => fileName,
+		getNewLine: () => ts.sys.newLine,
+	});
+
+	return {
+		ok: !diagnostics.some(
+			(diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error,
+		),
+		output,
+	};
+};

--- a/src/typescript/api/src/utils/utils.ts
+++ b/src/typescript/api/src/utils/utils.ts
@@ -1,18 +1,20 @@
 import * as os from "node:os";
 import * as path from "node:path";
 
-const platformDataDir = () => {
-	if (process.platform === "win32")
-		return process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming");
+export const dataDir = () => {
+	if (process.platform === "win32") {
+		const local =
+			process.env.LOCALAPPDATA ?? path.join(os.homedir(), "AppData", "Local");
+		return path.join(local, "vicinae", "data");
+	}
 	if (process.platform === "darwin")
-		return path.join(os.homedir(), ".local", "share");
+		return path.join(os.homedir(), ".local", "share", "vicinae");
 
-	return (
-		process.env.XDG_DATA_HOME || path.join(os.homedir(), ".local", "share")
+	return path.join(
+		process.env.XDG_DATA_HOME ?? path.join(os.homedir(), ".local", "share"),
+		"vicinae",
 	);
 };
-
-export const dataDir = () => path.join(platformDataDir(), "vicinae");
 
 export const extensionDataDir = () => path.join(dataDir(), "extensions");
 

--- a/src/typescript/api/src/utils/vicinae.ts
+++ b/src/typescript/api/src/utils/vicinae.ts
@@ -1,4 +1,5 @@
 import * as net from "node:net";
+import * as os from "node:os";
 import * as path from "node:path";
 import { Client, type PingResponse, RpcTransport } from "../proto/ipc.js";
 
@@ -14,8 +15,11 @@ const runtimeDir = (): string => {
 	return path.join(process.env.XDG_RUNTIME_DIR ?? "/tmp", "vicinae");
 };
 
-export const serverSocketPath = (): string =>
-	path.join(runtimeDir(), "vicinae.sock");
+export const serverSocketPath = (): string => {
+	if (process.platform === "win32")
+		return `\\\\.\\pipe\\vicinae-${os.userInfo().username}`;
+	return path.join(runtimeDir(), "vicinae.sock");
+};
 
 export class VicinaeClient {
 	constructor(private readonly options: VicinaeClientOptions = {}) {}


### PR DESCRIPTION
Modify the SDK exported by @vicinae/api so that it can be used on Windows as well:

- Connect to the windows named pipe instead of assuming a unix socket
- In order to avoid `npx` usage for typechecking we now add `typescript` as a non-dev dependency and use the compiler API to type check the code.