### PR TITLE
feat: generalize drag and drop support

### DIFF
--- a/figura/tsapi.fig
+++ b/figura/tsapi.fig
@@ -188,7 +188,7 @@ service WindowManagement {
 struct ClipboardContent {
   text?: string;
   html?: string;
-  path?: string;
+  urls?: string[];
 };
 
 struct ClipboardOptions {

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -162,6 +162,7 @@ set(SRCS
 	src/color-formatter.cpp
 
 	src/services/clipboard/clipboard-server.hpp
+	src/services/clipboard/clipboard-content.hpp
 	src/services/clipboard/clipboard-mime.hpp
 	src/services/clipboard/clipboard-mime.cpp
 	src/services/clipboard/clipboard-db.hpp

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -957,6 +957,7 @@ set(VICINAE_QML_FILES
 	src/qml/qml/ListAccessory.qml
 	src/qml/qml/ListAccessoryRow.qml
 	src/qml/qml/SelectableDelegate.qml
+	src/qml/qml/DraggableMouseArea.qml
 	src/qml/qml/SectionHeader.qml
 	src/qml/qml/Footer.qml
 	src/qml/qml/FooterButton.qml

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -474,6 +474,8 @@ set(SRCS
 	src/qml/root-search-model.cpp
 	src/qml/root-search-sources.hpp
 	src/qml/root-search-sources.cpp
+	src/qml/drag-utils.hpp
+	src/qml/drag-utils.cpp
 	src/qml/section-source.hpp
 	src/qml/section-list-model.hpp
 	src/qml/section-list-model.cpp

--- a/src/server/src/extend/grid-model.hpp
+++ b/src/server/src/extend/grid-model.hpp
@@ -6,6 +6,7 @@
 #include "extend/pagination-model.hpp"
 #include "extend/dropdown-model.hpp"
 #include "ui/image/url.hpp"
+#include "services/clipboard/clipboard-content.hpp"
 
 enum GridFit { GridContain, GridFill };
 
@@ -34,6 +35,7 @@ struct GridItemViewModel {
   std::optional<std::string> tooltip;
   std::vector<std::string> keywords;
   std::optional<ActionPannelModel> actionPannel;
+  std::optional<Clipboard::Content> dragContent;
 };
 
 struct GridSectionModel {

--- a/src/server/src/extend/list-model.hpp
+++ b/src/server/src/extend/list-model.hpp
@@ -7,6 +7,7 @@
 #include "extend/image-model.hpp"
 #include "extend/dropdown-model.hpp"
 #include "extend/pagination-model.hpp"
+#include "services/clipboard/clipboard-content.hpp"
 
 struct ListItemViewModel {
   bool changed = false;
@@ -18,6 +19,7 @@ struct ListItemViewModel {
   std::optional<ActionPannelModel> actionPannel;
   std::vector<AccessoryModel> accessories;
   std::vector<std::string> keywords;
+  std::optional<Clipboard::Content> dragContent;
 };
 
 struct ListSectionModel {

--- a/src/server/src/extend/model-deser.cpp
+++ b/src/server/src/extend/model-deser.cpp
@@ -297,6 +297,12 @@ template <> struct glz::meta<ListItemChild> {
   static constexpr auto ids = std::array{"action-panel", "list-item-detail"};
 };
 
+struct ClipboardContentWire {
+  std::optional<std::string> text;
+  std::optional<std::string> html;
+  std::vector<std::string> urls;
+};
+
 struct ListItemViewModelWire {
   std::string id;
   FlexString title;
@@ -304,6 +310,7 @@ struct ListItemViewModelWire {
   std::optional<ImageWrappedWire> icon;
   std::vector<AccessoryWire> accessories;
   std::vector<std::string> keywords;
+  std::optional<ClipboardContentWire> dragContent;
   std::vector<ListItemChild> children;
 };
 
@@ -357,6 +364,7 @@ struct GridItemViewModelWire {
   GridContentWire content;
   std::optional<std::string> tooltip;
   std::vector<std::string> keywords;
+  std::optional<ClipboardContentWire> dragContent;
   std::vector<SingleAPChild> children;
 };
 
@@ -769,6 +777,24 @@ static EmptyViewModel toEmptyViewModel(EmptyViewModelWire w) {
   return m;
 }
 
+static std::optional<Clipboard::Content> toClipboardContent(std::optional<ClipboardContentWire> wire) {
+  if (!wire) return std::nullopt;
+  if (wire->html) {
+    return Clipboard::Html{QString::fromStdString(std::move(*wire->html)),
+                           wire->text ? std::optional(QString::fromStdString(std::move(*wire->text)))
+                                      : std::nullopt};
+  }
+  if (!wire->urls.empty()) {
+    std::vector<QUrl> urls;
+    urls.reserve(wire->urls.size());
+    for (auto &url : wire->urls)
+      urls.emplace_back(QString::fromStdString(std::move(url)));
+    return Clipboard::Urls{std::move(urls)};
+  }
+  if (wire->text) return Clipboard::Text{QString::fromStdString(std::move(*wire->text))};
+  return std::nullopt;
+}
+
 static ListItemViewModel toListItemViewModel(ListItemViewModelWire w) {
   ListItemViewModel m;
   m.changed = true;
@@ -780,6 +806,7 @@ static ListItemViewModel toListItemViewModel(ListItemViewModelWire w) {
   for (auto &a : w.accessories)
     m.accessories.emplace_back(toAccessoryModel(std::move(a)));
   m.keywords = std::move(w.keywords);
+  m.dragContent = toClipboardContent(std::move(w.dragContent));
   for (auto &child : w.children) {
     match(
         child, [&](ActionPannelModelWire &c) { m.actionPannel = toActionPannelModel(std::move(c)); },
@@ -846,6 +873,7 @@ static GridItemViewModel toGridItemViewModel(GridItemViewModelWire w) {
   m.tooltip = std::move(w.tooltip);
   m.content = toGridContent(std::move(w.content), m.tooltip);
   m.keywords = std::move(w.keywords);
+  m.dragContent = toClipboardContent(std::move(w.dragContent));
   for (auto &child : w.children) {
     if (auto *ap = std::get_if<ActionPannelModelWire>(&child))
       m.actionPannel = toActionPannelModel(std::move(*ap));

--- a/src/server/src/extension/services/clipboard-service.hpp
+++ b/src/server/src/extension/services/clipboard-service.hpp
@@ -31,15 +31,30 @@ public:
 
     result.text = rc.text.toStdString();
     if (rc.html) result.html = rc.html->toStdString();
-    if (rc.file) result.path = rc.file->toStdString();
+    if (!rc.urls.empty()) {
+      result.urls.emplace();
+      result.urls->reserve(rc.urls.size());
+      for (const auto &url : rc.urls)
+        result.urls->emplace_back(url.toString().toStdString());
+    }
 
     return tsapi::Result<tsapi::ClipboardContent>::ok(std::move(result));
   }
 
 private:
   static Clipboard::Content parseContent(const tsapi::ClipboardContent &content) {
-    if (content.html) return Clipboard::Html({QString::fromStdString(*content.html)});
-    if (content.path) return Clipboard::File(std::string{*content.path});
+    if (content.html) {
+      return Clipboard::Html{.html = QString::fromStdString(*content.html),
+                             .text = content.text ? std::optional(QString::fromStdString(*content.text))
+                                                  : std::nullopt};
+    }
+    if (content.urls && !content.urls->empty()) {
+      std::vector<QUrl> urls;
+      urls.reserve(content.urls->size());
+      for (const auto &url : *content.urls)
+        urls.emplace_back(QString::fromStdString(url));
+      return Clipboard::Urls{std::move(urls)};
+    }
     if (content.text) return Clipboard::Text(QString::fromStdString(*content.text));
     return {};
   }

--- a/src/server/src/qml/drag-utils.cpp
+++ b/src/server/src/qml/drag-utils.cpp
@@ -1,0 +1,33 @@
+#include <QDrag>
+#include <QGuiApplication>
+#include <QPixmap>
+#include <utility>
+
+#include "drag-utils.hpp"
+#include "ui/image/image-renderer.hpp"
+#include "ui/image/url.hpp"
+
+namespace DragUtils {
+
+void startDrag(QObject *source, std::unique_ptr<QMimeData> mimeData, const QString &iconSource) {
+  if (!source || !mimeData) return;
+
+  auto *drag = new QDrag(source);
+  drag->setMimeData(mimeData.release());
+
+  if (auto frame = ImageRendering::cachedFrame(ImageURL(iconSource))) {
+    constexpr int DRAG_ICON_SIZE = 40;
+    auto const dpr = qGuiApp->devicePixelRatio();
+    auto const physicalSize = qRound(DRAG_ICON_SIZE * dpr);
+    auto image = frame->scaled(physicalSize, physicalSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    auto pixmap = QPixmap::fromImage(std::move(image));
+    pixmap.setDevicePixelRatio(dpr);
+    drag->setPixmap(pixmap);
+    drag->setHotSpot({DRAG_ICON_SIZE / 2, DRAG_ICON_SIZE / 2});
+  }
+
+  drag->exec(Qt::CopyAction);
+  drag->deleteLater();
+}
+
+} // namespace DragUtils

--- a/src/server/src/qml/drag-utils.hpp
+++ b/src/server/src/qml/drag-utils.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include <QMimeData>
+
+#include <memory>
+
+class QObject;
+class QString;
+
+namespace DragUtils {
+
+void startDrag(QObject *source, std::unique_ptr<QMimeData> mimeData, const QString &iconSource);
+
+}

--- a/src/server/src/qml/extension-grid-model.cpp
+++ b/src/server/src/qml/extension-grid-model.cpp
@@ -3,6 +3,7 @@
 #include <utility>
 #include "common/types.hpp"
 #include "fuzzy/fuzzy-searchable.hpp"
+#include "services/clipboard/clipboard-mime.hpp"
 #include "theme.hpp"
 #include "theme/theme-file.hpp"
 #include "ui/image/url.hpp"
@@ -57,6 +58,24 @@ const GridItemViewModel *ExtensionGridSection::itemAt(int i) const {
   }
   if (i < 0 || std::cmp_greater_equal(i, m_items.size())) return nullptr;
   return &m_items[i];
+}
+
+QString ExtensionGridSection::itemIconSource(int i) const {
+  if (auto *item = itemAt(i)) {
+    if (auto *image = std::get_if<ImageLikeModel>(&item->content))
+      return qml::imageSourceFor(ImageURL(*image));
+  }
+  return {};
+}
+
+bool ExtensionGridSection::isDraggable(int i) const {
+  auto *item = itemAt(i);
+  return item && item->dragContent.has_value();
+}
+
+std::unique_ptr<QMimeData> ExtensionGridSection::dragMimeData(int i) const {
+  auto *item = itemAt(i);
+  return item && item->dragContent ? Clipboard::mimeDataForContent(*item->dragContent) : nullptr;
 }
 
 std::unique_ptr<ActionPanelState> ExtensionGridSection::actionPanel(int i) const {

--- a/src/server/src/qml/extension-grid-model.hpp
+++ b/src/server/src/qml/extension-grid-model.hpp
@@ -32,6 +32,9 @@ public:
   const GridItemViewModel *itemAt(int i) const;
 
   std::unique_ptr<ActionPanelState> actionPanel(int i) const override;
+  QString itemIconSource(int i) const override;
+  bool isDraggable(int i) const override;
+  std::unique_ptr<QMimeData> dragMimeData(int i) const override;
 
 private:
   std::string m_name;

--- a/src/server/src/qml/extension-list-model.cpp
+++ b/src/server/src/qml/extension-list-model.cpp
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <utility>
 #include "fuzzy/fuzzy-searchable.hpp"
+#include "services/clipboard/clipboard-mime.hpp"
 #include "view-utils.hpp"
 #include "ui/image/url.hpp"
 
@@ -63,6 +64,13 @@ QVariantList ExtensionListSection::itemAccessories(int i) const {
   const auto &item = itemAt(i);
   if (!item.accessories.empty()) return qml::accessoriesToVariantList(item.accessories);
   return {};
+}
+
+bool ExtensionListSection::isDraggable(int i) const { return itemAt(i).dragContent.has_value(); }
+
+std::unique_ptr<QMimeData> ExtensionListSection::dragMimeData(int i) const {
+  const auto &content = itemAt(i).dragContent;
+  return content ? Clipboard::mimeDataForContent(*content) : nullptr;
 }
 
 std::unique_ptr<ActionPanelState> ExtensionListSection::actionPanel(int i) const {

--- a/src/server/src/qml/extension-list-model.hpp
+++ b/src/server/src/qml/extension-list-model.hpp
@@ -35,6 +35,8 @@ protected:
   QString itemIconSource(int i) const override;
   QVariantList itemAccessories(int i) const override;
   std::unique_ptr<ActionPanelState> actionPanel(int i) const override;
+  bool isDraggable(int i) const override;
+  std::unique_ptr<QMimeData> dragMimeData(int i) const override;
 
 private:
   std::string m_name;

--- a/src/server/src/qml/grid-source.hpp
+++ b/src/server/src/qml/grid-source.hpp
@@ -1,12 +1,14 @@
 #pragma once
-#include "view-scope.hpp"
-#include "view-utils.hpp"
+#include <QMimeData>
 #include <QVariant>
+
 #include <functional>
 #include <memory>
 #include <optional>
 #include <string_view>
 
+#include "view-scope.hpp"
+#include "view-utils.hpp"
 class ActionPanelState;
 
 class GridSource {
@@ -21,6 +23,9 @@ public:
   virtual std::optional<int> columns() const { return std::nullopt; }
   virtual std::optional<double> aspectRatio() const { return std::nullopt; }
   virtual std::optional<double> inset() const { return std::nullopt; }
+
+  virtual bool isDraggable(int) const { return false; }
+  virtual std::unique_ptr<QMimeData> dragMimeData(int) const { return {}; }
 
   virtual std::unique_ptr<ActionPanelState> actionPanel(int i) const = 0;
   virtual void onSelected(int) {}

--- a/src/server/src/qml/grid-source.hpp
+++ b/src/server/src/qml/grid-source.hpp
@@ -23,6 +23,7 @@ public:
   virtual std::optional<int> columns() const { return std::nullopt; }
   virtual std::optional<double> aspectRatio() const { return std::nullopt; }
   virtual std::optional<double> inset() const { return std::nullopt; }
+  virtual QString itemIconSource(int) const { return {}; }
 
   virtual bool isDraggable(int) const { return false; }
   virtual std::unique_ptr<QMimeData> dragMimeData(int) const { return {}; }

--- a/src/server/src/qml/qml/CommandListView.qml
+++ b/src/server/src/qml/qml/CommandListView.qml
@@ -25,10 +25,7 @@ GenericListView {
         required property string subtitle
         required property string iconSource
         required property var itemAccessory
-        required property string filePath
-        required property string fileUrl
-
-        Component.onCompleted: {}
+        required property bool isDraggable
 
         sourceComponent: isSection ? sectionComponent : itemComponent
 
@@ -51,10 +48,13 @@ GenericListView {
                 itemIsActive: false
                 itemAccessory: delegateLoader.itemAccessory
                 selected: commandListView.currentIndex === delegateLoader.index
+                draggable: delegateLoader.isDraggable
                 onClicked: commandListView.currentIndex = delegateLoader.index
                 onActivated: commandListView.itemActivated(delegateLoader.index)
-                filePath: delegateLoader.filePath
-                fileUrl: delegateLoader.fileUrl
+                onDragRequested: function (source) {
+                    commandListView.currentIndex = delegateLoader.index;
+                    commandListView.cmdModel.startDrag(delegateLoader.index, source);
+                }
             }
         }
     }

--- a/src/server/src/qml/qml/DraggableMouseArea.qml
+++ b/src/server/src/qml/qml/DraggableMouseArea.qml
@@ -1,0 +1,41 @@
+import QtQuick
+
+MouseArea {
+    id: root
+
+    property bool draggable: false
+    readonly property bool dragging: dragStarted
+
+    signal itemClicked
+    signal itemActivated
+    signal dragRequested
+
+    property bool dragStarted: false
+
+    drag.target: draggable ? dragTarget : null
+
+    onPressed: {
+        dragStarted = false;
+        dragTarget.x = 0;
+        dragTarget.y = 0;
+    }
+    onPositionChanged: {
+        if (drag.active && !dragStarted) {
+            dragStarted = true;
+            dragRequested();
+        }
+    }
+    onClicked: {
+        if (!dragStarted)
+            itemClicked();
+    }
+    onDoubleClicked: {
+        if (!dragStarted)
+            itemActivated();
+    }
+
+    Item {
+        id: dragTarget
+        visible: false
+    }
+}

--- a/src/server/src/qml/qml/GenericGridView.qml
+++ b/src/server/src/qml/qml/GenericGridView.qml
@@ -152,6 +152,7 @@ Item {
         visible: !root._empty
         model: root.cmdModel
         clip: true
+        interactive: false
         boundsBehavior: Flickable.StopAtBounds
         topMargin: root.cellSpacing
         bottomMargin: root.cellSpacing

--- a/src/server/src/qml/qml/GenericGridView.qml
+++ b/src/server/src/qml/qml/GenericGridView.qml
@@ -354,21 +354,28 @@ Item {
                                     opacity: 0.7
                                 }
 
-                                MouseArea {
+                                DraggableMouseArea {
                                     id: cellMouseArea
                                     anchors.fill: parent
                                     hoverEnabled: true
-                                    onClicked: {
+                                    draggable: root.cmdModel && root.cmdModel.isDraggable(cellWrapper.cellSection, cellWrapper.cellItem)
+                                    onItemClicked: {
                                         if (root.cmdModel) {
                                             root.cmdModel.select(cellWrapper.cellSection, cellWrapper.cellItem);
                                             if (Config.activateOnSingleClick)
                                                 root.cmdModel.activateSelected();
                                         }
                                     }
-                                    onDoubleClicked: {
+                                    onItemActivated: {
                                         if (root.cmdModel) {
                                             root.cmdModel.select(cellWrapper.cellSection, cellWrapper.cellItem);
                                             root.cmdModel.activateSelected();
+                                        }
+                                    }
+                                    onDragRequested: {
+                                        if (root.cmdModel) {
+                                            root.cmdModel.select(cellWrapper.cellSection, cellWrapper.cellItem);
+                                            root.cmdModel.startDrag(cellWrapper.cellSection, cellWrapper.cellItem, cellWrapper);
                                         }
                                     }
                                 }

--- a/src/server/src/qml/qml/GenericListView.qml
+++ b/src/server/src/qml/qml/GenericListView.qml
@@ -213,6 +213,7 @@ Item {
             clip: true
             reuseItems: true
             cacheBuffer: 200
+            interactive: false
             boundsBehavior: Flickable.StopAtBounds
             highlightMoveDuration: 0
             currentIndex: -1

--- a/src/server/src/qml/qml/ListItemDelegate.qml
+++ b/src/server/src/qml/qml/ListItemDelegate.qml
@@ -13,32 +13,6 @@ SelectableDelegate {
     required property bool itemIsActive
     property var itemAccessory: []
     property string itemAccessoryColor: ""
-    property string filePath: ""
-    property string fileUrl: ""
-
-    readonly property bool _isDraggable: root.filePath !== ""
-
-    Component.onCompleted: {
-        if (_isDraggable) {
-            //console.debug("[DRAG] ListItemDelegate created: filePath=" + root.filePath + " fileUrl=" + root.fileUrl);
-        }
-    }
-
-    Drag.dragType: root._isDraggable ? Drag.Automatic : Drag.None
-    Drag.active: root._isDraggable ? dragHandler.active : false
-    Drag.mimeData: root._isDraggable ? ({
-            "text/uri-list": root.fileUrl,
-            "text/plain": root.filePath
-        }) : ({})
-    Drag.supportedActions: Qt.CopyAction
-
-    DragHandler {
-        id: dragHandler
-        enabled: root._isDraggable
-        onActiveChanged: {
-            //console.debug("[DRAG] DragHandler ACTIVATED! filePath=" + root.filePath);
-        }
-    }
 
     RowLayout {
         anchors.fill: parent

--- a/src/server/src/qml/qml/RootSearchList.qml
+++ b/src/server/src/qml/qml/RootSearchList.qml
@@ -32,6 +32,7 @@ GenericListView {
         required property string calcAnswer
         required property string calcAnswerUnit
         required property bool isFile
+        required property bool isDraggable
 
         sourceComponent: {
             if (isSection)
@@ -76,8 +77,13 @@ GenericListView {
                 itemAccessory: delegateLoader.accessoryText
                 itemAccessoryColor: delegateLoader.accessoryColor
                 selected: searchListView.currentIndex === delegateLoader.index
+                draggable: delegateLoader.isDraggable
                 onClicked: searchListView.currentIndex = delegateLoader.index
                 onActivated: searchListView.itemActivated(delegateLoader.index)
+                onDragRequested: function (source) {
+                    searchListView.currentIndex = delegateLoader.index;
+                    searchListView.cmdModel.startDrag(delegateLoader.index, source);
+                }
             }
         }
     }

--- a/src/server/src/qml/qml/SelectableDelegate.qml
+++ b/src/server/src/qml/qml/SelectableDelegate.qml
@@ -7,23 +7,27 @@ Item {
     id: root
 
     property bool selected: false
+    property bool draggable: false
     readonly property bool hovered: mouseArea.containsMouse && HoverActivation.active
 
     default property alias contentData: contentItem.data
 
     signal clicked
     signal activated
+    signal dragRequested(var source)
 
-    MouseArea {
+    DraggableMouseArea {
         id: mouseArea
         anchors.fill: parent
         hoverEnabled: true
-        onClicked: {
+        draggable: root.draggable
+        onItemClicked: {
             root.clicked();
             if (Config.activateOnSingleClick)
                 root.activated();
         }
-        onDoubleClicked: root.activated()
+        onItemActivated: root.activated()
+        onDragRequested: root.dragRequested(root)
     }
 
     SourceBlendRect {

--- a/src/server/src/qml/root-search-sources.cpp
+++ b/src/server/src/qml/root-search-sources.cpp
@@ -104,6 +104,15 @@ QVariant RootLinkSection::customData(int, int role) const {
 QHash<int, QByteArray> RootLinkSection::customRoleNames() const { return root_search::customRoleNames(); }
 QHash<int, QVariant> RootLinkSection::customRoleDefaults() const { return root_search::customRoleDefaults(); }
 
+std::unique_ptr<QMimeData> RootLinkSection::dragMimeData(int) const {
+  if (!m_link) return {};
+
+  auto data = std::make_unique<QMimeData>();
+  data->setUrls({QUrl(m_link->url)});
+  data->setText(m_link->url);
+  return data;
+}
+
 std::unique_ptr<ActionPanelState> RootLinkSection::actionPanel(int) const {
   if (!m_link) return nullptr;
   auto panel = std::make_unique<ListActionPanelState>();
@@ -394,6 +403,16 @@ QVariant RootFilesSection::customData(int, int role) const {
 QHash<int, QByteArray> RootFilesSection::customRoleNames() const { return root_search::customRoleNames(); }
 QHash<int, QVariant> RootFilesSection::customRoleDefaults() const {
   return root_search::customRoleDefaults();
+}
+
+std::unique_ptr<QMimeData> RootFilesSection::dragMimeData(int i) const {
+  if (!isDraggable(i)) return {};
+
+  auto data = std::make_unique<QMimeData>();
+  auto path = QString::fromStdString(m_files[i].path.string());
+  data->setUrls({QUrl::fromLocalFile(path)});
+  data->setText(path);
+  return data;
 }
 
 std::unique_ptr<ActionPanelState> RootFilesSection::actionPanel(int i) const {

--- a/src/server/src/qml/root-search-sources.hpp
+++ b/src/server/src/qml/root-search-sources.hpp
@@ -51,6 +51,16 @@ QString resolveAccessoryColor(const std::optional<ColorLike> &color);
 class RootItemSection : public SectionSource {
 public:
   virtual const RootItem *rootItem(int i) const = 0;
+
+  bool isDraggable(int i) const override {
+    const auto *item = rootItem(i);
+    return item && item->isDraggable();
+  }
+
+  std::unique_ptr<QMimeData> dragMimeData(int i) const override {
+    const auto *item = rootItem(i);
+    return item ? item->dragMimeData() : nullptr;
+  }
 };
 
 class RootLinkSection : public SectionSource {
@@ -64,6 +74,8 @@ public:
   QVariant customData(int i, int role) const override;
   QHash<int, QByteArray> customRoleNames() const override;
   QHash<int, QVariant> customRoleDefaults() const override;
+  bool isDraggable(int) const override { return m_link.has_value(); }
+  std::unique_ptr<QMimeData> dragMimeData(int) const override;
   std::unique_ptr<ActionPanelState> actionPanel(int) const override;
 
   void setLink(std::optional<LinkItem> link) { m_link = std::move(link); }
@@ -202,6 +214,8 @@ public:
   QVariant customData(int i, int role) const override;
   QHash<int, QByteArray> customRoleNames() const override;
   QHash<int, QVariant> customRoleDefaults() const override;
+  bool isDraggable(int i) const override { return i >= 0 && std::cmp_less(i, m_files.size()); }
+  std::unique_ptr<QMimeData> dragMimeData(int i) const override;
   std::unique_ptr<ActionPanelState> actionPanel(int i) const override;
 
   void setFiles(std::vector<IndexerFileResult> files) { m_files = std::move(files); }

--- a/src/server/src/qml/search-files-model.cpp
+++ b/src/server/src/qml/search-files-model.cpp
@@ -1,8 +1,8 @@
+#include <QUrl>
+
 #include "search-files-model.hpp"
 #include "utils/file-list-item.hpp"
 #include "utils/utils.hpp"
-#include <QDebug>
-#include <QUrl>
 
 void SearchFilesSection::setFiles(std::vector<std::filesystem::path> files, const QString &sectionName) {
   m_files = std::move(files);
@@ -26,40 +26,10 @@ std::unique_ptr<ActionPanelState> SearchFilesSection::actionPanel(int i) const {
   return FileActions::actionPanel(m_files.at(i), scope().appContext());
 }
 
-QVariant SearchFilesSection::customData(int i, int role) const {
-  if (std::cmp_greater_equal(i, m_files.size())) return {};
-  static int dbgCount = 0;
-  switch (role) {
-  case SectionListModel::FilePath: {
-    auto val = QString::fromStdString(m_files[i].string());
-    if (dbgCount++ < 3) qDebug() << "[DRAG] customData FilePathRole i=" << i << "val=" << val;
-    return val;
-  }
-  case SectionListModel::FileUrl: {
-    auto val = QUrl::fromLocalFile(QString::fromStdString(m_files[i].string())).toString();
-    if (dbgCount++ < 3) qDebug() << "[DRAG] customData FileUrlRole i=" << i << "val=" << val;
-    return val;
-  }
-  default:
-    return {};
-  }
-}
-
-QHash<int, QByteArray> SearchFilesSection::customRoleNames() const {
-  static int callCount = 0;
-  if (callCount++ == 0) {
-    qDebug() << "[DRAG] SearchFilesSection::customRoleNames() called, roles:" << SectionListModel::FilePath
-             << SectionListModel::FileUrl;
-  }
-  return {
-      {SectionListModel::FilePath, "filePath"},
-      {SectionListModel::FileUrl, "fileUrl"},
-  };
-}
-
-QHash<int, QVariant> SearchFilesSection::customRoleDefaults() const {
-  return {
-      {SectionListModel::FilePath, QString()},
-      {SectionListModel::FileUrl, QString()},
-  };
+std::unique_ptr<QMimeData> SearchFilesSection::dragMimeData(int i) const {
+  auto data = std::make_unique<QMimeData>();
+  auto path = QString::fromStdString(m_files.at(i).string());
+  data->setUrls({QUrl::fromLocalFile(path)});
+  data->setText(path);
+  return data;
 }

--- a/src/server/src/qml/search-files-model.hpp
+++ b/src/server/src/qml/search-files-model.hpp
@@ -22,9 +22,8 @@ public:
 
   QString itemId(int i) const override;
 
-  QVariant customData(int i, int role) const override;
-  QHash<int, QByteArray> customRoleNames() const override;
-  QHash<int, QVariant> customRoleDefaults() const override;
+  bool isDraggable(int) const override { return true; }
+  std::unique_ptr<QMimeData> dragMimeData(int i) const override;
 
 protected:
   QString itemTitle(int i) const override;

--- a/src/server/src/qml/section-grid-model.cpp
+++ b/src/server/src/qml/section-grid-model.cpp
@@ -1,7 +1,6 @@
-#include <QDrag>
-
 #include <algorithm>
 
+#include "drag-utils.hpp"
 #include "section-grid-model.hpp"
 #include "services/navigation/list-navigation.hpp"
 SectionGridModel::SectionGridModel(QObject *parent) : QAbstractListModel(parent) {}
@@ -229,13 +228,8 @@ void SectionGridModel::startDrag(int section, int item, QObject *dragSource) {
   int itemIdx;
   if (!dragSource || !resolveSelection(section, item, sourceIdx, itemIdx)) return;
 
-  auto mimeData = m_sources[sourceIdx]->dragMimeData(itemIdx);
-  if (!mimeData) return;
-
-  auto *drag = new QDrag(dragSource);
-  drag->setMimeData(mimeData.release());
-  drag->exec(Qt::CopyAction);
-  drag->deleteLater();
+  auto *source = m_sources[sourceIdx];
+  DragUtils::startDrag(dragSource, source->dragMimeData(itemIdx), source->itemIconSource(itemIdx));
 }
 
 void SectionGridModel::selectFirst() {

--- a/src/server/src/qml/section-grid-model.cpp
+++ b/src/server/src/qml/section-grid-model.cpp
@@ -1,7 +1,9 @@
-#include "section-grid-model.hpp"
-#include "services/navigation/list-navigation.hpp"
+#include <QDrag>
+
 #include <algorithm>
 
+#include "section-grid-model.hpp"
+#include "services/navigation/list-navigation.hpp"
 SectionGridModel::SectionGridModel(QObject *parent) : QAbstractListModel(parent) {}
 
 void SectionGridModel::addSource(GridSource *source) {
@@ -214,6 +216,26 @@ void SectionGridModel::select(int section, int item) {
       m_scope.clearActions();
     }
   }
+}
+
+bool SectionGridModel::isDraggable(int section, int item) const {
+  int sourceIdx;
+  int itemIdx;
+  return resolveSelection(section, item, sourceIdx, itemIdx) && m_sources[sourceIdx]->isDraggable(itemIdx);
+}
+
+void SectionGridModel::startDrag(int section, int item, QObject *dragSource) {
+  int sourceIdx;
+  int itemIdx;
+  if (!dragSource || !resolveSelection(section, item, sourceIdx, itemIdx)) return;
+
+  auto mimeData = m_sources[sourceIdx]->dragMimeData(itemIdx);
+  if (!mimeData) return;
+
+  auto *drag = new QDrag(dragSource);
+  drag->setMimeData(mimeData.release());
+  drag->exec(Qt::CopyAction);
+  drag->deleteLater();
 }
 
 void SectionGridModel::selectFirst() {

--- a/src/server/src/qml/section-grid-model.hpp
+++ b/src/server/src/qml/section-grid-model.hpp
@@ -1,11 +1,12 @@
 #pragma once
-#include "grid-source.hpp"
-#include "view-scope.hpp"
 #include <QAbstractListModel>
+
 #include <cstdint>
 #include <memory>
 #include <vector>
 
+#include "grid-source.hpp"
+#include "view-scope.hpp"
 class ActionPanelState;
 
 class SectionGridModel : public QAbstractListModel {
@@ -55,6 +56,8 @@ public:
   void setSelectFirstOnReset(bool value) { m_selectFirstOnReset = value; }
 
   Q_INVOKABLE void select(int section, int item);
+  Q_INVOKABLE bool isDraggable(int section, int item) const;
+  Q_INVOKABLE void startDrag(int section, int item, QObject *source);
   Q_INVOKABLE void activateSelected();
   Q_INVOKABLE void navigateUp();
   Q_INVOKABLE void navigateDown();

--- a/src/server/src/qml/section-list-model.cpp
+++ b/src/server/src/qml/section-list-model.cpp
@@ -1,7 +1,8 @@
-#include "section-list-model.hpp"
+#include <QDrag>
 
 #include <utility>
 
+#include "section-list-model.hpp"
 #include "services/navigation/list-navigation.hpp"
 
 SectionListModel::SectionListModel(QObject *parent) : QAbstractListModel(parent) {
@@ -82,9 +83,8 @@ QVariant SectionListModel::data(const QModelIndex &index, int role) const {
       return QString();
     case Accessory:
       return {};
-    case FilePath:
-    case FileUrl:
-      return QString();
+    case IsDraggable:
+      return false;
     default: {
       auto it = m_customRoleDefaults.find(role);
       return it != m_customRoleDefaults.end() ? it.value() : QVariant{};
@@ -109,6 +109,8 @@ QVariant SectionListModel::data(const QModelIndex &index, int role) const {
     return source->itemIconSource(flat.itemIdx);
   case Accessory:
     return source->itemAccessories(flat.itemIdx);
+  case IsDraggable:
+    return source->isDraggable(flat.itemIdx);
   default: {
     auto v = source->customData(flat.itemIdx, role);
     if (v.isValid()) return v;
@@ -123,8 +125,7 @@ QHash<int, QByteArray> SectionListModel::roleNames() const {
       {IsSection, "isSection"},     {IsSelectable, "isSelectable"},
       {SectionName, "sectionName"}, {Title, "title"},
       {Subtitle, "subtitle"},       {IconSource, "iconSource"},
-      {Accessory, "itemAccessory"}, {FilePath, "filePath"},
-      {FileUrl, "fileUrl"},
+      {Accessory, "itemAccessory"}, {IsDraggable, "isDraggable"},
   };
   for (auto *source : m_sources)
     roles.insert(source->customRoleNames());
@@ -164,6 +165,20 @@ void SectionListModel::setSelectedIndex(int index) {
   }
 
   emit itemSelected(source, flat.itemIdx);
+}
+
+void SectionListModel::startDrag(int index, QObject *dragSource) {
+  int sourceIdx;
+  int itemIdx;
+  if (!dragSource || !dataItemAt(index, sourceIdx, itemIdx)) return;
+
+  auto mimeData = m_sources[sourceIdx]->dragMimeData(itemIdx);
+  if (!mimeData) return;
+
+  auto *drag = new QDrag(dragSource);
+  drag->setMimeData(mimeData.release());
+  drag->exec(Qt::CopyAction);
+  drag->deleteLater();
 }
 
 void SectionListModel::refreshActionPanel() { setSelectedIndex(m_selectedIndex); }

--- a/src/server/src/qml/section-list-model.cpp
+++ b/src/server/src/qml/section-list-model.cpp
@@ -1,7 +1,6 @@
-#include <QDrag>
-
 #include <utility>
 
+#include "drag-utils.hpp"
 #include "section-list-model.hpp"
 #include "services/navigation/list-navigation.hpp"
 
@@ -172,13 +171,8 @@ void SectionListModel::startDrag(int index, QObject *dragSource) {
   int itemIdx;
   if (!dragSource || !dataItemAt(index, sourceIdx, itemIdx)) return;
 
-  auto mimeData = m_sources[sourceIdx]->dragMimeData(itemIdx);
-  if (!mimeData) return;
-
-  auto *drag = new QDrag(dragSource);
-  drag->setMimeData(mimeData.release());
-  drag->exec(Qt::CopyAction);
-  drag->deleteLater();
+  auto *source = m_sources[sourceIdx];
+  DragUtils::startDrag(dragSource, source->dragMimeData(itemIdx), source->itemIconSource(itemIdx));
 }
 
 void SectionListModel::refreshActionPanel() { setSelectedIndex(m_selectedIndex); }

--- a/src/server/src/qml/section-list-model.hpp
+++ b/src/server/src/qml/section-list-model.hpp
@@ -1,11 +1,12 @@
 #pragma once
-#include "section-source.hpp"
-#include "view-scope.hpp"
-#include "theme.hpp"
 #include <QAbstractListModel>
+
 #include <memory>
 #include <vector>
 
+#include "section-source.hpp"
+#include "theme.hpp"
+#include "view-scope.hpp"
 class SectionListModel : public QAbstractListModel {
   Q_OBJECT
   Q_PROPERTY(bool selectFirstOnReset READ selectFirstOnReset NOTIFY selectFirstOnResetChanged)
@@ -28,8 +29,7 @@ public:
     Subtitle,
     IconSource,
     Accessory,
-    FilePath,
-    FileUrl,
+    IsDraggable,
   };
 
   explicit SectionListModel(QObject *parent = nullptr);
@@ -51,6 +51,7 @@ public:
   int selectedIndex() const { return m_selectedIndex; }
 
   Q_INVOKABLE virtual void setSelectedIndex(int index);
+  Q_INVOKABLE void startDrag(int index, QObject *source);
   Q_INVOKABLE void activateSelected();
   Q_INVOKABLE int nextSelectableIndex(int from, int direction) const;
   Q_INVOKABLE int nextSectionIndex(int from, int direction) const;

--- a/src/server/src/qml/section-source.hpp
+++ b/src/server/src/qml/section-source.hpp
@@ -1,11 +1,13 @@
 #pragma once
-#include "view-scope.hpp"
-#include "view-utils.hpp"
+#include <QMimeData>
 #include <QVariantList>
+
 #include <functional>
 #include <memory>
 #include <string_view>
 
+#include "view-scope.hpp"
+#include "view-utils.hpp"
 class ActionPanelState;
 
 class SectionSource {
@@ -23,6 +25,9 @@ public:
   virtual QString itemSubtitle(int) const { return {}; }
   virtual QString itemIconSource(int i) const = 0;
   virtual QVariantList itemAccessories(int) const { return {}; }
+
+  virtual bool isDraggable(int) const { return false; }
+  virtual std::unique_ptr<QMimeData> dragMimeData(int) const { return {}; }
 
   virtual QVariant customData(int, int) const { return {}; }
   virtual QHash<int, QByteArray> customRoleNames() const { return {}; }

--- a/src/server/src/services/clipboard/clipboard-content.hpp
+++ b/src/server/src/services/clipboard/clipboard-content.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <QUrl>
+
+#include <filesystem>
+#include <optional>
+#include <variant>
+#include <vector>
+
+#include "services/clipboard/clipboard-server.hpp"
+
+namespace Clipboard {
+
+using NoData = std::monostate;
+
+struct File {
+  std::filesystem::path path;
+};
+
+struct Urls {
+  std::vector<QUrl> values;
+};
+
+struct Text {
+  QString text;
+};
+
+struct Html {
+  QString html;
+  std::optional<QString> text;
+};
+
+struct SelectionRecordHandle {
+  QString id;
+};
+
+using Content = std::variant<NoData, File, Urls, Text, Html, SelectionRecordHandle, ClipboardSelection>;
+
+struct ReadContent {
+  QString text;
+  std::optional<QString> html;
+  std::vector<QUrl> urls;
+};
+
+} // namespace Clipboard

--- a/src/server/src/services/clipboard/clipboard-mime.cpp
+++ b/src/server/src/services/clipboard/clipboard-mime.cpp
@@ -4,6 +4,7 @@
 #include <QBuffer>
 #include <qlogging.h>
 #include <ranges>
+#include <concepts>
 
 static bool isLegacyContentType(const QString &str) {
   if (str.startsWith("-x") || str.startsWith("-X")) return false;
@@ -11,6 +12,30 @@ static bool isLegacyContentType(const QString &str) {
 }
 
 namespace Clipboard {
+
+std::unique_ptr<QMimeData> mimeDataForContent(const Content &content) {
+  return std::visit(
+      [](const auto &value) -> std::unique_ptr<QMimeData> {
+        using T = std::decay_t<decltype(value)>;
+        auto data = std::make_unique<QMimeData>();
+
+        if constexpr (std::same_as<T, Text>) {
+          data->setText(value.text);
+        } else if constexpr (std::same_as<T, Html>) {
+          data->setHtml(value.html);
+          if (value.text) data->setText(*value.text);
+        } else if constexpr (std::same_as<T, File>) {
+          data->setUrls({QUrl::fromLocalFile(QString::fromStdString(value.path.string()))});
+        } else if constexpr (std::same_as<T, Urls>) {
+          data->setUrls(QList<QUrl>(value.values.begin(), value.values.end()));
+        } else {
+          return nullptr;
+        }
+
+        return data;
+      },
+      content);
+}
 
 std::optional<ClipboardSelection> selectionFromMimeData(const QMimeData *mimeData) {
   if (!mimeData) return std::nullopt;

--- a/src/server/src/services/clipboard/clipboard-mime.hpp
+++ b/src/server/src/services/clipboard/clipboard-mime.hpp
@@ -1,10 +1,13 @@
 #pragma once
-#include <optional>
 #include <QMimeData>
+#include <memory>
+#include <optional>
+#include "services/clipboard/clipboard-content.hpp"
 #include "services/clipboard/clipboard-server.hpp"
 
 namespace Clipboard {
 
 std::optional<ClipboardSelection> selectionFromMimeData(const QMimeData *mimeData);
+std::unique_ptr<QMimeData> mimeDataForContent(const Content &content);
 
-}
+} // namespace Clipboard

--- a/src/server/src/services/clipboard/clipboard-service.cpp
+++ b/src/server/src/services/clipboard/clipboard-service.cpp
@@ -23,6 +23,7 @@
 #include "services/app-service/app-service.hpp"
 #include "services/clipboard/clipboard-db.hpp"
 #include "services/clipboard/clipboard-encrypter.hpp"
+#include "services/clipboard/clipboard-mime.hpp"
 #include "services/clipboard/clipboard-server.hpp"
 #include "utils.hpp"
 #ifdef Q_OS_LINUX
@@ -66,6 +67,7 @@ bool ClipboardService::copyContent(const Clipboard::Content &content, const Clip
     }
     bool operator()(const Clipboard::Html &html) const { return service.copyHtml(html, options); }
     bool operator()(const Clipboard::File &file) const { return service.copyFile(file.path, options); }
+    bool operator()(const Clipboard::Urls &urls) const { return service.copyUrls(urls.values, options); }
     bool operator()(const Clipboard::Text &text) const { return service.copyText(text.text, options); }
     bool operator()(const ClipboardSelection &selection) const {
       return service.copySelection(selection, options);
@@ -89,6 +91,12 @@ bool ClipboardService::copyFile(const std::filesystem::path &path, const Clipboa
   data->setUrls({QUrl::fromLocalFile(QString::fromStdString(path.string()))});
 
   return copyQMimeData(data, options);
+}
+
+bool ClipboardService::copyUrls(const std::vector<QUrl> &urls, const Clipboard::CopyOptions &options) {
+  auto data = Clipboard::mimeDataForContent(Clipboard::Urls{urls});
+
+  return copyQMimeData(data.release(), options);
 }
 
 void ClipboardService::setRecordAllOffers(bool value) { m_recordAllOffers = value; }
@@ -592,12 +600,8 @@ Clipboard::ReadContent ClipboardService::readContent() {
   if (!mimeData) return content;
 
   if (mimeData->hasUrls()) {
-    for (const auto &url : mimeData->urls()) {
-      if (url.isLocalFile()) {
-        content.file = url.toLocalFile();
-        break;
-      }
-    }
+    const auto urls = mimeData->urls();
+    content.urls.assign(urls.begin(), urls.end());
   }
 
   if (mimeData->hasHtml()) { content.html = mimeData->html(); }

--- a/src/server/src/services/clipboard/clipboard-service.hpp
+++ b/src/server/src/services/clipboard/clipboard-service.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "common.hpp"
 #include "extensions/wm/wm-extension.hpp"
+#include "services/clipboard/clipboard-content.hpp"
 #include "services/clipboard/clipboard-db.hpp"
 #include "services/clipboard/clipboard-encrypter.hpp"
 #include "services/clipboard/clipboard-server.hpp"
@@ -15,33 +16,6 @@
 #include <qmimedatabase.h>
 #include <qstringview.h>
 #include <QTimer>
-
-namespace Clipboard {
-using NoData = std::monostate;
-struct File {
-  std::filesystem::path path;
-};
-struct Text {
-  QString text;
-};
-struct Html {
-  QString html;
-  std::optional<QString> text;
-};
-
-struct SelectionRecordHandle {
-  QString id;
-};
-
-using Content = std::variant<NoData, File, Text, Html, SelectionRecordHandle, ClipboardSelection>;
-
-struct ReadContent {
-  QString text;
-  std::optional<QString> html;
-  std::optional<QString> file;
-};
-
-}; // namespace Clipboard
 
 class ClipboardService : public QObject, public NonCopyable {
   Q_OBJECT
@@ -89,6 +63,7 @@ public:
   bool copyHtml(const Clipboard::Html &data, const Clipboard::CopyOptions &options = {.concealed = false});
   bool copyFile(const std::filesystem::path &path,
                 const Clipboard::CopyOptions &options = {.concealed = false});
+  bool copyUrls(const std::vector<QUrl> &urls, const Clipboard::CopyOptions &options = {.concealed = false});
   bool copyContent(const Clipboard::Content &content,
                    const Clipboard::CopyOptions options = {.concealed = false});
   void setRecordAllOffers(bool value);

--- a/src/server/src/services/root-item-manager/root-item-manager.hpp
+++ b/src/server/src/services/root-item-manager/root-item-manager.hpp
@@ -16,6 +16,7 @@
 #include <qjsonobject.h>
 #include <qjsonvalue.h>
 #include <qlogging.h>
+#include <qmimedata.h>
 #include <qnamespace.h>
 #include <qobject.h>
 #include <qobjectdefs.h>
@@ -55,6 +56,9 @@ public:
   virtual QString title() const = 0;
 
   virtual ImageURL iconUrl() const = 0;
+
+  virtual bool isDraggable() const { return false; }
+  virtual std::unique_ptr<QMimeData> dragMimeData() const { return {}; }
 
   /**
    * Whether the item can be selected as a fallback command or not

--- a/src/server/src/ui/image/image-renderer.hpp
+++ b/src/server/src/ui/image/image-renderer.hpp
@@ -5,6 +5,8 @@
 #include <QSize>
 #include <QString>
 
+#include <optional>
+
 class ImageURL;
 class QThread;
 class QThreadPool;
@@ -12,6 +14,7 @@ class QThreadPool;
 namespace ImageRendering {
 
 QFuture<QImage> renderFirstFrame(const ImageURL &url, const QSize &size, bool safetyMargins = false);
+std::optional<QImage> cachedFrame(const ImageURL &url);
 
 QImage renderBuiltinSvg(const QString &name, const QSize &size, const QColor &fg, const QColor &bg);
 QImage renderEmoji(const QString &emoji, const QSize &size);

--- a/src/server/src/ui/image/image-stream.cpp
+++ b/src/server/src/ui/image/image-stream.cpp
@@ -36,6 +36,11 @@ static QCache<QString, QImage> &imageCache() {
   return cache;
 }
 
+static QCache<QString, QImage> &latestImageCache() {
+  static QCache<QString, QImage> cache(256);
+  return cache;
+}
+
 static QCache<QString, QByteArray> &bytesCache() {
   static QCache<QString, QByteArray> cache(32 * 1024 * 1024);
   return cache;
@@ -44,9 +49,17 @@ static QCache<QString, QByteArray> &bytesCache() {
 namespace ImageRendering {
 void clearCache() {
   imageCache().clear();
+  latestImageCache().clear();
   bytesCache().clear();
 }
 } // namespace ImageRendering
+
+static QString makeLatestCacheKey(const ImageURL &url) {
+  auto key = url.toString();
+  if (url.type() == ImageURLType::System || url.type() == ImageURLType::FileIcon)
+    key += QStringLiteral("|it:") + QIcon::themeName();
+  return key;
+}
 
 static QString makeCacheKey(const ImageURL &url, const QSize &size, bool safetyMargins) {
   auto key = QStringLiteral("%1|%2x%3").arg(url.toString()).arg(size.width()).arg(size.height());
@@ -55,6 +68,13 @@ static QString makeCacheKey(const ImageURL &url, const QSize &size, bool safetyM
     key += QStringLiteral("|it:") + QIcon::themeName();
   return key;
 }
+
+namespace ImageRendering {
+std::optional<QImage> cachedFrame(const ImageURL &url) {
+  if (auto *cached = latestImageCache().object(makeLatestCacheKey(url.resolved()))) return *cached;
+  return std::nullopt;
+}
+} // namespace ImageRendering
 
 static bool isGif(const QByteArray &data) {
   return data.size() >= 6 && (data.startsWith("GIF87a") || data.startsWith("GIF89a"));
@@ -75,6 +95,8 @@ ImageStream::ImageStream(const ImageURL &url, const QSize &size, ImageStreamOpti
   m_mask = m_url.mask();
   m_cacheKey = makeCacheKey(m_url, size, m_opts.safetyMargins);
   m_originalCacheKey = m_cacheKey;
+  m_latestCacheKey = makeLatestCacheKey(m_url);
+  m_originalLatestCacheKey = m_latestCacheKey;
 }
 
 ImageStream::~ImageStream() {
@@ -127,6 +149,7 @@ void ImageStream::tryFallback() {
   if (auto fill = m_url.fillColor()) m_fg = OmniPainter::resolveColor(*fill);
   m_mask = m_url.mask();
   m_cacheKey = makeCacheKey(m_url, m_size, m_opts.safetyMargins);
+  m_latestCacheKey = makeLatestCacheKey(m_url);
 
   if (m_opts.cache) {
     if (auto *cached = imageCache().object(m_cacheKey)) {
@@ -352,6 +375,9 @@ void ImageStream::emitStaticFrame(QImage img) {
     auto cost = static_cast<int>(img.sizeInBytes());
     imageCache().insert(m_cacheKey, new QImage(img), cost);
     if (m_originalCacheKey != m_cacheKey) imageCache().insert(m_originalCacheKey, new QImage(img), cost);
+    latestImageCache().insert(m_latestCacheKey, new QImage(img));
+    if (m_originalLatestCacheKey != m_latestCacheKey)
+      latestImageCache().insert(m_originalLatestCacheKey, new QImage(img));
   }
   emit frameReady(img);
 }
@@ -392,8 +418,14 @@ void ImageStream::startAnimation(QByteArray data) {
     emit worker->frameReady(frame);
   });
 
-  connect(worker, &AnimFrameWorker::frameReady, this,
-          [this](const QImage &frame) { emit this->frameReady(frame); });
+  connect(worker, &AnimFrameWorker::frameReady, this, [this](const QImage &frame) {
+    if (m_opts.cache) {
+      latestImageCache().insert(m_latestCacheKey, new QImage(frame));
+      if (m_originalLatestCacheKey != m_latestCacheKey)
+        latestImageCache().insert(m_originalLatestCacheKey, new QImage(frame));
+    }
+    emit this->frameReady(frame);
+  });
 
   m_movie = movie;
   movie->moveToThread(&ImageRendering::animationThread());

--- a/src/server/src/ui/image/image-stream.hpp
+++ b/src/server/src/ui/image/image-stream.hpp
@@ -51,6 +51,8 @@ private:
   OmniPainter::ImageMaskType m_mask = OmniPainter::NoMask;
   QString m_cacheKey;
   QString m_originalCacheKey;
+  QString m_latestCacheKey;
+  QString m_originalLatestCacheKey;
   int m_fallbacksRemaining = 2;
   ImageStreamOptions m_opts;
 

--- a/src/typescript/api/src/api/clipboard.ts
+++ b/src/typescript/api/src/api/clipboard.ts
@@ -1,4 +1,5 @@
 import type { PathLike } from "node:fs";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import type { ClipboardContent } from "./proto/api";
 import { getClient } from "./client";
 
@@ -11,19 +12,21 @@ export namespace Clipboard {
 	export type Content =
 		| { text: string }
 		| { file: PathLike }
+		| { urls: Array<string | URL> }
 		| { html: string; text?: string };
 
 	export type ReadContent = {
 		text?: string;
 		file?: string;
 		html?: string;
+		urls?: string[];
 	};
 
 	export type CopyOptions = {
 		concealed?: boolean;
 	};
 
-	function mapContent(
+	export function serializeContent(
 		content: string | number | Clipboard.Content,
 	): ClipboardContent {
 		let ct: ClipboardContent = {};
@@ -32,7 +35,12 @@ export namespace Clipboard {
 			ct.text = `${content}`;
 		} else {
 			if (content["file"]) {
-				ct.path = content["file"];
+				const file = content["file"];
+				ct.urls = [
+					file instanceof URL ? file.href : pathToFileURL(file.toString()).href,
+				];
+			} else if (content["urls"]) {
+				ct.urls = content["urls"].map((url) => url.toString());
 			} else if (content["html"]) {
 				ct.html = content["html"];
 				ct.text = content["text"];
@@ -53,7 +61,7 @@ export namespace Clipboard {
 		text: string | number | Clipboard.Content,
 		options: Clipboard.CopyOptions = {},
 	) {
-		await getClient().Clipboard.copy(mapContent(text), {
+		await getClient().Clipboard.copy(serializeContent(text), {
 			concealed: options.concealed ?? false,
 		});
 	}
@@ -65,7 +73,7 @@ export namespace Clipboard {
 	 * clipboard copy.
 	 */
 	export async function paste(text: string | number | Clipboard.Content) {
-		await getClient().Clipboard.paste(mapContent(text));
+		await getClient().Clipboard.paste(serializeContent(text));
 	}
 
 	/**
@@ -77,7 +85,24 @@ export namespace Clipboard {
 	 * ```
 	 */
 	export async function read(): Promise<Clipboard.ReadContent> {
-		return getClient().Clipboard.readContent();
+		const content = await getClient().Clipboard.readContent();
+		const fileUrl = content.urls?.find((url) => url.startsWith("file:"));
+		let file: string | undefined;
+
+		if (fileUrl) {
+			try {
+				file = fileURLToPath(fileUrl);
+			} catch {
+				// Ignore malformed file URLs supplied by another application.
+			}
+		}
+
+		return {
+			text: content.text,
+			html: content.html,
+			urls: content.urls,
+			file,
+		};
 	}
 
 	/**

--- a/src/typescript/api/src/api/components/grid.tsx
+++ b/src/typescript/api/src/api/components/grid.tsx
@@ -6,6 +6,7 @@ import { type ColorLike, serializeColorLike } from "../color";
 import { Dropdown } from "./dropdown";
 import { useEventCounted } from "../hooks/use-event-counted";
 import { usePagination } from "./pagination";
+import { Clipboard } from "../clipboard";
 
 enum GridInset {
 	Zero = "zero",
@@ -168,6 +169,8 @@ export namespace Grid {
 			id?: string;
 			subtitle?: string;
 			actions?: ReactNode;
+			/** Content transferred when this item is dragged. */
+			dragContent?: Clipboard.Content;
 			accessory?: Grid.Item.Accessory;
 		};
 
@@ -235,6 +238,7 @@ const GridRoot: React.FC<Grid.Props> = ({
 const GridItem: React.FC<Grid.Item.Props> = ({
 	detail,
 	actions,
+	dragContent,
 	content,
 	accessory,
 	...props
@@ -280,6 +284,9 @@ const GridItem: React.FC<Grid.Item.Props> = ({
 		<grid-item
 			{...props}
 			content={serializedContent}
+			dragContent={
+				dragContent ? Clipboard.serializeContent(dragContent) : undefined
+			}
 			tooltip={tooltip}
 			accessory={serializedAccessory}
 			id={id.current}

--- a/src/typescript/api/src/api/components/list.tsx
+++ b/src/typescript/api/src/api/components/list.tsx
@@ -18,6 +18,7 @@ import {
 } from "../color";
 import { Dropdown } from "./dropdown";
 import { usePagination } from "./pagination";
+import { Clipboard } from "../clipboard";
 
 /**
  * A List component that can be used to render a list of items sharing a similar representation.
@@ -200,6 +201,9 @@ export declare namespace List {
 			 */
 			actions?: ReactNode;
 
+			/** Content transferred when this item is dragged. */
+			dragContent?: Clipboard.Content;
+
 			accessories?: List.Item.Accessory[];
 
 			/**
@@ -348,6 +352,7 @@ const ListRoot: React.FC<List.Props> = ({
 const ListItem: React.FC<List.Item.Props> = ({
 	detail,
 	actions,
+	dragContent,
 	icon,
 	accessories,
 	...props
@@ -373,6 +378,9 @@ const ListItem: React.FC<List.Item.Props> = ({
 		<list-item
 			{...props}
 			icon={serializedIcon}
+			dragContent={
+				dragContent ? Clipboard.serializeContent(dragContent) : undefined
+			}
 			accessories={serializedAccessories}
 			id={id.current}
 		>

--- a/src/typescript/api/src/api/proto/api.ts
+++ b/src/typescript/api/src/api/proto/api.ts
@@ -200,7 +200,7 @@ export type Workspace = {
 export type ClipboardContent = {
 	text?: string;
 	html?: string;
-	path?: string;
+	urls?: string[];
 }
 
 export type ClipboardOptions = {

--- a/src/typescript/api/types/jsx.d.ts
+++ b/src/typescript/api/types/jsx.d.ts
@@ -9,6 +9,7 @@ import type {
 	SerializedColorLike,
 	SerializedImageLike,
 } from "../src";
+import type { ClipboardContent } from "../src/api/proto/api";
 
 type BaseFormField = {
 	onBlur?: Function;
@@ -62,6 +63,7 @@ declare module "react" {
 							tooltip: string;
 					  };
 				keywords?: string[];
+				dragContent?: ClipboardContent;
 				accessories?: List.Item.SerializedAccessory[];
 				children?: React.ReactNode;
 			};
@@ -103,6 +105,7 @@ declare module "react" {
 				content?: SerializedImageLike | { color: SerializedColorLike };
 				tooltip?: string;
 				keywords?: string[];
+				dragContent?: ClipboardContent;
 				accessory?: {
 					icon?: SerializedImageLike;
 					tooltip?: string | null;


### PR DESCRIPTION
Make drag and drop a first party concept for every view, so that it's not exclusive to the file search command.
This involves a few notable changes:

- list/grid views do no longer flick, as it would interfere with the drag and drop gesture. Flicking is not really expected on the desktop anyways.
- when dragging a draggable item, we use its icon as the drag icon so that there is some visual indication that the drag is happening.
- We now expose a `dragContent` prop for `<List.Item />` and `<Grid.Item />` so that they can specify what content should be transferred when dragging. This take a `Clipboard.Content` object, which is the same object taken by the `Clipboard` APIs.
- files can know be dragged in the root search as well