### PR TITLE
feat: handle url scheme on windows

### DIFF
--- a/extra/windows/vicinae.iss
+++ b/extra/windows/vicinae.iss
@@ -38,6 +38,22 @@ Name: "autostart"; Description: "Start Vicinae when you log in"
 [Files]
 Source: "{#StageDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 
+[Registry]
+; URL scheme handlers. Also self-registered by the server at startup; declared
+; here so uninstall cleans them up.
+Root: HKCU; Subkey: "Software\Classes\vicinae"; ValueType: string; ValueData: "URL:vicinae"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Classes\vicinae"; ValueType: string; ValueName: "URL Protocol"; ValueData: ""
+Root: HKCU; Subkey: "Software\Classes\vicinae\DefaultIcon"; ValueType: string; ValueData: "{app}\bin\vicinae-server.exe,0"
+Root: HKCU; Subkey: "Software\Classes\vicinae\shell\open\command"; ValueType: string; ValueData: """{app}\bin\vicinae-url-handler.exe"" ""%1"""
+Root: HKCU; Subkey: "Software\Classes\raycast"; ValueType: string; ValueData: "URL:raycast"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Classes\raycast"; ValueType: string; ValueName: "URL Protocol"; ValueData: ""
+Root: HKCU; Subkey: "Software\Classes\raycast\DefaultIcon"; ValueType: string; ValueData: "{app}\bin\vicinae-server.exe,0"
+Root: HKCU; Subkey: "Software\Classes\raycast\shell\open\command"; ValueType: string; ValueData: """{app}\bin\vicinae-url-handler.exe"" ""%1"""
+Root: HKCU; Subkey: "Software\Classes\com.raycast"; ValueType: string; ValueData: "URL:com.raycast"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Classes\com.raycast"; ValueType: string; ValueName: "URL Protocol"; ValueData: ""
+Root: HKCU; Subkey: "Software\Classes\com.raycast\DefaultIcon"; ValueType: string; ValueData: "{app}\bin\vicinae-server.exe,0"
+Root: HKCU; Subkey: "Software\Classes\com.raycast\shell\open\command"; ValueType: string; ValueData: """{app}\bin\vicinae-url-handler.exe"" ""%1"""
+
 [Icons]
 Name: "{autoprograms}\Vicinae"; Filename: "{app}\bin\vicinae-server.exe"
 Name: "{userstartup}\Vicinae"; Filename: "{app}\bin\vicinae-server.exe"; Tasks: autostart

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -30,3 +30,17 @@ embed_file(${PROJECT_NAME} "${EXTRA_DIR}/config.jsonc" DEFAULT_CONFIG)
 embed_file(${PROJECT_NAME} "${EXTRA_DIR}/theme-template.toml" THEME_TEMPLATE)
 target_link_libraries(${PROJECT_NAME} glaze::glaze vicinae::scriptcommand vicinae::common)
 install(TARGETS ${PROJECT_NAME})
+
+if (WIN32)
+	# Windowed forwarder registered as the shell handler for app URL schemes.
+	# We cannot use the CLI directly as it is registered to use the console subsystem, which
+	# would spawn a console every time it is invoked.
+	add_executable(vicinae-url-handler WIN32 src/url-handler-main.cpp src/local-socket.cpp ${SRCS})
+	vicinae_enable_utf8(vicinae-url-handler)
+	target_include_directories(vicinae-url-handler PRIVATE src ${GENOUT})
+	target_compile_features(vicinae-url-handler PUBLIC cxx_std_23)
+	target_link_libraries(vicinae-url-handler glaze::glaze vicinae::common)
+	# keep a standard main() entrypoint in the windowed subsystem
+	target_link_options(vicinae-url-handler PRIVATE /ENTRY:mainCRTStartup)
+	install(TARGETS vicinae-url-handler)
+endif()

