### PR TITLE
feat(macos): make accessibility permission mandatory

### DIFF
--- a/src/server/src/qml/onboarding-window.cpp
+++ b/src/server/src/qml/onboarding-window.cpp
@@ -19,6 +19,7 @@
 #include "macos-chrome-attached.hpp"
 #include "services/autostart/macos-login-item.hpp"
 #include "services/permissions/macos-permission-service.hpp"
+#include <ApplicationServices/ApplicationServices.h>
 #endif
 
 struct OnboardingState {
@@ -45,7 +46,9 @@ OnboardingWindow::OnboardingWindow(ApplicationContext &ctx, QObject *parent) : Q
 
 bool OnboardingWindow::shouldShow() {
 #if defined(Q_OS_MACOS) && defined(ENABLE_ONBOARDING)
-  return completedVersion() < ONBOARDING_VERSION;
+  // Accessibility is a hard requirement (global shortcuts, paste, snippets); if it was revoked we
+  // run the onboarding again until it's back.
+  return completedVersion() < ONBOARDING_VERSION || !AXIsProcessTrusted();
 #else
   return false;
 #endif
@@ -82,6 +85,11 @@ void OnboardingWindow::openUrl(const QString &url) { m_ctx.services->appDb()->op
 void OnboardingWindow::show() {
   ensureInitialized();
   if (!m_window) return;
+
+  // Returning users only ever land here because accessibility went missing: skip the intro.
+  constexpr int PERMISSION_STEP = 1;
+  if (completedVersion() >= ONBOARDING_VERSION) { m_window->setProperty("step", PERMISSION_STEP); }
+
   m_window->show();
   m_window->raise();
   m_window->requestActivate();

--- a/src/server/src/qml/qml/OnboardingWindow.qml
+++ b/src/server/src/qml/qml/OnboardingWindow.qml
@@ -10,6 +10,8 @@ Window {
     readonly property bool accessibilityGranted: Permissions.accessibilityGranted
 
     function advance() {
+        if (root.onPermissionStep && !root.accessibilityGranted)
+            return;
         if (root.step === root.stepCount - 1) {
             onboarding.finish();
             return;
@@ -153,8 +155,8 @@ Window {
 
                         SettingsGroup {
                             PermissionRow {
-                                label: "Accessibility"
-                                description: "Used to paste, expand snippets, and move windows."
+                                label: `Accessibility <font color="${Theme.danger}">*</font>`
+                                description: "Powers global shortcuts, paste, snippet expansion, and window management."
                                 iconSource: Img.system("accessibility").withFillColor(Theme.foreground)
                                 granted: root.accessibilityGranted
                                 onGrant: Permissions.requestAccessibility()
@@ -182,7 +184,7 @@ Window {
 
                         Text {
                             visible: !root.accessibilityGranted || !Permissions.fullDiskAccessGranted
-                            text: "If you skip this step, macOS may prompt you for some of these permissions later. Full disk access needs to be explicitly enabled if you want file search to cover all your files."
+                            text: !root.accessibilityGranted ? "Accessibility is required: global shortcuts, paste, and snippet expansion cannot work without it." : "Full disk access needs to be explicitly enabled if you want file search to cover all your files."
                             color: Theme.textMuted
                             font.pointSize: Theme.smallerFontSize
                             wrapMode: Text.Wrap
@@ -357,7 +359,11 @@ Window {
                                 anchors.margins: -5
                                 hoverEnabled: true
                                 cursorShape: Qt.PointingHandCursor
-                                onClicked: root.step = index
+                                onClicked: {
+                                    if (index > 1 && !root.accessibilityGranted)
+                                        return;
+                                    root.step = index;
+                                }
                             }
                         }
                     }
@@ -367,14 +373,10 @@ Window {
                     id: nextButton
                     anchors.right: parent.right
                     anchors.verticalCenter: parent.verticalCenter
-                    text: {
-                        if (root.step === root.stepCount - 1)
-                            return "Finish";
-                        if (root.onPermissionStep && !root.accessibilityGranted)
-                            return "Set up later";
-                        return "Continue";
-                    }
-                    variant: root.onPermissionStep && !root.accessibilityGranted ? "secondary" : "accent"
+                    enabled: !root.onPermissionStep || root.accessibilityGranted
+                    opacity: enabled ? 1 : 0.4
+                    text: root.step === root.stepCount - 1 ? "Finish" : "Continue"
+                    variant: "accent"
                     onClicked: root.advance()
                 }
             }


### PR DESCRIPTION
Now that we use an event tap to implement global shortcuts it is pretty much mandatory for us to be granted the accessibility permission on macOS. It was already required for several things such as paste, snippets, etc... to work.

Requiring it at startup is more honest and avoids creating unexpected broken states.