### PR TITLE
 feat(indexer): VACUUM db when enough to reclaim

### DIFF
--- a/src/file-indexer/src/db-writer.cpp
+++ b/src/file-indexer/src/db-writer.cpp
@@ -113,6 +113,12 @@ void DbWriter::compact(std::function<void()> onComplete) {
   });
 }
 
+void DbWriter::compactIfNeeded() {
+  submit([](FileIndexerDatabase &db) {
+    if (db.needsCompaction()) { db.compact(); }
+  });
+}
+
 void DbWriter::indexEvents(std::vector<FileEvent> events) {
   submit([events = std::move(events)](FileIndexerDatabase &db) { db.indexEvents(events); }, true);
 }

--- a/src/file-indexer/src/file-indexer-db.cpp
+++ b/src/file-indexer/src/file-indexer-db.cpp
@@ -451,7 +451,33 @@ void FileIndexerDatabase::deleteAllIndexedFiles() {
   }
 }
 
+bool FileIndexerDatabase::needsCompaction() const {
+  auto pragmaInt = [&](const char *sql) -> int64_t {
+    auto stmt = m_db.prepare(sql);
+    if (!stmt.step()) return 0;
+    return stmt.columnInt64(0);
+  };
+
+  int64_t const pageCount = pragmaInt("PRAGMA page_count");
+  int64_t const freeCount = pragmaInt("PRAGMA freelist_count");
+  int64_t const pageSize = pragmaInt("PRAGMA page_size");
+
+  if (pageCount * pageSize < COMPACT_MIN_DB_BYTES) return false;
+
+  return freeCount * 100 >= pageCount * COMPACT_MIN_FREE_PERCENT;
+}
+
 void FileIndexerDatabase::compact() {
+  flog::info() << "Compacting file indexer database";
+
+  // merge the incremental FTS b-trees first so VACUUM can reclaim the pages they free
+  if (!m_db.exec("INSERT INTO path_idx(path_idx) VALUES('optimize')")) {
+    flog::warn() << "path_idx optimize failed" << m_db.lastError();
+  }
+  if (!m_db.exec("INSERT INTO skeleton_idx(skeleton_idx) VALUES('optimize')")) {
+    flog::warn() << "skeleton_idx optimize failed" << m_db.lastError();
+  }
+
   if (!m_db.exec("VACUUM")) {
     flog::warn() << "VACUUM failed" << m_db.lastError();
     return;

--- a/src/file-indexer/src/file-indexer.cpp
+++ b/src/file-indexer/src/file-indexer.cpp
@@ -292,6 +292,7 @@ FileIndexer::FileIndexer() : m_writer(std::make_shared<DbWriter>()), m_dispatche
     m_db.init();
     m_writer->pruneScanHistory(
         std::chrono::duration_cast<std::chrono::seconds>(SCAN_HISTORY_MAX_AGE).count());
+    m_writer->compactIfNeeded();
   }
 
   m_dispatcher.setEventCallback([this](const ScanEvent &event) {

--- a/src/file-indexer/src/file-indexer/db-writer.hpp
+++ b/src/file-indexer/src/file-indexer/db-writer.hpp
@@ -62,6 +62,7 @@ public:
                           std::function<void()> onComplete = nullptr);
   void deleteAllIndexedFiles(std::function<void()> onComplete = nullptr);
   void compact(std::function<void()> onComplete = nullptr);
+  void compactIfNeeded();
 
   void rebuildSpellfixVocabulary();
 

--- a/src/file-indexer/src/file-indexer/file-indexer-db.hpp
+++ b/src/file-indexer/src/file-indexer/file-indexer-db.hpp
@@ -22,6 +22,9 @@ enum class IndexedFileCategory {
 };
 
 class FileIndexerDatabase {
+  static constexpr int64_t COMPACT_MIN_DB_BYTES = 32 * 1024 * 1024;
+  static constexpr int64_t COMPACT_MIN_FREE_PERCENT = 25;
+
   db::Database m_db;
   std::unordered_map<std::string, int64_t> m_mimeTypeIds;
 
@@ -86,6 +89,7 @@ public:
   };
 
   void deleteAllIndexedFiles();
+  bool needsCompaction() const;
   void compact();
   void rebuildSpellfixVocabulary();
   bool hasSpellfixVocabulary();


### PR DESCRIPTION
Run VACUUM on the file indexer db when there is enough data to reclaim from it. Vacuuming does a full rewrite of the DB so we don't want to do it on each startup.