--- a/src/cli/src/cli.cpp
+++ b/src/cli/src/cli.cpp
@@ -345,12 +345,7 @@ int CommandLineApp::run(int ac, char **av) {
   if (ac == 2) {
     std::string arg = av[1];
 
-    // raycast:// or com.raycast:/
-    auto pred = [&](std::string_view scheme) { return arg.starts_with(std::string{scheme} + ":/"); };
-    const bool hasScheme =
-        std::ranges::any_of(std::initializer_list{"vicinae", "raycast", "com.raycast"}, pred);
-
-    if (hasScheme) {
+    if (vicinae::isAppDeeplink(arg)) {
       if (auto res = cli::IpcClient::sendDeeplink(arg); !res) {
         std::println(std::cerr, "Deeplink execution failed: {}", res.error());
         return 1;

--- a/src/cli/src/url-handler-main.cpp
+++ b/src/cli/src/url-handler-main.cpp
@@ -1,0 +1,15 @@
+#include <string>
+#include "ipc-client.hpp"
+#include "common/common.hpp"
+
+int main(int ac, char **av) {
+  vicinae::enableUtf8();
+
+  if (ac != 2) return 1;
+
+  const std::string url = av[1];
+
+  if (!vicinae::isAppDeeplink(url)) return 1;
+
+  return cli::IpcClient::sendDeeplink(url) ? 0 : 1;
+}

--- a/src/lib/common/include/common/common.hpp
+++ b/src/lib/common/include/common/common.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <array>
 #include <filesystem>
 #include <fstream>
 #include <istream>
@@ -8,6 +9,11 @@
 #include <vector>
 
 namespace vicinae {
+inline constexpr std::array<std::string_view, 3> APP_SCHEMES{"vicinae", "raycast", "com.raycast"};
+
+// true for app deeplinks such as vicinae://toggle or com.raycast:/extensions/...
+bool isAppDeeplink(std::string_view url);
+
 // Switches the CRT locale to UTF-8 on Windows so that we operate on UTF-8 rather
 // than the legacy ANSI code page. No-op elsewhere.
 void enableUtf8();

--- a/src/lib/common/src/common.cpp
+++ b/src/lib/common/src/common.cpp
@@ -1,4 +1,5 @@
 #include "common/common.hpp"
+#include <algorithm>
 #include <clocale>
 #include <cstdlib>
 #include <filesystem>
@@ -18,6 +19,12 @@
 namespace fs = std::filesystem;
 
 namespace vicinae {
+bool isAppDeeplink(std::string_view url) {
+  return std::ranges::any_of(APP_SCHEMES, [&](std::string_view scheme) {
+    return url.starts_with(scheme) && url.substr(scheme.size()).starts_with(":/");
+  });
+}
+
 void enableUtf8() {
 #ifdef _WIN32
   std::setlocale(LC_ALL, ".UTF-8");

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -715,6 +715,8 @@ elseif (WIN32)
 		src/services/window-manager/windows/windows-window-manager.cpp
 		src/services/app-runtime/windows/win-app-runtime.hpp
 		src/services/app-runtime/windows/win-app-runtime.cpp
+		src/services/url-scheme/win-url-scheme-registrar.hpp
+		src/services/url-scheme/win-url-scheme-registrar.cpp
 	)
 	list(APPEND LIBS shell32 ole32 shlwapi user32 gdi32 advapi32 version windowsapp dwmapi comctl32 uuid)
 else()

--- a/src/server/src/server.cpp
+++ b/src/server/src/server.cpp
@@ -103,6 +103,10 @@
 #include <QFileOpenEvent>
 #endif
 
+#ifdef Q_OS_WIN
+#include "services/url-scheme/win-url-scheme-registrar.hpp"
+#endif
+
 #ifdef AUTO_ENABLE_AUTOSTART
 #include "services/autostart/macos-login-item.hpp"
 #endif
@@ -176,6 +180,10 @@ int startServer(const ServerLaunchOptions &launchOpts) {
       return 0;
     }
   }
+
+#ifdef Q_OS_WIN
+  vicinae::win::registerUrlSchemes();
+#endif
 
 #ifdef Q_OS_MACOS
   if (!qEnvironmentVariableIsSet("QT_MAC_SET_RAISE_PROCESS")) qputenv("QT_MAC_SET_RAISE_PROCESS", "0");

--- a/src/server/src/services/url-scheme/win-url-scheme-registrar.cpp
+++ b/src/server/src/services/url-scheme/win-url-scheme-registrar.cpp
@@ -1,0 +1,30 @@
+#include "win-url-scheme-registrar.hpp"
+#include "vicinae.hpp"
+#include <common/common.hpp>
+#include <QSettings>
+#include <QDebug>
+#include <format>
+
+namespace vicinae::win {
+
+void registerUrlSchemes() {
+  const auto handler = findHelperProgram("vicinae-url-handler");
+
+  if (!handler) {
+    qWarning() << "url-scheme: vicinae-url-handler binary not found, skipping registration";
+    return;
+  }
+
+  const QString command = QString::fromStdString(std::format(R"("{}" "%1")", handler->string()));
+  const QString icon = QString::fromStdString(std::format("{},0", selfPath().string()));
+
+  for (const QString &scheme : Omnicast::APP_SCHEMES) {
+    QSettings reg(R"(HKEY_CURRENT_USER\Software\Classes\)" + scheme, QSettings::NativeFormat);
+    reg.setValue("Default", "URL:" + scheme);
+    reg.setValue("URL Protocol", "");
+    reg.setValue("DefaultIcon/Default", icon);
+    reg.setValue("shell/open/command/Default", command);
+  }
+}
+
+} // namespace vicinae::win

--- a/src/server/src/services/url-scheme/win-url-scheme-registrar.hpp
+++ b/src/server/src/services/url-scheme/win-url-scheme-registrar.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace vicinae::win {
+void registerUrlSchemes();
+} // namespace vicinae::win


### PR DESCRIPTION
We need a dedicated `vicinae-url-handler.exe` because the CLI uses the console subsystem which would show a console every time a link is activated.