### PR TITLE
feat: windows wallpaper backend

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -721,6 +721,8 @@ elseif (WIN32)
 		src/root-search/control-panel/control-panel-root-provider.cpp
 		src/services/url-scheme/win-url-scheme-registrar.hpp
 		src/services/url-scheme/win-url-scheme-registrar.cpp
+		src/services/wallpaper/windows/windows-wallpaper-backend.hpp
+		src/services/wallpaper/windows/windows-wallpaper-backend.cpp
 	)
 	list(APPEND LIBS shell32 ole32 shlwapi user32 gdi32 advapi32 version windowsapp dwmapi comctl32 uuid)
 else()

--- a/src/server/src/services/wallpaper/wallpaper-manager.cpp
+++ b/src/server/src/services/wallpaper/wallpaper-manager.cpp
@@ -12,6 +12,9 @@
 #ifdef Q_OS_MACOS
 #include "macos/mac-wallpaper-backend.hpp"
 #endif
+#ifdef Q_OS_WIN
+#include "windows/windows-wallpaper-backend.hpp"
+#endif
 
 std::vector<std::unique_ptr<AbstractWallpaperBackend>> WallpaperManager::createCandidates() {
   // XXX - all new wallpaper backends must be added to this vector.
@@ -29,6 +32,9 @@ std::vector<std::unique_ptr<AbstractWallpaperBackend>> WallpaperManager::createC
 #endif
 #ifdef Q_OS_MACOS
   candidates.emplace_back(std::make_unique<MacWallpaperBackend>());
+#endif
+#ifdef Q_OS_WIN
+  candidates.emplace_back(std::make_unique<WindowsWallpaperBackend>());
 #endif
 
   return candidates;

--- a/src/server/src/services/wallpaper/windows/windows-wallpaper-backend.cpp
+++ b/src/server/src/services/wallpaper/windows/windows-wallpaper-backend.cpp
@@ -1,0 +1,85 @@
+#include "windows-wallpaper-backend.hpp"
+#include "utils/scoped-com.hpp"
+#include <QtConcurrent>
+#include <filesystem>
+#include <optional>
+#include <shobjidl_core.h>
+#include <string>
+#include <system_error>
+#include <wrl/client.h>
+
+using Microsoft::WRL::ComPtr;
+
+namespace {
+
+DESKTOP_WALLPAPER_POSITION positionForFit(WallpaperFit fit) {
+  switch (fit) {
+  case WallpaperFit::Cover:
+    return DWPOS_FILL;
+  case WallpaperFit::Contain:
+    return DWPOS_FIT;
+  case WallpaperFit::Stretch:
+    return DWPOS_STRETCH;
+  case WallpaperFit::Center:
+    return DWPOS_CENTER;
+  case WallpaperFit::Tile:
+    return DWPOS_TILE;
+  }
+  return DWPOS_FILL;
+}
+
+std::string hresultMessage(HRESULT hr) { return std::system_category().message(hr); }
+
+// Resolves a QScreen::name() GDI adapter name (e.g. \\.\DISPLAY1) into the monitor device
+// interface path IDesktopWallpaper expects.
+std::optional<std::wstring> monitorIdForScreen(IDesktopWallpaper *wallpaper, const std::string &screen) {
+  DISPLAY_DEVICEW device{};
+  device.cb = sizeof(device);
+  const std::wstring adapter = QString::fromStdString(screen).toStdWString();
+  if (!EnumDisplayDevicesW(adapter.c_str(), 0, &device, EDD_GET_DEVICE_INTERFACE_NAME)) {
+    return std::nullopt;
+  }
+
+  UINT count = 0;
+  if (FAILED(wallpaper->GetMonitorDevicePathCount(&count))) return std::nullopt;
+
+  for (UINT i = 0; i < count; ++i) {
+    LPWSTR pathAt = nullptr;
+    if (FAILED(wallpaper->GetMonitorDevicePathAt(i, &pathAt))) continue;
+    std::wstring id = pathAt;
+    CoTaskMemFree(pathAt);
+    if (_wcsicmp(id.c_str(), device.DeviceID) == 0) return id;
+  }
+
+  return std::nullopt;
+}
+
+std::expected<void, std::string> apply(const WallpaperRequest &request) {
+  ScopedCom com;
+  ComPtr<IDesktopWallpaper> wallpaper;
+
+  HRESULT hr = CoCreateInstance(CLSID_DesktopWallpaper, nullptr, CLSCTX_ALL, IID_PPV_ARGS(&wallpaper));
+  if (FAILED(hr)) {
+    return std::unexpected("failed to reach the desktop wallpaper service: " + hresultMessage(hr));
+  }
+
+  std::optional<std::wstring> monitorId;
+  if (request.screen) monitorId = monitorIdForScreen(wallpaper.Get(), *request.screen);
+
+  const std::wstring path = std::filesystem::path(request.path).wstring();
+
+  hr = wallpaper->SetWallpaper(monitorId ? monitorId->c_str() : nullptr, path.c_str());
+  if (FAILED(hr)) return std::unexpected("failed to set wallpaper: " + hresultMessage(hr));
+
+  hr = wallpaper->SetPosition(positionForFit(request.fit));
+  if (FAILED(hr)) return std::unexpected("failed to set wallpaper position: " + hresultMessage(hr));
+
+  return {};
+}
+
+} // namespace
+
+QFuture<std::expected<void, std::string>>
+WindowsWallpaperBackend::setWallpaper(const WallpaperRequest &request) {
+  return QtConcurrent::run(apply, request);
+}

--- a/src/server/src/services/wallpaper/windows/windows-wallpaper-backend.hpp
+++ b/src/server/src/services/wallpaper/windows/windows-wallpaper-backend.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include "services/wallpaper/abstract-wallpaper-backend.hpp"
+
+// Sets the wallpaper through the shell's IDesktopWallpaper (Windows 8+).
+// On Windows 11, only the current virtual workspace is modified.
+// On previous versions of Windows, all workspaces share the same wallpaper.
+class WindowsWallpaperBackend : public AbstractWallpaperBackend {
+public:
+  std::string id() const override { return "windows"; }
+  bool isActivatable() const override { return true; }
+  bool supportsPerScreen() const override { return true; }
+  QFuture<std::expected<void, std::string>> setWallpaper(const WallpaperRequest &request) override;
+};


### PR DESCRIPTION
Similarly to macOS, it is not possible to set the wallpaper for all virtual workspaces at once on Windows (the only way to do it is to rely on unstable private APIs)
