### PR TITLE
feat: implement extension manifest command keywords

### DIFF
--- a/src/server/src/extension/extension-command.cpp
+++ b/src/server/src/extension/extension-command.cpp
@@ -27,6 +27,8 @@ EntrypointId ExtensionCommand::uniqueId() const {
 
 QString ExtensionCommand::commandId() const { return m_command.name; }
 
+std::vector<QString> ExtensionCommand::keywords() const { return m_command.keywords; }
+
 QString ExtensionCommand::name() const { return m_command.title; }
 
 QString ExtensionCommand::repositoryDisplayName() const { return _extensionTitle; }

--- a/src/server/src/extension/extension-command.hpp
+++ b/src/server/src/extension/extension-command.hpp
@@ -67,6 +67,8 @@ public:
   QString name() const override;
   QString commandId() const override;
 
+  std::vector<QString> keywords() const override;
+
   ImageURL iconUrl() const override;
   QString repositoryDisplayName() const override;
   QString repositoryName() const override;
@@ -88,5 +90,5 @@ public:
 
   CommandContext *createContext(const std::shared_ptr<AbstractCmd> &command) const override;
 
-  ExtensionCommand() {}
+  ExtensionCommand() = default;
 };

--- a/src/server/src/extension/extension.cpp
+++ b/src/server/src/extension/extension.cpp
@@ -47,6 +47,7 @@ Extension::Extension(const ExtensionManifest &manifest) : m_manifest(manifest) {
     command->setExtensionPreferences(m_manifest.preferences);
     command->setExtensionName(m_manifest.name);
     command->setAuthor(author());
+
     m_commands.emplace_back(command);
   }
 }

--- a/src/server/src/services/extension-registry/extension-manifest.cpp
+++ b/src/server/src/services/extension-registry/extension-manifest.cpp
@@ -228,6 +228,10 @@ ExtensionManifest::Command ExtensionManifest::parseCommandFromObject(const QJson
     }
   }
 
+  for (const auto &obj : obj.value("keywords").toArray()) {
+    command.keywords.emplace_back(obj.toString());
+  }
+
   for (const auto &obj : obj.value("preferences").toArray()) {
     command.preferences.emplace_back(parsePreferenceFromObject(obj.toObject()));
   }

--- a/src/server/src/services/extension-registry/extension-manifest.hpp
+++ b/src/server/src/services/extension-registry/extension-manifest.hpp
@@ -21,6 +21,7 @@ struct ExtensionManifest {
     QString description;
     CommandMode mode;
     std::vector<Preference> preferences;
+    std::vector<QString> keywords;
     std::vector<CommandArgument> arguments;
     std::optional<QString> icon;
     std::optional<std::chrono::seconds> interval;


### PR DESCRIPTION
Extension commands can now specify a `keywords` array in their manifest that will be searched in the root search. Note that keywords carry less weight than the command name.