### PR TITLE
feat(indexer): use fixed size thread pool to enqueue scans

### DIFF
--- a/src/file-indexer/src/file-indexer.cpp
+++ b/src/file-indexer/src/file-indexer.cpp
@@ -17,24 +17,6 @@ struct ReconcilePlan {
   std::vector<fs::path> scanRoots;
 };
 
-std::vector<fs::path> compactSubtrees(std::vector<fs::path> paths) {
-  std::ranges::sort(paths, [](const fs::path &lhs, const fs::path &rhs) {
-    auto const lhsSize = std::ranges::distance(lhs);
-    auto const rhsSize = std::ranges::distance(rhs);
-    if (lhsSize != rhsSize) return lhsSize < rhsSize;
-    return lhs < rhs;
-  });
-
-  std::vector<fs::path> compacted;
-  compacted.reserve(paths.size());
-
-  for (const auto &path : paths) {
-    if (!file_indexer::isCoveredByAny(path, compacted)) { compacted.emplace_back(path); }
-  }
-
-  return compacted;
-}
-
 bool oldRootStillCovers(const fs::path &oldRoot, const std::vector<fs::path> &newRoots) {
   return file_indexer::isCoveredByAny(oldRoot, newRoots);
 }
@@ -73,8 +55,8 @@ ReconcilePlan buildReconcilePlan(const std::vector<fs::path> &oldRoots,
 
   std::erase_if(plan.scanRoots,
                 [&](const fs::path &path) { return file_indexer::isCoveredByAny(path, newExclusions); });
-  plan.deleteSubtrees = compactSubtrees(std::move(plan.deleteSubtrees));
-  plan.scanRoots = compactSubtrees(std::move(plan.scanRoots));
+  plan.deleteSubtrees = file_indexer::compactSubtrees(std::move(plan.deleteSubtrees));
+  plan.scanRoots = file_indexer::compactSubtrees(std::move(plan.scanRoots));
 
   return plan;
 }
@@ -194,7 +176,7 @@ void FileIndexer::markFullScanRootsPending(const std::vector<fs::path> &roots) {
     m_pendingFullScanRoots.emplace_back(file_indexer::normalizePath(root));
   }
 
-  m_pendingFullScanRoots = compactSubtrees(std::move(m_pendingFullScanRoots));
+  m_pendingFullScanRoots = file_indexer::compactSubtrees(std::move(m_pendingFullScanRoots));
 }
 
 void FileIndexer::markFullScanSucceeded(const fs::path &root) {
@@ -235,7 +217,7 @@ std::vector<fs::path> FileIndexer::pendingFullScanRootsFor(const std::vector<fs:
     }
   }
 
