### PR TITLE
feat(api): add pagination for List and Grid components

### DIFF
--- a/extra/extension-boilerplate/package.json
+++ b/extra/extension-boilerplate/package.json
@@ -44,6 +44,18 @@
 			"mode": "view"
 		},
 		{
+			"name": "paginated-list",
+			"title": "Paginated List",
+			"description": "An infinitely scrolling paginated list",
+			"mode": "view"
+		},
+		{
+			"name": "paginated-grid",
+			"title": "Paginated Grid",
+			"description": "An infinitely scrolling paginated grid",
+			"mode": "view"
+		},
+		{
 			"name": "simple-detail",
 			"title": "Simple Detail",
 			"description": "A simple detail view",

--- a/extra/extension-boilerplate/src/paginated-grid.tsx
+++ b/extra/extension-boilerplate/src/paginated-grid.tsx
@@ -1,0 +1,68 @@
+import { Grid } from "@vicinae/api";
+import { useEffect, useState } from "react";
+
+const PAGE_SIZE = 48;
+const TOTAL_ITEMS = 384;
+const PAGE_DELAY_MS = 600;
+
+const PALETTE = [
+	"#e06c75",
+	"#e5c07b",
+	"#98c379",
+	"#56b6c2",
+	"#61afef",
+	"#c678dd",
+];
+
+type Item = { id: number; title: string; color: string };
+
+const fetchPage = (offset: number): Promise<Item[]> =>
+	new Promise((resolve) =>
+		setTimeout(() => {
+			const count = Math.max(0, Math.min(PAGE_SIZE, TOTAL_ITEMS - offset));
+			resolve(
+				Array.from({ length: count }, (_, i) => ({
+					id: offset + i,
+					title: `Item ${offset + i + 1}`,
+					color: PALETTE[(offset + i) % PALETTE.length],
+				})),
+			);
+		}, PAGE_DELAY_MS),
+	);
+
+export default function PaginatedGrid() {
+	const [items, setItems] = useState<Item[]>([]);
+	const [hasMore, setHasMore] = useState(true);
+	const [isLoading, setIsLoading] = useState(true);
+
+	const loadMore = async () => {
+		setIsLoading(true);
+		const page = await fetchPage(items.length);
+		setItems([...items, ...page]);
+		setHasMore(items.length + page.length < TOTAL_ITEMS);
+		setIsLoading(false);
+	};
+
+	useEffect(() => {
+		loadMore();
+	}, []);
+
+	return (
+		<Grid
+			columns={8}
+			isLoading={isLoading}
+			searchBarPlaceholder="Search loaded items..."
+			pagination={{ onLoadMore: loadMore, hasMore }}
+		>
+			<Grid.Section title={`Loaded ${items.length} of ${TOTAL_ITEMS}`}>
+				{items.map((item) => (
+					<Grid.Item
+						key={item.id}
+						title={item.title}
+						content={{ color: item.color }}
+					/>
+				))}
+			</Grid.Section>
+		</Grid>
+	);
+}

--- a/extra/extension-boilerplate/src/paginated-list.tsx
+++ b/extra/extension-boilerplate/src/paginated-list.tsx
@@ -1,0 +1,57 @@
+import { List } from "@vicinae/api";
+import { useEffect, useState } from "react";
+
+const PAGE_SIZE = 30;
+const TOTAL_ITEMS = 200;
+const PAGE_DELAY_MS = 600;
+
+type Item = { id: number; title: string };
+
+const fetchPage = (offset: number): Promise<Item[]> =>
+	new Promise((resolve) =>
+		setTimeout(() => {
+			const count = Math.max(0, Math.min(PAGE_SIZE, TOTAL_ITEMS - offset));
+			resolve(
+				Array.from({ length: count }, (_, i) => ({
+					id: offset + i,
+					title: `Item ${offset + i + 1}`,
+				})),
+			);
+		}, PAGE_DELAY_MS),
+	);
+
+export default function PaginatedList() {
+	const [items, setItems] = useState<Item[]>([]);
+	const [hasMore, setHasMore] = useState(true);
+	const [isLoading, setIsLoading] = useState(true);
+
+	const loadMore = async () => {
+		setIsLoading(true);
+		const page = await fetchPage(items.length);
+		setItems([...items, ...page]);
+		setHasMore(items.length + page.length < TOTAL_ITEMS);
+		setIsLoading(false);
+	};
+
+	useEffect(() => {
+		loadMore();
+	}, []);
+
+	return (
+		<List
+			isLoading={isLoading}
+			searchBarPlaceholder="Search loaded items..."
+			pagination={{ onLoadMore: loadMore, hasMore }}
+		>
+			<List.Section title={`Loaded ${items.length} of ${TOTAL_ITEMS}`}>
+				{items.map((item) => (
+					<List.Item
+						key={item.id}
+						title={item.title}
+						subtitle={`#${item.id + 1}`}
+					/>
+				))}
+			</List.Section>
+		</List>
+	);
+}

--- a/src/server/src/extend/model-deser.cpp
+++ b/src/server/src/extend/model-deser.cpp
@@ -21,6 +21,8 @@
 #include "extend/image-model.hpp"
 #include "extend/list-model.hpp"
 #include "extend/metadata-model.hpp"
+#include "extend/model-parser.hpp"
+#include "extend/model.hpp"
 #include "extend/pagination-model.hpp"
 #include "extend/root-detail-model.hpp"
 #include "extend/tag-model.hpp"

--- a/src/server/src/extend/model-deser.cpp
+++ b/src/server/src/extend/model-deser.cpp
@@ -345,7 +345,8 @@ struct ListModelWire {
   std::optional<std::string> onSelectionChange;
   std::optional<std::string> onSearchTextChange;
   std::optional<EventCounted<std::string>> searchText;
-  std::optional<PaginationModel> pagination;
+  bool paginationHasMore = false;
+  std::optional<EventHandler> paginationOnLoadMore;
   std::vector<ListWireChild> children;
 };
 
@@ -392,7 +393,8 @@ struct GridModelWire {
   std::optional<std::string> onSearchTextChange;
   std::optional<std::string> selectedItemId;
   std::optional<EventCounted<std::string>> searchText;
-  std::optional<PaginationModel> pagination;
+  bool paginationHasMore = false;
+  std::optional<EventHandler> paginationOnLoadMore;
   std::vector<GridWireChild> children;
 };
 
@@ -811,7 +813,10 @@ static ListModel toListModel(ListModelWire &w) {
   m.onSelectionChanged = std::move(w.onSelectionChange);
   m.onSearchTextChange = std::move(w.onSearchTextChange);
   m.searchText = std::move(w.searchText);
-  m.pagination = std::move(w.pagination);
+
+  if (auto handler = w.paginationOnLoadMore) {
+    m.pagination = PaginationModel{.onLoadMore = handler.value(), .hasMore = w.paginationHasMore};
+  }
 
   m.items.reserve(w.children.size());
   size_t index = 0;
@@ -881,7 +886,10 @@ static GridModel toGridModel(GridModelWire &w) {
   m.onSearchTextChange = std::move(w.onSearchTextChange);
   m.selectedItemId = std::move(w.selectedItemId);
   m.searchText = std::move(w.searchText);
-  m.pagination = std::move(w.pagination);
+
+  if (auto handler = w.paginationOnLoadMore) {
+    m.pagination = PaginationModel{.onLoadMore = handler.value(), .hasMore = w.paginationHasMore};
+  }
 
   m.items.reserve(w.children.size());
   size_t index = 0;

--- a/src/server/src/extend/pagination-model.hpp
+++ b/src/server/src/extend/pagination-model.hpp
@@ -1,10 +1,8 @@
 #pragma once
-#include <cstddef>
 #include <optional>
-#include <string>
+#include "extend/model.hpp"
 
 struct PaginationModel {
-  std::optional<std::string> onLoadMore;
+  std::optional<EventHandler> onLoadMore;
   bool hasMore = false;
-  size_t pageSize = 0;
 };

--- a/src/server/src/extend/pagination-model.hpp
+++ b/src/server/src/extend/pagination-model.hpp
@@ -1,8 +1,7 @@
 #pragma once
-#include <optional>
 #include "extend/model.hpp"
 
 struct PaginationModel {
-  std::optional<EventHandler> onLoadMore;
+  EventHandler onLoadMore;
   bool hasMore = false;
 };

--- a/src/server/src/qml/extension-grid-model.cpp
+++ b/src/server/src/qml/extension-grid-model.cpp
@@ -99,6 +99,7 @@ void ExtensionGridModel::setExtensionData(const GridModel &model, bool resetSele
 void ExtensionGridModel::rebuildFromSections(bool resetSelection) {
   int const prevSection = selectedSection();
   int const prevItem = selectedItem();
+  int const prevRow = flatRowForSelection();
 
   clearSources();
   m_ownedSections.clear();
@@ -156,7 +157,7 @@ void ExtensionGridModel::rebuildFromSections(bool resetSelection) {
     if (prevValid) {
       if (prevSection == selectedSection() && prevItem == selectedItem()) {
         refreshActionPanel();
-        emit selectionChanged();
+        if (flatRowForSelection() != prevRow) emit selectionChanged();
       } else {
         select(prevSection, prevItem);
       }

--- a/src/server/src/qml/extension-view-host.cpp
+++ b/src/server/src/qml/extension-view-host.cpp
@@ -144,6 +144,7 @@ void ExtensionViewHost::renderList(const ListModel &model) {
   auto *list = activeModel<ExtensionListModel>();
   m_onSearchTextChange = model.onSearchTextChange;
   m_filtering = model.filtering;
+  m_pagination = model.pagination;
 
   if (model.throttle != m_throttle) {
     m_throttle = model.throttle;
@@ -178,12 +179,24 @@ void ExtensionViewHost::renderList(const ListModel &model) {
     emit selectFirstOnResetChanged();
     m_shouldResetSelection = false;
   }
+
+  // for now we mark it as changed on each render, it doesn't really matter as it
+  // only toggles a boolean.
+  emit paginationChanged();
+}
+
+void ExtensionViewHost::onLoadMore() {
+  if (auto p = m_pagination; p && p->hasMore) {
+    qDebug() << "Trying to load more data, send to " << p->onLoadMore.c_str();
+    m_notify(p->onLoadMore.c_str(), {});
+  }
 }
 
 void ExtensionViewHost::renderGrid(const GridModel &model) {
   auto *grid = activeModel<ExtensionGridModel>();
   m_onSearchTextChange = model.onSearchTextChange;
   m_filtering = model.filtering;
+  m_pagination = model.pagination;
 
   if (model.throttle != m_throttle) {
     m_throttle = model.throttle;
@@ -214,6 +227,10 @@ void ExtensionViewHost::renderGrid(const GridModel &model) {
     grid->setExtensionData(model, m_shouldResetSelection);
     m_shouldResetSelection = false;
   }
+
+  // for now we mark it as changed on each render, it doesn't really matter as it
+  // only toggles a boolean.
+  emit paginationChanged();
 }
 
 void ExtensionViewHost::textChanged(const QString &text) {

--- a/src/server/src/qml/extension-view-host.cpp
+++ b/src/server/src/qml/extension-view-host.cpp
@@ -171,6 +171,8 @@ void ExtensionViewHost::renderList(const ListModel &model) {
     updateDropdown(nullptr);
   }
 
+  emit paginationChanged();
+
   if (model.dirty) {
     m_selectFirstOnReset = m_shouldResetSelection;
     emit selectFirstOnResetChanged();
@@ -179,10 +181,6 @@ void ExtensionViewHost::renderList(const ListModel &model) {
     emit selectFirstOnResetChanged();
     m_shouldResetSelection = false;
   }
-
-  // for now we mark it as changed on each render, it doesn't really matter as it
-  // only toggles a boolean.
-  emit paginationChanged();
 }
 
 void ExtensionViewHost::onLoadMore() {
@@ -223,14 +221,12 @@ void ExtensionViewHost::renderGrid(const GridModel &model) {
     updateDropdown(nullptr);
   }
 
+  emit paginationChanged();
+
   if (model.dirty) {
     grid->setExtensionData(model, m_shouldResetSelection);
     m_shouldResetSelection = false;
   }
-
-  // for now we mark it as changed on each render, it doesn't really matter as it
-  // only toggles a boolean.
-  emit paginationChanged();
 }
 
 void ExtensionViewHost::textChanged(const QString &text) {

--- a/src/server/src/qml/extension-view-host.hpp
+++ b/src/server/src/qml/extension-view-host.hpp
@@ -1,11 +1,13 @@
 #pragma once
 #include "extend/model-parser.hpp"
+#include "extend/pagination-model.hpp"
 #include "extension/extension-action-panel-builder.hpp"
 #include "bridge-view.hpp"
 #include "extension-form-model.hpp"
 #include "extension-grid-model.hpp"
 #include "extension-list-model.hpp"
 #include <QTimer>
+#include <qtmetamacros.h>
 #include <variant>
 
 class ExtensionViewHost : public ViewHostBase {
@@ -22,6 +24,7 @@ class ExtensionViewHost : public ViewHostBase {
   Q_PROPERTY(QVariantList dropdownItems READ dropdownItems NOTIFY dropdownChanged)
   Q_PROPERTY(QVariant dropdownCurrentItem READ dropdownCurrentItem NOTIFY dropdownChanged)
   Q_PROPERTY(QString dropdownPlaceholder READ dropdownPlaceholder NOTIFY dropdownChanged)
+  Q_PROPERTY(bool hasMorePages READ hasMorePages NOTIFY paginationChanged)
 
 public:
   explicit ExtensionViewHost(ExtensionActionPanelBuilder::NotifyFn notify, QObject *parent = nullptr);
@@ -52,7 +55,12 @@ public:
   QVariant dropdownCurrentItem() const { return m_dropdownCurrentItem; }
   QString dropdownPlaceholder() const { return m_dropdownPlaceholder; }
 
+  bool hasMorePages() const {
+    return m_pagination.transform([](auto &&p) { return p.hasMore; }).value_or(false);
+  }
+
   Q_INVOKABLE void setDropdownValue(const QString &value);
+  Q_INVOKABLE void onLoadMore();
 
 signals:
   void selectFirstOnResetChanged();
@@ -62,6 +70,7 @@ signals:
   void suppressEmptyViewChanged();
   void linkAccessoryChanged();
   void dropdownChanged();
+  void paginationChanged();
 
 private:
   struct DetailState {
@@ -113,4 +122,5 @@ private:
   QString m_dropdownValue;
   QString m_dropdownPlaceholder;
   std::optional<std::string> m_dropdownOnChange;
+  std::optional<PaginationModel> m_pagination;
 };

--- a/src/server/src/qml/qml/ExtensionView.qml
+++ b/src/server/src/qml/qml/ExtensionView.qml
@@ -89,6 +89,9 @@ Item {
                 anchors.fill: parent
                 listModel: root.host.contentModel
                 model: root.host.contentModel
+                canLoadMore: root.host.hasMorePages
+                onEndReached: root.host.onLoadMore()
+
                 autoWireModel: true
                 selectFirstOnReset: root.host.selectFirstOnReset
                 suppressEmpty: root.host.suppressEmptyView
@@ -163,6 +166,8 @@ Item {
             anchors.fill: parent
             cmdModel: root.host.contentModel
             suppressEmpty: root.host.suppressEmptyView
+            canLoadMore: root.host.hasMorePages
+            onEndReached: root.host.onLoadMore()
         }
     }
 

--- a/src/server/src/qml/qml/GenericGridView.qml
+++ b/src/server/src/qml/qml/GenericGridView.qml
@@ -44,8 +44,12 @@ Item {
     property real endReachedThreshold: root.height * 1.5
     property bool _endArmed: true
 
-    onCanLoadMoreChanged: if (canLoadMore)
-        Qt.callLater(_maybeFireEnd)
+    onCanLoadMoreChanged: {
+        if (canLoadMore) {
+            _endArmed = true;
+            Qt.callLater(_maybeFireEnd);
+        }
+    }
 
     function _maybeFireEnd() {
         if (!root.canLoadMore || !root._endArmed)

--- a/src/server/src/qml/qml/GenericGridView.qml
+++ b/src/server/src/qml/qml/GenericGridView.qml
@@ -37,6 +37,30 @@ Item {
 
     property bool suppressEmpty: false
 
+    // Infinite-scroll pagination: consumers opt in by setting canLoadMore.
+    // endReached fires at most once per content growth cycle.
+    signal endReached
+    property bool canLoadMore: false
+    property real endReachedThreshold: root.height * 1.5
+    property bool _endArmed: true
+
+    onCanLoadMoreChanged: if (canLoadMore)
+        Qt.callLater(_maybeFireEnd)
+
+    function _maybeFireEnd() {
+        if (!root.canLoadMore || !root._endArmed)
+            return;
+        if (listView.contentHeight <= 0)
+            return;
+        const underfilled = listView.contentHeight <= listView.height;
+        if (!underfilled && listView.atYBeginning)
+            return;
+        if (listView.contentY + listView.height >= listView.contentHeight - root.endReachedThreshold) {
+            root._endArmed = false;
+            root.endReached();
+        }
+    }
+
     readonly property bool _empty: listView.count === 0
     readonly property bool _awaitingData: root.cmdModel && root.cmdModel.awaitingData === true
 
@@ -130,6 +154,16 @@ Item {
         spacing: root.cellSpacing
         reuseItems: true
         cacheBuffer: 200
+
+        property real _lastContentHeight: 0
+
+        onContentYChanged: root._maybeFireEnd()
+        onContentHeightChanged: {
+            if (contentHeight > _lastContentHeight)
+                root._endArmed = true;
+            _lastContentHeight = contentHeight;
+            root._maybeFireEnd();
+        }
 
         ViciWheelHandler {
             target: listView
@@ -350,6 +384,11 @@ Item {
 
     Connections {
         target: root.cmdModel
+        function onModelReset() {
+            root._endArmed = true;
+            listView._lastContentHeight = 0;
+            Qt.callLater(root._maybeFireEnd);
+        }
         function onSelectionChanged() {
             var row = root.cmdModel ? root.cmdModel.flatRowForSelection() : -1;
             if (row >= 0) {

--- a/src/server/src/qml/qml/GenericListView.qml
+++ b/src/server/src/qml/qml/GenericListView.qml
@@ -48,6 +48,30 @@ Item {
     signal itemActivated(int index)
     signal itemSelected(int index)
 
+    // Infinite-scroll pagination: consumers opt in by setting canLoadMore.
+    // endReached fires at most once per content growth cycle.
+    signal endReached
+    property bool canLoadMore: false
+    property real endReachedThreshold: root.height * 1.5
+    property bool _endArmed: true
+
+    onCanLoadMoreChanged: if (canLoadMore)
+        Qt.callLater(_maybeFireEnd)
+
+    function _maybeFireEnd() {
+        if (!root.canLoadMore || !root._endArmed)
+            return;
+        if (listView.contentHeight <= 0)
+            return;
+        const underfilled = listView.contentHeight <= listView.height;
+        if (!underfilled && listView.atYBeginning)
+            return;
+        if (listView.contentY + listView.height >= listView.contentHeight - root.endReachedThreshold) {
+            root._endArmed = false;
+            root.endReached();
+        }
+    }
+
     function sectionScrollTarget(index, direction) {
         if (!root.listModel || typeof root.listModel.scrollTargetIndex !== "function")
             return index;
@@ -142,6 +166,15 @@ Item {
         }
     }
 
+    Connections {
+        target: root.listModel
+        function onModelReset() {
+            root._endArmed = true;
+            listView._lastContentHeight = 0;
+            Qt.callLater(root._maybeFireEnd);
+        }
+    }
+
     HoverResetOnModelChange {
         target: root.listModel
     }
@@ -181,6 +214,16 @@ Item {
             currentIndex: -1
             topMargin: 4
             bottomMargin: 4
+
+            property real _lastContentHeight: 0
+
+            onContentYChanged: root._maybeFireEnd()
+            onContentHeightChanged: {
+                if (contentHeight > _lastContentHeight)
+                    root._endArmed = true;
+                _lastContentHeight = contentHeight;
+                root._maybeFireEnd();
+            }
 
             ViciWheelHandler {
                 target: listView

--- a/src/server/src/qml/qml/GenericListView.qml
+++ b/src/server/src/qml/qml/GenericListView.qml
@@ -55,8 +55,12 @@ Item {
     property real endReachedThreshold: root.height * 1.5
     property bool _endArmed: true
 
-    onCanLoadMoreChanged: if (canLoadMore)
-        Qt.callLater(_maybeFireEnd)
+    onCanLoadMoreChanged: {
+        if (canLoadMore) {
+            _endArmed = true;
+            Qt.callLater(_maybeFireEnd);
+        }
+    }
 
     function _maybeFireEnd() {
         if (!root.canLoadMore || !root._endArmed)

--- a/src/typescript/api/src/api/components/grid.tsx
+++ b/src/typescript/api/src/api/components/grid.tsx
@@ -5,6 +5,7 @@ import { EmptyView } from "./empty-view";
 import { type ColorLike, serializeColorLike } from "../color";
 import { Dropdown } from "./dropdown";
 import { useEventCounted } from "../hooks/use-event-counted";
+import { usePagination } from "./pagination";
 
 enum GridInset {
 	Zero = "zero",
@@ -114,6 +115,11 @@ export namespace Grid {
 		searchBarAccessory?: ReactNode;
 		onSearchTextChange?: (text: string) => void;
 		onSelectionChange?: (id: string) => void;
+
+		pagination?: {
+			onLoadMore: () => PromiseLike<void>;
+			hasMore: boolean;
+		};
 	};
 
 	/**
@@ -156,9 +162,9 @@ export namespace Grid {
 			keywords?: string[];
 			icon?: ImageLike;
 			content:
-				| Image.ImageLike
-				| { color: ColorLike }
-				| { value: Image.ImageLike | { color: ColorLike }; tooltip?: string };
+			| Image.ImageLike
+			| { color: ColorLike }
+			| { value: Image.ImageLike | { color: ColorLike }; tooltip?: string };
 			id?: string;
 			subtitle?: string;
 			actions?: ReactNode;
@@ -205,8 +211,11 @@ const GridRoot: React.FC<Grid.Props> = ({
 		onSearchTextChange,
 	);
 
+	const pagination = usePagination(props.pagination);
+
 	return (
 		<grid
+			pagination={pagination}
 			fit={fit}
 			throttle={throttle}
 			inset={inset}
@@ -259,11 +268,11 @@ const GridItem: React.FC<Grid.Item.Props> = ({
 	// Accessory
 	const serializedAccessory = accessory
 		? {
-				icon: accessory.icon
-					? serializeProtoImage(accessory.icon)
-					: accessory.icon,
-				tooltip: accessory.tooltip,
-			}
+			icon: accessory.icon
+				? serializeProtoImage(accessory.icon)
+				: accessory.icon,
+			tooltip: accessory.tooltip,
+		}
 		: undefined;
 
 	return (

--- a/src/typescript/api/src/api/components/grid.tsx
+++ b/src/typescript/api/src/api/components/grid.tsx
@@ -117,7 +117,7 @@ export namespace Grid {
 		onSelectionChange?: (id: string) => void;
 
 		pagination?: {
-			onLoadMore: () => PromiseLike<void>;
+			onLoadMore: () => Promise<void> | void;
 			hasMore: boolean;
 		};
 	};
@@ -162,9 +162,9 @@ export namespace Grid {
 			keywords?: string[];
 			icon?: ImageLike;
 			content:
-				| Image.ImageLike
-				| { color: ColorLike }
-				| { value: Image.ImageLike | { color: ColorLike }; tooltip?: string };
+			| Image.ImageLike
+			| { color: ColorLike }
+			| { value: Image.ImageLike | { color: ColorLike }; tooltip?: string };
 			id?: string;
 			subtitle?: string;
 			actions?: ReactNode;
@@ -269,11 +269,11 @@ const GridItem: React.FC<Grid.Item.Props> = ({
 	// Accessory
 	const serializedAccessory = accessory
 		? {
-				icon: accessory.icon
-					? serializeProtoImage(accessory.icon)
-					: accessory.icon,
-				tooltip: accessory.tooltip,
-			}
+			icon: accessory.icon
+				? serializeProtoImage(accessory.icon)
+				: accessory.icon,
+			tooltip: accessory.tooltip,
+		}
 		: undefined;
 
 	return (

--- a/src/typescript/api/src/api/components/grid.tsx
+++ b/src/typescript/api/src/api/components/grid.tsx
@@ -162,9 +162,9 @@ export namespace Grid {
 			keywords?: string[];
 			icon?: ImageLike;
 			content:
-			| Image.ImageLike
-			| { color: ColorLike }
-			| { value: Image.ImageLike | { color: ColorLike }; tooltip?: string };
+				| Image.ImageLike
+				| { color: ColorLike }
+				| { value: Image.ImageLike | { color: ColorLike }; tooltip?: string };
 			id?: string;
 			subtitle?: string;
 			actions?: ReactNode;
@@ -269,11 +269,11 @@ const GridItem: React.FC<Grid.Item.Props> = ({
 	// Accessory
 	const serializedAccessory = accessory
 		? {
-			icon: accessory.icon
-				? serializeProtoImage(accessory.icon)
-				: accessory.icon,
-			tooltip: accessory.tooltip,
-		}
+				icon: accessory.icon
+					? serializeProtoImage(accessory.icon)
+					: accessory.icon,
+				tooltip: accessory.tooltip,
+			}
 		: undefined;
 
 	return (

--- a/src/typescript/api/src/api/components/grid.tsx
+++ b/src/typescript/api/src/api/components/grid.tsx
@@ -162,9 +162,9 @@ export namespace Grid {
 			keywords?: string[];
 			icon?: ImageLike;
 			content:
-			| Image.ImageLike
-			| { color: ColorLike }
-			| { value: Image.ImageLike | { color: ColorLike }; tooltip?: string };
+				| Image.ImageLike
+				| { color: ColorLike }
+				| { value: Image.ImageLike | { color: ColorLike }; tooltip?: string };
 			id?: string;
 			subtitle?: string;
 			actions?: ReactNode;
@@ -215,7 +215,8 @@ const GridRoot: React.FC<Grid.Props> = ({
 
 	return (
 		<grid
-			pagination={pagination}
+			paginationHasMore={pagination?.hasMore ?? false}
+			paginationOnLoadMore={pagination?.onLoadMore}
 			fit={fit}
 			throttle={throttle}
 			inset={inset}
@@ -268,11 +269,11 @@ const GridItem: React.FC<Grid.Item.Props> = ({
 	// Accessory
 	const serializedAccessory = accessory
 		? {
-			icon: accessory.icon
-				? serializeProtoImage(accessory.icon)
-				: accessory.icon,
-			tooltip: accessory.tooltip,
-		}
+				icon: accessory.icon
+					? serializeProtoImage(accessory.icon)
+					: accessory.icon,
+				tooltip: accessory.tooltip,
+			}
 		: undefined;
 
 	return (

--- a/src/typescript/api/src/api/components/list.tsx
+++ b/src/typescript/api/src/api/components/list.tsx
@@ -116,7 +116,7 @@ export declare namespace List {
 		onSelectionChange?: (id: string) => void;
 
 		pagination?: {
-			onLoadMore: () => PromiseLike<void>;
+			onLoadMore: () => Promise<void> | void;
 			hasMore: boolean;
 		};
 	};
@@ -178,11 +178,11 @@ export declare namespace List {
 			 * @see {@link ImageLike}
 			 */
 			icon?:
-				| ImageLike
-				| {
-						value: ImageLike | undefined | null;
-						tooltip: string;
-				  };
+			| ImageLike
+			| {
+				value: ImageLike | undefined | null;
+				tooltip: string;
+			};
 
 			/**
 			 * Unique identifier for this item.

--- a/src/typescript/api/src/api/components/list.tsx
+++ b/src/typescript/api/src/api/components/list.tsx
@@ -178,11 +178,11 @@ export declare namespace List {
 			 * @see {@link ImageLike}
 			 */
 			icon?:
-			| ImageLike
-			| {
-				value: ImageLike | undefined | null;
-				tooltip: string;
-			};
+				| ImageLike
+				| {
+						value: ImageLike | undefined | null;
+						tooltip: string;
+				  };
 
 			/**
 			 * Unique identifier for this item.

--- a/src/typescript/api/src/api/components/list.tsx
+++ b/src/typescript/api/src/api/components/list.tsx
@@ -17,6 +17,7 @@ import {
 	serializeColorLike,
 } from "../color";
 import { Dropdown } from "./dropdown";
+import { usePagination } from "./pagination";
 
 /**
  * A List component that can be used to render a list of items sharing a similar representation.
@@ -113,6 +114,11 @@ export declare namespace List {
 		 * Note that this does *not* fire when transitioning from having a selected item to none at all.
 		 */
 		onSelectionChange?: (id: string) => void;
+
+		pagination?: {
+			onLoadMore: () => PromiseLike<void>;
+			hasMore: boolean;
+		};
 	};
 
 	/**
@@ -172,11 +178,11 @@ export declare namespace List {
 			 * @see {@link ImageLike}
 			 */
 			icon?:
-				| ImageLike
-				| {
-						value: ImageLike | undefined | null;
-						tooltip: string;
-				  };
+			| ImageLike
+			| {
+				value: ImageLike | undefined | null;
+				tooltip: string;
+			};
 
 			/**
 			 * Unique identifier for this item.
@@ -321,11 +327,14 @@ const ListRoot: React.FC<List.Props> = ({
 		onSearchTextChange,
 	);
 
+	const pagination = usePagination(props.pagination);
+
 	return (
 		<list
 			{...props}
 			searchText={countedSearchText}
 			onSearchTextChange={wrappedOnSearchTextChange}
+			pagination={pagination}
 		>
 			{searchBarAccessory}
 			{children}

--- a/src/typescript/api/src/api/components/list.tsx
+++ b/src/typescript/api/src/api/components/list.tsx
@@ -178,11 +178,11 @@ export declare namespace List {
 			 * @see {@link ImageLike}
 			 */
 			icon?:
-			| ImageLike
-			| {
-				value: ImageLike | undefined | null;
-				tooltip: string;
-			};
+				| ImageLike
+				| {
+						value: ImageLike | undefined | null;
+						tooltip: string;
+				  };
 
 			/**
 			 * Unique identifier for this item.
@@ -332,6 +332,8 @@ const ListRoot: React.FC<List.Props> = ({
 	return (
 		<list
 			{...props}
+			paginationHasMore={pagination?.hasMore ?? false}
+			paginationOnLoadMore={pagination?.onLoadMore}
 			searchText={countedSearchText}
 			onSearchTextChange={wrappedOnSearchTextChange}
 			pagination={pagination}

--- a/src/typescript/api/src/api/components/pagination.ts
+++ b/src/typescript/api/src/api/components/pagination.ts
@@ -1,0 +1,27 @@
+import { useRef } from "react";
+
+// light wrapper around the pagination flow, in which we automatically
+// block repeated load more calls from firing if one is already ongoing.
+// we don't bother queuing them or anything, maybe one day?
+export const usePagination = (options?: {
+	onLoadMore: () => PromiseLike<void>;
+	hasMore: boolean;
+}) => {
+	const isLoadingMore = useRef(false);
+
+	return (
+		options && {
+			onLoadMore: async () => {
+				if (!options.hasMore || isLoadingMore.current) return;
+
+				try {
+					isLoadingMore.current = true;
+					await options.onLoadMore();
+				} finally {
+					isLoadingMore.current = false;
+				}
+			},
+			hasMore: options.hasMore,
+		}
+	);
+};

--- a/src/typescript/api/src/api/components/pagination.ts
+++ b/src/typescript/api/src/api/components/pagination.ts
@@ -4,7 +4,7 @@ import { useRef } from "react";
 // block repeated load more calls from firing if one is already ongoing.
 // we don't bother queuing them or anything, maybe one day?
 export const usePagination = (options?: {
-	onLoadMore: () => PromiseLike<void>;
+	onLoadMore: () => Promise<void> | void;
 	hasMore: boolean;
 }) => {
 	const isLoadingMore = useRef(false);

--- a/src/typescript/api/types/jsx.d.ts
+++ b/src/typescript/api/types/jsx.d.ts
@@ -17,9 +17,11 @@ type BaseFormField = {
 	value?: any;
 };
 
-type Pagination = {
-	hasMore: boolean;
-	onLoadMore: () => PromiseLike<void>;
+type WithPagination = {
+	// flattened so that the handler is detected as one
+	// by the reconciler
+	paginationHasMore: boolean;
+	paginationOnLoadMore?: () => Promise<void> | void;
 };
 
 declare module "react" {
@@ -43,7 +45,7 @@ declare module "react" {
 				onSearchTextChange?: (...args: any[]) => void;
 				onSelectionChange?: (selectedItemId: string) => void;
 				pagination?: Pagination;
-			};
+			} & WithPagination;
 			"list-section": {
 				title?: string;
 				subtitle?: string;
@@ -54,11 +56,11 @@ declare module "react" {
 				id?: string;
 				subtitle?: string;
 				icon?:
-				| SerializedImageLike
-				| {
-					value?: SerializedImageLike | null;
-					tooltip: string;
-				};
+					| SerializedImageLike
+					| {
+							value?: SerializedImageLike | null;
+							tooltip: string;
+					  };
 				keywords?: string[];
 				accessories?: List.Item.SerializedAccessory[];
 				children?: React.ReactNode;
@@ -83,7 +85,7 @@ declare module "react" {
 				onSearchTextChange?: (...args: any[]) => void;
 				onSelectionChange?: (selectedItemId: string) => void;
 				pagination?: Pagination;
-			};
+			} & WithPagination;
 			"grid-section": {
 				inset?: Grid.Inset;
 				columns?: number;

--- a/src/typescript/api/types/jsx.d.ts
+++ b/src/typescript/api/types/jsx.d.ts
@@ -17,6 +17,11 @@ type BaseFormField = {
 	value?: any;
 };
 
+type Pagination = {
+	hasMore: boolean;
+	onLoadMore: () => PromiseLike<void>;
+};
+
 declare module "react" {
 	namespace JSX {
 		interface IntrinsicElements {
@@ -37,6 +42,7 @@ declare module "react" {
 				navigationTitle?: string;
 				onSearchTextChange?: (...args: any[]) => void;
 				onSelectionChange?: (selectedItemId: string) => void;
+				pagination?: Pagination;
 			};
 			"list-section": {
 				title?: string;
@@ -48,11 +54,11 @@ declare module "react" {
 				id?: string;
 				subtitle?: string;
 				icon?:
-					| SerializedImageLike
-					| {
-							value?: SerializedImageLike | null;
-							tooltip: string;
-					  };
+				| SerializedImageLike
+				| {
+					value?: SerializedImageLike | null;
+					tooltip: string;
+				};
 				keywords?: string[];
 				accessories?: List.Item.SerializedAccessory[];
 				children?: React.ReactNode;
@@ -76,6 +82,7 @@ declare module "react" {
 				navigationTitle?: string;
 				onSearchTextChange?: (...args: any[]) => void;
 				onSelectionChange?: (selectedItemId: string) => void;
+				pagination?: Pagination;
 			};
 			"grid-section": {
 				inset?: Grid.Inset;


### PR DESCRIPTION
Implements the pagination API so that list and grid components have an opportunity to load additional pages of content when reaching the end of the list