### PR TITLE
feat(macos): migrate global shortcut backend to use a tap

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -642,6 +642,8 @@ if (APPLE)
 		src/root-search/macos-settings/macos-settings-root-provider.mm
 		src/services/global-shortcuts/macos-global-shortcut-backend.hpp
 		src/services/global-shortcuts/macos-global-shortcut-backend.cpp
+		src/internal/keyboard/keyboard-macos.hpp
+		src/internal/keyboard/keyboard-macos.cpp
 		src/services/files-service/macos/spotlight-file-indexer.hpp
 		src/services/files-service/macos/spotlight-file-indexer.mm
 		src/services/tray/macos/tray-service-macos.hpp

--- a/src/server/src/internal/keyboard/keyboard-macos.cpp
+++ b/src/server/src/internal/keyboard/keyboard-macos.cpp
@@ -1,0 +1,104 @@
+#include "keyboard-macos.hpp"
+#include "keyboard.hpp"
+
+#include <array>
+
+namespace Keyboard::macos {
+
+QString translateKeycode(CFDataRef layoutData, uint16_t keycode, bool shifted, uint8_t kbdType) {
+  if (!layoutData) { return {}; }
+
+  const auto *layout = reinterpret_cast<const UCKeyboardLayout *>(CFDataGetBytePtr(layoutData));
+  const UInt32 modifierState = shifted ? ((shiftKey >> 8) & 0xFF) : 0;
+  UInt32 deadKeyState = 0;
+  std::array<UniChar, 4> chars{};
+  UniCharCount length = 0;
+
+  if (UCKeyTranslate(layout, keycode, kUCKeyActionDown, modifierState, kbdType, kUCKeyTranslateNoDeadKeysBit,
+                     &deadKeyState, chars.size(), &length, chars.data()) != noErr) {
+    return {};
+  }
+
+  return QString::fromUtf16(reinterpret_cast<const char16_t *>(chars.data()), static_cast<qsizetype>(length))
+      .toLower();
+}
+
+namespace {
+
+CFDataRef copyLayoutDataById(CFStringRef id) {
+  CFMutableDictionaryRef filter = CFDictionaryCreateMutable(
+      kCFAllocatorDefault, 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+  CFDictionarySetValue(filter, kTISPropertyInputSourceID, id);
+  CFArrayRef list = TISCreateInputSourceList(filter, true);
+  CFRelease(filter);
+  if (!list) { return nullptr; }
+
+  CFDataRef data = nullptr;
+  if (CFArrayGetCount(list) > 0) {
+    auto source = static_cast<TISInputSourceRef>(const_cast<void *>(CFArrayGetValueAtIndex(list, 0)));
+    data = static_cast<CFDataRef>(TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData));
+    if (data) { CFRetain(data); }
+  }
+  CFRelease(list);
+  return data;
+}
+
+} // namespace
+
+CFDataRef copyCurrentLayoutData() {
+  TISInputSourceRef source = TISCopyCurrentKeyboardLayoutInputSource();
+  if (!source) { return nullptr; }
+
+  auto data = static_cast<CFDataRef>(TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData));
+  if (data) { CFRetain(data); }
+  CFRelease(source);
+  return data;
+}
+
+CFDataRef copyQwertyLayoutData() {
+  if (CFDataRef data = copyLayoutDataById(CFSTR("com.apple.keylayout.US"))) { return data; }
+  return copyLayoutDataById(CFSTR("com.apple.keylayout.ABC"));
+}
+
+} // namespace Keyboard::macos
+
+namespace {
+
+constexpr uint16_t MAX_KEYCODE = 127;
+
+std::optional<uint16_t> keycodeForChar(CFDataRef layoutData, const QString &character, uint8_t kbdType) {
+  for (const bool shifted : {false, true}) {
+    for (uint16_t keycode = 0; keycode <= MAX_KEYCODE; ++keycode) {
+      if (Keyboard::macos::translateKeycode(layoutData, keycode, shifted, kbdType) == character) {
+        return keycode;
+      }
+    }
+  }
+  return std::nullopt;
+}
+
+} // namespace
+
+Qt::Key Keyboard::normalizeToLatin(Qt::Key key) {
+  const auto ch = printableCharForKey(key);
+  if (!ch) { return key; }
+  if (ch->script() == QChar::Script_Latin || ch->script() == QChar::Script_Common) { return key; }
+
+  const uint8_t kbdType = LMGetKbdType();
+
+  CFDataRef current = macos::copyCurrentLayoutData();
+  const auto keycode = keycodeForChar(current, QString(ch->toLower()), kbdType);
+  if (current) { CFRelease(current); }
+  if (!keycode) { return key; }
+
+  CFDataRef qwerty = macos::copyQwertyLayoutData();
+  const QString latin = macos::translateKeycode(qwerty, *keycode, false, kbdType);
+  if (qwerty) { CFRelease(qwerty); }
+
+  if (latin.size() != 1) { return key; }
+
+  const QChar latinChar = latin.front().toUpper();
+  if (!latinChar.isPrint() || latinChar.isSpace()) { return key; }
+
+  return static_cast<Qt::Key>(latinChar.unicode());
+}

