### PR TITLE
feat: windows settings and control panel applets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ We use C++23 so we have access to most modern C++ features.
 Here are a few rules to keep in mind:
 
 - Lack of value: use `std::optional` instead of arbitrary value discriminants such as the empty string. If this is not possible or goes against a commonly used convention, respect the convention first, no shoehorning. If we are dealing with raw pointers, the nullable component is already part of it so no need to add a layer of indirection.
+- Prefer `std::array` to C arrays where it makes sense. You can use `std::to_array` to initialize them automatically sized from an initializer list.
 - use `constexpr` and `consteval` as much as possible, we want to move what we can at compile time.
 - Avoid raw pointers: unless we are dealing with QT's ownership model or a C API. For QT classes that are not QObjects, you should probably use standard smart pointers as recommended in modern QT. 
 - QObjects must be deleted using `deleteLater` and never raw `delete`, as this can cause memory corruption with signal and slots. Calling `delete` on a `QObject` is a **STRONG** code smell.

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -715,6 +715,10 @@ elseif (WIN32)
 		src/services/window-manager/windows/windows-window-manager.cpp
 		src/services/app-runtime/windows/win-app-runtime.hpp
 		src/services/app-runtime/windows/win-app-runtime.cpp
+		src/root-search/windows-settings/windows-settings-root-provider.hpp
+		src/root-search/windows-settings/windows-settings-root-provider.cpp
+		src/root-search/control-panel/control-panel-root-provider.hpp
+		src/root-search/control-panel/control-panel-root-provider.cpp
 	)
 	list(APPEND LIBS shell32 ole32 shlwapi user32 gdi32 advapi32 version windowsapp dwmapi comctl32 uuid)
 else()

--- a/src/server/src/qml/extension-settings-model.cpp
+++ b/src/server/src/qml/extension-settings-model.cpp
@@ -286,9 +286,7 @@ void ExtensionSettingsModel::rebuild(const QString &filter) {
     pe.childCount = childCount;
     pe.expanded = isFiltering || m_expandedProviders.contains(pe.providerId);
     pe.provenance = provenanceForProvider(provider);
-
-    if (auto *ext = dynamic_cast<ExtensionRootProvider *>(provider))
-      pe.description = ext->repository()->description();
+    pe.description = provider->description();
 
     return pe;
   };

