### PR TITLE
feat(calculator): support structured Soulver results

### DIFF
--- a/src/server/src/qml/calc-history-view-host.cpp
+++ b/src/server/src/qml/calc-history-view-host.cpp
@@ -16,9 +16,20 @@ void CalcLiveSection::clear() {
   notifyItemsRefreshed();
 }
 
-QString CalcLiveSection::itemTitle(int) const {
-  if (!m_result) return {};
-  return m_result->question.text + QStringLiteral(" = ") + m_result->answer.text;
+int CalcLiveSection::count() const {
+  return m_result ? 1 + static_cast<int>(m_result->alternatives.size()) : 0;
+}
+
+const AbstractCalculatorBackend::CalculatorResult *CalcLiveSection::resultAt(int i) const {
+  if (!m_result || i < 0) return nullptr;
+  if (i == 0) return &*m_result;
+  if (std::cmp_greater(i, m_result->alternatives.size())) return nullptr;
+  return &m_result->alternatives[i - 1];
+}
+
+QString CalcLiveSection::itemTitle(int i) const {
+  const auto *result = resultAt(i);
+  return result ? result->question.text + QStringLiteral(" = ") + result->answer.text : QString();
 }
 
 QString CalcLiveSection::itemIconSource(int) const { return imageSourceFor(ImageURL::builtin("calculator")); }
@@ -27,21 +38,28 @@ QVariantList CalcLiveSection::itemAccessories(int) const { return {}; }
 
 QHash<int, QByteArray> CalcLiveSection::customRoleNames() const {
   return {
-      {IsCalculator, "isCalculator"},         {CalcQuestion, "calcQuestion"},
-      {CalcQuestionUnit, "calcQuestionUnit"}, {CalcAnswer, "calcAnswer"},
+      {IsCalculator, "isCalculator"},
+      {CalcQuestion, "calcQuestion"},
+      {CalcQuestionUnit, "calcQuestionUnit"},
+      {CalcQuestionSubtitle, "calcQuestionSubtitle"},
+      {CalcAnswer, "calcAnswer"},
       {CalcAnswerUnit, "calcAnswerUnit"},
+      {CalcAnswerSubtitle, "calcAnswerSubtitle"},
   };
 }
 
 QHash<int, QVariant> CalcLiveSection::customRoleDefaults() const {
   return {
-      {IsCalculator, false},   {CalcQuestion, QString()},   {CalcQuestionUnit, QString()},
-      {CalcAnswer, QString()}, {CalcAnswerUnit, QString()},
+      {IsCalculator, false},           {CalcQuestion, QString()},
+      {CalcQuestionUnit, QString()},   {CalcQuestionSubtitle, QString()},
+      {CalcAnswer, QString()},         {CalcAnswerUnit, QString()},
+      {CalcAnswerSubtitle, QString()},
   };
 }
 
-QVariant CalcLiveSection::customData(int, int role) const {
-  if (!m_result) {
+QVariant CalcLiveSection::customData(int i, int role) const {
+  const auto *result = resultAt(i);
+  if (!result) {
     if (role == IsCalculator) return false;
     return {};
   }
@@ -49,27 +67,32 @@ QVariant CalcLiveSection::customData(int, int role) const {
   case IsCalculator:
     return true;
   case CalcQuestion:
-    return m_result->question.text;
+    return result->question.text;
   case CalcQuestionUnit:
-    return m_result->question.unit ? m_result->question.unit->displayName : QString();
+    return result->question.unit ? result->question.unit->displayName : QString();
+  case CalcQuestionSubtitle:
+    return result->question.subtitle.value_or(QString());
   case CalcAnswer:
-    return m_result->answer.text;
+    return result->answer.text;
   case CalcAnswerUnit:
-    return m_result->answer.unit ? m_result->answer.unit->displayName : QString();
+    return result->answer.unit ? result->answer.unit->displayName : QString();
+  case CalcAnswerSubtitle:
+    return result->answer.subtitle.value_or(QString());
   default:
     return {};
   }
 }
 
-std::unique_ptr<ActionPanelState> CalcLiveSection::actionPanel(int) const {
-  if (!m_result) return nullptr;
+std::unique_ptr<ActionPanelState> CalcLiveSection::actionPanel(int i) const {
+  const auto *result = resultAt(i);
+  if (!result) return nullptr;
 
   auto panel = std::make_unique<ListActionPanelState>();
   auto *main = panel->createSection();
-  auto *copyAnswer = new CopyCalculatorAnswerAction(*m_result);
+  auto *copyAnswer = new CopyCalculatorAnswerAction(*result);
   copyAnswer->setPrimary(true);
   main->addAction(copyAnswer);
-  main->addAction(new CopyCalculatorQuestionAndAnswerAction(*m_result));
+  main->addAction(new CopyCalculatorQuestionAndAnswerAction(*result));
 
   return panel;
 }

--- a/src/server/src/qml/calc-history-view-host.hpp
+++ b/src/server/src/qml/calc-history-view-host.hpp
@@ -15,15 +15,17 @@ public:
     IsCalculator = Qt::UserRole + 100,
     CalcQuestion,
     CalcQuestionUnit,
+    CalcQuestionSubtitle,
     CalcAnswer,
     CalcAnswerUnit,
+    CalcAnswerSubtitle,
   };
 
   void setResult(std::optional<AbstractCalculatorBackend::CalculatorResult> result);
   void clear();
 
   QString sectionName() const override { return QStringLiteral("Calculator"); }
-  int count() const override { return m_result ? 1 : 0; }
+  int count() const override;
 
   QHash<int, QByteArray> customRoleNames() const override;
   QHash<int, QVariant> customRoleDefaults() const override;
@@ -36,6 +38,7 @@ protected:
   std::unique_ptr<ActionPanelState> actionPanel(int i) const override;
 
 private:
+  const AbstractCalculatorBackend::CalculatorResult *resultAt(int i) const;
   std::optional<AbstractCalculatorBackend::CalculatorResult> m_result;
 };
 

--- a/src/server/src/qml/qml/CalcHistoryListView.qml
+++ b/src/server/src/qml/qml/CalcHistoryListView.qml
@@ -53,8 +53,10 @@ GenericListView {
                 width: delegateLoader.width
                 calcQuestion: delegateLoader.calcQuestion
                 calcQuestionUnit: delegateLoader.calcQuestionUnit
+                calcQuestionSubtitle: delegateLoader.calcQuestionSubtitle
                 calcAnswer: delegateLoader.calcAnswer
                 calcAnswerUnit: delegateLoader.calcAnswerUnit
+                calcAnswerSubtitle: delegateLoader.calcAnswerSubtitle
                 selected: calcHistoryView.currentIndex === delegateLoader.index
                 onClicked: calcHistoryView.currentIndex = delegateLoader.index
                 onActivated: calcHistoryView.itemActivated(delegateLoader.index)

--- a/src/server/src/qml/qml/CalculatorResultDelegate.qml
+++ b/src/server/src/qml/qml/CalculatorResultDelegate.qml
@@ -7,8 +7,10 @@ SelectableDelegate {
 
     required property string calcQuestion
     required property string calcQuestionUnit
+    required property string calcQuestionSubtitle
     required property string calcAnswer
     required property string calcAnswerUnit
+    required property string calcAnswerSubtitle
 
     Item {
         anchors.fill: parent
@@ -37,7 +39,7 @@ SelectableDelegate {
 
             Text {
                 width: parent.width
-                text: root.calcQuestionUnit || "Question"
+                text: root.calcQuestionSubtitle || root.calcQuestionUnit || "Question"
                 color: Theme.textMuted
                 font.pointSize: Theme.smallerFontSize
                 elide: Text.ElideRight
@@ -94,7 +96,7 @@ SelectableDelegate {
 
             Text {
                 width: parent.width
-                text: root.calcAnswerUnit || "Answer"
+                text: root.calcAnswerSubtitle || root.calcAnswerUnit || "Answer"
                 color: Theme.textMuted
                 font.pointSize: Theme.smallerFontSize
                 elide: Text.ElideRight

--- a/src/server/src/qml/qml/RootSearchList.qml
+++ b/src/server/src/qml/qml/RootSearchList.qml
@@ -55,8 +55,10 @@ GenericListView {
                 width: delegateLoader.width
                 calcQuestion: delegateLoader.calcQuestion
                 calcQuestionUnit: delegateLoader.calcQuestionUnit
+                calcQuestionSubtitle: delegateLoader.calcQuestionSubtitle
                 calcAnswer: delegateLoader.calcAnswer
                 calcAnswerUnit: delegateLoader.calcAnswerUnit
+                calcAnswerSubtitle: delegateLoader.calcAnswerSubtitle
                 selected: searchListView.currentIndex === delegateLoader.index
                 onClicked: searchListView.currentIndex = delegateLoader.index
                 onActivated: searchListView.itemActivated(delegateLoader.index)

--- a/src/server/src/qml/root-search-sources.cpp
+++ b/src/server/src/qml/root-search-sources.cpp
@@ -28,8 +28,10 @@ const QHash<int, QByteArray> &customRoleNames() {
       {IsCalculator, "isCalculator"},
       {CalcQuestion, "calcQuestion"},
       {CalcQuestionUnit, "calcQuestionUnit"},
+      {CalcQuestionSubtitle, "calcQuestionSubtitle"},
       {CalcAnswer, "calcAnswer"},
       {CalcAnswerUnit, "calcAnswerUnit"},
+      {CalcAnswerSubtitle, "calcAnswerSubtitle"},
       {IsFile, "isFile"},
   };
   return roles;
@@ -37,10 +39,20 @@ const QHash<int, QByteArray> &customRoleNames() {
 
 const QHash<int, QVariant> &customRoleDefaults() {
   static const QHash<int, QVariant> defaults = {
-      {ItemType, QString()},   {Alias, QString()},          {ShortcutTokens, QVariantList()},
-      {IsActive, false},       {AccessoryText, QString()},  {AccessoryColor, QString()},
-      {IsCalculator, false},   {CalcQuestion, QString()},   {CalcQuestionUnit, QString()},
-      {CalcAnswer, QString()}, {CalcAnswerUnit, QString()}, {IsFile, false},
+      {ItemType, QString()},
+      {Alias, QString()},
+      {ShortcutTokens, QVariantList()},
+      {IsActive, false},
+      {AccessoryText, QString()},
+      {AccessoryColor, QString()},
+      {IsCalculator, false},
+      {CalcQuestion, QString()},
+      {CalcQuestionUnit, QString()},
+      {CalcQuestionSubtitle, QString()},
+      {CalcAnswer, QString()},
+      {CalcAnswerUnit, QString()},
+      {CalcAnswerSubtitle, QString()},
+      {IsFile, false},
   };
   return defaults;
 }
@@ -115,31 +127,49 @@ std::unique_ptr<ActionPanelState> RootLinkSection::actionPanel(int) const {
   return panel;
 }
 
-QString RootCalculatorSection::itemId(int) const {
-  return m_result ? QStringLiteral("calc:") + m_result->question.text : QString();
+int RootCalculatorSection::count() const {
+  return m_result ? 1 + static_cast<int>(m_result->alternatives.size()) : 0;
 }
 
-QString RootCalculatorSection::itemTitle(int) const {
-  return m_result ? m_result->question.text + QStringLiteral(" = ") + m_result->answer.text : QString();
+const AbstractCalculatorBackend::CalculatorResult *RootCalculatorSection::resultAt(int i) const {
+  if (!m_result || i < 0) return nullptr;
+  if (i == 0) return &*m_result;
+  if (std::cmp_greater(i, m_result->alternatives.size())) return nullptr;
+  return &m_result->alternatives[i - 1];
+}
+
+QString RootCalculatorSection::itemId(int i) const {
+  const auto *result = resultAt(i);
+  return result ? QStringLiteral("calc:") + result->question.text + ':' + QString::number(i) : QString();
+}
+
+QString RootCalculatorSection::itemTitle(int i) const {
+  const auto *result = resultAt(i);
+  return result ? result->question.text + QStringLiteral(" = ") + result->answer.text : QString();
 }
 
 QString RootCalculatorSection::itemIconSource(int) const {
   return imageSourceFor(ImageURL::builtin("calculator"));
 }
 
-QVariant RootCalculatorSection::customData(int, int role) const {
+QVariant RootCalculatorSection::customData(int i, int role) const {
   if (role == ItemType) return QStringLiteral("calculator");
   if (role == IsCalculator) return true;
-  if (!m_result) return {};
+  const auto *result = resultAt(i);
+  if (!result) return {};
   switch (role) {
   case CalcQuestion:
-    return m_result->question.text;
+    return result->question.text;
   case CalcQuestionUnit:
-    return m_result->question.unit ? m_result->question.unit->displayName : QString();
+    return result->question.unit ? result->question.unit->displayName : QString();
+  case CalcQuestionSubtitle:
+    return result->question.subtitle.value_or(QString());
   case CalcAnswer:
-    return m_result->answer.text;
+    return result->answer.text;
   case CalcAnswerUnit:
-    return m_result->answer.unit ? m_result->answer.unit->displayName : QString();
+    return result->answer.unit ? result->answer.unit->displayName : QString();
+  case CalcAnswerSubtitle:
+    return result->answer.subtitle.value_or(QString());
   default:
     return {};
   }
@@ -152,15 +182,16 @@ QHash<int, QVariant> RootCalculatorSection::customRoleDefaults() const {
   return root_search::customRoleDefaults();
 }
 
-std::unique_ptr<ActionPanelState> RootCalculatorSection::actionPanel(int) const {
-  if (!m_result) return nullptr;
+std::unique_ptr<ActionPanelState> RootCalculatorSection::actionPanel(int i) const {
+  const auto *result = resultAt(i);
+  if (!result) return nullptr;
   auto panel = std::make_unique<ListActionPanelState>();
   auto *section = panel->createSection();
-  auto *copyAnswer = new CopyCalculatorAnswerAction(*m_result);
+  auto *copyAnswer = new CopyCalculatorAnswerAction(*result);
   copyAnswer->setPrimary(true);
   section->addAction(copyAnswer);
-  section->addAction(new CopyCalculatorQuestionAndAnswerAction(*m_result));
-  section->addAction(new PutCalculatorAnswerInSearchBar(*m_result));
+  section->addAction(new CopyCalculatorQuestionAndAnswerAction(*result));
+  section->addAction(new PutCalculatorAnswerInSearchBar(*result));
   section->addAction(new OpenCalculatorHistoryAction());
   return panel;
 }

--- a/src/server/src/qml/root-search-sources.hpp
+++ b/src/server/src/qml/root-search-sources.hpp
@@ -23,8 +23,10 @@ enum RootSearchRole {
   IsCalculator,
   CalcQuestion,
   CalcQuestionUnit,
+  CalcQuestionSubtitle,
   CalcAnswer,
   CalcAnswerUnit,
+  CalcAnswerSubtitle,
   IsFile,
   ShortcutTokens,
 };
@@ -69,7 +71,7 @@ private:
 class RootCalculatorSection : public SectionSource {
 public:
   QString sectionName() const override { return QStringLiteral("Calculator"); }
-  int count() const override { return m_result ? 1 : 0; }
+  int count() const override;
   QString itemId(int) const override;
   QString itemTitle(int) const override;
   QString itemIconSource(int) const override;
@@ -82,6 +84,7 @@ public:
   const auto &result() const { return m_result; }
 
 private:
+  const AbstractCalculatorBackend::CalculatorResult *resultAt(int i) const;
   std::optional<AbstractCalculatorBackend::CalculatorResult> m_result;
 };
 

--- a/src/server/src/services/calculator-service/abstract-calculator-backend.hpp
+++ b/src/server/src/services/calculator-service/abstract-calculator-backend.hpp
@@ -6,6 +6,7 @@
 #include <ranges>
 #include <string>
 #include <string_view>
+#include <vector>
 
 class AbstractCalculatorBackend {
 public:
@@ -34,12 +35,16 @@ public:
     struct {
       QString text;
       std::optional<Unit> unit;
+      std::optional<QString> subtitle;
     } question;
 
     struct {
       QString text;
       std::optional<Unit> unit;
+      std::optional<QString> subtitle;
     } answer;
+
+    std::vector<CalculatorResult> alternatives;
   };
 
   struct CalculatorError {

--- a/src/server/src/services/calculator-service/soulver-core/soulver-core.cpp
+++ b/src/server/src/services/calculator-service/soulver-core/soulver-core.cpp
@@ -3,6 +3,7 @@
 #include <QtConcurrent/qtconcurrentrun.h>
 #include <filesystem>
 #include <QDebug>
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include "common/c-ptr.hpp"
@@ -71,6 +72,8 @@ void SoulverCoreCalculator::loadABI() {
   m_abi.soulver_is_initialized =
       reinterpret_cast<bool (*)(void)>(dlsym(m_dlHandle, "soulver_is_initialized"));
   m_abi.soulver_evaluate = reinterpret_cast<char *(*)(const char *)>(dlsym(m_dlHandle, "soulver_evaluate"));
+  m_abi.soulver_evaluate_ex =
+      reinterpret_cast<char *(*)(const char *)>(dlsym(m_dlHandle, "soulver_evaluate_ex"));
 }
 
 std::vector<fs::path> SoulverCoreCalculator::availableResourcePaths() const {
@@ -97,10 +100,27 @@ SoulverCoreCalculator::compute(const QString &question, const ComputeOptions &op
   if (soulverRes.value().type == "none") return fail("Result type is none");
 
   CalculatorResult result;
+  const auto candidateResult = [](const SoulverResult::Alternative &candidate) {
+    CalculatorResult alternative;
+    alternative.question.text = candidate.title;
+    alternative.answer.text = candidate.result;
+    alternative.answer.subtitle = candidate.subtitle;
+    alternative.type = CalculatorAnswerType::NORMAL;
+    return alternative;
+  };
 
-  result.question.text = question;
-  result.answer.text = soulverRes.value().result;
-  result.type = CalculatorAnswerType::NORMAL;
+  if (soulverRes.value().alternatives.empty()) {
+    result.question.text = question;
+    result.answer.text = soulverRes.value().result;
+    result.answer.subtitle = soulverRes.value().subtitle;
+    result.type = CalculatorAnswerType::NORMAL;
+  } else {
+    result = candidateResult(soulverRes.value().alternatives.front());
+    result.alternatives.reserve(soulverRes.value().alternatives.size() - 1);
+    for (const auto &candidate : soulverRes.value().alternatives | std::views::drop(1)) {
+      result.alternatives.emplace_back(candidateResult(candidate));
+    }
+  }
 
   return result;
 };
@@ -115,11 +135,12 @@ SoulverCoreCalculator::asyncCompute(const QString &question, const ComputeOption
 
 std::expected<SoulverCoreCalculator::SoulverResult, QString>
 SoulverCoreCalculator::calculate(const QString &expression) const {
-  const CPtr<char> answer(m_abi.soulver_evaluate(expression.toStdString().c_str()));
+  const auto evaluate = m_abi.soulver_evaluate_ex ? m_abi.soulver_evaluate_ex : m_abi.soulver_evaluate;
+  const CPtr<char> answer(evaluate(expression.toStdString().c_str()));
 
   if (!answer) {
-    qWarning() << "soulver_evaluate returned a null pointer. This suggests soulver crashed or wasn't "
-                  "properly initialized.";
+    qWarning() << (m_abi.soulver_evaluate_ex ? "soulver_evaluate_ex" : "soulver_evaluate")
+               << "returned a null pointer. This suggests soulver crashed or wasn't properly initialized.";
     return std::unexpected("Failed to parse json");
   }
 
@@ -129,13 +150,31 @@ SoulverCoreCalculator::calculate(const QString &expression) const {
   if (parseError.error != QJsonParseError::NoError) { return std::unexpected("Failed to parse json"); }
 
   auto json = doc.object();
-  QString const value = json.value("value").toString();
-  QString const type = json.value("type").toString();
-
   SoulverResult result;
 
   result.result = json.value("value").toString();
   result.type = json.value("type").toString();
+  if (const auto subtitle = json.value("subtitle"); subtitle.isString()) {
+    result.subtitle = subtitle.toString();
+  }
+
+  const auto candidates = json.value("candidates").toArray();
+  result.alternatives.reserve(candidates.size());
+  for (const auto &value : candidates) {
+    const auto candidate = value.toObject();
+    const auto title = candidate.value("title");
+    const auto answer = candidate.value("value");
+    if (!title.isString() || !answer.isString()) continue;
+
+    SoulverResult::Alternative alternative{
+        .title = title.toString(),
+        .result = answer.toString(),
+    };
+    if (const auto subtitle = candidate.value("subtitle"); subtitle.isString()) {
+      alternative.subtitle = subtitle.toString();
+    }
+    result.alternatives.emplace_back(std::move(alternative));
+  }
 
   if (json.contains("error")) { result.error = json.value("error").toString(); }
 

--- a/src/server/src/services/calculator-service/soulver-core/soulver-core.hpp
+++ b/src/server/src/services/calculator-service/soulver-core/soulver-core.hpp
@@ -8,8 +8,16 @@ class SoulverCoreCalculator : public AbstractCalculatorBackend {
 
 public:
   struct SoulverResult {
+    struct Alternative {
+      QString title;
+      QString result;
+      std::optional<QString> subtitle;
+    };
+
     QString type;
     QString result;
+    std::optional<QString> subtitle;
+    std::vector<Alternative> alternatives;
     std::optional<QString> error;
   };
 
@@ -28,6 +36,7 @@ private:
     bool (*soulver_initialize)(const char *) = nullptr;
     bool (*soulver_is_initialized)(void) = nullptr;
     char *(*soulver_evaluate)(const char *) = nullptr;
+    char *(*soulver_evaluate_ex)(const char *) = nullptr;
   };
 
   std::expected<SoulverResult, QString> calculate(const QString &expression) const;


### PR DESCRIPTION
## Summary

- probe an optional `soulver_evaluate_ex` ABI symbol while retaining the existing `soulver_evaluate` fallback
- parse versioned subtitles and alternative answers into a backend-neutral calculator result contract
- render answer subtitles in the existing muted lines and expose alternatives as individually selectable calculator rows
- keep calculator history storage unchanged; only the selected row is persisted

The extension is additive: wrappers without `soulver_evaluate_ex` continue through the existing ABI unchanged. The `alternatives` field is backend-neutral and can also support multiple answers from other calculators later.

Expected extended payload shape:

```json
{
  "version": 1,
  "value": "3:35 PM · Jul 18, 2026",
  "type": "time",
  "subtitle": "Georgia (country) · Asia/Tbilisi · GMT+4",
  "candidates": [
    {
      "title": "Santa Clara, CA (US)",
      "value": "3:55 AM · Jul 18, 2026",
      "subtitle": "America/Los_Angeles · PDT"
    }
  ]
}
```

## Verification

- `cmake -G Ninja -DBUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug -DLTO=OFF -B build`
- `cmake --build build -j 8`
- `make check-format`
- isolated offscreen server/CLI smoke, including calculator delegate instantiation
- confirmed a wrapper without `_ex` exposes only `soulver_evaluate` and remains compatible