### PR TITLE
feat: add CLI verbs to show the logs

### DIFF
--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -16,7 +16,7 @@ figura_compile(
 	OUTPUT ipc-client.hpp
 )
 
-set(CLI_SOURCES src/main.cpp src/cli.cpp src/theme.cpp src/fs.cpp src/local-socket.cpp ${SRCS})
+set(CLI_SOURCES src/main.cpp src/cli.cpp src/theme.cpp src/fs.cpp src/tail.cpp src/local-socket.cpp ${SRCS})
 if (NOT WIN32)
 	list(APPEND CLI_SOURCES src/server.cpp)
 endif()

--- a/src/cli/src/cli.cpp
+++ b/src/cli/src/cli.cpp
@@ -9,6 +9,7 @@
 #include "script.hpp"
 #include "common/common.hpp"
 #include "state.hpp"
+#include "tail.hpp"
 #include "generated/version.h"
 #include "theme.hpp"
 #include "ipc-client.hpp"
@@ -412,6 +413,34 @@ private:
   std::string link;
 };
 
+class LogsCommand : public AbstractCommandLineCommand {
+  std::string id() const override { return "logs"; }
+  std::string description() const override { return "Show the vicinae server logs"; }
+
+  void setup(CLI::App *app) override {
+    app->add_flag("--follow,-f", m_follow, "Keep printing new log lines as they are written");
+  }
+
+  bool run(CLI::App *) override {
+    auto const path = vicinae::logFilePath();
+    cli::FileTailer tailer(path);
+
+    if (!tailer.isOpen() && !m_follow) {
+      std::println(std::cerr, "No log file at {}. Has the server been started yet?", path.string());
+      return false;
+    }
+
+    tailer.drain(std::cout);
+
+    if (m_follow) tailer.follow(std::cout);
+
+    return true;
+  }
+
+private:
+  bool m_follow = false;
+};
+
 int CommandLineApp::run(int ac, char **av) {
   CLI::App app(m_name);
 
@@ -486,6 +515,7 @@ int CommandLineInterface::execute(int ac, char **av) {
   app.registerCommand<ConfigCommand>();
   app.registerCommand<ScriptCommand>();
   app.registerCommand<StateCommand>();
+  app.registerCommand<LogsCommand>();
 
   return app.run(ac, av);
 }

--- a/src/cli/src/tail.cpp
+++ b/src/cli/src/tail.cpp
@@ -1,0 +1,65 @@
+#include "tail.hpp"
+#include <array>
+#include <iostream>
+#include <thread>
+#include <utility>
+
+namespace cli {
+
+FileTailer::FileTailer(std::filesystem::path path)
+    : m_path(std::move(path)), m_stream(m_path, std::ios::binary) {}
+
+std::streamoff FileTailer::drain(std::ostream &out) {
+  std::array<char, 8192> buf;
+  std::streamoff written = 0;
+
+  for (;;) {
+    m_stream.read(buf.data(), buf.size());
+    auto const count = m_stream.gcount();
+
+    if (count <= 0) break;
+
+    out.write(buf.data(), count);
+    written += count;
+  }
+
+  m_stream.clear();
+  out.flush();
+  m_offset += written;
+
+  return written;
+}
+
+void FileTailer::reopen(std::ostream &out) {
+  m_stream.close();
+  m_stream.clear();
+  m_stream.open(m_path, std::ios::binary);
+  m_offset = 0;
+
+  if (m_stream) drain(out);
+}
+
+void FileTailer::follow(std::ostream &out) {
+  for (;;) {
+    std::this_thread::sleep_for(POLL_INTERVAL);
+
+    std::error_code ec;
+    auto const size = std::filesystem::file_size(m_path, ec);
+
+    if (ec) continue;
+
+    if (!m_stream.is_open() || std::cmp_less(size, m_offset)) {
+      reopen(out);
+      continue;
+    }
+
+    if (std::cmp_equal(size, m_offset)) continue;
+
+    m_stream.clear();
+    m_stream.seekg(m_offset);
+
+    if (drain(out) == 0) reopen(out);
+  }
+}
+
+} // namespace cli

--- a/src/cli/src/tail.hpp
+++ b/src/cli/src/tail.hpp
@@ -1,0 +1,28 @@
+#pragma once
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iosfwd>
+
+namespace cli {
+
+class FileTailer {
+public:
+  explicit FileTailer(std::filesystem::path path);
+
+  bool isOpen() const { return m_stream.is_open(); }
+
+  std::streamoff drain(std::ostream &out);
+  void follow(std::ostream &out);
+
+private:
+  static constexpr auto POLL_INTERVAL = std::chrono::milliseconds(200);
+
+  void reopen(std::ostream &out);
+
+  std::filesystem::path m_path;
+  std::ifstream m_stream;
+  std::streamoff m_offset = 0;
+};
+
+} // namespace cli

--- a/src/lib/common/include/common/common.hpp
+++ b/src/lib/common/include/common/common.hpp
@@ -26,6 +26,8 @@ std::string slurp(std::istream &ifs);
 std::optional<std::filesystem::path> findServerBinary();
 
 std::filesystem::path runtimeDir();
+std::filesystem::path stateDir();
+std::filesystem::path logFilePath();
 std::filesystem::path serverSocketPath();
 
 std::string currentUserName();

--- a/src/lib/common/src/common.cpp
+++ b/src/lib/common/src/common.cpp
@@ -103,6 +103,22 @@ fs::path runtimeDir() {
 #endif
 }
 
+fs::path stateDir() {
+#ifdef __APPLE__
+  if (const char *h = std::getenv("HOME")) return fs::path(h) / ".local" / "state" / "vicinae";
+  return "/tmp/vicinae";
+#elif defined(_WIN32)
+  if (const char *l = std::getenv("LOCALAPPDATA")) return fs::path(l) / "vicinae" / "state";
+  return fs::temp_directory_path() / "vicinae" / "state";
+#else
+  if (const char *s = std::getenv("XDG_STATE_HOME")) return fs::path(s) / "vicinae";
+  if (const char *h = std::getenv("HOME")) return fs::path(h) / ".local" / "state" / "vicinae";
+  return "/tmp/vicinae";
+#endif
+}
+
+fs::path logFilePath() { return stateDir() / "vicinae.log"; }
+
 fs::path serverSocketPath() { return runtimeDir() / "vicinae.sock"; }
 
 #ifdef _WIN32

--- a/src/server/src/extension/manager/extension-manager.cpp
+++ b/src/server/src/extension/manager/extension-manager.cpp
@@ -10,7 +10,7 @@
 #include <utility>
 #include "pid-file/pid-file.hpp"
 #include "generated/version.h"
-#include "rang/rang.hpp"
+#include "log/message-handler.hpp"
 #include "vicinae.hpp"
 
 namespace fs = std::filesystem;
@@ -164,10 +164,16 @@ void ExtensionManager::finished(int exitCode, QProcess::ExitStatus status) {
 
 void ExtensionManager::readError() {
   auto buf = m_process.readAllStandardError();
-  auto ts = QDateTime::currentDateTime().toString("yyyy-MM-dd'T'hh:mm:ss");
 
-  for (const auto &line : buf.trimmed().split('\n')) {
-    std::cout << "[" << rang::fg::magenta << "E" << rang::fg::reset << "] " << rang::fg::gray
-              << ts.toStdString() << " " << line.toStdString() << "\n";
+  for (const auto &raw : buf.trimmed().split('\n')) {
+    QString const line = QString::fromUtf8(raw);
+    int const tab = line.indexOf('\t');
+
+    if (tab == -1) {
+      vicinae::log::subprocessLine(vicinae::log::EXTENSION, {}, line);
+      continue;
+    }
+
+    vicinae::log::subprocessLine(vicinae::log::EXTENSION, line.left(tab), line.sliced(tab + 1));
   }
 }

--- a/src/server/src/extensions/vicinae/vicinae-extension.cpp
+++ b/src/server/src/extensions/vicinae/vicinae-extension.cpp
@@ -85,6 +85,23 @@ class OpenVicinaeConfig : public BuiltinCallbackCommand {
   }
 };
 
+class ShowLogs : public BuiltinCallbackCommand {
+  Q_DECLARE_TR_FUNCTIONS(OpenVicinaeConfig)
+
+  QString id() const override { return "show-logs"; }
+  QString name() const override { return tr("Show Log File"); }
+  QString description() const override { return tr("Open the Vicinae log file in your file browser"); }
+  ImageURL iconUrl() const override {
+    return ImageURL::builtin(BuiltinIcon::Paragraph).setBackgroundTint(Omnicast::ACCENT_COLOR);
+  }
+
+  void execute(CommandController &controller) const override {
+    auto ctx = controller.context();
+    ctx->services->appDb()->showInFileBrowser(Omnicast::stateDir() / "vicinae.log", true);
+    ctx->navigation->closeWindow();
+  }
+};
+
 class OpenDefaultVicinaeConfig : public BuiltinCallbackCommand {
   Q_DECLARE_TR_FUNCTIONS(OpenDefaultVicinaeConfig)
 
@@ -305,4 +322,5 @@ VicinaeExtension::VicinaeExtension() {
   registerCommand<PruneMemoryCommand>();
   registerCommand<IconBrowserCommand>();
   registerCommand<ForgetTelemetryCommand>();
+  registerCommand<ShowLogs>();
 }

--- a/src/server/src/log/message-handler.cpp
+++ b/src/server/src/log/message-handler.cpp
@@ -1,45 +1,152 @@
 #include "message-handler.hpp"
 #include "rang/rang.hpp"
+#include <format>
+#include <fstream>
+#include <mutex>
 
-void coloredMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg) {
-  QString const timestamp = QDateTime::currentDateTime().toString("yyyy-MM-dd'T'hh:mm:ss");
-  rang::fg color;
-  std::string_view levelName;
+namespace fs = std::filesystem;
 
+namespace {
+
+constexpr auto MAX_LOG_SIZE = 5 * 1024 * 1024;
+
+struct LevelStyle {
+  rang::fg color = rang::fg::reset;
+  std::string_view name;
+};
+
+rang::fg sourceColor(std::string_view source) {
+  if (source == vicinae::log::FILE_INDEXER) return rang::fg::blue;
+  if (source == vicinae::log::EXTENSION) return rang::fg::magenta;
+  if (source == vicinae::log::INPUT_SERVER) return rang::fg::cyan;
+  if (source == vicinae::log::CLIPBOARD_SERVER) return rang::fg::green;
+  return rang::fg::yellow;
+}
+
+std::string timestamp() {
+  return QDateTime::currentDateTime().toString("yyyy-MM-dd'T'hh:mm:ss").toStdString();
+}
+
+LevelStyle levelStyle(QStringView name) {
+  if (name == u"error" || name == u"fatal") return {rang::fg::red, "error"};
+  if (name == u"warn" || name == u"warning") return {rang::fg::yellow, "warn "};
+  if (name == u"debug" || name == u"trace") return {rang::fg::cyan, "debug"};
+  return {rang::fg::green, "info "};
+}
+
+LevelStyle levelStyle(QtMsgType type) {
   switch (type) {
   case QtDebugMsg:
-    color = rang::fg::cyan;
-    levelName = "debug";
-    break;
+    return {rang::fg::cyan, "debug"};
   case QtInfoMsg:
-    color = rang::fg::green;
-    levelName = "info ";
-    break;
+    return {rang::fg::green, "info "};
   case QtWarningMsg:
-    color = rang::fg::yellow;
-    levelName = "warn ";
-    break;
+    return {rang::fg::yellow, "warn "};
   case QtCriticalMsg:
-    color = rang::fg::red;
-    levelName = "error";
-    break;
+    return {rang::fg::red, "error"};
   case QtFatalMsg:
-    color = rang::fg::magenta;
-    levelName = "FATAL";
-    break;
+    return {rang::fg::magenta, "FATAL"};
   }
 
-  std::cerr << rang::fg::reset << "[" << rang::fg::yellow << "V" << rang::fg::reset << "] " << rang::fg::gray
-            << timestamp.toStdString() << " " << color << levelName << rang::fg::reset << " - "
-            << msg.toStdString();
+  return {};
+}
+
+class MessageSink {
+public:
+  static MessageSink &instance() {
+    static MessageSink sink;
+    return sink;
+  }
+
+  void openFile(const fs::path &path) {
+    std::lock_guard const lock(m_mutex);
+    std::error_code ec;
+
+    m_path = path;
+    m_rotatedPath = path.parent_path() / (path.filename().string() + ".1");
+    fs::create_directories(m_path.parent_path(), ec);
+    m_file.open(m_path, std::ios::out | std::ios::app);
+
+    auto const size = fs::file_size(m_path, ec);
+    m_size = ec ? 0 : size;
+  }
+
+  void write(std::string_view source, const LevelStyle &style, std::string_view timestamp,
+             std::string_view message, std::string_view location) {
+    std::lock_guard const lock(m_mutex);
+
+    std::cerr << rang::fg::reset << "[" << sourceColor(source) << source << rang::fg::reset << "] "
+              << rang::fg::gray << timestamp << " " << style.color << style.name << rang::fg::reset << " - "
+              << message;
+
+    if (!location.empty()) { std::cerr << " (" << rang::fg::blue << location << rang::fg::reset << ")"; }
+
+    std::cerr << "\n";
+
+    auto line = std::format("[{}] {} {} - {}", source, timestamp, style.name, message);
+
+    if (!location.empty()) { line += std::format(" ({})", location); }
+
+    line += '\n';
+    writeToFile(line);
+  }
+
+private:
+  void writeToFile(std::string_view line) {
+    if (!m_file.is_open()) return;
+
+    m_file.write(line.data(), line.size());
+    m_file.flush();
+    m_size += line.size();
+
+    if (m_size >= MAX_LOG_SIZE) { rotate(); }
+  }
+
+  void rotate() {
+    m_file.close();
+
+    std::error_code ec;
+    fs::rename(m_path, m_rotatedPath, ec);
+
+    m_file.open(m_path, std::ios::out | std::ios::trunc);
+    m_size = 0;
+  }
+
+  std::mutex m_mutex;
+  fs::path m_path;
+  fs::path m_rotatedPath;
+  std::ofstream m_file;
+  std::uintmax_t m_size = 0;
+};
+
+void coloredMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg) {
+  std::string location;
 
   if (context.file) {
-    std::filesystem::path const file(context.file);
-    std::cerr << " (" << rang::fg::blue << file.filename().string() << ":" << context.line << rang::fg::reset
-              << ")";
+    fs::path const file(context.file);
+    location = std::format("{}:{}", file.filename().string(), context.line);
   }
 
-  std::cerr << "\n";
+  MessageSink::instance().write(vicinae::log::SERVER, levelStyle(type), timestamp(), msg.toStdString(),
+                                location);
 
   if (type == QtFatalMsg) { abort(); }
 }
+
+} // namespace
+
+namespace vicinae::log {
+
+void installMessageHandler() { qInstallMessageHandler(coloredMessageHandler); }
+
+void openFile(const std::filesystem::path &path) { MessageSink::instance().openFile(path); }
+
+void subprocessLine(std::string_view source, QStringView level, QStringView message) {
+  auto const trimmed = message.trimmed();
+
+  if (trimmed.isEmpty()) return;
+
+  MessageSink::instance().write(source, levelStyle(level), timestamp(), trimmed.toString().toStdString(), {});
+}
+
+} // namespace vicinae::log

--- a/src/server/src/log/message-handler.hpp
+++ b/src/server/src/log/message-handler.hpp
@@ -4,4 +4,18 @@
 #include <qlogging.h>
 #include <filesystem>
 
-void coloredMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg);
+namespace vicinae::log {
+
+inline constexpr std::string_view SERVER = "V";
+inline constexpr std::string_view FILE_INDEXER = "F";
+inline constexpr std::string_view EXTENSION = "E";
+inline constexpr std::string_view INPUT_SERVER = "I";
+inline constexpr std::string_view CLIPBOARD_SERVER = "C";
+
+void installMessageHandler();
+
+void openFile(const std::filesystem::path &path);
+
+void subprocessLine(std::string_view source, QStringView level, QStringView message);
+
+} // namespace vicinae::log

--- a/src/server/src/server.cpp
+++ b/src/server/src/server.cpp
@@ -13,6 +13,7 @@
 #include "extension-interval-scheduler.hpp"
 #include "ipc-command-server.hpp"
 #include "keyboard/keybind-manager.hpp"
+#include "common/common.hpp"
 #include "log/message-handler.hpp"
 #include "overlay-controller/overlay-controller.hpp"
 #include "extensions/root/root-command.hpp"
@@ -178,7 +179,8 @@ static QFont resolveAppFont(const config::FontConfig &fontConfig) {
 }
 
 int startServer(const ServerLaunchOptions &launchOpts) {
-  qInstallMessageHandler(coloredMessageHandler);
+  vicinae::log::installMessageHandler();
+  vicinae::log::openFile(vicinae::logFilePath());
 
 #ifdef AUTO_INSTALL_BROWSER_MANIFESTS
   // always refresh manifests

--- a/src/server/src/services/clipboard/data-control/data-control-clipboard-server.cpp
+++ b/src/server/src/services/clipboard/data-control/data-control-clipboard-server.cpp
@@ -1,3 +1,4 @@
+#include "log/message-handler.hpp"
 #include "pid-file/pid-file.hpp"
 #include "services/clipboard/clipboard-server.hpp"
 #include <QtCore>
@@ -63,7 +64,9 @@ bool DataControlClipboardServer::start() {
 }
 
 void DataControlClipboardServer::handleReadError() {
-  QTextStream(stderr) << m_process.readAllStandardError();
+  for (const auto &line : m_process.readAllStandardError().trimmed().split('\n')) {
+    vicinae::log::subprocessLine(vicinae::log::CLIPBOARD_SERVER, {}, QString::fromUtf8(line));
+  }
 }
 
 void DataControlClipboardServer::handleRead() {

--- a/src/server/src/services/files-service/file-indexer/file-indexer.cpp
+++ b/src/server/src/services/files-service/file-indexer/file-indexer.cpp
@@ -10,7 +10,7 @@
 #include <filesystem>
 #include <utility>
 #include "common/common.hpp"
-#include "rang/rang.hpp"
+#include "log/message-handler.hpp"
 
 void FileIndexerBus::send(std::string_view data) {
   uint32_t size = data.size();
@@ -297,31 +297,13 @@ void FileIndexer::handleStderr() {
     m_stderrBuf = m_stderrBuf.sliced(idx + 1);
 
     QString const line = QString::fromUtf8(lineBytes);
-    if (line.isEmpty()) continue;
+    int const tab = line.indexOf('\t');
 
-    QString level;
-    QString message = line;
-    if (int const tab = line.indexOf('\t'); tab != -1) {
-      level = line.left(tab);
-      message = line.sliced(tab + 1);
+    if (tab == -1) {
+      vicinae::log::subprocessLine(vicinae::log::FILE_INDEXER, {}, line);
+      continue;
     }
 
-    rang::fg color = rang::fg::reset;
-    if (level == "trace") {
-      color = rang::fg::gray;
-    } else if (level == "debug") {
-      color = rang::fg::cyan;
-    } else if (level == "info") {
-      color = rang::fg::green;
-    } else if (level == "warn") {
-      color = rang::fg::yellow;
-    } else if (level == "error") {
-      color = rang::fg::red;
-    }
-
-    auto const ts = QDateTime::currentDateTime().toString("yyyy-MM-dd'T'hh:mm:ss");
-    std::cerr << "[" << rang::fg::blue << "F" << rang::fg::reset << "] " << rang::fg::gray << ts.toStdString()
-              << " " << color << level.toStdString() << rang::fg::reset << (level.isEmpty() ? "" : " - ")
-              << message.toStdString() << "\n";
+    vicinae::log::subprocessLine(vicinae::log::FILE_INDEXER, line.left(tab), line.sliced(tab + 1));
   }
 }

--- a/src/server/src/services/input-server/linux-input-server.cpp
+++ b/src/server/src/services/input-server/linux-input-server.cpp
@@ -1,4 +1,5 @@
 #include "linux-input-server.hpp"
+#include "log/message-handler.hpp"
 #include <cstdint>
 #include <QTimer>
 #include <qtenvironmentvariables.h>
@@ -175,7 +176,7 @@ void LinuxInputServer::setKeyDelay(int us) {
 }
 
 void LinuxInputServer::handleError() {
-  for (const auto &line : m_process.readAllStandardError().split('\n')) {
-    qDebug() << "[INPUT-SERVER]" << line;
+  for (const auto &line : m_process.readAllStandardError().trimmed().split('\n')) {
+    vicinae::log::subprocessLine(vicinae::log::INPUT_SERVER, {}, QString::fromUtf8(line));
   }
 }

--- a/src/server/src/vicinae.cpp
+++ b/src/server/src/vicinae.cpp
@@ -44,15 +44,7 @@ fs::path Omnicast::configDir() {
 #endif
 }
 
-fs::path Omnicast::stateDir() {
-#ifdef Q_OS_MACOS
-  return homeDir() / ".local" / "state" / "vicinae";
-#elif defined(Q_OS_WIN)
-  return winLocalAppData() / "state";
-#else
-  return xdgpp::stateHome() / "vicinae";
-#endif
-}
+fs::path Omnicast::stateDir() { return vicinae::stateDir(); }
 
 fs::path Omnicast::cacheDir() {
 #ifdef Q_OS_MACOS

--- a/src/typescript/extension-manager/src/logger.ts
+++ b/src/typescript/extension-manager/src/logger.ts
@@ -1,123 +1,18 @@
-// https://github.com/sindresorhus/yoctocolors
-
-import tty from "node:tty";
-
-export type Format = (string?: string) => string;
-
-// eslint-disable-next-line no-warning-comments
-// TODO: Use a better method when it's added to Node.js (https://github.com/nodejs/node/pull/40240)
-// Lots of optionals here to support Deno.
-const hasColors = tty?.WriteStream?.prototype?.hasColors?.() ?? false;
-
-const format = (open: number, close: number): Format => {
-	if (!hasColors) {
-		return (input?: string) => input ?? "";
-	}
-
-	const openCode = `\u001B[${open}m`;
-	const closeCode = `\u001B[${close}m`;
-
-	return (input: string = "") => {
-		let index = input.indexOf(closeCode);
-
-		if (index === -1) {
-			// Note: Intentionally not using string interpolation for performance reasons.
-			return openCode + input + closeCode;
-		}
-
-		// Handle nested colors.
-
-		// We could have done this, but it's too slow (as of Node.js 22).
-		// return openCode + string.replaceAll(closeCode, (close === 22 ? closeCode : '') + openCode) + closeCode;
-
-		let result = openCode;
-		let lastIndex = 0;
-
-		// SGR 22 resets both bold (1) and dim (2). When we encounter a nested
-		// close for styles that use 22, we need to re-open the outer style.
-		const reopenOnNestedClose = close === 22;
-		const replaceCode = (reopenOnNestedClose ? closeCode : "") + openCode;
-
-		while (index !== -1) {
-			result += input.slice(lastIndex, index) + replaceCode;
-			lastIndex = index + closeCode.length;
-			index = input.indexOf(closeCode, lastIndex);
-		}
-
-		result += input.slice(lastIndex) + closeCode;
-
-		return result;
-	};
-};
-
-export const reset = format(0, 0);
-export const bold = format(1, 22);
-export const dim = format(2, 22);
-export const italic = format(3, 23);
-export const underline = format(4, 24);
-export const overline = format(53, 55);
-export const inverse = format(7, 27);
-export const hidden = format(8, 28);
-export const strikethrough = format(9, 29);
-
-export const black = format(30, 39);
-export const red = format(31, 39);
-export const green = format(32, 39);
-export const yellow = format(33, 39);
-export const blue = format(34, 39);
-export const magenta = format(35, 39);
-export const cyan = format(36, 39);
-export const white = format(37, 39);
-export const gray = format(90, 39);
-
-export const bgBlack = format(40, 49);
-export const bgRed = format(41, 49);
-export const bgGreen = format(42, 49);
-export const bgYellow = format(43, 49);
-export const bgBlue = format(44, 49);
-export const bgMagenta = format(45, 49);
-export const bgCyan = format(46, 49);
-export const bgWhite = format(47, 49);
-export const bgGray = format(100, 49);
-
-export const redBright = format(91, 39);
-export const greenBright = format(92, 39);
-export const yellowBright = format(93, 39);
-export const blueBright = format(94, 39);
-export const magentaBright = format(95, 39);
-export const cyanBright = format(96, 39);
-export const whiteBright = format(97, 39);
-
-export const bgRedBright = format(101, 49);
-export const bgGreenBright = format(102, 49);
-export const bgYellowBright = format(103, 49);
-export const bgBlueBright = format(104, 49);
-export const bgMagentaBright = format(105, 49);
-export const bgCyanBright = format(106, 49);
-export const bgWhiteBright = format(107, 49);
-
 export class Logger {
-	prefixes = {
-		error: `${red("error")}${reset()}`,
-		event: `${magenta("event")}${reset()}`,
-		info: `${blue("info")}${reset()}`,
-		ready: `${green("ready")}${reset()}`,
-	};
-
 	error(message: string) {
-		console.error(`${this.prefixes.error.padEnd(15)} - ${message}`);
+		this.write("error", message);
 	}
 
 	event(message: string) {
-		console.error(`${this.prefixes.event.padEnd(15)} - ${message}`);
+		this.write("event", message);
 	}
 
 	info(message: string) {
-		console.error(`${this.prefixes.info.padEnd(15)} - ${message}`);
+		this.write("info", message);
 	}
 
 	ready(message: string) {
-		console.error(`${this.prefixes.ready.padEnd(15)} - ${message}`);
+		this.write("ready", message);
 	}
 
 	logTimestamp(s: string) {
@@ -129,7 +24,11 @@ export class Logger {
 
 			if (i === lines.length - 1 && line.length === 0) continue;
 
-			console.log(`${gray(ts.padEnd(20))}${reset()} - ${line}`);
+			console.log(`${ts.padEnd(20)} - ${line}`);
 		}
+	}
+
+	private write(level: string, message: string) {
+		console.error(`${level}\t${message}`);
 	}
 }


### PR DESCRIPTION
Add a `vicinae logs` command to show the logs of the vicinae server.

In order for that to work this PR modifies the custom QT logger so that it also writes the logs into a file, which is the universal source of truth for `vicinae logs` in all platforms.