--- a/src/server/src/root-search/control-panel/control-panel-root-provider.cpp
+++ b/src/server/src/root-search/control-panel/control-panel-root-provider.cpp
@@ -195,7 +195,7 @@ WinControlPanelRootItem::newActionPanel(ApplicationContext *ctx, const RootItemM
   auto itemSection = panel->createSection();
 
   const QString target = "shell:" + m_applet.parsingName;
-  auto open = new OpenControlPanelItemAction(QString("Open %1").arg(m_applet.displayName), iconUrl(), target);
+  auto open = new OpenControlPanelItemAction("Open Applet", iconUrl(), target);
   mainSection->addAction(new DefaultActionWrapper(uniqueId(), open));
 
   utils->addAction(new CopyToClipboardAction(Clipboard::Text(target), "Copy Path"));
@@ -234,8 +234,7 @@ WinControlPanelTaskRootItem::newActionPanel(ApplicationContext *ctx, const RootI
   auto mainSection = panel->createSection();
   auto itemSection = panel->createSection();
 
-  auto open =
-      new OpenControlPanelTaskAction(QString("Open %1").arg(m_task.displayName), iconUrl(), m_task.pidl);
+  auto open = new OpenControlPanelTaskAction("Open", iconUrl(), m_task.pidl);
   mainSection->addAction(new DefaultActionWrapper(uniqueId(), open));
 
   for (const auto &action : RootSearchActionGenerator::generateActions(*this, metadata)) {

--- a/src/server/src/root-search/control-panel/control-panel-root-provider.cpp
+++ b/src/server/src/root-search/control-panel/control-panel-root-provider.cpp
@@ -1,0 +1,280 @@
+#include "root-search/control-panel/control-panel-root-provider.hpp"
+#include "actions/root-search/root-search-actions.hpp"
+#include "clipboard-actions.hpp"
+#include "navigation-controller.hpp"
+#include "service-registry.hpp"
+#include "services/toast/toast-service.hpp"
+#include "ui/action-pannel/action-panel-state.hpp"
+#include "ui/image/url.hpp"
+#include "utils/scoped-com.hpp"
+
+#include <windows.h>
+#include <shellapi.h>
+#include <shlobj.h>
+#include <shlwapi.h>
+#include <wrl/client.h>
+
+#include <algorithm>
+#include <set>
+
+using Microsoft::WRL::ComPtr;
+
+namespace {
+
+constexpr const char *CONTROL_PANEL_CLSID = "::{26EE0668-A00A-44D7-9371-BEB064C98683}";
+constexpr const wchar_t *CONTROL_PANEL_FOLDER = L"::{26EE0668-A00A-44D7-9371-BEB064C98683}\\0";
+constexpr const wchar_t *ALL_TASKS_FOLDER = L"shell:::{ED7BA470-8E54-465E-825C-99712043E01C}";
+constexpr const char *ALL_TASKS_ICON_PREFIX = "::{ED7BA470-8E54-465E-825C-99712043E01C}\\";
+
+// Tasks that only duplicate entries the app provider already surfaces.
+constexpr const char *SKIPPED_TASK_IDS[] = {
+    "{e9c71548-b580-43b2-acdb-1ba924002754}", // Task Manager
+};
+
+class OpenControlPanelItemAction : public AbstractAction {
+public:
+  OpenControlPanelItemAction(const QString &title, const ImageURL &icon, QString target)
+      : AbstractAction(title, icon), m_target(std::move(target)) {}
+
+  void execute(ApplicationContext *ctx) override {
+    const std::wstring target = m_target.toStdWString();
+    const HINSTANCE ret = ShellExecuteW(nullptr, L"open", target.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+
+    if (reinterpret_cast<INT_PTR>(ret) <= 32) {
+      ctx->services->toastService()->failure("Failed to open settings");
+      return;
+    }
+
+    ctx->navigation->closeWindow();
+    ctx->navigation->clearSearchText();
+  }
+
+private:
+  QString m_target;
+};
+
+class OpenControlPanelTaskAction : public AbstractAction {
+public:
+  OpenControlPanelTaskAction(const QString &title, const ImageURL &icon, QByteArray pidl)
+      : AbstractAction(title, icon), m_pidl(std::move(pidl)) {}
+
+  void execute(ApplicationContext *ctx) override {
+    SHELLEXECUTEINFOW sei{};
+    sei.cbSize = sizeof(sei);
+    sei.fMask = SEE_MASK_IDLIST;
+    sei.nShow = SW_SHOWNORMAL;
+    sei.lpIDList = const_cast<char *>(m_pidl.constData());
+
+    if (!ShellExecuteExW(&sei)) {
+      ctx->services->toastService()->failure("Failed to open settings");
+      return;
+    }
+
+    ctx->navigation->closeWindow();
+    ctx->navigation->clearSearchText();
+  }
+
+private:
+  QByteArray m_pidl;
+};
+
+QString displayNameOf(IShellFolder *folder, PCUITEMID_CHILD child, SHGDNF flags) {
+  STRRET ret;
+  if (FAILED(folder->GetDisplayNameOf(child, flags, &ret))) return {};
+
+  wchar_t buf[512];
+  if (FAILED(StrRetToBufW(&ret, child, buf, static_cast<UINT>(std::size(buf))))) return {};
+
+  return QString::fromWCharArray(buf);
+}
+
+struct BoundShellFolder {
+  ComPtr<IShellFolder> folder;
+  QByteArray pidl;
+};
+
+std::optional<BoundShellFolder> bindShellFolder(const wchar_t *path) {
+  PIDLIST_ABSOLUTE folderPidl = nullptr;
+  if (FAILED(SHParseDisplayName(path, nullptr, &folderPidl, 0, nullptr))) return std::nullopt;
+
+  BoundShellFolder bound;
+  bound.pidl = QByteArray(reinterpret_cast<const char *>(folderPidl), ILGetSize(folderPidl));
+  const HRESULT hr = SHBindToObject(nullptr, folderPidl, nullptr, IID_PPV_ARGS(&bound.folder));
+  ILFree(folderPidl);
+  if (FAILED(hr)) return std::nullopt;
+  return bound;
+}
+
+std::vector<WinControlPanelApplet> enumerateControlPanelApplets() {
+  std::vector<WinControlPanelApplet> applets;
+  ScopedCom com;
+
+  auto bound = bindShellFolder(CONTROL_PANEL_FOLDER);
+  if (!bound) return applets;
+
+  ComPtr<IEnumIDList> ids;
+  if (bound->folder->EnumObjects(nullptr, SHCONTF_FOLDERS | SHCONTF_NONFOLDERS, &ids) != S_OK || !ids)
+    return applets;
+
+  PITEMID_CHILD child = nullptr;
+  while (ids->Next(1, &child, nullptr) == S_OK) {
+    QString name = displayNameOf(bound->folder.Get(), child, SHGDN_NORMAL);
+    QString parsingName = displayNameOf(bound->folder.Get(), child, SHGDN_FORPARSING);
+    ILFree(child);
+
+    if (name.isEmpty() || parsingName.isEmpty()) continue;
+    // Only CLSID-backed applets round-trip through parsing names; the lone "Fonts" delegate entry
+    // yields a path that neither resolves to an icon nor launches.
+    if (!parsingName.section('\\', -1).startsWith("::{")) continue;
+    applets.emplace_back(WinControlPanelApplet{std::move(name), std::move(parsingName)});
+  }
+
+  return applets;
+}
+
+std::vector<WinControlPanelTask> enumerateControlPanelTasks() {
+  std::vector<WinControlPanelTask> tasks;
+  ScopedCom com;
+
+  auto bound = bindShellFolder(ALL_TASKS_FOLDER);
+  if (!bound) return tasks;
+
+  ComPtr<IEnumIDList> ids;
+  if (bound->folder->EnumObjects(nullptr, SHCONTF_FOLDERS | SHCONTF_NONFOLDERS, &ids) != S_OK || !ids)
+    return tasks;
+
+  const auto *parentPidl = reinterpret_cast<PCIDLIST_ABSOLUTE>(bound->pidl.constData());
+
+  PITEMID_CHILD child = nullptr;
+  while (ids->Next(1, &child, nullptr) == S_OK) {
+    QString name = displayNameOf(bound->folder.Get(), child, SHGDN_NORMAL);
+    QString taskId = displayNameOf(bound->folder.Get(), child, SHGDN_FORPARSING | SHGDN_INFOLDER);
+
+    if (!name.isEmpty() && !taskId.isEmpty()) {
+      QByteArray pidl;
+      if (PIDLIST_ABSOLUTE full = ILCombine(parentPidl, child)) {
+        pidl = QByteArray(reinterpret_cast<const char *>(full), ILGetSize(full));
+        ILFree(full);
+      }
+      if (!pidl.isEmpty()) {
+        tasks.emplace_back(WinControlPanelTask{std::move(name), std::move(taskId), std::move(pidl)});
+      }
+    }
+    ILFree(child);
+  }
+
+  return tasks;
+}
+
+} // namespace
+
+QString WinControlPanelRootItem::title() const { return m_applet.displayName; }
+
+QString WinControlPanelRootItem::typeDisplayName() const { return "Control Panel"; }
+
+ImageURL WinControlPanelRootItem::iconUrl() const { return ImageURL::winShellIcon(m_applet.parsingName); }
+
+EntrypointId WinControlPanelRootItem::uniqueId() const {
+  const QString id = "cpl." + m_applet.parsingName.section('\\', -1);
+  return EntrypointId("control-panel", id.toStdString());
+}
+
+AccessoryList WinControlPanelRootItem::accessories() const {
+  return {{.text = "Control Panel", .color = SemanticColor::TextMuted}};
+}
+
+std::vector<std::pair<QString, QString>> WinControlPanelRootItem::settingsMetadata() const {
+  return {{"Name", m_applet.displayName}, {"Where", "shell:" + m_applet.parsingName}};
+}
+
+std::unique_ptr<ActionPanelState>
+WinControlPanelRootItem::newActionPanel(ApplicationContext *ctx, const RootItemMetadata &metadata) const {
+  auto panel = std::make_unique<ListActionPanelState>();
+  auto mainSection = panel->createSection();
+  auto utils = panel->createSection();
+  auto itemSection = panel->createSection();
+
+  const QString target = "shell:" + m_applet.parsingName;
+  auto open = new OpenControlPanelItemAction(QString("Open %1").arg(m_applet.displayName), iconUrl(), target);
+  mainSection->addAction(new DefaultActionWrapper(uniqueId(), open));
+
+  utils->addAction(new CopyToClipboardAction(Clipboard::Text(target), "Copy Path"));
+
+  for (const auto &action : RootSearchActionGenerator::generateActions(*this, metadata)) {
+    itemSection->addAction(action);
+  }
+
+  panel->setTitle(m_applet.displayName);
+  return panel;
+}
+
+QString WinControlPanelTaskRootItem::title() const { return m_task.displayName; }
+
+QString WinControlPanelTaskRootItem::typeDisplayName() const { return "Control Panel"; }
+
+ImageURL WinControlPanelTaskRootItem::iconUrl() const {
+  return ImageURL::winShellIcon(ALL_TASKS_ICON_PREFIX + m_task.taskId);
+}
+
+EntrypointId WinControlPanelTaskRootItem::uniqueId() const {
+  return EntrypointId("control-panel", ("task." + m_task.taskId).toStdString());
+}
+
+AccessoryList WinControlPanelTaskRootItem::accessories() const {
+  return {{.text = "Control Panel", .color = SemanticColor::TextMuted}};
+}
+
+std::vector<std::pair<QString, QString>> WinControlPanelTaskRootItem::settingsMetadata() const {
+  return {{"Name", m_task.displayName}, {"Task ID", m_task.taskId}};
+}
+
+std::unique_ptr<ActionPanelState>
+WinControlPanelTaskRootItem::newActionPanel(ApplicationContext *ctx, const RootItemMetadata &metadata) const {
+  auto panel = std::make_unique<ListActionPanelState>();
+  auto mainSection = panel->createSection();
+  auto itemSection = panel->createSection();
+
+  auto open =
+      new OpenControlPanelTaskAction(QString("Open %1").arg(m_task.displayName), iconUrl(), m_task.pidl);
+  mainSection->addAction(new DefaultActionWrapper(uniqueId(), open));
+
+  for (const auto &action : RootSearchActionGenerator::generateActions(*this, metadata)) {
+    itemSection->addAction(action);
+  }
+
+  panel->setTitle(m_task.displayName);
+  return panel;
+}
+
+QString WinControlPanelRootProvider::uniqueId() const { return "control-panel"; }
+
+QString WinControlPanelRootProvider::displayName() const { return "Control Panel"; }
+
+QString WinControlPanelRootProvider::description() const { return "Control Panel applets and system tasks."; }
+
+ImageURL WinControlPanelRootProvider::icon() const { return ImageURL::winShellIcon(CONTROL_PANEL_CLSID); }
+
+RootProvider::Type WinControlPanelRootProvider::type() const { return RootProvider::Type::GroupProvider; }
+
+std::vector<std::shared_ptr<RootItem>> WinControlPanelRootProvider::loadItems() const {
+  auto applets = enumerateControlPanelApplets();
+  auto tasks = enumerateControlPanelTasks();
+
+  std::vector<std::shared_ptr<RootItem>> items;
+  items.reserve(applets.size() + tasks.size());
+
+  std::set<QString> seenTitles;
+
+  for (auto &applet : applets) {
+    seenTitles.insert(applet.displayName.toLower());
+    items.emplace_back(std::make_shared<WinControlPanelRootItem>(std::move(applet)));
+  }
+  // Tasks are the noisiest source: drop the ones whose title an applet already covers.
+  for (auto &task : tasks) {
+    if (seenTitles.contains(task.displayName.toLower())) continue;
+    if (std::ranges::contains(SKIPPED_TASK_IDS, task.taskId.toLower())) continue;
+    items.emplace_back(std::make_shared<WinControlPanelTaskRootItem>(std::move(task)));
+  }
+
+  return items;
+}

--- a/src/server/src/root-search/control-panel/control-panel-root-provider.hpp
+++ b/src/server/src/root-search/control-panel/control-panel-root-provider.hpp
@@ -1,0 +1,57 @@
+#pragma once
+#include "services/root-item-manager/root-item-manager.hpp"
+
+struct WinControlPanelApplet {
+  QString displayName;
+  QString parsingName;
+};
+
+// A task from the "All Tasks" shell folder (god mode). Tasks cannot be re-created from a parsing
+// name (the folder does not implement ParseDisplayName), so the absolute PIDL is kept for launching.
+struct WinControlPanelTask {
+  QString displayName;
+  QString taskId; // in-folder parsing name, "{guid}"
+  QByteArray pidl;
+};
+
+class WinControlPanelRootItem : public RootItem {
+  WinControlPanelApplet m_applet;
+
+  QString title() const override;
+  QString typeDisplayName() const override;
+  ImageURL iconUrl() const override;
+  EntrypointId uniqueId() const override;
+  AccessoryList accessories() const override;
+  std::unique_ptr<ActionPanelState> newActionPanel(ApplicationContext *ctx,
+                                                   const RootItemMetadata &metadata) const override;
+  std::vector<std::pair<QString, QString>> settingsMetadata() const override;
+
+public:
+  explicit WinControlPanelRootItem(WinControlPanelApplet applet) : m_applet(std::move(applet)) {}
+};
+
+class WinControlPanelTaskRootItem : public RootItem {
+  WinControlPanelTask m_task;
+
+  QString title() const override;
+  QString typeDisplayName() const override;
+  ImageURL iconUrl() const override;
+  EntrypointId uniqueId() const override;
+  AccessoryList accessories() const override;
+  std::unique_ptr<ActionPanelState> newActionPanel(ApplicationContext *ctx,
+                                                   const RootItemMetadata &metadata) const override;
+  std::vector<std::pair<QString, QString>> settingsMetadata() const override;
+
+public:
+  explicit WinControlPanelTaskRootItem(WinControlPanelTask task) : m_task(std::move(task)) {}
+};
+
+class WinControlPanelRootProvider : public RootProvider {
+public:
+  QString uniqueId() const override;
+  QString displayName() const override;
+  QString description() const override;
+  ImageURL icon() const override;
+  Type type() const override;
+  std::vector<std::shared_ptr<RootItem>> loadItems() const override;
+};

--- a/src/server/src/root-search/extensions/extension-root-provider.hpp
+++ b/src/server/src/root-search/extensions/extension-root-provider.hpp
@@ -44,6 +44,7 @@ public:
   const std::shared_ptr<AbstractCommandRepository> &repository() const { return m_repo; }
   PreferenceList preferences() const override { return m_repo->preferences(); }
   QString displayName() const override { return m_repo->displayName(); }
+  QString description() const override { return m_repo->description(); }
   QString uniqueId() const override { return repositoryId(); }
   ImageURL icon() const override { return m_repo->iconUrl(); };
   Type type() const override { return RootProvider::Type::ExtensionProvider; }

--- a/src/server/src/root-search/windows-settings/windows-settings-root-provider.cpp
+++ b/src/server/src/root-search/windows-settings/windows-settings-root-provider.cpp
@@ -1,0 +1,227 @@
+#include "root-search/windows-settings/windows-settings-root-provider.hpp"
+#include "actions/root-search/root-search-actions.hpp"
+#include "clipboard-actions.hpp"
+#include "navigation-controller.hpp"
+#include "service-registry.hpp"
+#include "services/toast/toast-service.hpp"
+#include "ui/action-pannel/action-panel-state.hpp"
+#include "ui/image/url.hpp"
+
+#include <QFontDatabase>
+
+#include <windows.h>
+#include <shellapi.h>
+
+namespace {
+
+constexpr const char *SETTINGS_APP_PARSING_NAME =
+    "shell:AppsFolder\\windows.immersivecontrolpanel_cw5n1h2txyewy!microsoft.windows.immersivecontrolpanel";
+constexpr const char *SEGOE_FLUENT_FONT = "Segoe Fluent Icons";
+constexpr const char *SEGOE_MDL2_FONT = "Segoe MDL2 Assets"; // Windows 10 fallback
+
+const QString &settingsGlyphFont() {
+  static const QString family = QFontDatabase::hasFamily(SEGOE_FLUENT_FONT)
+                                    ? QString::fromUtf8(SEGOE_FLUENT_FONT)
+                                    : QString::fromUtf8(SEGOE_MDL2_FONT);
+  return family;
+}
+
+// clang-format off
+constexpr WinSettingsPage SETTINGS_PAGES[] = {
+    {"display", "Display", "System", "ms-settings:display", SegoeIcon::TVMonitor, "monitor resolution brightness scale hdr screen"},
+    {"night-light", "Night Light", "System", "ms-settings:nightlight", SegoeIcon::QuietHours, "blue light filter"},
+    {"sound", "Sound", "System", "ms-settings:sound", SegoeIcon::Volume, "audio output input volume speaker microphone"},
+    {"volume-mixer", "Volume Mixer", "System", "ms-settings:apps-volume", SegoeIcon::Equalizer, "audio per app"},
+    {"notifications", "Notifications", "System", "ms-settings:notifications", SegoeIcon::Ringer, "banners alerts"},
+    {"focus", "Focus", "System", "ms-settings:quiethours", SegoeIcon::RingerSilent, "do not disturb dnd quiet hours"},
+    {"power", "Power & Battery", "System", "ms-settings:powersleep", SegoeIcon::Battery10, "sleep saver screen timeout energy hibernate"},
+    {"storage", "Storage", "System", "ms-settings:storagesense", SegoeIcon::HardDrive, "disk space cleanup sense"},
+    {"nearby-sharing", "Nearby Sharing", "System", "ms-settings:crossdevice", SegoeIcon::Share, "share files"},
+    {"multitasking", "Multitasking", "System", "ms-settings:multitasking", SegoeIcon::TaskView, "snap layouts alt tab virtual desktops"},
+    {"activation", "Activation", "System", "ms-settings:activation", SegoeIcon::Permissions, "license product key"},
+    {"troubleshoot", "Troubleshoot", "System", "ms-settings:troubleshoot", SegoeIcon::Repair, "fix problems"},
+    {"recovery", "Recovery", "System", "ms-settings:recovery", SegoeIcon::UpdateRestore, "reset pc restore reinstall"},
+    {"projection", "Projecting to This PC", "System", "ms-settings:project", SegoeIcon::MiracastLogoSmall, "miracast wireless display cast"},
+    {"remote-desktop", "Remote Desktop", "System", "ms-settings:remotedesktop", SegoeIcon::Remote, "rdp"},
+    {"clipboard", "Clipboard", "System", "ms-settings:clipboard", SegoeIcon::Paste, "history sync paste"},
+    {"about", "About", "System", "ms-settings:about", SegoeIcon::Info, "system info version specs rename pc"},
+    {"optional-features", "Optional Features", "System", "ms-settings:optionalfeatures", SegoeIcon::Add, "add windows features"},
+    {"developers", "For Developers", "System", "ms-settings:developers", SegoeIcon::DeveloperTools, "developer mode sudo"},
+
+    {"bluetooth", "Bluetooth & Devices", "Bluetooth & Devices", "ms-settings:bluetooth", SegoeIcon::Bluetooth, "pair pairing wireless"},
+    {"connected-devices", "Devices", "Bluetooth & Devices", "ms-settings:connecteddevices", SegoeIcon::Devices, "add device"},
+    {"printers", "Printers & Scanners", "Bluetooth & Devices", "ms-settings:printers", SegoeIcon::Print, "print scan"},
+    {"mobile-devices", "Mobile Devices", "Bluetooth & Devices", "ms-settings:mobile-devices", SegoeIcon::CellPhone, "phone link android iphone"},
+    {"cameras", "Cameras", "Bluetooth & Devices", "ms-settings:camera", SegoeIcon::Camera, "webcam"},
+    {"mouse", "Mouse", "Bluetooth & Devices", "ms-settings:mousetouchpad", SegoeIcon::Mouse, "cursor pointer speed scroll"},
+    {"touchpad", "Touchpad", "Bluetooth & Devices", "ms-settings:devices-touchpad", SegoeIcon::Touchpad, "gestures trackpad"},
+    {"pen", "Pen & Windows Ink", "Bluetooth & Devices", "ms-settings:pen", SegoeIcon::Edit, "tablet stylus"},
+    {"autoplay", "AutoPlay", "Bluetooth & Devices", "ms-settings:autoplay", SegoeIcon::Play, "removable drive memory card"},
+    {"usb", "USB", "Bluetooth & Devices", "ms-settings:usb", SegoeIcon::USB, ""},
+
+    {"network", "Network & Internet", "Network & Internet", "ms-settings:network-status", SegoeIcon::Globe, "internet status connection"},
+    {"wifi", "Wi-Fi", "Network & Internet", "ms-settings:network-wifi", SegoeIcon::Wifi, "wireless wlan"},
+    {"ethernet", "Ethernet", "Network & Internet", "ms-settings:network-ethernet", SegoeIcon::Ethernet, "lan wired"},
+    {"vpn", "VPN", "Network & Internet", "ms-settings:network-vpn", SegoeIcon::VPN, "tunnel"},
+    {"mobile-hotspot", "Mobile Hotspot", "Network & Internet", "ms-settings:network-mobilehotspot", SegoeIcon::InternetSharing, "tethering"},
+    {"airplane-mode", "Airplane Mode", "Network & Internet", "ms-settings:network-airplanemode", SegoeIcon::Airplane, "flight"},
+    {"proxy", "Proxy", "Network & Internet", "ms-settings:network-proxy", SegoeIcon::Globe, ""},
+    {"dial-up", "Dial-up", "Network & Internet", "ms-settings:network-dialup", SegoeIcon::Phone, "modem"},
+    {"advanced-network", "Advanced Network Settings", "Network & Internet", "ms-settings:network-advancedsettings", SegoeIcon::NetworkAdapter, "adapters data usage"},
+
+    {"background", "Background", "Personalization", "ms-settings:personalization-background", SegoeIcon::Picture, "wallpaper desktop"},
+    {"colors", "Colors", "Personalization", "ms-settings:personalization-colors", SegoeIcon::Color, "accent dark mode light mode theme"},
+    {"themes", "Themes", "Personalization", "ms-settings:themes", SegoeIcon::Personalize, ""},
+    {"lock-screen", "Lock Screen", "Personalization", "ms-settings:lockscreen", SegoeIcon::Lock, ""},
+    {"touch-keyboard", "Touch Keyboard", "Personalization", "ms-settings:personalization-touchkeyboard", SegoeIcon::KeyboardClassic, "osk"},
+    {"start", "Start", "Personalization", "ms-settings:personalization-start", SegoeIcon::GridView, "start menu"},
+    {"taskbar", "Taskbar", "Personalization", "ms-settings:taskbar", SegoeIcon::DockBottom, "system tray"},
+    {"fonts", "Fonts", "Personalization", "ms-settings:fonts", SegoeIcon::Font, "typeface install font"},
+    {"dynamic-lighting", "Dynamic Lighting", "Personalization", "ms-settings:personalization-lighting", SegoeIcon::Lightbulb, "rgb"},
+
+    {"installed-apps", "Installed Apps", "Apps", "ms-settings:appsfeatures", SegoeIcon::AllApps, "uninstall programs remove add"},
+    {"default-apps", "Default Apps", "Apps", "ms-settings:defaultapps", SegoeIcon::OpenWith, "browser file associations"},
+    {"offline-maps", "Offline Maps", "Apps", "ms-settings:maps", SegoeIcon::DownloadMap, ""},
+    {"apps-for-websites", "Apps for Websites", "Apps", "ms-settings:appsforwebsites", SegoeIcon::Link, ""},
+    {"video-playback", "Video Playback", "Apps", "ms-settings:videoplayback", SegoeIcon::Video, "hdr streaming"},
+    {"startup-apps", "Startup Apps", "Apps", "ms-settings:startupapps", SegoeIcon::LightningBolt, "boot autostart"},
+
+    {"your-info", "Your Info", "Accounts", "ms-settings:yourinfo", SegoeIcon::Contact, "account picture profile"},
+    {"email-accounts", "Email & Accounts", "Accounts", "ms-settings:emailandaccounts", SegoeIcon::Mail, "mail"},
+    {"sign-in-options", "Sign-in Options", "Accounts", "ms-settings:signinoptions", SegoeIcon::Fingerprint, "windows hello pin password face"},
+    {"work-school", "Access Work or School", "Accounts", "ms-settings:workplace", SegoeIcon::Work, "domain organization"},
+    {"family-users", "Family & Other Users", "Accounts", "ms-settings:otherusers", SegoeIcon::People, "accounts kiosk"},
+    {"windows-backup", "Windows Backup", "Accounts", "ms-settings:backup", SegoeIcon::Cloud, "onedrive sync"},
+
+    {"date-time", "Date & Time", "Time & Language", "ms-settings:dateandtime", SegoeIcon::Recent, "timezone clock"},
+    {"language-region", "Language & Region", "Time & Language", "ms-settings:regionlanguage", SegoeIcon::TimeLanguage, "locale format keyboard layout"},
+    {"typing", "Typing", "Time & Language", "ms-settings:typing", SegoeIcon::KeyboardClassic, "autocorrect text suggestions"},
+    {"speech", "Speech", "Time & Language", "ms-settings:speech", SegoeIcon::Microphone, "voice"},
+
+    {"game-bar", "Game Bar", "Gaming", "ms-settings:gaming-gamebar", SegoeIcon::Game, "xbox"},
+    {"captures", "Captures", "Gaming", "ms-settings:gaming-gamedvr", SegoeIcon::Video, "recording screenshots dvr"},
+    {"game-mode", "Game Mode", "Gaming", "ms-settings:gaming-gamemode", SegoeIcon::SpeedHigh, "performance"},
+
+    {"text-size", "Text Size", "Accessibility", "ms-settings:easeofaccess-display", SegoeIcon::FontSize, "bigger accessibility"},
+    {"visual-effects", "Visual Effects", "Accessibility", "ms-settings:easeofaccess-visualeffects", SegoeIcon::RedEye, "animations transparency"},
+    {"magnifier", "Magnifier", "Accessibility", "ms-settings:easeofaccess-magnifier", SegoeIcon::Zoom, "zoom"},
+    {"color-filters", "Color Filters", "Accessibility", "ms-settings:easeofaccess-colorfilter", SegoeIcon::Color, "colorblind"},
+    {"contrast-themes", "Contrast Themes", "Accessibility", "ms-settings:easeofaccess-highcontrast", SegoeIcon::Color, "high contrast"},
+    {"narrator", "Narrator", "Accessibility", "ms-settings:easeofaccess-narrator", SegoeIcon::Narrator, "screen reader"},
+    {"accessibility-audio", "Accessibility Audio", "Accessibility", "ms-settings:easeofaccess-audio", SegoeIcon::Headphone, "mono"},
+    {"captions", "Captions", "Accessibility", "ms-settings:easeofaccess-closedcaptioning", SegoeIcon::CC, "subtitles"},
+    {"accessibility-keyboard", "Accessibility Keyboard", "Accessibility", "ms-settings:easeofaccess-keyboard", SegoeIcon::KeyboardClassic, "sticky keys filter keys"},
+    {"accessibility-mouse", "Accessibility Mouse", "Accessibility", "ms-settings:easeofaccess-mouse", SegoeIcon::Mouse, "mouse keys"},
+    {"eye-control", "Eye Control", "Accessibility", "ms-settings:easeofaccess-eyecontrol", SegoeIcon::RedEye, "tracking"},
+
+    {"windows-security", "Windows Security", "Privacy & Security", "ms-settings:windowsdefender", SegoeIcon::Shield, "defender antivirus firewall virus"},
+    {"find-my-device", "Find My Device", "Privacy & Security", "ms-settings:findmydevice", SegoeIcon::Location, "locate"},
+    {"privacy", "Privacy", "Privacy & Security", "ms-settings:privacy", SegoeIcon::Lock, "permissions"},
+    {"location", "Location", "Privacy & Security", "ms-settings:privacy-location", SegoeIcon::MapPin, "gps permissions"},
+    {"camera-access", "Camera Access", "Privacy & Security", "ms-settings:privacy-webcam", SegoeIcon::Camera, "permissions"},
+    {"microphone-access", "Microphone Access", "Privacy & Security", "ms-settings:privacy-microphone", SegoeIcon::Microphone, "permissions"},
+    {"activity-history", "Activity History", "Privacy & Security", "ms-settings:privacy-activityhistory", SegoeIcon::History, ""},
+    {"diagnostics", "Diagnostics & Feedback", "Privacy & Security", "ms-settings:privacy-feedback", SegoeIcon::Diagnostic, "telemetry"},
+    {"search-permissions", "Search Permissions", "Privacy & Security", "ms-settings:search-permissions", SegoeIcon::Search, "safesearch"},
+
+    {"windows-update", "Windows Update", "Windows Update", "ms-settings:windowsupdate", SegoeIcon::Sync, "check updates upgrade patch"},
+    {"update-history", "Update History", "Windows Update", "ms-settings:windowsupdate-history", SegoeIcon::History, "installed updates"},
+    {"update-advanced", "Advanced Update Options", "Windows Update", "ms-settings:windowsupdate-options", SegoeIcon::Settings, "active hours delivery optimization"},
+    {"windows-insider", "Windows Insider Program", "Windows Update", "ms-settings:windowsinsider", SegoeIcon::FavoriteStar, "beta dev canary preview"},
+};
+// clang-format on
+
+class OpenWindowsSettingAction : public AbstractAction {
+public:
+  OpenWindowsSettingAction(const QString &title, const ImageURL &icon, QString target)
+      : AbstractAction(title, icon), m_target(std::move(target)) {}
+
+  void execute(ApplicationContext *ctx) override {
+    const std::wstring target = m_target.toStdWString();
+    const HINSTANCE ret = ShellExecuteW(nullptr, L"open", target.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+
+    if (reinterpret_cast<INT_PTR>(ret) <= 32) {
+      ctx->services->toastService()->failure("Failed to open settings");
+      return;
+    }
+
+    ctx->navigation->closeWindow();
+    ctx->navigation->clearSearchText();
+  }
+
+private:
+  QString m_target;
+};
+
+} // namespace
+
+QString WinSettingsPageRootItem::title() const { return m_page.title; }
+
+QString WinSettingsPageRootItem::subtitle() const { return m_page.category; }
+
+QString WinSettingsPageRootItem::typeDisplayName() const { return "System Settings"; }
+
+ImageURL WinSettingsPageRootItem::iconUrl() const {
+  return ImageURL::fontPreview(settingsGlyphFont(), QString(QChar(static_cast<char16_t>(m_page.glyph))))
+      .setFill(SemanticColor::Foreground);
+}
+
+EntrypointId WinSettingsPageRootItem::uniqueId() const { return EntrypointId("windows-settings", m_page.id); }
+
+AccessoryList WinSettingsPageRootItem::accessories() const {
+  return {{.text = "Settings", .color = SemanticColor::TextMuted}};
+}
+
+std::vector<QString> WinSettingsPageRootItem::keywords() const {
+  std::vector<QString> words;
+  for (const QString &word : QString::fromUtf8(m_page.keywords).split(' ', Qt::SkipEmptyParts)) {
+    words.emplace_back(word);
+  }
+  return words;
+}
+
+std::vector<std::pair<QString, QString>> WinSettingsPageRootItem::settingsMetadata() const {
+  return {{"Name", m_page.title}, {"Category", m_page.category}, {"URL", m_page.url}};
+}
+
+std::unique_ptr<ActionPanelState>
+WinSettingsPageRootItem::newActionPanel(ApplicationContext *ctx, const RootItemMetadata &metadata) const {
+  auto panel = std::make_unique<ListActionPanelState>();
+  auto mainSection = panel->createSection();
+  auto utils = panel->createSection();
+  auto itemSection = panel->createSection();
+
+  auto open = new OpenWindowsSettingAction(QString("Open %1 Settings").arg(m_page.title), iconUrl(),
+                                           QString::fromUtf8(m_page.url));
+  mainSection->addAction(new DefaultActionWrapper(uniqueId(), open));
+
+  utils->addAction(new CopyToClipboardAction(Clipboard::Text(m_page.url), "Copy URL"));
+
+  for (const auto &action : RootSearchActionGenerator::generateActions(*this, metadata)) {
+    itemSection->addAction(action);
+  }
+
+  panel->setTitle(m_page.title);
+  return panel;
+}
+
+QString WinSettingsRootProvider::uniqueId() const { return "windows-settings"; }
+
+QString WinSettingsRootProvider::displayName() const { return "Windows Settings"; }
+
+QString WinSettingsRootProvider::description() const { return "Pages of the Windows Settings app."; }
+
+ImageURL WinSettingsRootProvider::icon() const { return ImageURL::winShellIcon(SETTINGS_APP_PARSING_NAME); }
+
+RootProvider::Type WinSettingsRootProvider::type() const { return RootProvider::Type::GroupProvider; }
+
+std::vector<std::shared_ptr<RootItem>> WinSettingsRootProvider::loadItems() const {
+  std::vector<std::shared_ptr<RootItem>> items;
+  items.reserve(std::size(SETTINGS_PAGES));
+
+  for (const auto &page : SETTINGS_PAGES) {
+    items.emplace_back(std::make_shared<WinSettingsPageRootItem>(page));
+  }
+
+  return items;
+}

--- a/src/server/src/root-search/windows-settings/windows-settings-root-provider.cpp
+++ b/src/server/src/root-search/windows-settings/windows-settings-root-provider.cpp
@@ -12,6 +12,8 @@
 #include <windows.h>
 #include <shellapi.h>
 
+#include <array>
+
 namespace {
 
 constexpr const char *SETTINGS_APP_PARSING_NAME =
@@ -27,7 +29,7 @@ const QString &settingsGlyphFont() {
 }
 
 // clang-format off
-constexpr WinSettingsPage SETTINGS_PAGES[] = {
+constexpr auto SETTINGS_PAGES = std::to_array<WinSettingsPage>({
     {"display", "Display", "System", "ms-settings:display", SegoeIcon::TVMonitor, "monitor resolution brightness scale hdr screen"},
     {"night-light", "Night Light", "System", "ms-settings:nightlight", SegoeIcon::QuietHours, "blue light filter"},
     {"sound", "Sound", "System", "ms-settings:sound", SegoeIcon::Volume, "audio output input volume speaker microphone"},
@@ -128,7 +130,7 @@ constexpr WinSettingsPage SETTINGS_PAGES[] = {
     {"update-history", "Update History", "Windows Update", "ms-settings:windowsupdate-history", SegoeIcon::History, "installed updates"},
     {"update-advanced", "Advanced Update Options", "Windows Update", "ms-settings:windowsupdate-options", SegoeIcon::Settings, "active hours delivery optimization"},
     {"windows-insider", "Windows Insider Program", "Windows Update", "ms-settings:windowsinsider", SegoeIcon::FavoriteStar, "beta dev canary preview"},
-};
+});
 // clang-format on
 
 class OpenWindowsSettingAction : public AbstractAction {
@@ -217,7 +219,7 @@ RootProvider::Type WinSettingsRootProvider::type() const { return RootProvider::
 
 std::vector<std::shared_ptr<RootItem>> WinSettingsRootProvider::loadItems() const {
   std::vector<std::shared_ptr<RootItem>> items;
-  items.reserve(std::size(SETTINGS_PAGES));
+  items.reserve(SETTINGS_PAGES.size());
 
   for (const auto &page : SETTINGS_PAGES) {
     items.emplace_back(std::make_shared<WinSettingsPageRootItem>(page));

--- a/src/server/src/root-search/windows-settings/windows-settings-root-provider.hpp
+++ b/src/server/src/root-search/windows-settings/windows-settings-root-provider.hpp
@@ -1,0 +1,121 @@
+#pragma once
+#include "services/root-item-manager/root-item-manager.hpp"
+
+// Official Segoe Fluent Icons glyph names (all also present in Segoe MDL2 Assets on Windows 10).
+enum class SegoeIcon : char16_t {
+  Add = 0xE710,
+  Airplane = 0xE709,
+  AllApps = 0xE71D,
+  Battery10 = 0xE83F,
+  Bluetooth = 0xE702,
+  CC = 0xE7F0,
+  Camera = 0xE722,
+  CellPhone = 0xE8EA,
+  Cloud = 0xE753,
+  Color = 0xE790,
+  Contact = 0xE77B,
+  DeveloperTools = 0xEC7A,
+  Devices = 0xE772,
+  Diagnostic = 0xE9D9,
+  DockBottom = 0xE90E,
+  DownloadMap = 0xE826,
+  Edit = 0xE70F,
+  Equalizer = 0xE9E9,
+  Ethernet = 0xE839,
+  FavoriteStar = 0xE734,
+  Fingerprint = 0xE928,
+  Font = 0xE8D2,
+  FontSize = 0xE8E9,
+  Game = 0xE7FC,
+  Globe = 0xE774,
+  GridView = 0xF0E2,
+  HardDrive = 0xEDA2,
+  Headphone = 0xE7F6,
+  History = 0xE81C,
+  Info = 0xE946,
+  InternetSharing = 0xE704,
+  KeyboardClassic = 0xE765,
+  Lightbulb = 0xEA80,
+  LightningBolt = 0xE945,
+  Link = 0xE71B,
+  Location = 0xE81D,
+  Lock = 0xE72E,
+  Mail = 0xE715,
+  MapPin = 0xE707,
+  Microphone = 0xE720,
+  MiracastLogoSmall = 0xEC15,
+  Mouse = 0xE962,
+  Narrator = 0xED4D,
+  NetworkAdapter = 0xEDA3,
+  OpenWith = 0xE7AC,
+  Paste = 0xE77F,
+  People = 0xE716,
+  Permissions = 0xE8D7,
+  Personalize = 0xE771,
+  Phone = 0xE717,
+  Picture = 0xE8B9,
+  Play = 0xE768,
+  Print = 0xE749,
+  QuietHours = 0xE708,
+  Recent = 0xE823,
+  RedEye = 0xE7B3,
+  Remote = 0xE8AF,
+  Repair = 0xE90F,
+  Ringer = 0xEA8F,
+  RingerSilent = 0xE7ED,
+  Search = 0xE721,
+  Settings = 0xE713,
+  Share = 0xE72D,
+  Shield = 0xEA18,
+  SpeedHigh = 0xEC4A,
+  Sync = 0xE895,
+  TVMonitor = 0xE7F4,
+  TaskView = 0xE7C4,
+  TimeLanguage = 0xE775,
+  Touchpad = 0xEFA5,
+  USB = 0xE88E,
+  UpdateRestore = 0xE777,
+  VPN = 0xE705,
+  Video = 0xE714,
+  Volume = 0xE767,
+  Wifi = 0xE701,
+  Work = 0xE821,
+  Zoom = 0xE71E,
+};
+
+struct WinSettingsPage {
+  const char *id;
+  const char *title;
+  const char *category;
+  const char *url;
+  SegoeIcon glyph;
+  const char *keywords;
+};
+
+class WinSettingsPageRootItem : public RootItem {
+  const WinSettingsPage &m_page;
+
+  QString title() const override;
+  QString subtitle() const override;
+  QString typeDisplayName() const override;
+  ImageURL iconUrl() const override;
+  EntrypointId uniqueId() const override;
+  AccessoryList accessories() const override;
+  std::vector<QString> keywords() const override;
+  std::unique_ptr<ActionPanelState> newActionPanel(ApplicationContext *ctx,
+                                                   const RootItemMetadata &metadata) const override;
+  std::vector<std::pair<QString, QString>> settingsMetadata() const override;
+
+public:
+  explicit WinSettingsPageRootItem(const WinSettingsPage &page) : m_page(page) {}
+};
+
+class WinSettingsRootProvider : public RootProvider {
+public:
+  QString uniqueId() const override;
+  QString displayName() const override;
+  QString description() const override;
+  ImageURL icon() const override;
+  Type type() const override;
+  std::vector<std::shared_ptr<RootItem>> loadItems() const override;
+};

--- a/src/server/src/server.cpp
+++ b/src/server/src/server.cpp
@@ -22,6 +22,10 @@
 #ifdef Q_OS_MACOS
 #include "root-search/macos-settings/macos-settings-root-provider.hpp"
 #endif
+#ifdef Q_OS_WIN
+#include "root-search/control-panel/control-panel-root-provider.hpp"
+#include "root-search/windows-settings/windows-settings-root-provider.hpp"
+#endif
 #include "service-registry.hpp"
 #include "services/window-material/window-material-manager.hpp"
 #include "qml/window-material-attached.hpp"
@@ -376,6 +380,10 @@ int startServer(const ServerLaunchOptions &launchOpts) {
     root->loadProvider(std::make_unique<BrowserTabProvider>(*registry->browserExtension()));
 #ifdef Q_OS_MACOS
     root->loadProvider(std::make_unique<MacSettingsRootProvider>());
+#endif
+#ifdef Q_OS_WIN
+    root->loadProvider(std::make_unique<WinSettingsRootProvider>());
+    root->loadProvider(std::make_unique<WinControlPanelRootProvider>());
 #endif
 
     // Force reload providers to make sure items that depend on them are shown

--- a/src/server/src/services/root-item-manager/root-item-manager.hpp
+++ b/src/server/src/services/root-item-manager/root-item-manager.hpp
@@ -158,6 +158,7 @@ public:
 
   virtual QString uniqueId() const = 0;
   virtual QString displayName() const = 0;
+  virtual QString description() const { return {}; }
   virtual ImageURL icon() const = 0;
   virtual Type type() const = 0;
 

--- a/src/server/src/ui/image/win-file-icon-loader.cpp
+++ b/src/server/src/ui/image/win-file-icon-loader.cpp
@@ -8,6 +8,7 @@
 #endif
 #include <windows.h>
 #include <shlobj.h>
+#include <shlwapi.h>
 #include <shellapi.h>
 #include <shobjidl_core.h>
 #include <wrl/client.h>
@@ -16,8 +17,15 @@
 
 #include <algorithm>
 #include <string>
+#include <unordered_map>
 
 namespace {
+
+// Items of the "All Tasks" folder cannot be re-created from a parsing name (the folder does not
+// implement ParseDisplayName); they are resolved by enumerating the folder and matching the
+// in-folder parsing name ("{guid}").
+constexpr const wchar_t *ALL_TASKS_FOLDER = L"shell:::{ED7BA470-8E54-465E-825C-99712043E01C}";
+constexpr QStringView ALL_TASKS_PREFIX = u"::{ED7BA470-8E54-465E-825C-99712043E01C}\\";
 
 // Some icons come back with an all-zero alpha channel (stored without alpha); force those opaque.
 QImage imageFromHBITMAP(HBITMAP bitmap) {
@@ -68,6 +76,62 @@ QImage imageFromHBITMAP(HBITMAP bitmap) {
   return image;
 }
 
+// Enumerating the folder is expensive (it instantiates every task provider), so it is done once
+// and the PIDLs are kept as raw bytes, which are safe to rebind from any COM-initialized thread.
+struct AllTasksCache {
+  QByteArray parentPidl;
+  std::unordered_map<QString, QByteArray> children; // lowercase "{guid}" -> child PIDL bytes
+};
+
+const AllTasksCache &allTasksCache() {
+  static const AllTasksCache cache = [] {
+    AllTasksCache c;
+
+    PIDLIST_ABSOLUTE folderPidl = nullptr;
+    if (FAILED(SHParseDisplayName(ALL_TASKS_FOLDER, nullptr, &folderPidl, 0, nullptr))) return c;
+    c.parentPidl = QByteArray(reinterpret_cast<const char *>(folderPidl), ILGetSize(folderPidl));
+
+    Microsoft::WRL::ComPtr<IShellFolder> folder;
+    const HRESULT bindHr = SHBindToObject(nullptr, folderPidl, nullptr, IID_PPV_ARGS(&folder));
+    ILFree(folderPidl);
+    if (FAILED(bindHr)) return c;
+
+    Microsoft::WRL::ComPtr<IEnumIDList> ids;
+    if (folder->EnumObjects(nullptr, SHCONTF_FOLDERS | SHCONTF_NONFOLDERS, &ids) != S_OK || !ids) return c;
+
+    PITEMID_CHILD child = nullptr;
+    while (ids->Next(1, &child, nullptr) == S_OK) {
+      STRRET ret;
+      wchar_t buf[128];
+      if (SUCCEEDED(folder->GetDisplayNameOf(child, SHGDN_FORPARSING | SHGDN_INFOLDER, &ret)) &&
+          SUCCEEDED(StrRetToBufW(&ret, child, buf, static_cast<UINT>(std::size(buf))))) {
+        c.children.emplace(QString::fromWCharArray(buf).toLower(),
+                           QByteArray(reinterpret_cast<const char *>(child), ILGetSize(child)));
+      }
+      ILFree(child);
+    }
+
+    return c;
+  }();
+  return cache;
+}
+
+Microsoft::WRL::ComPtr<IShellItemImageFactory> allTasksItemFactory(const QString &taskId) {
+  Microsoft::WRL::ComPtr<IShellItemImageFactory> factory;
+
+  const AllTasksCache &cache = allTasksCache();
+  const auto it = cache.children.find(taskId.toLower());
+  if (it == cache.children.end() || cache.parentPidl.isEmpty()) return factory;
+
+  Microsoft::WRL::ComPtr<IShellFolder> folder;
+  const auto *parent = reinterpret_cast<PCIDLIST_ABSOLUTE>(cache.parentPidl.constData());
+  if (FAILED(SHBindToObject(nullptr, parent, nullptr, IID_PPV_ARGS(&folder)))) return factory;
+
+  const auto *child = reinterpret_cast<PCUITEMID_CHILD>(it->second.constData());
+  SHCreateItemWithParent(nullptr, folder.Get(), child, IID_PPV_ARGS(&factory));
+  return factory;
+}
+
 } // namespace
 
 QImage renderWinShellIcon(const QString &parsingName, const QSize &size) {
@@ -79,8 +143,14 @@ QImage renderWinShellIcon(const QString &parsingName, const QSize &size) {
   QImage result;
 
   Microsoft::WRL::ComPtr<IShellItemImageFactory> factory;
-  const std::wstring wname = parsingName.toStdWString();
-  HRESULT hr = SHCreateItemFromParsingName(wname.c_str(), nullptr, IID_PPV_ARGS(&factory));
+  HRESULT hr = E_FAIL;
+  if (parsingName.startsWith(ALL_TASKS_PREFIX)) {
+    factory = allTasksItemFactory(parsingName.mid(ALL_TASKS_PREFIX.size()));
+    if (factory) hr = S_OK;
+  } else {
+    const std::wstring wname = parsingName.toStdWString();
+    hr = SHCreateItemFromParsingName(wname.c_str(), nullptr, IID_PPV_ARGS(&factory));
+  }
   if (SUCCEEDED(hr) && factory) {
     const SIZE requested{size.width(), size.height()};
     HBITMAP bitmap = nullptr;


### PR DESCRIPTION
Add two new root search providers: one to list all modern Windows settings, and the other to list all the control panel applets. They are distinct providers so that it is easy for the user to disable one or the other completely (there are a lot of control panel applets, and some users may not want them in the root search).