--- a/src/server/src/internal/keyboard/keyboard-macos.cpp
+++ b/src/server/src/internal/keyboard/keyboard-macos.cpp
@@ -25,6 +25,9 @@ QString translateKeycode(CFDataRef layoutData, uint16_t keycode, bool shifted, u
 
 namespace {
 
+const CFStringRef US_LAYOUT_ID = CFSTR("com.apple.keylayout.US");
+const CFStringRef ABC_LAYOUT_ID = CFSTR("com.apple.keylayout.ABC");
+
 CFDataRef copyLayoutDataById(CFStringRef id) {
   CFMutableDictionaryRef filter = CFDictionaryCreateMutable(
       kCFAllocatorDefault, 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
@@ -56,8 +59,8 @@ CFDataRef copyCurrentLayoutData() {
 }
 
 CFDataRef copyQwertyLayoutData() {
-  if (CFDataRef data = copyLayoutDataById(CFSTR("com.apple.keylayout.US"))) { return data; }
-  return copyLayoutDataById(CFSTR("com.apple.keylayout.ABC"));
+  if (CFDataRef data = copyLayoutDataById(US_LAYOUT_ID)) { return data; }
+  return copyLayoutDataById(ABC_LAYOUT_ID);
 }
 
 } // namespace Keyboard::macos

--- a/src/server/src/internal/keyboard/keyboard-macos.hpp
+++ b/src/server/src/internal/keyboard/keyboard-macos.hpp
@@ -1,0 +1,22 @@
+#pragma once
+// Keep AssertMacros from defining bare check()/verify()/require(), which collide with Qt and the STL.
+#define __ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES 0
+#include <Carbon/Carbon.h>
+
+#include <QString>
+
+// Shared keyboard-layout helpers for the shortcut recorder normalization and the global shortcut
+// backend. Both sides must translate identically or recorded shortcuts drift from match-time.
+namespace Keyboard::macos {
+
+// Lowercased character(s) the key at `keycode` types under `layoutData`
+// (kTISPropertyUnicodeKeyLayoutData bytes). Empty on failure or null layout.
+QString translateKeycode(CFDataRef layoutData, uint16_t keycode, bool shifted, uint8_t kbdType);
+
+// Layout data of the active keyboard layout. Caller releases.
+CFDataRef copyCurrentLayoutData();
+
+// Layout data of US QWERTY, falling back to ABC when US is not installed. Caller releases.
+CFDataRef copyQwertyLayoutData();
+
+} // namespace Keyboard::macos

--- a/src/server/src/internal/keyboard/keyboard-macos.hpp
+++ b/src/server/src/internal/keyboard/keyboard-macos.hpp
@@ -5,18 +5,17 @@
 
 #include <QString>
 
-// Shared keyboard-layout helpers for the shortcut recorder normalization and the global shortcut
-// backend. Both sides must translate identically or recorded shortcuts drift from match-time.
+// Layout helpers shared by recorder normalization and the global shortcut backend, so both
+// sides translate identically.
 namespace Keyboard::macos {
 
-// Lowercased character(s) the key at `keycode` types under `layoutData`
-// (kTISPropertyUnicodeKeyLayoutData bytes). Empty on failure or null layout.
+// Lowercased character(s) the key types under `layoutData` (kTISPropertyUnicodeKeyLayoutData bytes).
 QString translateKeycode(CFDataRef layoutData, uint16_t keycode, bool shifted, uint8_t kbdType);
 
-// Layout data of the active keyboard layout. Caller releases.
+// Caller releases.
 CFDataRef copyCurrentLayoutData();
 
-// Layout data of US QWERTY, falling back to ABC when US is not installed. Caller releases.
+// US QWERTY, ABC when US is not installed. Caller releases.
 CFDataRef copyQwertyLayoutData();
 
 } // namespace Keyboard::macos

--- a/src/server/src/internal/keyboard/keyboard.cpp
+++ b/src/server/src/internal/keyboard/keyboard.cpp
@@ -146,7 +146,6 @@ namespace Keyboard {
 Qt::Key normalizeToLatin(Qt::Key key) { return key; }
 #endif
 
-// Qt::Key values below the special-key range are the uppercase code point of the typed char.
 std::optional<QChar> printableCharForKey(Qt::Key key) {
   const auto code = static_cast<uint32_t>(key);
   if (code >= 0x10000) return {};

--- a/src/server/src/internal/keyboard/keyboard.cpp
+++ b/src/server/src/internal/keyboard/keyboard.cpp
@@ -96,6 +96,18 @@ static const std::unordered_map<QString, Qt::Key> keyMap = [](){
 		{"f10", Qt::Key_F10},
 		{"f11", Qt::Key_F11},
 		{"f12", Qt::Key_F12},
+		{"f13", Qt::Key_F13},
+		{"f14", Qt::Key_F14},
+		{"f15", Qt::Key_F15},
+		{"f16", Qt::Key_F16},
+		{"f17", Qt::Key_F17},
+		{"f18", Qt::Key_F18},
+		{"f19", Qt::Key_F19},
+		{"f20", Qt::Key_F20},
+		{"f21", Qt::Key_F21},
+		{"f22", Qt::Key_F22},
+		{"f23", Qt::Key_F23},
+		{"f24", Qt::Key_F24},
 	};
 }();
 
@@ -130,14 +142,36 @@ static const std::unordered_map<QString, Qt::KeyboardModifier> modifierMap = {
 
 namespace Keyboard {
 
+#ifndef Q_OS_MACOS
+Qt::Key normalizeToLatin(Qt::Key key) { return key; }
+#endif
+
+// Qt::Key values below the special-key range are the uppercase code point of the typed char.
+std::optional<QChar> printableCharForKey(Qt::Key key) {
+  const auto code = static_cast<uint32_t>(key);
+  if (code >= 0x10000) return {};
+
+  const QChar ch(static_cast<char16_t>(code));
+  if (!ch.isPrint() || ch.isSpace()) return {};
+
+  return ch;
+}
+
 std::optional<QString> stringForKey(Qt::Key key) {
   if (auto it = keyMapReverse.find(key); it != keyMapReverse.end()) return it->second;
+  if (auto ch = printableCharForKey(key)) return QString(ch->toLower());
   return {};
 }
 
 std::optional<Qt::Key> keyFromString(QStringView key) {
   auto keyString = key.toString().toLower();
   if (auto it = keyMap.find(keyString); it != keyMap.end()) return it->second;
+
+  if (keyString.size() == 1) {
+    const auto candidate = static_cast<Qt::Key>(keyString.front().toUpper().unicode());
+    if (printableCharForKey(candidate)) return candidate;
+  }
+
   return {};
 }
 
@@ -275,7 +309,8 @@ std::vector<DisplayTokenSpec> buildDisplayTokenSpecs(const Shortcut &shortcut) {
 } // namespace
 
 Shortcut::Shortcut(const QKeyEvent *event)
-    : m_key(static_cast<Qt::Key>(event->key())), m_modifiers(event->modifiers()), m_isValid(true) {}
+    : m_key(normalizeToLatin(static_cast<Qt::Key>(event->key()))), m_modifiers(event->modifiers()),
+      m_isValid(true) {}
 
 Shortcut Shortcut::fromKeyPress(const QKeyEvent &event) { return Shortcut(&event); }
 

--- a/src/server/src/internal/keyboard/keyboard.hpp
+++ b/src/server/src/internal/keyboard/keyboard.hpp
@@ -15,8 +15,7 @@ namespace Keyboard {
 // so recorded shortcuts stay layout-independent. Identity for Latin keys and non-macOS platforms.
 Qt::Key normalizeToLatin(Qt::Key key);
 
-// The typed character for keys below the special-key range (whose Qt::Key value is the uppercase
-// code point), or nullopt for named/special keys.
+// Typed character for keys whose Qt::Key value is its uppercase code point, nullopt for named keys.
 std::optional<QChar> printableCharForKey(Qt::Key key);
 
 std::optional<QString> stringForKey(Qt::Key key);

--- a/src/server/src/internal/keyboard/keyboard.hpp
+++ b/src/server/src/internal/keyboard/keyboard.hpp
@@ -2,6 +2,7 @@
 // We use our own shortcut stuff by design, instead of using QShortcut and the likes.
 #include <optional>
 #include <vector>
+#include <QChar>
 #include <QStringView>
 #include <QVariantList>
 #include <qnamespace.h>
@@ -10,6 +11,14 @@
 class QKeyEvent;
 
 namespace Keyboard {
+// Maps a non-Latin character key (e.g Cyrillic) to the Latin key at the same physical position,
+// so recorded shortcuts stay layout-independent. Identity for Latin keys and non-macOS platforms.
+Qt::Key normalizeToLatin(Qt::Key key);
+
+// The typed character for keys below the special-key range (whose Qt::Key value is the uppercase
+// code point), or nullopt for named/special keys.
+std::optional<QChar> printableCharForKey(Qt::Key key);
+
 std::optional<QString> stringForKey(Qt::Key key);
 std::optional<Qt::Key> keyFromString(QStringView key);
 std::optional<Qt::KeyboardModifier> modifierFromString(QStringView modifier);
@@ -47,7 +56,7 @@ public:
   std::vector<Qt::KeyboardModifier> modList() const;
 
   bool isValidKey() const { return stringForKey(m_key).has_value(); }
-  bool isFunctionKey() const { return m_key >= Qt::Key_F1 && m_key <= Qt::Key_F12; }
+  bool isFunctionKey() const { return m_key >= Qt::Key_F1 && m_key <= Qt::Key_F24; }
 
   // The keyboard shortcut as a string.
   // This form is used to serialize shortcut data in config files/database.

--- a/src/server/src/qml/keyboard-bridge.hpp
+++ b/src/server/src/qml/keyboard-bridge.hpp
@@ -19,6 +19,10 @@ public:
 
   int physicalCtrlModifier() const { return static_cast<int>(KeyBindingService::PHYSICAL_CTRL); }
 
+  Q_INVOKABLE int normalizeKey(int key) const {
+    return static_cast<int>(Keyboard::normalizeToLatin(static_cast<Qt::Key>(key)));
+  }
+
   Q_INVOKABLE QString serialize(int key, int modifiers) const {
     Keyboard::Shortcut const shortcut(static_cast<Qt::Key>(key),
                                       static_cast<Qt::KeyboardModifiers>(modifiers));

--- a/src/server/src/qml/qml/ShortcutRecorderField.qml
+++ b/src/server/src/qml/qml/ShortcutRecorderField.qml
@@ -90,7 +90,7 @@ Popup {
             event.accepted = true;
             closeTimer.stop();
 
-            var key = event.key;
+            var key = Keyboard.normalizeKey(event.key);
             var mods = event.modifiers;
 
             var isModKey = key === Qt.Key_Shift || key === Qt.Key_Control || key === Qt.Key_Alt || key === Qt.Key_Meta;

--- a/src/server/src/services/global-shortcuts/macos-global-shortcut-backend.cpp
+++ b/src/server/src/services/global-shortcuts/macos-global-shortcut-backend.cpp
@@ -10,6 +10,7 @@ namespace {
 
 constexpr uint64_t MODIFIER_MASK =
     kCGEventFlagMaskCommand | kCGEventFlagMaskControl | kCGEventFlagMaskAlternate | kCGEventFlagMaskShift;
+constexpr int PERMISSION_RETRY_INTERVAL_MS = 2000;
 
 std::optional<uint32_t> staticKeycodeForQtKey(Qt::Key key) {
   switch (key) {
@@ -152,7 +153,7 @@ bool MacOSGlobalShortcutBackend::start() {
   startTapThread();
 
   if (!AXIsProcessTrusted()) {
-    m_permissionRetryTimer.setInterval(2000);
+    m_permissionRetryTimer.setInterval(PERMISSION_RETRY_INTERVAL_MS);
     connect(&m_permissionRetryTimer, &QTimer::timeout, this, [this]() {
       if (!AXIsProcessTrusted()) return;
       m_permissionRetryTimer.stop();
@@ -283,8 +284,7 @@ bool MacOSGlobalShortcutBackend::handleKeyDown(uint32_t keycode, uint64_t rawFla
       candidates[0] = Keyboard::macos::translateKeycode(active, code, false, m_kbdType);
       // shortcuts can hold a shifted char (e.g ':' recorded on layouts where it is Shift+';')
       if (shift) { candidates[1] = Keyboard::macos::translateKeycode(active, code, true, m_kbdType); }
-      // QWERTY fallback so Latin shortcuts keep firing while a non-Latin layout is active,
-      // mirroring how native macOS key equivalents behave
+      // QWERTY fallback keeps Latin shortcuts firing while a non-Latin layout is active
       candidates[2] = Keyboard::macos::translateKeycode(qwerty, code, false, m_kbdType);
       if (shift) { candidates[3] = Keyboard::macos::translateKeycode(qwerty, code, true, m_kbdType); }
     }

--- a/src/server/src/services/global-shortcuts/macos-global-shortcut-backend.cpp
+++ b/src/server/src/services/global-shortcuts/macos-global-shortcut-backend.cpp
@@ -1,87 +1,18 @@
 #include "services/global-shortcuts/macos-global-shortcut-backend.hpp"
+#include "keyboard/keyboard-macos.hpp"
 
-// Keep AssertMacros from defining bare check()/verify()/require(), which collide with Qt and the STL.
-#define __ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES 0
-#include <Carbon/Carbon.h>
+#include <algorithm>
+#include <array>
+#include <QChar>
+#include <QDebug>
 
 namespace {
 
-constexpr OSType HOT_KEY_SIGNATURE = 'vici';
+constexpr uint64_t MODIFIER_MASK =
+    kCGEventFlagMaskCommand | kCGEventFlagMaskControl | kCGEventFlagMaskAlternate | kCGEventFlagMaskShift;
 
-std::optional<uint32_t> macVirtualKeyForQtKey(Qt::Key key) {
+std::optional<uint32_t> staticKeycodeForQtKey(Qt::Key key) {
   switch (key) {
-  case Qt::Key_A:
-    return kVK_ANSI_A;
-  case Qt::Key_B:
-    return kVK_ANSI_B;
-  case Qt::Key_C:
-    return kVK_ANSI_C;
-  case Qt::Key_D:
-    return kVK_ANSI_D;
-  case Qt::Key_E:
-    return kVK_ANSI_E;
-  case Qt::Key_F:
-    return kVK_ANSI_F;
-  case Qt::Key_G:
-    return kVK_ANSI_G;
-  case Qt::Key_H:
-    return kVK_ANSI_H;
-  case Qt::Key_I:
-    return kVK_ANSI_I;
-  case Qt::Key_J:
-    return kVK_ANSI_J;
-  case Qt::Key_K:
-    return kVK_ANSI_K;
-  case Qt::Key_L:
-    return kVK_ANSI_L;
-  case Qt::Key_M:
-    return kVK_ANSI_M;
-  case Qt::Key_N:
-    return kVK_ANSI_N;
-  case Qt::Key_O:
-    return kVK_ANSI_O;
-  case Qt::Key_P:
-    return kVK_ANSI_P;
-  case Qt::Key_Q:
-    return kVK_ANSI_Q;
-  case Qt::Key_R:
-    return kVK_ANSI_R;
-  case Qt::Key_S:
-    return kVK_ANSI_S;
-  case Qt::Key_T:
-    return kVK_ANSI_T;
-  case Qt::Key_U:
-    return kVK_ANSI_U;
-  case Qt::Key_V:
-    return kVK_ANSI_V;
-  case Qt::Key_W:
-    return kVK_ANSI_W;
-  case Qt::Key_X:
-    return kVK_ANSI_X;
-  case Qt::Key_Y:
-    return kVK_ANSI_Y;
-  case Qt::Key_Z:
-    return kVK_ANSI_Z;
-  case Qt::Key_0:
-    return kVK_ANSI_0;
-  case Qt::Key_1:
-    return kVK_ANSI_1;
-  case Qt::Key_2:
-    return kVK_ANSI_2;
-  case Qt::Key_3:
-    return kVK_ANSI_3;
-  case Qt::Key_4:
-    return kVK_ANSI_4;
-  case Qt::Key_5:
-    return kVK_ANSI_5;
-  case Qt::Key_6:
-    return kVK_ANSI_6;
-  case Qt::Key_7:
-    return kVK_ANSI_7;
-  case Qt::Key_8:
-    return kVK_ANSI_8;
-  case Qt::Key_9:
-    return kVK_ANSI_9;
   case Qt::Key_Space:
     return kVK_Space;
   case Qt::Key_Return:
@@ -112,28 +43,6 @@ std::optional<uint32_t> macVirtualKeyForQtKey(Qt::Key key) {
     return kVK_UpArrow;
   case Qt::Key_Down:
     return kVK_DownArrow;
-  case Qt::Key_Minus:
-    return kVK_ANSI_Minus;
-  case Qt::Key_Equal:
-    return kVK_ANSI_Equal;
-  case Qt::Key_BracketLeft:
-    return kVK_ANSI_LeftBracket;
-  case Qt::Key_BracketRight:
-    return kVK_ANSI_RightBracket;
-  case Qt::Key_Backslash:
-    return kVK_ANSI_Backslash;
-  case Qt::Key_Semicolon:
-    return kVK_ANSI_Semicolon;
-  case Qt::Key_Apostrophe:
-    return kVK_ANSI_Quote;
-  case Qt::Key_Comma:
-    return kVK_ANSI_Comma;
-  case Qt::Key_Period:
-    return kVK_ANSI_Period;
-  case Qt::Key_Slash:
-    return kVK_ANSI_Slash;
-  case Qt::Key_QuoteLeft:
-    return kVK_ANSI_Grave;
   case Qt::Key_F1:
     return kVK_F1;
   case Qt::Key_F2:
@@ -158,100 +67,244 @@ std::optional<uint32_t> macVirtualKeyForQtKey(Qt::Key key) {
     return kVK_F11;
   case Qt::Key_F12:
     return kVK_F12;
+  case Qt::Key_F13:
+    return kVK_F13;
+  case Qt::Key_F14:
+    return kVK_F14;
+  case Qt::Key_F15:
+    return kVK_F15;
+  case Qt::Key_F16:
+    return kVK_F16;
+  case Qt::Key_F17:
+    return kVK_F17;
+  case Qt::Key_F18:
+    return kVK_F18;
+  case Qt::Key_F19:
+    return kVK_F19;
+  case Qt::Key_F20:
+    return kVK_F20;
   default:
     return std::nullopt;
   }
 }
 
 // On macOS Qt swaps Ctrl/Meta: ControlModifier is the Cmd key, MetaModifier is the Control key.
-uint32_t carbonModifiers(Qt::KeyboardModifiers mods) {
-  uint32_t carbon = 0;
-  if (mods.testFlag(Qt::ControlModifier)) { carbon |= cmdKey; }
-  if (mods.testFlag(Qt::MetaModifier)) { carbon |= controlKey; }
-  if (mods.testFlag(Qt::AltModifier)) { carbon |= optionKey; }
-  if (mods.testFlag(Qt::ShiftModifier)) { carbon |= shiftKey; }
-  return carbon;
+uint64_t cgFlagsForQtModifiers(Qt::KeyboardModifiers mods) {
+  uint64_t flags = 0;
+  if (mods.testFlag(Qt::ControlModifier)) { flags |= kCGEventFlagMaskCommand; }
+  if (mods.testFlag(Qt::MetaModifier)) { flags |= kCGEventFlagMaskControl; }
+  if (mods.testFlag(Qt::AltModifier)) { flags |= kCGEventFlagMaskAlternate; }
+  if (mods.testFlag(Qt::ShiftModifier)) { flags |= kCGEventFlagMaskShift; }
+  return flags;
 }
 
-OSStatus hotKeyHandler(EventHandlerCallRef, EventRef event, void *userData) {
-  EventHotKeyID hotKeyId{};
-  if (GetEventParameter(event, kEventParamDirectObject, typeEventHotKeyID, nullptr, sizeof(hotKeyId), nullptr,
-                        &hotKeyId) != noErr) {
-    return eventNotHandledErr;
-  }
+CGEventRef tapCallback(CGEventTapProxy, CGEventType type, CGEventRef event, void *refcon) {
+  auto *self = static_cast<MacOSGlobalShortcutBackend *>(refcon);
 
-  const auto timestamp = static_cast<quint64>(GetEventTime(event) * 1000.0);
-  static_cast<MacOSGlobalShortcutBackend *>(userData)->handleHotKey(hotKeyId.id, timestamp);
-  return noErr;
+  if (type == kCGEventTapDisabledByTimeout || type == kCGEventTapDisabledByUserInput) {
+    self->reenableTap();
+    return event;
+  }
+  if (type != kCGEventKeyDown) { return event; }
+
+  const auto keycode = static_cast<uint32_t>(CGEventGetIntegerValueField(event, kCGKeyboardEventKeycode));
+  const bool autorepeat = CGEventGetIntegerValueField(event, kCGKeyboardEventAutorepeat) != 0;
+  const quint64 timestamp = CGEventGetTimestamp(event) / 1'000'000; // ns -> ms
+
+  if (self->handleKeyDown(keycode, CGEventGetFlags(event), autorepeat, timestamp)) { return nullptr; }
+  return event;
+}
+
+void layoutChangedCallback(CFNotificationCenterRef, void *observer, CFNotificationName, const void *,
+                           CFDictionaryRef) {
+  static_cast<MacOSGlobalShortcutBackend *>(observer)->refreshLayout();
 }
 
 } // namespace
 
-MacOSGlobalShortcutBackend::MacOSGlobalShortcutBackend() = default;
+MacOSGlobalShortcutBackend::MacOSGlobalShortcutBackend() { m_bindings.reserve(8); }
 
 MacOSGlobalShortcutBackend::~MacOSGlobalShortcutBackend() {
-  for (auto &[id, binding] : m_bindings) {
-    if (binding.ref) { UnregisterEventHotKey(static_cast<EventHotKeyRef>(binding.ref)); }
+  CFNotificationCenterRemoveObserver(CFNotificationCenterGetDistributedCenter(), this,
+                                     kTISNotifySelectedKeyboardInputSourceChanged, nullptr);
+
+  if (void *loop = m_runLoop.load()) { CFRunLoopStop(static_cast<CFRunLoopRef>(loop)); }
+  if (m_thread.joinable()) { m_thread.join(); }
+
+  std::lock_guard lock(m_mutex);
+  if (m_layoutData) {
+    CFRelease(m_layoutData);
+    m_layoutData = nullptr;
   }
-  if (m_handler) { RemoveEventHandler(static_cast<EventHandlerRef>(m_handler)); }
+  if (m_qwertyLayoutData) {
+    CFRelease(m_qwertyLayoutData);
+    m_qwertyLayoutData = nullptr;
+  }
 }
 
 bool MacOSGlobalShortcutBackend::start() {
   if (m_started) { return true; }
 
-  const EventTypeSpec spec{kEventClassKeyboard, kEventHotKeyPressed};
-  EventHandlerRef handlerRef = nullptr;
-  if (InstallApplicationEventHandler(&hotKeyHandler, 1, &spec, this, &handlerRef) != noErr) { return false; }
+  refreshLayout();
+  CFNotificationCenterAddObserver(CFNotificationCenterGetDistributedCenter(), this, &layoutChangedCallback,
+                                  kTISNotifySelectedKeyboardInputSourceChanged, nullptr,
+                                  CFNotificationSuspensionBehaviorDeliverImmediately);
+  startTapThread();
 
-  m_handler = handlerRef;
+  if (!AXIsProcessTrusted()) {
+    m_permissionRetryTimer.setInterval(2000);
+    connect(&m_permissionRetryTimer, &QTimer::timeout, this, [this]() {
+      if (!AXIsProcessTrusted()) return;
+      m_permissionRetryTimer.stop();
+      ensureTapRunning();
+    });
+    m_permissionRetryTimer.start();
+  }
+
   m_started = true;
   emit ready();
   return true;
 }
 
+// The tap gets its own run loop thread so a busy Qt main loop can't get it disabled by timeout.
+void MacOSGlobalShortcutBackend::startTapThread() {
+  m_tapThreadDone = false;
+  m_thread = std::thread([this]() {
+    runTap();
+    m_tapThreadDone = true;
+  });
+}
+
+void MacOSGlobalShortcutBackend::ensureTapRunning() {
+  if (!m_tapThreadDone) return;
+  if (m_thread.joinable()) m_thread.join();
+  startTapThread();
+}
+
+void MacOSGlobalShortcutBackend::runTap() {
+  const CGEventMask mask = CGEventMaskBit(kCGEventKeyDown);
+
+  CFMachPortRef tap = CGEventTapCreate(kCGSessionEventTap, kCGHeadInsertEventTap, kCGEventTapOptionDefault,
+                                       mask, tapCallback, this);
+
+  if (!tap) {
+    qWarning()
+        << "MacOSGlobalShortcutBackend: failed to create event tap (accessibility permission missing?)";
+    return;
+  }
+
+  CFRunLoopSourceRef source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0);
+  CFRunLoopAddSource(CFRunLoopGetCurrent(), source, kCFRunLoopCommonModes);
+  CGEventTapEnable(tap, true);
+
+  m_tap = tap;
+  m_runLoop = CFRunLoopGetCurrent();
+
+  CFRunLoopRun();
+
+  m_runLoop = nullptr;
+  CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, kCFRunLoopCommonModes);
+  CFRelease(source);
+  CFRelease(tap);
+  m_tap = nullptr;
+}
+
+void MacOSGlobalShortcutBackend::reenableTap() {
+  if (m_tap) { CGEventTapEnable(static_cast<CFMachPortRef>(m_tap), true); }
+}
+
+void MacOSGlobalShortcutBackend::refreshLayout() {
+  CFDataRef data = Keyboard::macos::copyCurrentLayoutData();
+
+  std::lock_guard lock(m_mutex);
+  if (m_layoutData) { CFRelease(m_layoutData); }
+  m_layoutData = data;
+  m_kbdType = LMGetKbdType();
+
+  if (!m_qwertyLayoutData) { m_qwertyLayoutData = Keyboard::macos::copyQwertyLayoutData(); }
+}
+
 std::expected<void, QString> MacOSGlobalShortcutBackend::bindShortcut(const GlobalShortcutRequest &request) {
   unbindShortcut(request.id);
 
-  const auto keyCode = macVirtualKeyForQtKey(request.trigger.key());
-  if (!keyCode) { return std::unexpected(QStringLiteral("unsupported or invalid trigger")); }
+  Binding binding{.id = request.id, .flags = cgFlagsForQtModifiers(request.trigger.mods())};
 
-  const uint32_t carbonId = m_nextCarbonId++;
-  const EventHotKeyID hotKeyId{.signature = HOT_KEY_SIGNATURE, .id = carbonId};
-  EventHotKeyRef ref = nullptr;
-  const OSStatus status = RegisterEventHotKey(*keyCode, carbonModifiers(request.trigger.mods()), hotKeyId,
-                                              GetApplicationEventTarget(), 0, &ref);
-
-  if (status != noErr || !ref) {
-    return std::unexpected(QStringLiteral("RegisterEventHotKey failed (%1)").arg(status));
+  if (const auto keycode = staticKeycodeForQtKey(request.trigger.key())) {
+    binding.keycode = *keycode;
+  } else if (const auto character = Keyboard::printableCharForKey(request.trigger.key())) {
+    binding.character = QString(character->toLower());
+  } else {
+    return std::unexpected(QStringLiteral("unsupported or invalid trigger"));
   }
 
-  m_bindings.emplace(request.id, Binding{.ref = ref, .carbonId = carbonId});
-  m_idByCarbonId.emplace(carbonId, request.id);
+  std::lock_guard lock(m_mutex);
+  m_bindings.emplace_back(std::move(binding));
   return {};
 }
 
 void MacOSGlobalShortcutBackend::unbindShortcut(const QString &id) {
-  const auto it = m_bindings.find(id);
-  if (it == m_bindings.end()) { return; }
-
-  if (it->second.ref) {
-    UnregisterEventHotKey(static_cast<EventHotKeyRef>(it->second.ref));
-    m_idByCarbonId.erase(it->second.carbonId);
-  }
-
-  m_bindings.erase(it);
+  std::lock_guard lock(m_mutex);
+  std::erase_if(m_bindings, [&](const Binding &binding) { return binding.id == id; });
 }
 
 void MacOSGlobalShortcutBackend::unbindAll() {
-  for (auto &[id, binding] : m_bindings) {
-    if (binding.ref) { UnregisterEventHotKey(static_cast<EventHotKeyRef>(binding.ref)); }
-  }
+  std::lock_guard lock(m_mutex);
   m_bindings.clear();
-  m_idByCarbonId.clear();
 }
 
-void MacOSGlobalShortcutBackend::handleHotKey(uint32_t carbonId, quint64 timestamp) {
-  if (const auto it = m_idByCarbonId.find(carbonId); it != m_idByCarbonId.end()) {
-    emit shortcutActivated(it->second, timestamp);
+bool MacOSGlobalShortcutBackend::handleKeyDown(uint32_t keycode, uint64_t rawFlags, bool autorepeat,
+                                               quint64 timestamp) {
+  const uint64_t flags = rawFlags & MODIFIER_MASK;
+
+  std::lock_guard lock(m_mutex);
+  if (m_bindings.empty()) { return false; }
+
+  const Binding *match = nullptr;
+  std::array<QString, 4> candidates;
+  bool translated = false;
+
+  for (const auto &binding : m_bindings) {
+    if (binding.flags != flags) { continue; }
+
+    if (binding.keycode) {
+      if (*binding.keycode == keycode) {
+        match = &binding;
+        break;
+      }
+      continue;
+    }
+
+    if (!translated) {
+      translated = true;
+      const bool shift = (flags & kCGEventFlagMaskShift) != 0;
+      const auto active = static_cast<CFDataRef>(m_layoutData);
+      const auto qwerty = static_cast<CFDataRef>(m_qwertyLayoutData);
+      const auto code = static_cast<uint16_t>(keycode);
+      candidates[0] = Keyboard::macos::translateKeycode(active, code, false, m_kbdType);
+      // shortcuts can hold a shifted char (e.g ':' recorded on layouts where it is Shift+';')
+      if (shift) { candidates[1] = Keyboard::macos::translateKeycode(active, code, true, m_kbdType); }
+      // QWERTY fallback so Latin shortcuts keep firing while a non-Latin layout is active,
+      // mirroring how native macOS key equivalents behave
+      candidates[2] = Keyboard::macos::translateKeycode(qwerty, code, false, m_kbdType);
+      if (shift) { candidates[3] = Keyboard::macos::translateKeycode(qwerty, code, true, m_kbdType); }
+    }
+
+    const bool matches = std::ranges::any_of(candidates, [&](const QString &candidate) {
+      return !candidate.isEmpty() && binding.character == candidate;
+    });
+
+    if (matches) {
+      match = &binding;
+      break;
+    }
   }
+
+  if (!match) { return false; }
+
+  if (!autorepeat) {
+    const QString id = match->id;
+    QMetaObject::invokeMethod(
+        this, [this, id, timestamp]() { emit shortcutActivated(id, timestamp); }, Qt::QueuedConnection);
+  }
+  return true;
 }

--- a/src/server/src/services/global-shortcuts/macos-global-shortcut-backend.hpp
+++ b/src/server/src/services/global-shortcuts/macos-global-shortcut-backend.hpp
@@ -1,11 +1,17 @@
 #pragma once
+#include <atomic>
 #include <cstdint>
 #include <expected>
-#include <unordered_map>
+#include <mutex>
+#include <optional>
+#include <thread>
+#include <vector>
+#include <QTimer>
 #include "services/global-shortcuts/abstract-global-shortcut-backend.hpp"
 
-// Global shortcuts on macOS via Carbon RegisterEventHotKey. Carbon types stay out of this header
-// (opaque void *) so plain C++ translation units can include it.
+// Global shortcuts on macOS via a CGEventTap. Character keys are matched by translating the incoming
+// keycode through the active layout, so shortcuts follow the character across layouts. CF/CG types
+// stay out of this header (opaque void *) so plain C++ translation units can include it.
 class MacOSGlobalShortcutBackend : public AbstractGlobalShortcutBackend {
   Q_OBJECT
 
@@ -13,24 +19,42 @@ public:
   MacOSGlobalShortcutBackend();
   ~MacOSGlobalShortcutBackend() override;
 
-  QString id() const override { return "carbon"; }
+  QString id() const override { return "event-tap"; }
 
   bool start() override;
   std::expected<void, QString> bindShortcut(const GlobalShortcutRequest &request) override;
   void unbindShortcut(const QString &id) override;
   void unbindAll() override;
 
-  void handleHotKey(uint32_t carbonId, quint64 timestamp);
+  // called from the tap thread
+  bool handleKeyDown(uint32_t keycode, uint64_t flags, bool autorepeat, quint64 timestamp);
+  void reenableTap();
+
+  // called on the main thread when the keyboard layout changes
+  void refreshLayout();
 
 private:
   struct Binding {
-    void *ref = nullptr; // EventHotKeyRef
-    uint32_t carbonId = 0;
+    QString id;
+    std::optional<uint32_t> keycode;
+    QString character;
+    uint64_t flags = 0;
   };
 
-  std::unordered_map<QString, Binding> m_bindings;
-  std::unordered_map<uint32_t, QString> m_idByCarbonId;
-  void *m_handler = nullptr; // EventHandlerRef
-  uint32_t m_nextCarbonId = 1;
+  void startTapThread();
+  void ensureTapRunning();
+  void runTap();
+
+  std::vector<Binding> m_bindings;          // guarded by m_mutex
+  const void *m_layoutData = nullptr;       // CFDataRef, guarded by m_mutex
+  const void *m_qwertyLayoutData = nullptr; // CFDataRef, guarded by m_mutex
+  uint8_t m_kbdType = 0;                    // guarded by m_mutex
+  mutable std::mutex m_mutex;
+
+  std::thread m_thread;
+  std::atomic<void *> m_runLoop = nullptr;
+  std::atomic<bool> m_tapThreadDone = false;
+  void *m_tap = nullptr; // CFMachPortRef, tap thread only
+  QTimer m_permissionRetryTimer;
   bool m_started = false;
 };


### PR DESCRIPTION
We now use a keyboard event tap in order to implement the global shortcut backend on macOS.

The main reason is that this allows us to bind more complex shortcuts that can't be handled by the Carbon API. This also makes it easier to match shortcuts against the current keyboard layout, or fallback to QWERTY for non latin scripts.

This will also enable the use of an "hyper key" or similar concept in the future.

fixes #1705 
fixes #1678