### PR TITLE
fix: improve scroll handling

### DIFF
--- a/src/server/src/qml/qml/AboutSettingsPage.qml
+++ b/src/server/src/qml/qml/AboutSettingsPage.qml
@@ -5,11 +5,16 @@ Item {
     id: root
 
     Flickable {
+        id: flickable
         anchors.fill: parent
         contentWidth: width
         contentHeight: content.implicitHeight
         clip: true
         boundsBehavior: Flickable.StopAtBounds
+
+        ViciWheelHandler {
+            target: flickable
+        }
 
         ColumnLayout {
             id: content

--- a/src/server/src/qml/qml/AdvancedSettingsPage.qml
+++ b/src/server/src/qml/qml/AdvancedSettingsPage.qml
@@ -11,6 +11,10 @@ Flickable {
 
     readonly property var model: settings.generalModel
 
+    ViciWheelHandler {
+        target: root
+    }
+
     ScrollBar.vertical: ViciScrollBar {
         policy: root.contentHeight > root.height ? ScrollBar.AsNeeded : ScrollBar.AlwaysOff
     }

--- a/src/server/src/qml/qml/AppearanceSettingsPage.qml
+++ b/src/server/src/qml/qml/AppearanceSettingsPage.qml
@@ -11,6 +11,10 @@ Flickable {
 
     readonly property var model: settings.generalModel
 
+    ViciWheelHandler {
+        target: root
+    }
+
     ScrollBar.vertical: ViciScrollBar {
         policy: ScrollBar.AsNeeded
     }

--- a/src/server/src/qml/qml/ExtensionSettingsPage.qml
+++ b/src/server/src/qml/qml/ExtensionSettingsPage.qml
@@ -60,6 +60,10 @@ Item {
         contentHeight: contentColumn.implicitHeight
         contentWidth: width
 
+        ViciWheelHandler {
+            target: cmdFlickable
+        }
+
         function scrollToIndex(row) {
             const item = cmdRepeater.itemAt(row);
             if (!item)

--- a/src/server/src/qml/qml/FormCompletedTextArea.qml
+++ b/src/server/src/qml/qml/FormCompletedTextArea.qml
@@ -67,9 +67,6 @@ FocusScope {
             anchors.leftMargin: 10
             anchors.rightMargin: 10
             acceptedButtons: Qt.NoButton
-            onWheel: wheel => {
-                wheel.accepted = flickable.contentHeight > flickable.height;
-            }
 
             Flickable {
                 id: flickable
@@ -78,6 +75,11 @@ FocusScope {
                 contentHeight: edit.height
                 clip: true
                 boundsBehavior: Flickable.StopAtBounds
+
+                ViciWheelHandler {
+                    target: flickable
+                    blockTargetWheel: false
+                }
 
                 ScrollBar.vertical: ViciScrollBar {
                     policy: flickable.contentHeight > flickable.height ? ScrollBar.AsNeeded : ScrollBar.AlwaysOff

--- a/src/server/src/qml/qml/FormTextArea.qml
+++ b/src/server/src/qml/qml/FormTextArea.qml
@@ -61,9 +61,6 @@ FocusScope {
             anchors.leftMargin: 10
             anchors.rightMargin: 10
             acceptedButtons: Qt.NoButton
-            onWheel: wheel => {
-                wheel.accepted = flickable.contentHeight > flickable.height;
-            }
 
             Flickable {
                 id: flickable
@@ -72,6 +69,11 @@ FocusScope {
                 contentHeight: edit.height
                 clip: true
                 boundsBehavior: Flickable.StopAtBounds
+
+                ViciWheelHandler {
+                    target: flickable
+                    blockTargetWheel: false
+                }
 
                 ScrollBar.vertical: ViciScrollBar {
                     policy: flickable.contentHeight > flickable.height ? ScrollBar.AsNeeded : ScrollBar.AlwaysOff

--- a/src/server/src/qml/qml/FormView.qml
+++ b/src/server/src/qml/qml/FormView.qml
@@ -15,6 +15,10 @@ Flickable {
     property real padding: 16
     property real maxContentWidth: Infinity
 
+    ViciWheelHandler {
+        target: root
+    }
+
     function focusFirst() {
         _focusFirstIn(layout);
     }

--- a/src/server/src/qml/qml/GeneralSettingsPage.qml
+++ b/src/server/src/qml/qml/GeneralSettingsPage.qml
@@ -11,6 +11,10 @@ Flickable {
 
     readonly property var model: settings.generalModel
 
+    ViciWheelHandler {
+        target: root
+    }
+
     ScrollBar.vertical: ViciScrollBar {
         policy: root.contentHeight > root.height ? ScrollBar.AsNeeded : ScrollBar.AlwaysOff
     }

--- a/src/server/src/qml/qml/MetadataBar.qml
+++ b/src/server/src/qml/qml/MetadataBar.qml
@@ -14,10 +14,15 @@ Item {
     implicitHeight: column.implicitHeight + 20  // 2 * margins
 
     Flickable {
+        id: flickable
         anchors.fill: parent
         contentHeight: column.implicitHeight + 20
         clip: true
         boundsBehavior: Flickable.StopAtBounds
+
+        ViciWheelHandler {
+            target: flickable
+        }
 
         ColumnLayout {
             id: column

--- a/src/server/src/qml/qml/ScriptOutputText.qml
+++ b/src/server/src/qml/qml/ScriptOutputText.qml
@@ -8,6 +8,10 @@ ScrollView {
 
     Component.onCompleted: contentItem.boundsBehavior = Flickable.StopAtBounds
 
+    ViciWheelHandler {
+        target: root.contentItem
+    }
+
     function moveUp() {
         contentItem.contentY = Math.max(0, contentItem.contentY - 40);
     }

--- a/src/server/src/qml/qml/ShortcutsSettingsPage.qml
+++ b/src/server/src/qml/qml/ShortcutsSettingsPage.qml
@@ -31,11 +31,16 @@ Item {
     }
 
     Flickable {
+        id: flickable
         anchors.fill: parent
         clip: true
         boundsBehavior: Flickable.StopAtBounds
         contentHeight: contentColumn.implicitHeight
         contentWidth: width
+
+        ViciWheelHandler {
+            target: flickable
+        }
 
         ScrollBar.vertical: ViciScrollBar {
             policy: ScrollBar.AsNeeded

--- a/src/server/src/qml/qml/StoreDetailView.qml
+++ b/src/server/src/qml/qml/StoreDetailView.qml
@@ -49,6 +49,7 @@ Item {
     }
 
     Flickable {
+        id: flickable
         anchors.fill: parent
         contentWidth: width
         contentHeight: _content.implicitHeight
@@ -56,6 +57,10 @@ Item {
         flickableDirection: Flickable.VerticalFlick
         boundsBehavior: Flickable.StopAtBounds
         visible: root.host.isReady
+
+        ViciWheelHandler {
+            target: flickable
+        }
 
         ColumnLayout {
             id: _content

--- a/src/server/src/qml/qml/TextViewer.qml
+++ b/src/server/src/qml/qml/TextViewer.qml
@@ -12,6 +12,10 @@ ScrollView {
 
     Component.onCompleted: contentItem.boundsBehavior = Flickable.StopAtBounds
 
+    ViciWheelHandler {
+        target: root.contentItem
+    }
+
     TextEdit {
         width: root.availableWidth
         text: root.text

--- a/src/server/src/qml/qml/UIShowcase.qml
+++ b/src/server/src/qml/qml/UIShowcase.qml
@@ -8,6 +8,10 @@ Flickable {
     clip: true
     boundsBehavior: Flickable.StopAtBounds
 
+    ViciWheelHandler {
+        target: root
+    }
+
     ColumnLayout {
         id: content
         anchors.horizontalCenter: parent.horizontalCenter

--- a/src/server/src/qml/qml/ViciScrollBar.qml
+++ b/src/server/src/qml/qml/ViciScrollBar.qml
@@ -4,12 +4,27 @@ import QtQuick.Controls
 ScrollBar {
     id: control
 
+    property bool _recentlyScrolled: false
+
+    function revealOnScroll() {
+        _recentlyScrolled = true;
+        scrollActivityTimer.restart();
+    }
+
+    onPositionChanged: revealOnScroll()
+
+    Timer {
+        id: scrollActivityTimer
+        interval: 400
+        onTriggered: control._recentlyScrolled = false
+    }
+
     contentItem: Rectangle {
         implicitWidth: 6
         implicitHeight: 6
         radius: 3
         color: Theme.scrollBarBackground
-        opacity: control.active ? 1.0 : 0.0
+        opacity: control.active || control._recentlyScrolled ? 1.0 : 0.0
 
         Behavior on opacity {
             NumberAnimation {

--- a/src/server/src/qml/qml/markdown/MarkdownView.qml
+++ b/src/server/src/qml/qml/markdown/MarkdownView.qml
@@ -67,6 +67,10 @@ Item {
         clip: true
         boundsBehavior: Flickable.StopAtBounds
 
+        ViciWheelHandler {
+            target: flickable
+        }
+
         onContentHeightChanged: {
             if (root._autoScroll) {
                 root._autoScroll = false;


### PR DESCRIPTION
This pr adds the ViciWheelHandler to scrollable surfaces that are missing it.

The current behavior of the scroll thumb is that it is only shown when hovering over it. This change it to also show when the user scrolls.