-  return compactSubtrees(std::move(pendingRoots));
+  return file_indexer::compactSubtrees(std::move(pendingRoots));
 }
 
 void FileIndexer::setConfig(std::vector<fs::path> paths, std::vector<fs::path> excludedPaths) {
@@ -259,7 +241,7 @@ void FileIndexer::applyConfig(std::vector<fs::path> paths, std::vector<fs::path>
   for (auto &pendingRoot : pendingRoots) {
     plan.scanRoots.emplace_back(std::move(pendingRoot));
   }
-  plan.scanRoots = compactSubtrees(std::move(plan.scanRoots));
+  plan.scanRoots = file_indexer::compactSubtrees(std::move(plan.scanRoots));
 
   m_entrypoints = std::move(newEntryPoints);
   m_excludedPaths = std::move(newExcludedPaths);

--- a/src/file-indexer/src/file-indexer/abstract-scanner.hpp
+++ b/src/file-indexer/src/file-indexer/abstract-scanner.hpp
@@ -7,6 +7,7 @@
 #include <chrono>
 #include <functional>
 #include <memory>
+#include <utility>
 
 class AbstractScanner {
 public:
@@ -14,6 +15,7 @@ public:
 
 protected:
   std::shared_ptr<DbWriter> m_writer;
+  Scan m_scan;
 
 private:
   static constexpr std::chrono::milliseconds PROGRESS_NOTIFY_INTERVAL{500};
@@ -25,12 +27,12 @@ private:
   std::atomic<bool> m_interrupted = false;
 
 protected:
-  void start(const Scan &scan) {
-    auto result = m_writer->createScan(scan.path, scan.type());
+  void start() {
+    auto result = m_writer->createScan(m_scan.path, m_scan.type());
 
     if (!result.has_value()) {
-      flog::warn() << "Not scanning" << scan.path.native() << "because scan record creation failed with error"
-                   << result.error();
+      flog::warn() << "Not scanning" << m_scan.path.native()
+                   << "because scan record creation failed with error" << result.error();
       m_statusCallback(ScanStatus::Failed, m_processedCount);
       return;
     }
@@ -71,11 +73,10 @@ protected:
   bool isInterrupted() const { return m_interrupted; }
 
 public:
-  AbstractScanner(std::shared_ptr<DbWriter> writer, const Scan &scan, StatusCallback callback)
-      : m_writer(writer), m_statusCallback(callback) {}
+  AbstractScanner(std::shared_ptr<DbWriter> writer, Scan scan, StatusCallback callback)
+      : m_writer(std::move(writer)), m_scan(std::move(scan)), m_statusCallback(std::move(callback)) {}
   virtual ~AbstractScanner() = default;
 
+  virtual void run() = 0;
   virtual void interrupt() = 0;
-
-  virtual void join() = 0;
 };

--- a/src/file-indexer/src/file-indexer/incremental-scanner.hpp
+++ b/src/file-indexer/src/file-indexer/incremental-scanner.hpp
@@ -7,15 +7,13 @@
 #include <functional>
 #include <memory>
 #include <optional>
-#include <thread>
 #include <unordered_set>
 #include <vector>
 
 class IncrementalScanner : public AbstractScanner, file_indexer::NonCopyable {
   using EntryCallback = std::function<void(const std::filesystem::directory_entry &entry, bool isNew)>;
 
-  std::unique_ptr<FileIndexerDatabase> m_read_db;
-  std::thread m_scanThread;
+  FileIndexerDatabase &m_readDb;
   EntryFilter m_filter;
   file_indexer::IoPacer m_pacer;
   std::unordered_set<std::filesystem::path> m_currentEntries;
@@ -34,9 +32,10 @@ class IncrementalScanner : public AbstractScanner, file_indexer::NonCopyable {
   void prunedScan(const std::filesystem::path &path, const IncrementalScan &scan);
 
 public:
-  IncrementalScanner(std::shared_ptr<DbWriter> writer, const Scan &scan, StatusCallback callback);
-  ~IncrementalScanner() = default;
+  IncrementalScanner(std::shared_ptr<DbWriter> writer, const Scan &scan, FileIndexerDatabase &readDb,
+                     StatusCallback callback);
+  ~IncrementalScanner() override = default;
 
+  void run() override;
   void interrupt() override;
-  void join() override;
 };

--- a/src/file-indexer/src/file-indexer/indexer-scanner.hpp
+++ b/src/file-indexer/src/file-indexer/indexer-scanner.hpp
@@ -2,24 +2,20 @@
 #include "file-indexer/util.hpp"
 #include "file-indexer/abstract-scanner.hpp"
 #include "file-indexer/filesystem-walker.hpp"
-#include <atomic>
 #include <memory>
-#include <thread>
 
 class IndexerScanner : public AbstractScanner, public file_indexer::NonCopyable {
 public:
   IndexerScanner(const std::shared_ptr<DbWriter> &writer, const Scan &scan, StatusCallback callback);
   ~IndexerScanner() override = default;
 
+  void run() override;
   void interrupt() override;
-  void join() override;
 
 private:
   static constexpr size_t INDEX_BATCH_SIZE = 5'000;
 
   void scan(const Scan &scan);
 
-  std::atomic<bool> m_alive = true;
   FileSystemWalker m_walker;
-  std::thread m_scanThread;
 };

--- a/src/file-indexer/src/file-indexer/scan-dispatcher.hpp
+++ b/src/file-indexer/src/file-indexer/scan-dispatcher.hpp
@@ -5,12 +5,13 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <deque>
 #include <functional>
 #include <map>
 #include <memory>
 #include <mutex>
-#include <queue>
 #include <thread>
+#include <utility>
 #include <vector>
 
 class ScanDispatcher {
@@ -18,13 +19,11 @@ public:
   using EventCallback = std::function<void(const ScanEvent &)>;
 
 private:
+  static constexpr size_t WORKER_COUNT = 2;
   static const constexpr std::chrono::seconds DEBOUNCE_QUIET{5};
   static const constexpr std::chrono::seconds DEBOUNCE_MAX_DELAY{30};
 
-  std::shared_ptr<DbWriter> m_writer;
-  EventCallback m_eventCallback;
-
-  struct Element {
+  struct Running {
     Scan scan;
     std::unique_ptr<AbstractScanner> scanner;
     std::chrono::steady_clock::time_point startedAt;
@@ -36,26 +35,28 @@ private:
     std::chrono::steady_clock::time_point firstSeen;
   };
 
-  std::mutex m_scannerMapMtx;
-  std::map<int, Element> m_scannerMap;
+  std::shared_ptr<DbWriter> m_writer;
+  EventCallback m_eventCallback;
+
+  std::mutex m_workMtx;
+  std::deque<std::pair<int, Scan>> m_ready;
+  std::map<int, Running> m_running;
+  std::condition_variable m_workCv;
   std::condition_variable m_idleCv;
   int m_nextScanId = 0;
-
-  std::mutex m_collectorQueueMtx;
-  std::queue<int> m_collectorQueue;
-
-  std::thread m_collectorThread;
-  std::condition_variable m_collectorCv;
-  std::atomic<bool> m_running;
+  std::atomic<bool> m_alive;
 
   std::mutex m_pendingMtx;
   std::vector<Pending> m_pending;
   std::condition_variable m_pendingCv;
+
+  std::vector<std::thread> m_workers;
   std::thread m_schedulerThread;
 
-  void handleFinishedScan(int id, ScanStatus status);
   void schedulerLoop();
-  int enqueueLocked(const Scan &scan);
+  void workerLoop();
+  void mergePendingLocked(const Scan &scan, std::chrono::steady_clock::time_point now);
+  std::unique_ptr<AbstractScanner> makeScanner(int scanId, const Scan &scan, FileIndexerDatabase &readDb);
 
 public:
   ScanDispatcher(std::shared_ptr<DbWriter> writer);

--- a/src/file-indexer/src/file-indexer/util.hpp
+++ b/src/file-indexer/src/file-indexer/util.hpp
@@ -62,6 +62,23 @@ inline bool isCoveredByAny(const std::filesystem::path &path,
       roots, [&](const std::filesystem::path &root) { return isSameOrDescendantOf(path, root); });
 }
 
+inline std::vector<std::filesystem::path> compactSubtrees(std::vector<std::filesystem::path> paths) {
+  std::ranges::sort(paths, [](const std::filesystem::path &lhs, const std::filesystem::path &rhs) {
+    auto const lhsSize = std::ranges::distance(lhs);
+    auto const rhsSize = std::ranges::distance(rhs);
+    if (lhsSize != rhsSize) return lhsSize < rhsSize;
+    return lhs < rhs;
+  });
+
+  std::vector<std::filesystem::path> compacted;
+  compacted.reserve(paths.size());
+
+  for (const auto &path : paths) {
+    if (!isCoveredByAny(path, compacted)) { compacted.emplace_back(path); }
+  }
+
+  return compacted;
+}
 inline std::optional<int64_t> fileSizeBytesFor(const std::filesystem::path &path, bool isDirectory) {
   if (isDirectory) return std::nullopt;
 

--- a/src/file-indexer/src/incremental-scanner.cpp
+++ b/src/file-indexer/src/incremental-scanner.cpp
@@ -1,5 +1,4 @@
 #include "file-indexer/incremental-scanner.hpp"
-#include "file-indexer/background-thread.hpp"
 #include "file-indexer/filesystem-walker.hpp"
 #include "file-indexer/log.hpp"
 #include <chrono>
@@ -13,7 +12,7 @@ namespace fs = std::filesystem;
 void IncrementalScanner::processDirectory(const fs::path &root, const EntryCallback &onEntry) {
   m_pacer.checkpoint();
 
-  auto indexedFiles = m_read_db->listIndexedDirectoryFiles(root);
+  auto indexedFiles = m_readDb.listIndexedDirectoryFiles(root);
   std::vector<fs::path> deletedFiles;
   std::vector<FileEvent> events;
   std::error_code ec;
@@ -53,7 +52,7 @@ IncrementalScanner::getScannableDirectories(const fs::path &path, std::optional<
   FileSystemWalker walker;
 
   scannableDirs.emplace_back(path);
-  auto lastSuccessfulScan = m_read_db->getLastSuccessfulScan(path);
+  auto lastSuccessfulScan = m_readDb.getLastSuccessfulScan(path);
 
   if (!lastSuccessfulScan.has_value()) {
     flog::error() << "No previous successful scan found for incremental scan at" << path.c_str();
@@ -81,7 +80,7 @@ bool IncrementalScanner::shouldProcessEntry(const fs::directory_entry &entry, in
     auto const lastModifiedSeconds =
         static_cast<int64_t>(duration_cast<seconds>(sctp.time_since_epoch()).count());
 
-    return lastModifiedSeconds >= cutOffSeconds || !m_read_db->tracksFile(entry.path());
+    return lastModifiedSeconds >= cutOffSeconds || !m_readDb.tracksFile(entry.path());
   }
 
   return true;
@@ -115,7 +114,7 @@ void IncrementalScanner::prunedScan(const fs::path &scanPath, const IncrementalS
   int64_t cutOffSeconds = 0;
 
   for (fs::path path = scanPath;; path = path.parent_path()) {
-    if (auto lastSuccessfulScan = m_read_db->getLastSuccessfulScan(path)) {
+    if (auto lastSuccessfulScan = m_readDb.getLastSuccessfulScan(path)) {
       cutOffSeconds = lastSuccessfulScan->createdAt;
       break;
     }
@@ -154,23 +153,19 @@ void IncrementalScanner::scan(const fs::path &path, const IncrementalScan &scan)
 }
 
 IncrementalScanner::IncrementalScanner(std::shared_ptr<DbWriter> writer, const Scan &sc,
-                                       StatusCallback callback)
-    : AbstractScanner(std::move(writer), sc, std::move(callback)) {
-  m_scanThread = std::thread([this, sc]() {
-    file_indexer::setBackgroundThreadPriority();
-    m_read_db = std::make_unique<FileIndexerDatabase>();
-    start(sc);
+                                       FileIndexerDatabase &readDb, StatusCallback callback)
+    : AbstractScanner(std::move(writer), sc, std::move(callback)), m_readDb(readDb) {}
 
-    try {
-      scan(sc.path, std::get<IncrementalScan>(sc.data));
-      finish();
-    } catch (const std::exception &error) {
-      flog::error() << "Caught exception during incremental scan" << error.what();
-      fail();
-    }
-  });
+void IncrementalScanner::run() {
+  start();
+
+  try {
+    scan(m_scan.path, std::get<IncrementalScan>(m_scan.data));
+    finish();
+  } catch (const std::exception &error) {
+    flog::error() << "Caught exception during incremental scan" << error.what();
+    fail();
+  }
 }
 
 void IncrementalScanner::interrupt() { setInterruptFlag(); }
-
-void IncrementalScanner::join() { m_scanThread.join(); }

--- a/src/file-indexer/src/indexer-scanner.cpp
+++ b/src/file-indexer/src/indexer-scanner.cpp
@@ -1,7 +1,5 @@
 #include "file-indexer/indexer-scanner.hpp"
 #include "file-indexer/abstract-scanner.hpp"
-#include "file-indexer/background-thread.hpp"
-#include "file-indexer/filesystem-walker.hpp"
 #include "file-indexer/log.hpp"
 #include <utility>
 
@@ -39,27 +37,23 @@ void IndexerScanner::scan(const Scan &scan) {
 
 IndexerScanner::IndexerScanner(const std::shared_ptr<DbWriter> &writer, const Scan &sc,
                                StatusCallback callback)
-    : AbstractScanner(writer, sc, std::move(callback)) {
-  m_scanThread = std::thread([this, sc]() {
-    file_indexer::setBackgroundThreadPriority();
-    start(sc);
+    : AbstractScanner(writer, sc, std::move(callback)) {}
 
-    bool failed = false;
-    try {
-      scan(sc);
-    } catch (const std::exception &error) {
-      flog::error() << "Caught exception during fullscan" << error.what();
-      failed = true;
-    }
+void IndexerScanner::run() {
+  start();
 
-    failed ? fail() : finish();
-  });
+  bool failed = false;
+  try {
+    scan(m_scan);
+  } catch (const std::exception &error) {
+    flog::error() << "Caught exception during fullscan" << error.what();
+    failed = true;
+  }
+
+  failed ? fail() : finish();
 }
 
 void IndexerScanner::interrupt() {
   setInterruptFlag();
-  m_alive = false;
   m_walker.stop();
 }
-
-void IndexerScanner::join() { m_scanThread.join(); }

--- a/src/file-indexer/src/scan-dispatcher.cpp
+++ b/src/file-indexer/src/scan-dispatcher.cpp
@@ -1,4 +1,5 @@
 #include "file-indexer/scan-dispatcher.hpp"
+#include "file-indexer/background-thread.hpp"
 #include "file-indexer/indexer-scanner.hpp"
 #include "file-indexer/incremental-scanner.hpp"
 #include "file-indexer/log.hpp"
@@ -6,7 +7,6 @@
 #include <algorithm>
 #include <chrono>
 #include <format>
-#include <map>
 #include <memory>
 #include <mutex>
 #include <ranges>
@@ -30,82 +30,124 @@ flog::LogStream scanLog(const Scan &scan) {
 
 } // namespace
 
-void ScanDispatcher::handleFinishedScan(int id, ScanStatus status) {
-  {
-    std::scoped_lock const l(m_collectorQueueMtx);
-    m_collectorQueue.push(id);
-  }
-  m_collectorCv.notify_one();
-}
-
 int ScanDispatcher::enqueue(const Scan &scan) {
-  std::scoped_lock const l(m_scannerMapMtx);
+  {
+    std::scoped_lock const l(m_workMtx);
 
-  if (std::ranges::any_of(m_scannerMap | std::views::values,
-                          [&](const Element &element) { return element.scan.path == scan.path; })) {
-    scanLog(scan) << std::format("Skipping {} scan for {} (already running)", scanTypeLabel(scan.type()),
-                                 scan.path.c_str());
-    return -1;
+    bool const duplicate =
+        std::ranges::any_of(m_running | std::views::values,
+                            [&](const Running &running) { return running.scan.path == scan.path; }) ||
+        std::ranges::any_of(m_ready, [&](const auto &ready) { return ready.second.path == scan.path; });
+
+    if (duplicate) {
+      scanLog(scan) << std::format("Skipping {} scan for {} (already running)", scanTypeLabel(scan.type()),
+                                   scan.path.c_str());
+      return -1;
+    }
+
+    int const scanId = m_nextScanId++;
+
+    scanLog(scan) << std::format("Enqueuing {} scan for {} ({})", scanTypeLabel(scan.type()),
+                                 scan.path.c_str(), scanModeLabel(scan));
+    m_ready.emplace_back(scanId, scan);
+    m_workCv.notify_one();
+    return scanId;
   }
-
-  scanLog(scan) << std::format("Enqueuing {} scan for {} ({})", scanTypeLabel(scan.type()), scan.path.c_str(),
-                               scanModeLabel(scan));
-  return enqueueLocked(scan);
 }
 
-int ScanDispatcher::enqueueLocked(const Scan &scan) {
-  int const scanId = m_nextScanId++;
-  auto handler = [this, scanId, scan](ScanStatus status, size_t processedCount) {
-    if (scan.notify && m_eventCallback) {
+std::unique_ptr<AbstractScanner> ScanDispatcher::makeScanner(int scanId, const Scan &scan,
+                                                             FileIndexerDatabase &readDb) {
+  auto handler = [this, scanId, path = scan.path, type = scan.type(),
+                  notify = scan.notify](ScanStatus status, size_t processedCount) {
+    if (notify && m_eventCallback) {
       m_eventCallback({.scanId = scanId,
-                       .type = scan.type(),
+                       .type = type,
                        .status = status,
-                       .entrypoint = scan.path,
+                       .entrypoint = path,
                        .processedFileCount = processedCount});
     }
-    if (status != ScanStatus::Started) { handleFinishedScan(scanId, status); }
   };
-
-  auto startedAt = std::chrono::steady_clock::now();
 
   switch (scan.type()) {
   case ScanType::Full:
-    m_scannerMap[scanId] = {scan, std::make_unique<IndexerScanner>(m_writer, scan, handler), startedAt};
-    break;
+    return std::make_unique<IndexerScanner>(m_writer, scan, std::move(handler));
   case ScanType::Incremental:
-    m_scannerMap[scanId] = {scan, std::make_unique<IncrementalScanner>(m_writer, scan, handler), startedAt};
-    break;
+    return std::make_unique<IncrementalScanner>(m_writer, scan, readDb, std::move(handler));
   }
 
-  return scanId;
+  return nullptr;
+}
+
+void ScanDispatcher::workerLoop() {
+  file_indexer::setBackgroundThreadPriority();
+  FileIndexerDatabase readDb;
+
+  std::unique_lock lock(m_workMtx);
+
+  while (true) {
+    m_workCv.wait(lock, [&] { return !m_ready.empty() || !m_alive; });
+    if (!m_alive) break;
+
+    auto [scanId, scan] = std::move(m_ready.front());
+    m_ready.pop_front();
+
+    auto it = m_running
+                  .emplace(scanId, Running{std::move(scan), nullptr, std::chrono::steady_clock::now()})
+                  .first;
+    it->second.scanner = makeScanner(scanId, it->second.scan, readDb);
+    auto *scanner = it->second.scanner.get();
+
+    lock.unlock();
+    scanner->run();
+    lock.lock();
+
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
+                                                                          it->second.startedAt)
+                        .count();
+
+    scanLog(it->second.scan) << std::format("Done scanning {} in {}ms ({}, {})",
+                                            it->second.scan.path.c_str(), duration,
+                                            scanTypeLabel(it->second.scan.type()),
+                                            scanModeLabel(it->second.scan));
+
+    m_running.erase(it);
+    m_idleCv.notify_all();
+  }
 }
 
 void ScanDispatcher::enqueueDebounced(const Scan &scan) {
   auto const now = std::chrono::steady_clock::now();
   {
     std::scoped_lock const l(m_pendingMtx);
-    auto it = std::ranges::find(m_pending, scan, &Pending::scan);
-
-    if (it != m_pending.end()) {
-      it->deadline = std::min(now + DEBOUNCE_QUIET, it->firstSeen + DEBOUNCE_MAX_DELAY);
-    } else {
-      m_pending.emplace_back(scan, now + DEBOUNCE_QUIET, now);
-    }
+    mergePendingLocked(scan, now);
   }
   m_pendingCv.notify_one();
+}
+
+void ScanDispatcher::mergePendingLocked(const Scan &scan, std::chrono::steady_clock::time_point now) {
+  auto it = std::ranges::find_if(m_pending, [&](const Pending &pending) {
+    return pending.scan.path == scan.path && pending.scan.type() == scan.type();
+  });
+
+  if (it == m_pending.end()) {
+    m_pending.emplace_back(scan, now + DEBOUNCE_QUIET, now);
+    return;
+  }
+
+  it->deadline = std::min(now + DEBOUNCE_QUIET, it->firstSeen + DEBOUNCE_MAX_DELAY);
 }
 
 void ScanDispatcher::schedulerLoop() {
   std::unique_lock lock(m_pendingMtx);
 
-  while (m_running) {
+  while (m_alive) {
     if (m_pending.empty()) {
-      m_pendingCv.wait(lock, [&]() { return !m_pending.empty() || !m_running; });
+      m_pendingCv.wait(lock, [&]() { return !m_pending.empty() || !m_alive; });
       continue;
     }
 
     auto const next = std::ranges::min_element(m_pending, {}, &Pending::deadline)->deadline;
-    if (m_pendingCv.wait_until(lock, next, [&]() { return !m_running.load(); })) break;
+    if (m_pendingCv.wait_until(lock, next, [&]() { return !m_alive.load(); })) break;
 
     auto const now = std::chrono::steady_clock::now();
     std::vector<Scan> due;
@@ -118,74 +160,57 @@ void ScanDispatcher::schedulerLoop() {
     });
 
     lock.unlock();
-    for (const auto &scan : due) {
-      if (!m_running) break;
-      enqueue(scan);
+    std::vector<Scan> deferred;
+    deferred.reserve(due.size());
+
+    for (auto &scan : due) {
+      if (!m_alive) break;
+      if (enqueue(scan) < 0) { deferred.emplace_back(std::move(scan)); }
     }
+
     lock.lock();
+    auto const rearmTime = std::chrono::steady_clock::now();
+    for (const auto &scan : deferred) {
+      mergePendingLocked(scan, rearmTime);
+    }
   }
 }
 
 ScanDispatcher::ScanDispatcher(std::shared_ptr<DbWriter> writer)
-    : m_writer(std::move(writer)), m_running(true) {
+    : m_writer(std::move(writer)), m_alive(true) {
   m_schedulerThread = std::thread([this]() { schedulerLoop(); });
-  m_collectorThread = std::thread([this]() {
-    while (true) {
-      {
-        std::unique_lock lock(m_collectorQueueMtx);
-        m_collectorCv.wait(lock, [&]() { return !m_collectorQueue.empty() || !m_running; });
-      }
-      if (!m_running && m_collectorQueue.empty()) break;
 
-      int id;
-      {
-        std::scoped_lock const l(m_collectorQueueMtx);
-        id = m_collectorQueue.front();
-        m_collectorQueue.pop();
-      }
-      {
-        std::scoped_lock const l(m_scannerMapMtx);
-        auto it = m_scannerMap.find(id);
-        if (it == m_scannerMap.end()) {
-          // Attempted to close the same scanner twice
-          continue;
-        }
-
-        auto &scan = it->second.scan;
-        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
-                            std::chrono::steady_clock::now() - it->second.startedAt)
-                            .count();
-
-        scanLog(scan) << std::format("Done scanning {} in {}ms ({}, {})", scan.path.c_str(), duration,
-                                     scanTypeLabel(scan.type()), scanModeLabel(scan));
-
-        it->second.scanner->join();
-        m_scannerMap.erase(it);
-        m_idleCv.notify_all();
-      }
-    }
-  });
+  m_workers.reserve(WORKER_COUNT);
+  for (size_t i = 0; i < WORKER_COUNT; ++i) {
+    m_workers.emplace_back([this]() { workerLoop(); });
+  }
 }
 
 bool ScanDispatcher::interrupt(int id) {
-  {
-    std::scoped_lock const l(m_scannerMapMtx);
-    auto element = m_scannerMap.find(id);
-    if (element == m_scannerMap.end()) return false;
+  std::scoped_lock const l(m_workMtx);
 
-    element->second.scanner->interrupt();
+  if (auto it = m_running.find(id); it != m_running.end()) {
+    it->second.scanner->interrupt();
+    return true;
   }
-  return true;
+
+  if (auto it = std::ranges::find(m_ready, id, &std::pair<int, Scan>::first); it != m_ready.end()) {
+    m_ready.erase(it);
+    m_idleCv.notify_all();
+    return true;
+  }
+
+  return false;
 }
 
 void ScanDispatcher::interruptAll() {
-  {
-    std::scoped_lock const l(m_scannerMapMtx);
+  std::scoped_lock const l(m_workMtx);
 
-    for (auto &[id, element] : m_scannerMap) {
-      element.scanner->interrupt();
-    }
+  m_ready.clear();
+  for (auto &[id, running] : m_running) {
+    running.scanner->interrupt();
   }
+  m_idleCv.notify_all();
 }
 
 void ScanDispatcher::clearPending() {
@@ -194,19 +219,24 @@ void ScanDispatcher::clearPending() {
 }
 
 void ScanDispatcher::waitUntilIdle() {
-  std::unique_lock lock(m_scannerMapMtx);
-  m_idleCv.wait(lock, [this] { return m_scannerMap.empty(); });
+  std::unique_lock lock(m_workMtx);
+  m_idleCv.wait(lock, [this] { return m_running.empty() && m_ready.empty(); });
 }
 
 std::vector<std::pair<int, Scan>> ScanDispatcher::scans() {
-  {
-    std::scoped_lock const l(m_scannerMapMtx);
+  std::scoped_lock const l(m_workMtx);
 
-    return m_scannerMap | std::views::transform([](auto const &it) -> std::pair<int, Scan> {
-             return {it.first, it.second.scan};
-           }) |
-           std::ranges::to<std::vector>();
+  std::vector<std::pair<int, Scan>> result;
+  result.reserve(m_running.size() + m_ready.size());
+
+  for (auto const &[id, running] : m_running) {
+    result.emplace_back(id, running.scan);
   }
+  for (auto const &[id, scan] : m_ready) {
+    result.emplace_back(id, scan);
+  }
+
+  return result;
 }
 
 ScanDispatcher::~ScanDispatcher() {
@@ -214,10 +244,12 @@ ScanDispatcher::~ScanDispatcher() {
   interruptAll();
   waitUntilIdle();
 
-  m_running = false;
-  m_pendingCv.notify_one();
-  m_collectorCv.notify_one();
+  m_alive = false;
+  m_pendingCv.notify_all();
+  m_workCv.notify_all();
 
   m_schedulerThread.join();
-  m_collectorThread.join();
+  for (auto &worker : m_workers) {
+    worker.join();
+  }
 }

--- a/src/file-indexer/src/scan-dispatcher.cpp
+++ b/src/file-indexer/src/scan-dispatcher.cpp
@@ -91,9 +91,8 @@ void ScanDispatcher::workerLoop() {
     auto [scanId, scan] = std::move(m_ready.front());
     m_ready.pop_front();
 
-    auto it = m_running
-                  .emplace(scanId, Running{std::move(scan), nullptr, std::chrono::steady_clock::now()})
-                  .first;
+    auto it =
+        m_running.emplace(scanId, Running{std::move(scan), nullptr, std::chrono::steady_clock::now()}).first;
     it->second.scanner = makeScanner(scanId, it->second.scan, readDb);
     auto *scanner = it->second.scanner.get();
 
@@ -105,9 +104,8 @@ void ScanDispatcher::workerLoop() {
                                                                           it->second.startedAt)
                         .count();
 
-    scanLog(it->second.scan) << std::format("Done scanning {} in {}ms ({}, {})",
-                                            it->second.scan.path.c_str(), duration,
-                                            scanTypeLabel(it->second.scan.type()),
+    scanLog(it->second.scan) << std::format("Done scanning {} in {}ms ({}, {})", it->second.scan.path.c_str(),
+                                            duration, scanTypeLabel(it->second.scan.type()),
                                             scanModeLabel(it->second.scan));
 
     m_running.erase(it);

--- a/src/file-indexer/tests/main.cpp
+++ b/src/file-indexer/tests/main.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <ranges>
 #include "file-indexer/io-pacer.hpp"
+#include "file-indexer/util.hpp"
 #include "file-indexer/vocabulary.hpp"
 #include "file-indexer/file-indexer-query-engine.hpp"
 
@@ -197,6 +198,15 @@ TEST_CASE("correctionWeight decays with spelling distance") {
   CHECK(correctionWeight(0) == CORRECTION_PENALTY);
   CHECK(correctionWeight(20) > correctionWeight(120) * 1.5);
   CHECK(correctionWeight(MAX_CORRECTION_DISTANCE) == CORRECTION_PENALTY * 0.5);
+}
+
+TEST_CASE("compactSubtrees drops paths covered by another path") {
+  namespace fs = std::filesystem;
+  using file_indexer::compactSubtrees;
+
+  CHECK(compactSubtrees({"/a/b/c", "/a/b", "/a/bc", "/d"}) == std::vector<fs::path>{"/d", "/a/b", "/a/bc"});
+  CHECK(compactSubtrees({"/a", "/a"}) == std::vector<fs::path>{"/a"});
+  CHECK(compactSubtrees({}) == std::vector<fs::path>{});
 }
 
 TEST_CASE("splitQueryWords trims and drops empty words") {


### PR DESCRIPTION
Instead of creating one thread per enqueued scan we now dispatch scans to a fixed size thread pool. This way concurrency remains fully bounded and we don't end up spinning up potentially thousand of threads in some scenarios.