### PR TITLE
fix: expose telemetry payload in release logs

### DIFF
--- a/src/server/src/services/telemetry/telemetry-service.cpp
+++ b/src/server/src/services/telemetry/telemetry-service.cpp
@@ -97,7 +97,7 @@ void TelemetryService::sendSystemInfo() {
 
   std::string debugBuf;
   [[maybe_unused]] auto writeErr = glz::write_json(payload, debugBuf);
-  qDebug().noquote() << "Sending system info:\n" << glz::prettify_json(debugBuf);
+  qInfo().noquote() << "Sending system info:\n" << glz::prettify_json(debugBuf);
 
   m_client.post<SystemInfoResponse, SystemInfoRequest>("/telemetry/system-info", std::move(payload))
       .then([this](const http::Client::Result<SystemInfoResponse> &res) {

--- a/src/server/src/services/telemetry/telemetry-service.cpp
+++ b/src/server/src/services/telemetry/telemetry-service.cpp
@@ -95,9 +95,9 @@ void TelemetryService::sendSystemInfo() {
   payload.productVersion = QSysInfo::productVersion().toStdString();
   payload.qtVersion = QT_VERSION_STR;
 
-  std::string debugBuf;
-  [[maybe_unused]] auto writeErr = glz::write_json(payload, debugBuf);
-  qInfo().noquote() << "Sending system info:\n" << glz::prettify_json(debugBuf);
+  std::string payloadJson;
+  [[maybe_unused]] auto writeErr = glz::write_json(payload, payloadJson);
+  qInfo().noquote() << "Sending system info:\n" << glz::prettify_json(payloadJson);
 
   m_client.post<SystemInfoResponse, SystemInfoRequest>("/telemetry/system-info", std::move(payload))
       .then([this](const http::Client::Result<SystemInfoResponse> &res) {


### PR DESCRIPTION
- log the telemetry payload at info level instead of debug level
- make the exact payload visible in release logs before it is sent

- `make check-format`
- `cmake --build --preset macos-debug --target vicinae-server --parallel`
- ran the release-mode server with isolated state and `VICINAE_API_URL` redirected to localhost; confirmed the full payload is written at info level before the POST attempt

Closes #1737