### PR TITLE
clear search field after a delay after closing

### DIFF
--- a/src/server/src/config/config.hpp
+++ b/src/server/src/config/config.hpp
@@ -274,6 +274,8 @@ struct ConfigValue {
   bool closeOnFocusLoss = false;
   bool considerPreedit = false;
   bool popToRootOnClose = false;
+  // seconds; with popToRootOnClose, reopening within this window keeps the query/view stack
+  int popToRootOnCloseDelay = 0;
   bool popOnBackspace = true;
   bool activateOnSingleClick = false;
 #ifdef Q_OS_LINUX
@@ -331,6 +333,7 @@ template <> struct Partial<ConfigValue> {
   std::optional<bool> closeOnFocusLoss;
   std::optional<bool> considerPreedit;
   std::optional<bool> popToRootOnClose;
+  std::optional<int> popToRootOnCloseDelay;
   std::optional<bool> popOnBackspace;
   std::optional<bool> activateOnSingleClick;
   std::optional<bool> encryptSensitiveData;

--- a/src/server/src/navigation-controller.cpp
+++ b/src/server/src/navigation-controller.cpp
@@ -90,9 +90,16 @@ void NavigationController::showHud(const QString &title, const std::optional<Ima
 }
 
 void NavigationController::applyPopToRoot(const PendingPopToRoot &settings) {
+  // Raycast-style delayed pop to root: a Default-policy close that reopens within
+  // m_popToRootOnCloseDelay seconds keeps the view stack and search text.
+  bool const closedRecently = m_popToRootOnCloseDelay > 0 && m_closedAt.isValid() &&
+                              m_closedAt.elapsed() < qint64(m_popToRootOnCloseDelay) * 1000;
+
   auto resolveApplicablePopToRoot = [&]() {
-    if (settings.type == PopToRootType::Default)
+    if (settings.type == PopToRootType::Default) {
+      if (closedRecently) return PopToRootType::Suspended;
       return m_popToRootOnClose ? PopToRootType::Immediate : PopToRootType::Suspended;
+    }
     return settings.type;
   };
 
@@ -106,7 +113,7 @@ void NavigationController::applyPopToRoot(const PendingPopToRoot &settings) {
     break;
   }
 
-  if (isRootSearch() && settings.clearSearch) clearSearchText();
+  if (isRootSearch() && settings.clearSearch && !closedRecently) clearSearchText();
 }
 
 void NavigationController::setDialog(DialogContentWidget *widget) {
@@ -312,6 +319,8 @@ QString NavigationController::navigationTitle(const BaseView *caller) const {
 
 void NavigationController::setPopToRootOnClose(bool value) { m_popToRootOnClose = value; }
 
+void NavigationController::setPopToRootOnCloseDelay(int seconds) { m_popToRootOnCloseDelay = seconds; }
+
 void NavigationController::closeWindow(const CloseWindowOptions &settings, std::chrono::milliseconds delay) {
   QTimer::singleShot(delay, [this, settings]() { closeWindow(settings); });
 }
@@ -328,6 +337,7 @@ void NavigationController::closeWindow(const CloseWindowOptions &settings) {
   }
 
   m_pendingPopToRoot = PendingPopToRoot{.type = type, .clearSearch = settings.clearRootSearch};
+  m_closedAt.start();
   m_windowOpened = false;
   emit windowVisiblityChanged(false);
 }

--- a/src/server/src/navigation-controller.hpp
+++ b/src/server/src/navigation-controller.hpp
@@ -9,6 +9,7 @@
 #include "ui/action-pannel/action-panel-state.hpp"
 #include "ui/dialog/dialog.hpp"
 #include "ui/image/url.hpp"
+#include <QElapsedTimer>
 #include <QString>
 #include <chrono>
 #include <cstdint>
@@ -144,6 +145,7 @@ public:
   QWindow *window() const { return m_window; }
 
   void setPopToRootOnClose(bool value);
+  void setPopToRootOnCloseDelay(int seconds);
 
   bool hasCompleter() const;
 
@@ -272,6 +274,8 @@ private:
   bool m_windowActivated = false;
   bool m_isPanelOpened = false;
   bool m_popToRootOnClose = false;
+  int m_popToRootOnCloseDelay = 0; // seconds; > 0 keeps state when reopened within the delay
+  QElapsedTimer m_closedAt;
   bool m_instantDismiss = false;
   bool m_closeOnFocusLoss = false;
   QWindow *m_window = nullptr;

--- a/src/server/src/server.cpp
+++ b/src/server/src/server.cpp
@@ -444,6 +444,7 @@ int startServer(const ServerLaunchOptions &launchOpts) {
     }
 
     ctx.navigation->setPopToRootOnClose(next.popToRootOnClose);
+    ctx.navigation->setPopToRootOnCloseDelay(next.popToRootOnCloseDelay);
     ctx.navigation->setCloseOnFocusLoss(next.closeOnFocusLoss);
 #ifdef Q_OS_LINUX
     ctx.services->inputServer()->setEnabled(next.inputServer.enabled);


### PR DESCRIPTION
> New config field pop_to_root_on_close_delay (seconds, default 0 = unchanged behavior). With pop_to_root_on_close enabled, closing and reopening the window within the delay keeps the view stack and search text (shown selected, so typing replaces it); after the delay it pops to root and clears the query as before. Matches Raycast's 'Pop to Root Search: After X seconds'.
> 
> Explicit resets (instantDismiss / PopToRootType::Immediate) are not gated.

fix #1392