### PR TITLE
fix: use wire list item ID for extension lists

### DIFF
--- a/src/server/src/qml/extension-list-model.cpp
+++ b/src/server/src/qml/extension-list-model.cpp
@@ -47,6 +47,8 @@ void ExtensionListSection::onSelected(int i) {
   if (m_onItemSelected) m_onItemSelected(&itemAt(i));
 }
 
+QString ExtensionListSection::itemId(int i) const { return QString::fromStdString(itemAt(i).id); }
+
 QString ExtensionListSection::itemTitle(int i) const { return QString::fromStdString(itemAt(i).title); }
 
 QString ExtensionListSection::itemSubtitle(int i) const { return QString::fromStdString(itemAt(i).subtitle); }
@@ -135,9 +137,9 @@ void ExtensionListModel::setExtensionData(const ListModel &model, bool resetSele
     refreshActionPanel();
   }
 
-  refreshCurrentDetail();
-
   if (wasShowingDetail != m_model.isShowingDetail) emit isShowingDetailChanged();
+
+  refreshCurrentDetail();
 
   emit emptyViewChanged();
 }

--- a/src/server/src/qml/extension-list-model.hpp
+++ b/src/server/src/qml/extension-list-model.hpp
@@ -29,6 +29,7 @@ public:
   const ListItemViewModel &itemAt(int i) const;
 
 protected:
+  QString itemId(int i) const override;
   QString itemTitle(int i) const override;
   QString itemSubtitle(int i) const override;
   QString itemIconSource(int i) const override;


### PR DESCRIPTION
We were using the item title as a unique key to identity list items which is obviously incorrect as duplicates can easily occur. This makes sure we use the `itemId` already communicated on the wire, which is explicitly designed for that purpose.

fixes #1629