### PR TITLE
fix(hyprpaper): remove deprecated and migrate to current syntax

### DIFF
--- a/src/server/src/services/wallpaper/hyprpaper/hyprpaper-wallpaper-backend.cpp
+++ b/src/server/src/services/wallpaper/hyprpaper/hyprpaper-wallpaper-backend.cpp
@@ -9,11 +9,13 @@ namespace {
 QString modePrefix(WallpaperFit fit) {
   switch (fit) {
   case WallpaperFit::Contain:
-    return "contain:";
+    return "contain";
   case WallpaperFit::Tile:
-    return "tile:";
+    return "tile";
   case WallpaperFit::Cover:
+    return "cover";
   case WallpaperFit::Stretch:
+    return "fill";
   case WallpaperFit::Center:
     return "";
   }
@@ -24,7 +26,7 @@ QString modePrefix(WallpaperFit fit) {
 
 bool HyprpaperWallpaperBackend::isActivatable() const {
   return !QStandardPaths::findExecutable("hyprctl").isEmpty() &&
-         wallpaper::runCommand("hyprctl", {"hyprpaper", "listloaded"}).has_value();
+         wallpaper::runCommand("hyprctl", {"hyprpaper", "listactive"}).has_value();
 }
 
 QFuture<std::expected<void, std::string>>
@@ -32,12 +34,9 @@ HyprpaperWallpaperBackend::setWallpaper(const WallpaperRequest &request) {
   return QtConcurrent::run([request]() -> std::expected<void, std::string> {
     const QString path = QString::fromStdString(request.path);
 
-    if (auto preload = wallpaper::runCommand("hyprctl", {"hyprpaper", "preload", path}); !preload) {
-      return std::unexpected(preload.error());
-    }
 
     const QString monitor = request.screen ? QString::fromStdString(*request.screen) : QString{};
-    const QString spec = QString{"%1,%2%3"}.arg(monitor, modePrefix(request.fit), path);
+    const QString spec = QString{"%1,%2,%3"}.arg(monitor, path, modePrefix(request.fit));
 
     if (auto res = wallpaper::runCommand("hyprctl", {"hyprpaper", "wallpaper", spec}); !res) {
       return std::unexpected(res.error());

--- a/src/server/src/services/wallpaper/hyprpaper/hyprpaper-wallpaper-backend.cpp
+++ b/src/server/src/services/wallpaper/hyprpaper/hyprpaper-wallpaper-backend.cpp
@@ -34,7 +34,6 @@ HyprpaperWallpaperBackend::setWallpaper(const WallpaperRequest &request) {
   return QtConcurrent::run([request]() -> std::expected<void, std::string> {
     const QString path = QString::fromStdString(request.path);
 
-
     const QString monitor = request.screen ? QString::fromStdString(*request.screen) : QString{};
     const QString spec = QString{"%1,%2,%3"}.arg(monitor, path, modePrefix(request.fit));
 


### PR DESCRIPTION
migrates to latest hyprpaper syntax and removes deprecated checking.

written according to [hyprpaper documentation](https://wiki.hypr.land/Hypr-Ecosystem/hyprpaper/)


tested on on hyprpaper v0.8.4 and hyprctl version
```
Hyprland 0.55.0 built from branch unknown at commit 55ce25bd67ab6f2ae7d60883f6c626be7d2ee12f dirty (unknown).
Date: 2026-07-18
Tag: v0.55.0, commits: 0

Libraries:
Hyprgraphics: built against 0.5.1, system has unknown
Hyprutils: built against 0.13.1, system has unknown
Hyprcursor: built against 0.1.13, system has unknown
Hyprlang: built against 0.6.8, system has unknown
Aquamarine: built against 0.12.1, system has unknown

Version ABI string: 55ce25bd67ab6f2ae7d60883f6c626be7d2ee12f_aq_0.12_hu_0.13_hg_0.5_hc_0.1_hlg_0.6
flags set:
nix
```