### PR TITLE
feat: make navigation wrapping opt-in

### DIFF
--- a/src/server/src/config/config.hpp
+++ b/src/server/src/config/config.hpp
@@ -280,6 +280,7 @@ struct ConfigValue {
   bool popToRootOnClose = false;
   bool popOnBackspace = true;
   bool activateOnSingleClick = false;
+  bool wrapNavigation = false;
 #if defined(Q_OS_LINUX) || defined(Q_OS_WIN)
   bool encryptSensitiveData = false;
 #else
@@ -337,6 +338,7 @@ template <> struct Partial<ConfigValue> {
   std::optional<bool> popToRootOnClose;
   std::optional<bool> popOnBackspace;
   std::optional<bool> activateOnSingleClick;
+  std::optional<bool> wrapNavigation;
   std::optional<bool> encryptSensitiveData;
   std::optional<std::string> escapeKeyBehavior;
   std::optional<std::string> faviconService;

--- a/src/server/src/qml/action-panel-model.cpp
+++ b/src/server/src/qml/action-panel-model.cpp
@@ -1,5 +1,6 @@
 #include "action-panel-model.hpp"
 #include "fuzzy/fuzzy-searchable.hpp"
+#include "services/navigation/list-navigation.hpp"
 #include "theme.hpp"
 #include <QKeyEvent>
 #include <utility>
@@ -203,24 +204,8 @@ void ActionPanelModel::setFilter(const QString &text) {
 
 int ActionPanelModel::nextSelectableIndex(int from, int direction) const {
   int const count = static_cast<int>(m_flat.size());
-  if (count == 0) return from;
-
-  int idx = from + direction;
-  if (idx < 0)
-    idx = count - 1;
-  else if (idx >= count)
-    idx = 0;
-
-  while (idx != from) {
-    if (m_flat[idx].kind == FlatItem::ActionItem) return idx;
-    idx += direction;
-    if (idx < 0)
-      idx = count - 1;
-    else if (idx >= count)
-      idx = 0;
-  }
-
-  return from;
+  return ListNavigation::nextIndex(from, direction, count,
+                                   [&](int idx) { return m_flat[idx].kind == FlatItem::ActionItem; });
 }
 
 int ActionPanelModel::nextSectionIndex(int from, int direction) const {
@@ -237,6 +222,7 @@ int ActionPanelModel::nextSectionIndex(int from, int direction) const {
         return idx;
       }
     }
+    if (!ListNavigation::wrapEnabled()) return from;
     return nextSelectableIndex(-1, 1);
   }
 
@@ -265,6 +251,8 @@ int ActionPanelModel::nextSectionIndex(int from, int direction) const {
       if (m_flat[i].kind == FlatItem::ActionItem && m_flat[i].sectionIdx == prevSection) return i;
     }
   }
+
+  if (!ListNavigation::wrapEnabled()) return from;
 
   // Wrap: last section.
   for (int i = count - 1; i >= 0; --i) {

--- a/src/server/src/qml/completion-model.cpp
+++ b/src/server/src/qml/completion-model.cpp
@@ -1,5 +1,6 @@
 #include "completion-model.hpp"
 #include "fuzzy/fuzzy-searchable.hpp"
+#include "services/navigation/list-navigation.hpp"
 #include <utility>
 
 template <> struct fuzzy::FuzzySearchable<CompletionModel::Item> {
@@ -78,24 +79,8 @@ void CompletionModel::setFilter(const QString &query) {
 int CompletionModel::nextSelectableIndex(int from, int direction) const {
   const auto count = static_cast<int>(m_flat.size());
   if (count == 0) return -1;
-
-  int idx = from + direction;
-  if (idx < 0)
-    idx = count - 1;
-  else if (idx >= count)
-    idx = 0;
-
-  const int start = idx;
-  do {
-    if (m_flat[idx].kind == FlatItem::Entry) return idx;
-    idx += direction;
-    if (idx < 0)
-      idx = count - 1;
-    else if (idx >= count)
-      idx = 0;
-  } while (idx != start);
-
-  return -1;
+  return ListNavigation::nextIndex(from, direction, count,
+                                   [&](int idx) { return m_flat[idx].kind == FlatItem::Entry; });
 }
 
 int CompletionModel::indexOfItemId(const QString &id) const {

--- a/src/server/src/qml/general-settings-model.cpp
+++ b/src/server/src/qml/general-settings-model.cpp
@@ -55,6 +55,9 @@ void GeneralSettingsModel::setActivateOnSingleClick(bool v) {
   cfgManager().mergeWithUser({.activateOnSingleClick = v});
 }
 
+bool GeneralSettingsModel::wrapNavigation() const { return cfg().wrapNavigation; }
+void GeneralSettingsModel::setWrapNavigation(bool v) { cfgManager().mergeWithUser({.wrapNavigation = v}); }
+
 bool GeneralSettingsModel::encryptSensitiveData() const { return cfg().encryptSensitiveData; }
 void GeneralSettingsModel::setEncryptSensitiveData(bool v) {
   cfgManager().mergeWithUser({.encryptSensitiveData = v});

--- a/src/server/src/qml/general-settings-model.hpp
+++ b/src/server/src/qml/general-settings-model.hpp
@@ -16,6 +16,7 @@ class GeneralSettingsModel : public QObject {
   Q_PROPERTY(bool popOnBackspace READ popOnBackspace WRITE setPopOnBackspace NOTIFY configChanged)
   Q_PROPERTY(bool activateOnSingleClick READ activateOnSingleClick WRITE setActivateOnSingleClick NOTIFY
                  configChanged)
+  Q_PROPERTY(bool wrapNavigation READ wrapNavigation WRITE setWrapNavigation NOTIFY configChanged)
   Q_PROPERTY(
       bool encryptSensitiveData READ encryptSensitiveData WRITE setEncryptSensitiveData NOTIFY configChanged)
   Q_PROPERTY(
@@ -65,6 +66,8 @@ public:
   void setPopOnBackspace(bool v);
   bool activateOnSingleClick() const;
   void setActivateOnSingleClick(bool v);
+  bool wrapNavigation() const;
+  void setWrapNavigation(bool v);
   bool encryptSensitiveData() const;
   void setEncryptSensitiveData(bool v);
   bool telemetrySystemInfo() const;

--- a/src/server/src/qml/qml/AdvancedSettingsPage.qml
+++ b/src/server/src/qml/qml/AdvancedSettingsPage.qml
@@ -51,6 +51,15 @@ Flickable {
             }
 
             SettingsRow {
+                label: "Wrap navigation"
+                description: "Wrap around to the opposite end when moving past the first or last item."
+                SettingsToggle {
+                    checked: root.model.wrapNavigation
+                    onToggled: root.model.wrapNavigation = checked
+                }
+            }
+
+            SettingsRow {
                 label: "IME handling"
                 description: "Include IME Preedit strings as part of search queries."
                 SettingsToggle {

--- a/src/server/src/qml/section-grid-model.cpp
+++ b/src/server/src/qml/section-grid-model.cpp
@@ -1,4 +1,5 @@
 #include "section-grid-model.hpp"
+#include "services/navigation/list-navigation.hpp"
 #include <algorithm>
 
 SectionGridModel::SectionGridModel(QObject *parent) : QAbstractListModel(parent) {}
@@ -258,12 +259,15 @@ int SectionGridModel::sectionColumns(int sectionIdx) const {
 int SectionGridModel::nextNonEmptySection(int sectionIdx, int direction) const {
   if (m_sections.empty()) return -1;
 
+  const bool wrap = ListNavigation::wrapEnabled();
   int idx = sectionIdx;
   for (size_t attempts = 0; attempts < m_sections.size(); ++attempts) {
     idx += direction;
     if (idx < 0) {
+      if (!wrap) return -1;
       idx = static_cast<int>(m_sections.size()) - 1;
     } else if (std::cmp_greater_equal(idx, m_sections.size())) {
+      if (!wrap) return -1;
       idx = 0;
     }
     if (m_sections[idx].count > 0) return idx;
@@ -315,7 +319,10 @@ void SectionGridModel::navigateRight() {
   int g = toGlobal(m_selSection, m_selItem) + 1;
   int const total = totalItemCount();
   if (total == 0) return;
-  if (g >= total) g = 0;
+  if (g >= total) {
+    if (!ListNavigation::wrapEnabled()) return;
+    g = 0;
+  }
   int s, i;
   fromGlobal(g, s, i);
   select(s, i);
@@ -327,7 +334,10 @@ void SectionGridModel::navigateLeft() {
   int g = toGlobal(m_selSection, m_selItem) - 1;
   int const total = totalItemCount();
   if (total == 0) return;
-  if (g < 0) g = total - 1;
+  if (g < 0) {
+    if (!ListNavigation::wrapEnabled()) return;
+    g = total - 1;
+  }
   int s, i;
   fromGlobal(g, s, i);
   select(s, i);
@@ -358,6 +368,8 @@ void SectionGridModel::navigateDown() {
       return;
     }
   }
+
+  if (!ListNavigation::wrapEnabled()) return;
 
   for (int s = 0; std::cmp_less(s, m_sections.size()); ++s) {
     if (m_sections[s].count > 0) {
@@ -394,6 +406,8 @@ void SectionGridModel::navigateUp() {
       return;
     }
   }
+
+  if (!ListNavigation::wrapEnabled()) return;
 
   for (int s = static_cast<int>(m_sections.size()) - 1; s >= 0; --s) {
     if (m_sections[s].count > 0) {

--- a/src/server/src/qml/section-list-model.cpp
+++ b/src/server/src/qml/section-list-model.cpp
@@ -2,6 +2,8 @@
 
 #include <utility>
 
+#include "services/navigation/list-navigation.hpp"
+
 SectionListModel::SectionListModel(QObject *parent) : QAbstractListModel(parent) {
   connect(&ThemeService::instance(), &ThemeService::themeChanged, this, [this]() {
     if (rowCount() > 0) emit dataChanged(index(0), index(rowCount() - 1), {IconSource});
@@ -170,24 +172,8 @@ void SectionListModel::activateSelected() { m_scope.executePrimaryAction(); }
 
 int SectionListModel::nextSelectableIndex(int from, int direction) const {
   int const count = static_cast<int>(m_flat.size());
-  if (count == 0) return from;
-
-  int idx = from + direction;
-  if (idx < 0)
-    idx = count - 1;
-  else if (idx >= count)
-    idx = 0;
-
-  while (idx != from) {
-    if (m_flat[idx].kind != FlatItem::SectionHeader) return idx;
-    idx += direction;
-    if (idx < 0)
-      idx = count - 1;
-    else if (idx >= count)
-      idx = 0;
-  }
-
-  return from;
+  return ListNavigation::nextIndex(from, direction, count,
+                                   [&](int idx) { return m_flat[idx].kind != FlatItem::SectionHeader; });
 }
 
 int SectionListModel::nextSectionIndex(int from, int direction) const {
@@ -210,6 +196,7 @@ int SectionListModel::nextSectionIndex(int from, int direction) const {
         return firstDataItemFrom(idx + 1);
       }
     }
+    if (!ListNavigation::wrapEnabled()) return from;
     return nextSelectableIndex(-1, 1);
   }
 
@@ -240,6 +227,8 @@ int SectionListModel::nextSectionIndex(int from, int direction) const {
       break;
     }
   }
+
+  if (!ListNavigation::wrapEnabled()) return from;
 
   int lastSource = -1;
   for (int i = count - 1; i >= 0; --i) {

--- a/src/server/src/services/navigation/list-navigation.hpp
+++ b/src/server/src/services/navigation/list-navigation.hpp
@@ -1,0 +1,36 @@
+#pragma once
+#include "service-registry.hpp"
+#include "config/config.hpp"
+
+// Centralizes selection stepping semantics for every list-like surface
+// (root list, grids, action panel, completions). Wrap-around at the ends
+// is opt-in through the `wrap_navigation` config toggle; the default is
+// to clamp at the first and last selectable item.
+class ListNavigation {
+public:
+  static bool wrapEnabled() { return ServiceRegistry::instance()->config()->value().wrapNavigation; }
+
+  template <typename IsSelectable>
+  static int nextIndex(int from, int direction, int count, IsSelectable &&isSelectable) {
+    if (count <= 0) return from;
+
+    const bool wrap = wrapEnabled();
+    int idx = from;
+
+    for (int steps = 0; steps < count; ++steps) {
+      idx += direction;
+
+      if (idx < 0) {
+        if (!wrap) return from;
+        idx = count - 1;
+      } else if (idx >= count) {
+        if (!wrap) return from;
+        idx = 0;
+      }
+
+      if (isSelectable(idx)) return idx;
+    }
+
+    return from;
+  }
+};


### PR DESCRIPTION
Change the default behavior of the navigation so that going up when the first item is selected no longer wraps to the bottom-most item and vice versa. This is generally unusual behavior for most launchers. 

This remains available under a setting in "Advanced"