### PR TITLE
feat: root search history

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -325,6 +325,7 @@ set(SRCS
 	src/services/file-chooser/file-chooser-service.cpp
 	src/services/root-item-manager/root-item-manager.hpp
 	src/services/root-item-manager/root-item-manager.cpp
+	src/services/root-item-manager/search-history.cpp
 	src/services/root-item-manager/visit-tracker.cpp
 	
 	src/services/app-service/app-service.hpp

--- a/src/server/src/actions/root-search/root-search-actions.cpp
+++ b/src/server/src/actions/root-search/root-search-actions.cpp
@@ -80,22 +80,6 @@ void ToggleItemAsFavorite::execute(ApplicationContext *ctx) {
 ToggleItemAsFavorite::ToggleItemAsFavorite(const EntrypointId &id, bool currentValue)
     : m_id(id), m_value(currentValue) {}
 
-void DefaultActionWrapper::execute(ApplicationContext *ctx) {
-  // auto manager = ctx->services->rootItemManager();
-  // auto q = ctx->navigation->searchText().toStdString();
-
-  // if (!manager->registerVisit(m_id, q)) { qWarning() << "Failed to register root item visit"; }
-
-  m_action->execute(ctx);
-}
-
-QString DefaultActionWrapper::title() const { return m_action->title(); }
-
-DefaultActionWrapper::DefaultActionWrapper(const EntrypointId &id, AbstractAction *action)
-    : AbstractAction(action->title(), action->icon()), m_id(id), m_action(action) {
-  setAutoClose(action->autoClose());
-}
-
 void DisableItemAction::execute(ApplicationContext *ctx) {
   auto alert = new CallbackAlertWidget();
 

--- a/src/server/src/actions/root-search/root-search-actions.cpp
+++ b/src/server/src/actions/root-search/root-search-actions.cpp
@@ -81,12 +81,10 @@ ToggleItemAsFavorite::ToggleItemAsFavorite(const EntrypointId &id, bool currentV
     : m_id(id), m_value(currentValue) {}
 
 void DefaultActionWrapper::execute(ApplicationContext *ctx) {
-  auto manager = ctx->services->rootItemManager();
+  // auto manager = ctx->services->rootItemManager();
+  // auto q = ctx->navigation->searchText().toStdString();
 
-  if (manager->registerVisit(m_id)) {
-  } else {
-    qWarning() << "Failed to register root item visit";
-  }
+  // if (!manager->registerVisit(m_id, q)) { qWarning() << "Failed to register root item visit"; }
 
   m_action->execute(ctx);
 }

--- a/src/server/src/actions/root-search/root-search-actions.hpp
+++ b/src/server/src/actions/root-search/root-search-actions.hpp
@@ -78,21 +78,6 @@ public:
   DisableApplication(const EntrypointId &itemId) : DisableItemAction(itemId) {}
 };
 
-/**
- * Wrapper for the main action of a root item, automatically recording execution.
- */
-class DefaultActionWrapper : public AbstractAction {
-  EntrypointId m_id;
-  std::unique_ptr<AbstractAction> m_action;
-
-  void execute(ApplicationContext *context) override;
-
-public:
-  QString title() const override;
-
-  DefaultActionWrapper(const EntrypointId &id, AbstractAction *action);
-};
-
 class SetRootItemAliasAction : public AbstractAction {
 public:
   QString title() const override { return "Set alias"; }

--- a/src/server/src/navigation-controller.cpp
+++ b/src/server/src/navigation-controller.cpp
@@ -427,6 +427,8 @@ void NavigationController::executeActionNow(AbstractAction *action) {
   auto state = topState();
   if (!state) return;
 
+  state->sender->beforeActionExecuted(action);
+
   if (action->isSubmenu()) {
     openActionPanel();
     return;

--- a/src/server/src/navigation-controller.cpp
+++ b/src/server/src/navigation-controller.cpp
@@ -605,6 +605,10 @@ bool NavigationController::activateEntrypoint(const EntrypointId &id,
 
   popToRoot({.clearSearch = false});
 
+  // programmatic activation bypasses the action execution funnel, so the view hook
+  // never fires for it: register the visit explicitly.
+  m_ctx.services->rootItemManager()->registerVisit(id);
+
   // FIXME: we need a unified interface for this
   if (auto *ext = dynamic_cast<const CommandRootItem *>(entrypoint)) {
     launch(ext->command(), options.props);

--- a/src/server/src/qml/launcher-window.cpp
+++ b/src/server/src/qml/launcher-window.cpp
@@ -350,6 +350,14 @@ bool LauncherWindow::eventFilter(QObject *obj, QEvent *event) {
     if (ke->modifiers().testFlag(Qt::KeypadModifier)) {
       ke->setModifiers(ke->modifiers() & ~Qt::KeypadModifier);
     }
+    // the current view host gets first pick at any key press, unless a component
+    // that owns the keyboard (overlay, alert, action panel) is up.
+    const bool viewOwnsInput =
+        !m_hasOverlay && !m_alertModel->visible() && !m_actionPanel->isOpen() && !m_footerPanel->isOpen();
+    if (viewOwnsInput) {
+      auto *host = dynamic_cast<ViewHostBase *>(m_commandViewHost);
+      if (host && host->inputFilter(ke)) return true;
+    }
     // unmodified keys (return included) belong to the focused component: forwarding
     // them globally would steal text input or returns meant for local widgets such as
     // text areas, overlays or the opened action panel.

--- a/src/server/src/qml/root-search-model.cpp
+++ b/src/server/src/qml/root-search-model.cpp
@@ -1,8 +1,6 @@
 #include "root-search-model.hpp"
 #include "config/config.hpp"
 #include "services/calculator-service/abstract-calculator-backend.hpp"
-#include "ui/action-pannel/action-panel-view.hpp"
-#include "ui/views/base-view.hpp"
 #include "service-registry.hpp"
 #include "services/app-service/app-service.hpp"
 #include "services/calculator-service/calculator-service.hpp"
@@ -201,6 +199,15 @@ void RootSearchModel::setSelectedIndex(int index) {
 
     if (!createdCompleter) scope().destroyCurrentCompletion();
   }
+}
+
+const RootItem *RootSearchModel::selectedRootItem() const {
+  int sourceIdx = -1;
+  int itemIdx = -1;
+  if (!dataItemAt(selectedIndex(), sourceIdx, itemIdx)) return nullptr;
+
+  auto *section = dynamic_cast<const RootItemSection *>(sources()[sourceIdx]);
+  return section ? section->rootItem(itemIdx) : nullptr;
 }
 
 bool RootSearchModel::tryAliasFastTrack() {

--- a/src/server/src/qml/root-search-model.hpp
+++ b/src/server/src/qml/root-search-model.hpp
@@ -29,6 +29,8 @@ public:
   void setSelectedIndex(int index) override;
   Q_INVOKABLE bool tryAliasFastTrack();
 
+  const RootItem *selectedRootItem() const;
+
 private:
   void refresh();
   bool rerunSearch();

--- a/src/server/src/qml/root-search-sources.cpp
+++ b/src/server/src/qml/root-search-sources.cpp
@@ -451,3 +451,8 @@ std::unique_ptr<ActionPanelState> RootFallbackSection::actionPanel(int i) const 
   return m_items[i]->fallbackActionPanel(scope().appContext(),
                                          m_manager->itemMetadata(m_items[i]->uniqueId()));
 }
+
+const RootItem *RootFallbackSection::rootItem(int i) const {
+  if (std::cmp_greater_equal(i, m_items.size())) return nullptr;
+  return m_items[i].get();
+}

--- a/src/server/src/qml/root-search-sources.hpp
+++ b/src/server/src/qml/root-search-sources.hpp
@@ -47,6 +47,11 @@ QString resolveAccessoryColor(const std::optional<ColorLike> &color);
 
 } // namespace root_search
 
+class RootItemSection : public SectionSource {
+public:
+  virtual const RootItem *rootItem(int i) const = 0;
+};
+
 class RootLinkSection : public SectionSource {
 public:
   QString sectionName() const override { return QStringLiteral("Link"); }
@@ -126,7 +131,7 @@ private:
   std::vector<const NewsItem *> m_items;
 };
 
-class RootFavoritesSection : public SectionSource {
+class RootFavoritesSection : public RootItemSection {
 public:
   explicit RootFavoritesSection(RootItemManager *mgr) : m_manager(mgr) {}
 
@@ -142,14 +147,14 @@ public:
   std::unique_ptr<ActionPanelState> actionPanel(int i) const override;
 
   void setItems(std::vector<std::shared_ptr<RootItem>> items) { m_items = std::move(items); }
-  const RootItem *rootItem(int i) const;
+  const RootItem *rootItem(int i) const override;
 
 private:
   RootItemManager *m_manager;
   std::vector<std::shared_ptr<RootItem>> m_items;
 };
 
-class RootResultsSection : public SectionSource {
+class RootResultsSection : public RootItemSection {
 public:
   explicit RootResultsSection(RootItemManager *mgr) : m_manager(mgr) {}
 
@@ -166,7 +171,7 @@ public:
 
   void setItems(std::vector<OwnedResult> items) { m_items = std::move(items); }
   void setQueryEmpty(bool empty) { m_queryEmpty = empty; }
-  const RootItem *rootItem(int i) const;
+  const RootItem *rootItem(int i) const override;
 
 private:
   RootItemManager *m_manager;
@@ -196,7 +201,7 @@ private:
   std::vector<IndexerFileResult> m_files;
 };
 
-class RootFallbackSection : public SectionSource {
+class RootFallbackSection : public RootItemSection {
 public:
   explicit RootFallbackSection(RootItemManager *mgr) : m_manager(mgr) {}
 
@@ -213,6 +218,7 @@ public:
 
   void setItems(std::vector<std::shared_ptr<RootItem>> items) { m_items = std::move(items); }
   void setQuery(std::string query) { m_query = std::move(query); }
+  const RootItem *rootItem(int i) const override;
 
 private:
   RootItemManager *m_manager;

--- a/src/server/src/qml/root-view-host.cpp
+++ b/src/server/src/qml/root-view-host.cpp
@@ -46,7 +46,7 @@ void RootViewHost::beforeActionExecuted(const AbstractAction *action) {
 bool RootViewHost::inputFilter(QKeyEvent *event) {
   auto manager = context()->services->rootItemManager();
   auto &nav = context()->navigation;
-  // wrapped navigation is incompatible with overriding key up, so we disable history for them
+  // wrapped navigation is incompatible with overriding key up, so we disable history in that case
   const bool activatableHistory = !context()->services->config()->value().wrapNavigation &&
                                   m_model->selectedIndex() == m_model->nextSelectableIndex(-1, 1);
   const bool shouldCycleHistory = !event->modifiers() && event->key() == Qt::Key_Up && activatableHistory;
@@ -58,9 +58,17 @@ bool RootViewHost::inputFilter(QKeyEvent *event) {
       *m_historyOffset += 1;
     }
 
-    if (auto history = manager->searchHistory().at(*m_historyOffset)) {
+    auto entry = manager->searchHistory().at(*m_historyOffset);
+
+    // skip entry if it's already our search text, we don't care
+    while (entry && QString::fromStdString(entry->q) == nav->searchText()) {
+      *m_historyOffset += 1;
+      entry = manager->searchHistory().at(*m_historyOffset);
+    }
+
+    if (entry) {
       m_textChangedByHistory = true;
-      nav->setSearchText(QString::fromStdString(history->q));
+      nav->setSearchText(QString::fromStdString(entry->q));
       m_textChangedByHistory = false;
     }
 

--- a/src/server/src/qml/root-view-host.cpp
+++ b/src/server/src/qml/root-view-host.cpp
@@ -1,6 +1,7 @@
 #include "root-view-host.hpp"
 #include "root-search-model.hpp"
 #include "section-source.hpp"
+#include "services/keybinding/keybinding-service.hpp"
 #include "view-scope.hpp"
 #include <qevent.h>
 
@@ -46,10 +47,13 @@ void RootViewHost::beforeActionExecuted(const AbstractAction *action) {
 bool RootViewHost::inputFilter(QKeyEvent *event) {
   auto manager = context()->services->rootItemManager();
   auto &nav = context()->navigation;
+  auto &cfg = context()->services->config()->value();
+
   // wrapped navigation is incompatible with overriding key up, so we disable history in that case
-  const bool activatableHistory = !context()->services->config()->value().wrapNavigation &&
-                                  m_model->selectedIndex() == m_model->nextSelectableIndex(-1, 1);
-  const bool shouldCycleHistory = !event->modifiers() && event->key() == Qt::Key_Up && activatableHistory;
+  const bool activatableHistory =
+      !cfg.wrapNavigation && m_model->selectedIndex() == m_model->nextSelectableIndex(-1, 1);
+  const bool shouldCycleHistory =
+      (event->key() == Qt::Key_Up || KeyBindingService::isUpKey(event, cfg.keybinding)) && activatableHistory;
 
   if (shouldCycleHistory) {
     if (!m_historyOffset) {

--- a/src/server/src/qml/root-view-host.cpp
+++ b/src/server/src/qml/root-view-host.cpp
@@ -2,6 +2,7 @@
 #include "root-search-model.hpp"
 #include "section-source.hpp"
 #include "view-scope.hpp"
+#include <qevent.h>
 
 void RootViewHost::initialize() {
   using namespace std::chrono_literals;
@@ -10,37 +11,71 @@ void RootViewHost::initialize() {
   m_model = new RootSearchModel(ViewScope(context(), this), this);
   m_clockTimer->setInterval(1min);
   m_clockTimer->start();
-
-  auto refreshClock = [this]() {
-    QLocale locale;
-    QString timeStr = locale.toString(QTime::currentTime(), QLocale::ShortFormat);
-    ViewScope scope(context(), this);
-    scope.setNavigationTitle(timeStr);
-  };
-
   refreshClock();
 
-  connect(m_clockTimer, &QTimer::timeout, this, refreshClock);
-
+  connect(m_clockTimer, &QTimer::timeout, this, &RootViewHost::refreshClock);
   connect(m_model, &SectionListModel::itemSelected, this, [this](SectionSource *source, int itemIdx) {
     if (auto panel = source->actionPanel(itemIdx))
       setActions(std::move(panel));
     else
       clearActions();
   });
-
   connect(m_model, &SectionListModel::selectionCleared, this, [this]() { clearActions(); });
 
   m_model->setFilter({});
 }
 
+void RootViewHost::refreshClock() {
+  QLocale locale;
+  QString timeStr = locale.toString(QTime::currentTime(), QLocale::ShortFormat);
+  ViewScope scope(context(), this);
+  scope.setNavigationTitle(timeStr);
+}
+
 QUrl RootViewHost::qmlComponentUrl() const { return QUrl(QStringLiteral("qrc:/Vicinae/RootSearchList.qml")); }
+
+void RootViewHost::beforeActionExecuted(const AbstractAction *action) {
+  auto manager = context()->services->rootItemManager();
+  auto text = context()->navigation->searchText(this);
+
+  manager->searchHistory().add(text.toStdString());
+
+  if (auto item = m_model->selectedRootItem()) { manager->registerVisit(item->uniqueId()); }
+}
+
+bool RootViewHost::inputFilter(QKeyEvent *event) {
+  auto manager = context()->services->rootItemManager();
+  auto &nav = context()->navigation;
+  // wrapped navigation is incompatible with overriding key up, so we disable history for them
+  const bool activatableHistory = !context()->services->config()->value().wrapNavigation &&
+                                  m_model->selectedIndex() == m_model->nextSelectableIndex(-1, 1);
+  const bool shouldCycleHistory = !event->modifiers() && event->key() == Qt::Key_Up && activatableHistory;
+
+  if (shouldCycleHistory) {
+    if (!m_historyOffset) {
+      m_historyOffset = 0;
+    } else {
+      *m_historyOffset += 1;
+    }
+
+    if (auto history = manager->searchHistory().at(*m_historyOffset)) {
+      m_textChangedByHistory = true;
+      nav->setSearchText(QString::fromStdString(history->q));
+      m_textChangedByHistory = false;
+    }
+
+    return true;
+  }
+
+  return false;
+}
 
 QVariantMap RootViewHost::qmlProperties() {
   return {{QStringLiteral("cmdModel"), QVariant::fromValue(static_cast<QObject *>(m_model))}};
 }
 
 void RootViewHost::textChanged(const QString &text) {
+  if (!m_textChangedByHistory) { m_historyOffset.reset(); }
   if (m_model) m_model->setFilter(text);
 }
 

--- a/src/server/src/qml/root-view-host.hpp
+++ b/src/server/src/qml/root-view-host.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "bridge-view.hpp"
+#include "ui/action-pannel/action.hpp"
 #include <qtimer.h>
 
 class RootSearchModel;
@@ -22,7 +23,14 @@ public:
   QObject *listModel() const;
   Q_INVOKABLE bool tryAliasFastTrack();
 
+protected:
+  bool inputFilter(QKeyEvent *) override;
+  void refreshClock();
+  void beforeActionExecuted(const AbstractAction *action) override;
+
 private:
+  bool m_textChangedByHistory = false;
+  std::optional<int> m_historyOffset;
   QTimer *m_clockTimer = new QTimer(this);
   RootSearchModel *m_model = nullptr;
 };

--- a/src/server/src/root-search/apps/app-root-provider.cpp
+++ b/src/server/src/root-search/apps/app-root-provider.cpp
@@ -83,10 +83,10 @@ std::unique_ptr<ActionPanelState> AppRootItem::newActionPanel(ApplicationContext
   if (!activeWindows.empty()) {
     auto focus = new FocusWindowAction(activeWindows.front());
     if (defaultAction == "focus") {
-      mainSection->addAction(new DefaultActionWrapper(uniqueId(), focus));
+      mainSection->addAction(focus);
       mainSection->addAction(open);
     } else {
-      mainSection->addAction(new DefaultActionWrapper(uniqueId(), open));
+      mainSection->addAction(open);
       mainSection->addAction(focus);
     }
 
@@ -97,7 +97,7 @@ std::unique_ptr<ActionPanelState> AppRootItem::newActionPanel(ApplicationContext
     }
     mainSection->addAction(new CloseWindowAction(activeWindows.front()));
   } else {
-    mainSection->addAction(new DefaultActionWrapper(uniqueId(), open));
+    mainSection->addAction(open);
   }
 
   auto actions = m_app->actions();

--- a/src/server/src/root-search/control-panel/control-panel-root-provider.cpp
+++ b/src/server/src/root-search/control-panel/control-panel-root-provider.cpp
@@ -196,7 +196,7 @@ WinControlPanelRootItem::newActionPanel(ApplicationContext *ctx, const RootItemM
 
   const QString target = "shell:" + m_applet.parsingName;
   auto open = new OpenControlPanelItemAction("Open Applet", iconUrl(), target);
-  mainSection->addAction(new DefaultActionWrapper(uniqueId(), open));
+  mainSection->addAction(open);
 
   utils->addAction(new CopyToClipboardAction(Clipboard::Text(target), "Copy Path"));
 
@@ -235,7 +235,7 @@ WinControlPanelTaskRootItem::newActionPanel(ApplicationContext *ctx, const RootI
   auto itemSection = panel->createSection();
 
   auto open = new OpenControlPanelTaskAction("Open", iconUrl(), m_task.pidl);
-  mainSection->addAction(new DefaultActionWrapper(uniqueId(), open));
+  mainSection->addAction(open);
 
   for (const auto &action : RootSearchActionGenerator::generateActions(*this, metadata)) {
     itemSection->addAction(action);

--- a/src/server/src/root-search/extensions/extension-root-provider.cpp
+++ b/src/server/src/root-search/extensions/extension-root-provider.cpp
@@ -36,7 +36,7 @@ std::unique_ptr<ActionPanelState> CommandRootItem::newActionPanel(ApplicationCon
   auto extensionSection = panel->createSection();
   auto dangerSection = panel->createSection();
 
-  mainSection->addAction(new DefaultActionWrapper(uniqueId(), open));
+  mainSection->addAction(open);
 
   for (const auto action : RootSearchActionGenerator::generateActions(*this, metadata)) {
     itemSection->addAction(action);

--- a/src/server/src/root-search/scripts/script-root-provider.hpp
+++ b/src/server/src/root-search/scripts/script-root-provider.hpp
@@ -79,7 +79,7 @@ class ScriptRootItem : public RootItem {
     auto exec = new ScriptExecutorAction(m_file);
     auto extraSection = panel->createSection();
 
-    section->addAction(new DefaultActionWrapper(uniqueId(), exec));
+    section->addAction(exec);
 
     if (editor) {
       auto open = new OpenFileAction(m_file->path(), editor);

--- a/src/server/src/root-search/shortcuts/shortcut-root-provider.cpp
+++ b/src/server/src/root-search/shortcuts/shortcut-root-provider.cpp
@@ -33,7 +33,7 @@ std::unique_ptr<ActionPanelState> RootShortcutItem::newActionPanel(ApplicationCo
   remove->setShortcut(Keybind::DangerousRemoveAction);
 
   panel->setTitle(m_link->name());
-  mainSection->addAction(new DefaultActionWrapper(uniqueId(), open));
+  mainSection->addAction(open);
   mainSection->addAction(openWith);
   mainSection->addAction(copy);
 

--- a/src/server/src/root-search/windows-settings/windows-settings-root-provider.cpp
+++ b/src/server/src/root-search/windows-settings/windows-settings-root-provider.cpp
@@ -195,7 +195,7 @@ WinSettingsPageRootItem::newActionPanel(ApplicationContext *ctx, const RootItemM
 
   auto open = new OpenWindowsSettingAction(QString("Open %1 Settings").arg(m_page.title), iconUrl(),
                                            QString::fromUtf8(m_page.url));
-  mainSection->addAction(new DefaultActionWrapper(uniqueId(), open));
+  mainSection->addAction(open);
 
   utils->addAction(new CopyToClipboardAction(Clipboard::Text(m_page.url), "Copy URL"));
 

--- a/src/server/src/services/root-item-manager/root-item-manager.cpp
+++ b/src/server/src/services/root-item-manager/root-item-manager.cpp
@@ -14,7 +14,8 @@
 #include "vicinae.hpp"
 
 RootItemManager::RootItemManager(config::Manager &cfg, LocalStorageService &storage)
-    : m_cfg(cfg), m_storage(storage), m_visitTracker(Omnicast::dataDir() / "metadata.json") {
+    : m_cfg(cfg), m_storage(storage), m_visitTracker(Omnicast::dataDir() / "metadata.json"),
+      m_searchHistory(Omnicast::dataDir() / "search-history.json") {
   connect(&cfg, &config::Manager::configChanged, this, [this](const config::ConfigValue &next) {
     mergeConfigWithMetadata(next);
     qDebug() << "configuration changed";

--- a/src/server/src/services/root-item-manager/root-item-manager.hpp
+++ b/src/server/src/services/root-item-manager/root-item-manager.hpp
@@ -6,6 +6,7 @@
 #include "navigation-controller.hpp"
 #include "services/local-storage/local-storage-service.hpp"
 #include "services/local-storage/scoped-local-storage.hpp"
+#include "services/root-item-manager/search-history.hpp"
 #include "services/root-item-manager/visit-tracker.hpp"
 #include "ui/image/url.hpp"
 #include "preference.hpp"
@@ -290,6 +291,7 @@ public:
   std::vector<std::shared_ptr<RootItem>> queryFavorites(std::optional<int> limit = {});
   bool resetRanking(const EntrypointId &id);
   bool registerVisit(const EntrypointId &id);
+  SearchHistory &searchHistory() { return m_searchHistory; }
   bool setItemAsFavorite(const EntrypointId &item, bool value = true);
   bool setProviderEnabled(const QString &providerId, bool value);
   bool disableItem(const EntrypointId &id);
@@ -359,4 +361,5 @@ private:
   LocalStorageService &m_storage;
   std::vector<SearchableRootItem> m_items;
   VisitTracker m_visitTracker;
+  SearchHistory m_searchHistory;
 };

--- a/src/server/src/services/root-item-manager/search-history.cpp
+++ b/src/server/src/services/root-item-manager/search-history.cpp
@@ -1,0 +1,44 @@
+#include "services/root-item-manager/search-history.hpp"
+#include <glaze/json/read.hpp>
+#include <glaze/json/write.hpp>
+#include <utility>
+#include <qlogging.h>
+#include <QDateTime>
+
+namespace fs = std::filesystem;
+
+namespace {
+constexpr auto MAX_HISTORY_SIZE = 1000;
+}
+
+SearchHistory::SearchHistory(const fs::path &path) : m_path(path) { loadFromDisk(); }
+
+void SearchHistory::add(std::string_view q) {
+  if (q.empty()) return;
+
+  std::erase_if(m_data.entries, [&](const Entry &entry) { return entry.q == q; });
+  m_data.entries.emplace_front(
+      Entry{.q = std::string{q}, .ts = static_cast<std::uint64_t>(QDateTime::currentSecsSinceEpoch())});
+  if (m_data.entries.size() > MAX_HISTORY_SIZE) { m_data.entries.resize(MAX_HISTORY_SIZE); }
+
+  saveToDisk();
+}
+
+std::optional<SearchHistory::Entry> SearchHistory::at(int offset) const {
+  if (offset < 0 || std::cmp_greater_equal(offset, m_data.entries.size())) return std::nullopt;
+  return m_data.entries[offset];
+}
+
+void SearchHistory::loadFromDisk() {
+  if (!fs::exists(m_path)) return;
+
+  if (auto error = glz::read_file_jsonc(m_data, m_path.string(), m_buf)) {
+    qWarning() << "Failed to load search history from" << m_path.string().c_str() << glz::format_error(error);
+  }
+}
+
+void SearchHistory::saveToDisk() {
+  if (auto error = glz::write_file_json(m_data, m_path.string(), m_buf)) {
+    qWarning() << "Failed to save search history to" << m_path.string().c_str() << glz::format_error(error);
+  }
+}

--- a/src/server/src/services/root-item-manager/search-history.hpp
+++ b/src/server/src/services/root-item-manager/search-history.hpp
@@ -1,0 +1,32 @@
+#pragma once
+#include <cstdint>
+#include <deque>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+
+class SearchHistory {
+public:
+  struct Entry {
+    std::string q;
+    std::uint64_t ts = 0;
+  };
+
+  explicit SearchHistory(const std::filesystem::path &path);
+
+  void add(std::string_view q);
+  std::optional<Entry> at(int offset) const;
+
+private:
+  struct Data {
+    std::deque<Entry> entries;
+  };
+
+  void loadFromDisk();
+  void saveToDisk();
+
+  std::filesystem::path m_path;
+  std::string m_buf;
+  Data m_data;
+};

--- a/src/server/src/services/root-item-manager/visit-tracker.cpp
+++ b/src/server/src/services/root-item-manager/visit-tracker.cpp
@@ -14,7 +14,6 @@ void VisitTracker::registerVisit(const EntrypointId &id) {
   VisitInfo &data = m_data.visited[id];
   data.lastVisitedAt = QDateTime::currentSecsSinceEpoch();
   ++data.visitCount;
-  // todo: we might want to flush ever X seconds instead of saving directly
   saveToDisk();
 }
 

--- a/src/server/src/services/root-item-manager/visit-tracker.hpp
+++ b/src/server/src/services/root-item-manager/visit-tracker.hpp
@@ -1,8 +1,8 @@
 #pragma once
-#include "common/entrypoint.hpp"
 #include <cstdint>
 #include <unordered_map>
 #include <filesystem>
+#include "common/entrypoint.hpp"
 
 class VisitTracker {
 public:

--- a/src/server/src/ui/views/base-view.hpp
+++ b/src/server/src/ui/views/base-view.hpp
@@ -2,6 +2,7 @@
 #include "argument.hpp"
 #include "command-controller.hpp"
 #include "common.hpp"
+#include "ui/action-pannel/action.hpp"
 #include <QObject>
 #include <vector>
 
@@ -44,6 +45,7 @@ public:
   virtual void argumentValuesChanged(const std::vector<std::pair<QString, QString>> &arguments) {}
 
   virtual void textChanged(const QString &text);
+  virtual void beforeActionExecuted(const AbstractAction *action) {}
 
   QString navigationTitle() const;
 


### PR DESCRIPTION
Accumulate history as items are activated in root search. Pressing the up navigation key when on top of the root search will cycle through previous entries.

fixes #1337 