### PR TITLE
fix(macos): prevent clipboard copy HUD stealing focus

### DIFF
--- a/src/server/src/qml/macos-chrome-attached.mm
+++ b/src/server/src/qml/macos-chrome-attached.mm
@@ -471,6 +471,8 @@ void MacOSPanelAttached::apply() {
   NSWindow *nswin = nsview.window;
   if (!nswin) return;
 
+  const bool acceptsFocus = !(m_window->flags() & Qt::WindowDoesNotAcceptFocus);
+
   if (!m_snapshot.valid) {
     m_snapshot.valid = true;
     m_snapshot.styleMask = (unsigned long)nswin.styleMask;
@@ -512,7 +514,7 @@ void MacOSPanelAttached::apply() {
   if ([nswin isKindOfClass:[NSPanel class]]) {
     NSPanel *panel = (NSPanel *)nswin;
     panel.floatingPanel = YES;
-    panel.becomesKeyOnlyIfNeeded = NO;
+    panel.becomesKeyOnlyIfNeeded = acceptsFocus ? NO : YES;
     panel.worksWhenModal = YES;
   }
 

--- a/src/server/src/qml/qml/HudWindowMacOS.qml
+++ b/src/server/src/qml/qml/HudWindowMacOS.qml
@@ -5,7 +5,7 @@ HudWindow {
 
     readonly property int bottomMargin: 96
 
-    flags: Qt.Tool | Qt.FramelessWindowHint
+    flags: Qt.Tool | Qt.FramelessWindowHint | Qt.WindowDoesNotAcceptFocus
 
     // The glass material provides the background, so the shared pill stays transparent.
     pillColor: "transparent"


### PR DESCRIPTION
On macOS, when copying an item from Clipboard History, Vicinae shows a HUD saying "Selection copied to clipboard".

   Accessibility Inspector reports this HUD as a system dialog / AXSystemDialog with Keyboard Focused = true. This causes the currently focused app/window to lose focus
 temporarily. The issue is especially visible when using yabai/skhd: after copying from Vicinae Clipboard History, focus returns with a delay or appears blocked by the HUD.

   Expected behavior:
   The HUD should not accept keyboard focus, or Clipboard History copy should avoid showing a focusable HUD on macOS.

   Environment:
   - macOS
   - yabai + skhd
   - Vicinae v0.23.1

   Workaround tested:
   Building Vicinae with the macOS HUD window using Qt.WindowDoesNotAcceptFocus and suppressing the Clipboard History copy HUD on macOS resolves the focus issue.