### PR TITLE
feat(indexer): prune old scan records

### DIFF
--- a/src/file-indexer/src/db-writer.cpp
+++ b/src/file-indexer/src/db-writer.cpp
@@ -63,6 +63,10 @@ void DbWriter::setScanError(int scanId, const std::string &error) {
   submit([scanId, error = std::move(error)](FileIndexerDatabase &db) { db.setScanError(scanId, error); });
 }
 
+void DbWriter::pruneScanHistory(int64_t maxAgeSeconds) {
+  submit([maxAgeSeconds](FileIndexerDatabase &db) { db.pruneScanHistory(maxAgeSeconds); });
+}
+
 void DbWriter::finalizeScan(int scanId, ScanStatus status, int64_t indexedFileCount) {
   submit([scanId, status, indexedFileCount](FileIndexerDatabase &db) {
     db.finalizeScan(scanId, status, indexedFileCount);

--- a/src/file-indexer/src/file-indexer-db.cpp
+++ b/src/file-indexer/src/file-indexer-db.cpp
@@ -212,6 +212,21 @@ bool FileIndexerDatabase::finalizeScan(int scanId, ScanStatus status, int64_t in
   return true;
 }
 
+bool FileIndexerDatabase::pruneScanHistory(int64_t maxAgeSeconds) {
+  auto stmt = m_db.prepare("DELETE FROM scan_history "
+                           "WHERE created_at < unixepoch() - :maxAge "
+                           "AND id NOT IN (SELECT MAX(id) FROM scan_history "
+                           "GROUP BY entrypoint, type, status)");
+  stmt.bind(":maxAge", maxAgeSeconds);
+
+  if (!stmt.exec()) {
+    flog::warn() << "Failed to prune scan history" << stmt.lastError();
+    return false;
+  }
+
+  return true;
+}
+
 bool FileIndexerDatabase::updateScanStatus(int scanId, ScanStatus status) {
   auto stmt = m_db.prepare("UPDATE scan_history SET status = :status WHERE id = :id");
   stmt.bind(":id", scanId);

--- a/src/file-indexer/src/file-indexer.cpp
+++ b/src/file-indexer/src/file-indexer.cpp
@@ -288,7 +288,11 @@ bool FileIndexer::shouldRebuildVocabulary() {
 }
 
 FileIndexer::FileIndexer() : m_writer(std::make_shared<DbWriter>()), m_dispatcher(m_writer) {
-  if (m_db.isOpen()) { m_db.init(); }
+  if (m_db.isOpen()) {
+    m_db.init();
+    m_writer->pruneScanHistory(
+        std::chrono::duration_cast<std::chrono::seconds>(SCAN_HISTORY_MAX_AGE).count());
+  }
 
   m_dispatcher.setEventCallback([this](const ScanEvent &event) {
     if (event.type == ScanType::Full && event.status == ScanStatus::Succeeded) {

--- a/src/file-indexer/src/file-indexer/db-writer.hpp
+++ b/src/file-indexer/src/file-indexer/db-writer.hpp
@@ -53,6 +53,7 @@ public:
   void finalizeScan(int scanId, ScanStatus status, int64_t indexedFileCount);
 
   void setScanError(int scanId, const std::string &error);
+  void pruneScanHistory(int64_t maxAgeSeconds);
   std::expected<FileIndexerDatabase::ScanRecord, std::string> createScan(const std::filesystem::path &path,
                                                                          ScanType type);
 

--- a/src/file-indexer/src/file-indexer/file-indexer-db.hpp
+++ b/src/file-indexer/src/file-indexer/file-indexer-db.hpp
@@ -65,6 +65,10 @@ public:
 
   bool setScanError(int scanId, const std::string &error);
 
+  // drops rows older than maxAgeSeconds, keeping the latest per (entrypoint, type, status)
+  // so cutoff and interrupted-scan lookups keep working
+  bool pruneScanHistory(int64_t maxAgeSeconds);
+
   std::optional<int64_t> retrieveIndexedLastModified(const std::filesystem::path &path) const;
   std::optional<int64_t> retrieveIndexedSizeBytes(const std::filesystem::path &path) const;
   std::optional<int64_t> retrieveIndexedAt(const std::filesystem::path &path) const;

--- a/src/file-indexer/src/file-indexer/file-indexer.hpp
+++ b/src/file-indexer/src/file-indexer/file-indexer.hpp
@@ -41,6 +41,7 @@ public:
   pendingFullScanRootsFor(const std::vector<std::filesystem::path> &roots,
                           const std::vector<std::filesystem::path> &exclusions);
 
+  static constexpr std::chrono::days SCAN_HISTORY_MAX_AGE{7};
   static constexpr std::chrono::minutes VOCAB_REBUILD_MIN_INTERVAL{10};
   std::mutex m_vocabRebuildMtx;
   std::chrono::steady_clock::time_point m_lastVocabRebuild{};

--- a/src/file-indexer/src/file-indexer/migrations.hpp
+++ b/src/file-indexer/src/file-indexer/migrations.hpp
@@ -17,6 +17,10 @@ CREATE TABLE IF NOT EXISTS scan_history (
 		indexed_file_count INT DEFAULT 0
 );
 
+-- serves the per-directory cutoff lookups issued by every incremental scan
+CREATE INDEX IF NOT EXISTS scan_history_entrypoint_idx
+	ON scan_history(entrypoint, status, created_at);
+
 CREATE TABLE IF NOT EXISTS indexed_file (
 	id INTEGER PRIMARY KEY AUTOINCREMENT,
 	path TEXT UNIQUE NOT NULL,


### PR DESCRIPTION
Currently scan records accumulate indefinitely in the file indexer database which is not very useful. We only care about the last scan for a given entrypoint.