### PR TITLE
fix: use list shortcut preset for extension detail views

### DIFF
--- a/src/server/src/qml/extension-view-host.cpp
+++ b/src/server/src/qml/extension-view-host.cpp
@@ -327,7 +327,8 @@ void ExtensionViewHost::renderDetail(const RootDetailModel &model) {
   detail->actions = model.actions;
   if (model.actions) {
     auto notify = [this](const QString &handler, const QJsonArray &args) { notifyExtension(handler, args); };
-    setActions(ExtensionActionPanelBuilder::build(*model.actions, notify));
+    setActions(
+        ExtensionActionPanelBuilder::build(*model.actions, notify, ActionPanelState::ShortcutPreset::List));
   }
 }
 


### PR DESCRIPTION
No shortcut preset was set to build the detail action panel, resulting in the primary action not being activatable using return.