### PR TITLE
feat: allow excluding apps from the global toggle hotkey

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -72,5 +72,6 @@ jobs:
         run: |
           ./build/bin/vicinae-glyph-tests
           ./build/bin/vicinae-fuzzy-tests
+          ./build/bin/vicinae-server-config-tests
           ./build/bin/xdgpp-tests
           ./build/bin/scriptcommand-tests

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ test:
 	./$(BIN_DIR)/vicinae-glyph-tests
 	./$(BIN_DIR)/vicinae-fuzzy-tests
 	./$(BIN_DIR)/vicinae-server-tests
+	./$(BIN_DIR)/vicinae-server-config-tests
 	./$(BIN_DIR)/xdgpp-tests
 	./$(BIN_DIR)/scriptcommand-tests
 	./$(BIN_DIR)/vicinae-file-indexer-tests

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -1235,3 +1235,16 @@ if (BUILD_TESTS AND UNIX AND NOT APPLE)
 	target_link_libraries(${TEST_TARGET} PRIVATE Catch2::Catch2WithMain Qt6::Core Qt6::Gui)
 	target_compile_features(${TEST_TARGET} PUBLIC cxx_std_23)
 endif()
+
+if (BUILD_TESTS)
+	set(CONFIG_TEST_TARGET ${TARGET}-config-tests)
+	find_package(Catch2 3 REQUIRED)
+	add_executable(${CONFIG_TEST_TARGET}
+		src/config/config.cpp
+		src/utils/utils.cpp
+		tests/config/manager.cpp
+		${CMAKE_CURRENT_BINARY_DIR}/resources-core.qrc
+	)
+	target_link_libraries(${CONFIG_TEST_TARGET} PRIVATE Catch2::Catch2WithMain glaze::glaze Qt6::Core Qt6::Gui)
+	target_compile_features(${CONFIG_TEST_TARGET} PUBLIC cxx_std_23)
+endif()

--- a/src/server/src/config/config.cpp
+++ b/src/server/src/config/config.cpp
@@ -308,9 +308,10 @@ void Manager::prunePartial(Partial<ConfigValue> &user) {
           }
 
           if (vi.alias && vi.alias->empty()) { vi.alias.reset(); }
+          if (vi.hotkeyExcluded && !*vi.hotkeyExcluded) { vi.hotkeyExcluded.reset(); }
           if (vi.shortcut && vi.shortcut->empty()) { vi.shortcut.reset(); }
-          if (!vi.enabled.has_value() && vi.preferences.value_or(glz::generic::object_t{}).empty() &&
-              !vi.alias && !vi.shortcut) {
+          if (!vi.enabled.has_value() && !vi.hotkeyExcluded &&
+              vi.preferences.value_or(glz::generic::object_t{}).empty() && !vi.alias && !vi.shortcut) {
             entrypoints.erase(currentIt);
           }
         }

--- a/src/server/src/config/config.hpp
+++ b/src/server/src/config/config.hpp
@@ -19,6 +19,7 @@ namespace config {
 struct ProviderItemData {
   std::optional<std::string> alias;
   std::optional<bool> enabled;
+  std::optional<bool> hotkeyExcluded;
   std::optional<std::string> shortcut;
   std::optional<glz::generic::object_t> preferences;
 };
@@ -451,6 +452,8 @@ private:
 #define SNAKE_CASIFY(T)                                                                                      \
   template <> struct glz::meta<T> : glz::snake_case {};                                                      \
   template <> struct glz::meta<config::Partial<T>> : glz::snake_case {};
+
+template <> struct glz::meta<config::ProviderItemData> : glz::snake_case {};
 
 SNAKE_CASIFY(config::LayerShellConfig);
 SNAKE_CASIFY(config::WindowConfig);

--- a/src/server/src/qml/extension-settings-model.cpp
+++ b/src/server/src/qml/extension-settings-model.cpp
@@ -309,6 +309,7 @@ void ExtensionSettingsModel::rebuild(const QString &filter) {
       ie.isProvider = false;
       ie.indent = 1;
       ie.enabled = metadata.enabled;
+      ie.hotkeyExcluded = metadata.hotkeyExcluded;
       ie.alias = QString::fromStdString(metadata.alias.value_or(""));
       ie.shortcut = QString::fromStdString(metadata.shortcut.value_or(""));
       ie.entrypointId = item->uniqueId();
@@ -396,7 +397,7 @@ void ExtensionSettingsModel::loadCommandsForProvider(const QString &providerId) 
         auto *item = manager->findItemById(e.entrypointId);
         bool const hasPrefs = item && !item->preferences().empty();
         commands.push_back({e.name, e.type, e.iconSource, e.description, e.enabled, hasPrefs, e.alias,
-                            QString::fromStdString(e.entrypointId), e.shortcut});
+                            QString::fromStdString(e.entrypointId), e.shortcut, e.hotkeyExcluded});
       }
       break;
     }
@@ -435,6 +436,16 @@ void ExtensionSettingsModel::setEnabledByEntrypointId(const QString &id, bool va
     setEnabled(row, value);
     m_commandModel->setEnabled(id, value);
   }
+}
+
+void ExtensionSettingsModel::setHotkeyExcludedByEntrypointId(const QString &id, bool value) {
+  auto *manager = ServiceRegistry::instance()->rootItemManager();
+  manager->setItemHotkeyExcluded(EntrypointId::fromSerialized(id.toStdString()), value);
+
+  if (int const row = findVisibleEntryByEntrypointId(id); row >= 0) {
+    m_allEntries.at(m_visibleIndices.at(row)).hotkeyExcluded = value;
+  }
+  m_commandModel->setHotkeyExcluded(id, value);
 }
 
 void ExtensionSettingsModel::setAliasByEntrypointId(const QString &id, const QString &alias) {

--- a/src/server/src/qml/extension-settings-model.hpp
+++ b/src/server/src/qml/extension-settings-model.hpp
@@ -79,6 +79,7 @@ public:
   Q_INVOKABLE void activate();
   Q_INVOKABLE void selectProviderById(const QString &providerId);
   Q_INVOKABLE void setEnabledByEntrypointId(const QString &id, bool value);
+  Q_INVOKABLE void setHotkeyExcludedByEntrypointId(const QString &id, bool value);
   Q_INVOKABLE void setAliasByEntrypointId(const QString &id, const QString &alias);
   Q_INVOKABLE void setShortcutByEntrypointId(const QString &id, const QString &shortcut);
   Q_INVOKABLE void clearShortcutByEntrypointId(const QString &id);
@@ -92,6 +93,7 @@ private:
     QString description;
     bool isProvider;
     bool enabled;
+    bool hotkeyExcluded = false;
     QString alias;
     QString shortcut;
     EntrypointId entrypointId;

--- a/src/server/src/qml/provider-command-model.cpp
+++ b/src/server/src/qml/provider-command-model.cpp
@@ -30,6 +30,8 @@ QVariant ProviderCommandModel::data(const QModelIndex &index, int role) const {
     return cmd.hasPreferences;
   case ShortcutRole:
     return cmd.shortcut;
+  case HotkeyExcludedRole:
+    return cmd.hotkeyExcluded;
   default:
     return {};
   }
@@ -44,7 +46,8 @@ QHash<int, QByteArray> ProviderCommandModel::roleNames() const {
           {EntrypointIdRole, "entrypointId"},
           {DescriptionRole, "description"},
           {HasPreferencesRole, "hasPreferences"},
-          {ShortcutRole, "shortcut"}};
+          {ShortcutRole, "shortcut"},
+          {HotkeyExcludedRole, "hotkeyExcluded"}};
 }
 
 void ProviderCommandModel::load(std::vector<Command> commands) {
@@ -137,6 +140,21 @@ bool ProviderCommandModel::setShortcut(const QString &entrypointId, const QStrin
     if (row >= 0) {
       auto idx = index(row);
       emit dataChanged(idx, idx, {ShortcutRole});
+    }
+    return true;
+  }
+  return false;
+}
+
+bool ProviderCommandModel::setHotkeyExcluded(const QString &entrypointId, bool value) {
+  for (int i = 0; std::cmp_less(i, m_allCommands.size()); ++i) {
+    auto &command = m_allCommands.at(i);
+    if (command.entrypointId != entrypointId) continue;
+    command.hotkeyExcluded = value;
+    int const row = visibleRowFor(i);
+    if (row >= 0) {
+      auto idx = index(row);
+      emit dataChanged(idx, idx, {HotkeyExcludedRole});
     }
     return true;
   }

--- a/src/server/src/qml/provider-command-model.hpp
+++ b/src/server/src/qml/provider-command-model.hpp
@@ -23,7 +23,8 @@ public:
     EntrypointIdRole,
     DescriptionRole,
     HasPreferencesRole,
-    ShortcutRole
+    ShortcutRole,
+    HotkeyExcludedRole
   };
 
   struct Command {
@@ -36,6 +37,7 @@ public:
     QString alias;
     QString entrypointId;
     QString shortcut;
+    bool hotkeyExcluded = false;
 
     bool operator==(const Command &) const = default;
   };
@@ -54,6 +56,7 @@ public:
   void setAllEnabled(bool value);
   bool setAlias(const QString &entrypointId, const QString &alias);
   bool setShortcut(const QString &entrypointId, const QString &shortcut);
+  bool setHotkeyExcluded(const QString &entrypointId, bool value);
 
   Q_INVOKABLE int findByEntrypointId(const QString &id) const;
   Q_INVOKABLE void setFilter(const QString &text);

--- a/src/server/src/qml/qml/ExtensionSettingsPage.qml
+++ b/src/server/src/qml/qml/ExtensionSettingsPage.qml
@@ -160,6 +160,7 @@ Item {
                         required property string entrypointId
                         required property bool hasPreferences
                         required property string shortcut
+                        required property bool hotkeyExcluded
 
                         readonly property bool isExpanded: root.expandedCommandId === entrypointId
 
@@ -246,6 +247,38 @@ Item {
                                     text: cmdDelegate.alias
                                     placeholder: qsTr("Add Alias")
                                     onCommitted: value => root.extModel.setAliasByEntrypointId(cmdDelegate.entrypointId, value)
+                                }
+
+                                Rectangle {
+                                    visible: root.providerId === "applications" && Platform.supports("globalShortcuts")
+                                    Layout.preferredWidth: 20
+                                    Layout.preferredHeight: 20
+                                    radius: 4
+                                    color: cmdDelegate.hotkeyExcluded ? Theme.accent : "transparent"
+                                    border.color: Config.withAlpha(cmdDelegate.hotkeyExcluded ? Theme.accent : Theme.inputBorder, Config.surfaceOpacity)
+                                    border.width: 1
+
+                                    ViciImage {
+                                        anchors.centerIn: parent
+                                        width: 12
+                                        height: 12
+                                        source: Img.builtin("keyboard").withFillColor(cmdDelegate.hotkeyExcluded ? "#ffffff" : Theme.textMuted)
+                                    }
+
+                                    HoverHandler {
+                                        id: hotkeyExcludedHover
+                                    }
+
+                                    ViciToolTip {
+                                        text: qsTr("Don't toggle Vicinae with the global hotkey while this app is focused")
+                                        visible: hotkeyExcludedHover.hovered
+                                    }
+
+                                    MouseArea {
+                                        anchors.fill: parent
+                                        cursorShape: Qt.PointingHandCursor
+                                        onClicked: root.extModel.setHotkeyExcludedByEntrypointId(cmdDelegate.entrypointId, !cmdDelegate.hotkeyExcluded)
+                                    }
                                 }
 
                                 Rectangle {

--- a/src/server/src/server.cpp
+++ b/src/server/src/server.cpp
@@ -280,8 +280,8 @@ int startServer(const ServerLaunchOptions &launchOpts) {
                                                        std::move(platformPaste));
     auto fontService = std::make_unique<FontService>();
     auto rootItemManager = std::make_unique<RootItemManager>(*configService, *localStorage);
-    auto globalShortcutService = std::make_unique<GlobalShortcutService>(*configService, *rootItemManager,
-                                                                         createGlobalShortcutBackend());
+    auto globalShortcutService = std::make_unique<GlobalShortcutService>(
+        *configService, *rootItemManager, *windowManager, *appService, createGlobalShortcutBackend());
     auto shortcutService =
         std::make_unique<ShortcutService>(Omnicast::dataDir() / "shortcuts" / "shortcuts.json", omniDb.get());
     auto toastService = std::make_unique<ToastService>();

--- a/src/server/src/services/global-shortcuts/abstract-global-shortcut-backend.hpp
+++ b/src/server/src/services/global-shortcuts/abstract-global-shortcut-backend.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include <expected>
+#include <functional>
 #include <optional>
+#include <utility>
 #include <QObject>
 #include "keyboard/keyboard.hpp"
 
@@ -36,4 +38,16 @@ public:
   virtual std::expected<void, QString> bindShortcut(const GlobalShortcutRequest &request) = 0;
   virtual void unbindShortcut(const QString &id) = 0;
   virtual void unbindAll() = 0;
+
+  /**
+   * Install a predicate consulted before acting on a shortcut activation. Must be safe to call from
+   * any thread (implementations may be invoked from a platform event-tap thread). Returning true
+   * means the activation should be suppressed: backends that can avoid consuming the physical
+   * keystroke (e.g. a non-exclusive macOS CGEventTap) should let it propagate to the focused app
+   * instead of acting on it.
+   */
+  void setActivationGate(std::function<bool(const QString &id)> gate) { m_gate = std::move(gate); }
+
+protected:
+  std::function<bool(const QString &id)> m_gate;
 };

--- a/src/server/src/services/global-shortcuts/global-shortcut-service.cpp
+++ b/src/server/src/services/global-shortcuts/global-shortcut-service.cpp
@@ -1,16 +1,27 @@
 #include "services/global-shortcuts/global-shortcut-service.hpp"
 #include "common/types.hpp"
 #include "config/config.hpp"
+#include "services/app-service/abstract-app-db.hpp"
+#include "services/app-service/app-service.hpp"
 #include "services/root-item-manager/root-item-manager.hpp"
+#include "services/window-manager/window-manager.hpp"
 #include <utility>
 
 GlobalShortcutService::GlobalShortcutService(config::Manager &config, RootItemManager &rootItemManager,
+                                             WindowManager &windowManager, AppService &appService,
                                              std::unique_ptr<AbstractGlobalShortcutBackend> backend)
-    : m_config(config), m_rootItemManager(rootItemManager), m_backend(std::move(backend)) {
+    : m_config(config), m_rootItemManager(rootItemManager), m_windowManager(windowManager),
+      m_appService(appService), m_backend(std::move(backend)) {
   connect(m_backend.get(), &AbstractGlobalShortcutBackend::shortcutActivated, this,
           &GlobalShortcutService::onActivated);
   connect(m_backend.get(), &AbstractGlobalShortcutBackend::ready, this, &GlobalShortcutService::reconcile);
   connect(&m_config, &config::Manager::configChanged, this, [this] { reconcile(); });
+  connect(&m_windowManager, &WindowManager::focusChanged, this,
+          &GlobalShortcutService::updateToggleSuppression);
+
+  m_backend->setActivationGate([this](const QString &id) {
+    return id == QString::fromUtf8(TOGGLE_ID) && m_toggleSuppressed.load(std::memory_order_relaxed);
+  });
 
   m_backend->start();
   reconcile();
@@ -34,6 +45,14 @@ void GlobalShortcutService::reconcile() {
   if (!isSupported()) { return; }
 
   const config::ConfigValue &cfg = m_config.value();
+
+  m_hotkeyExcludedAppIds.clear();
+  if (auto it = cfg.providers.find("applications"); it != cfg.providers.end()) {
+    for (const auto &[entrypoint, item] : it->second.entrypoints) {
+      if (item.hotkeyExcluded.value_or(false)) { m_hotkeyExcludedAppIds.insert(entrypoint); }
+    }
+  }
+  updateToggleSuppression();
 
   std::unordered_map<QString, Desired> desired;
 
@@ -103,6 +122,23 @@ std::optional<QString> GlobalShortcutService::probeBind(const Keyboard::Shortcut
 QString GlobalShortcutService::describeCommand(const EntrypointId &id) const {
   if (auto meta = m_rootItemManager.itemMetadata(id); meta.item) { return meta.item->title(); }
   return QString::fromStdString(id);
+}
+
+void GlobalShortcutService::updateToggleSuppression() {
+  if (m_hotkeyExcludedAppIds.empty()) {
+    m_toggleSuppressed.store(false, std::memory_order_relaxed);
+    return;
+  }
+
+  auto const focusedApplicationId = m_windowManager.focusedApplicationId();
+  if (!focusedApplicationId) {
+    m_toggleSuppressed.store(false, std::memory_order_relaxed);
+    return;
+  }
+
+  auto const app = m_appService.findByClass(*focusedApplicationId);
+  bool const suppressed = app && m_hotkeyExcludedAppIds.contains(app->id().remove(".desktop").toStdString());
+  m_toggleSuppressed.store(suppressed, std::memory_order_relaxed);
 }
 
 void GlobalShortcutService::onActivated(const QString &id, quint64 timestamp) {

--- a/src/server/src/services/global-shortcuts/global-shortcut-service.hpp
+++ b/src/server/src/services/global-shortcuts/global-shortcut-service.hpp
@@ -1,6 +1,8 @@
 #pragma once
+#include <atomic>
 #include <memory>
 #include <unordered_map>
+#include <unordered_set>
 #include <QObject>
 #include "common/entrypoint.hpp"
 #include "services/global-shortcuts/abstract-global-shortcut-backend.hpp"
@@ -9,7 +11,9 @@ namespace config {
 class Manager;
 }
 
+class AppService;
 class RootItemManager;
+class WindowManager;
 
 /**
  * Projects the global shortcuts declared in the config onto the provided backend, and dispatches
@@ -30,6 +34,7 @@ public:
   static constexpr const char *TOGGLE_ID = "@toggle-launcher";
 
   GlobalShortcutService(config::Manager &config, RootItemManager &rootItemManager,
+                        WindowManager &windowManager, AppService &appService,
                         std::unique_ptr<AbstractGlobalShortcutBackend> backend);
 
   AbstractGlobalShortcutBackend *backend() const { return m_backend.get(); }
@@ -64,10 +69,19 @@ private:
   void onActivated(const QString &id, quint64 timestamp);
   QString describeCommand(const EntrypointId &id) const;
 
+  // Recomputes whether the toggle shortcut should be suppressed for the currently focused app.
+  // Cheap to call often: the actual window/app lookup only happens here, never on the hot path of
+  // a keypress. Consulted by `m_backend` via the activation gate, possibly from a non-Qt thread.
+  void updateToggleSuppression();
+
   config::Manager &m_config;
   RootItemManager &m_rootItemManager;
-  std::unique_ptr<AbstractGlobalShortcutBackend> m_backend;
+  WindowManager &m_windowManager;
+  AppService &m_appService;
   std::unordered_map<QString, Action> m_actions;
   std::unordered_map<QString, QString> m_appliedTriggers;
+  std::unordered_set<std::string> m_hotkeyExcludedAppIds;
+  std::atomic<bool> m_toggleSuppressed{false};
   bool m_capturing = false;
+  std::unique_ptr<AbstractGlobalShortcutBackend> m_backend;
 };

--- a/src/server/src/services/global-shortcuts/macos-global-shortcut-backend.cpp
+++ b/src/server/src/services/global-shortcuts/macos-global-shortcut-backend.cpp
@@ -301,6 +301,11 @@ bool MacOSGlobalShortcutBackend::handleKeyDown(uint32_t keycode, uint64_t rawFla
 
   if (!match) { return false; }
 
+  // Suppressed activations (e.g. the toggle hotkey while an excluded app is focused) are not
+  // consumed: returning false here makes tapCallback hand the original event back to the OS, so it
+  // reaches the focused app exactly as if we weren't intercepting it.
+  if (m_gate && m_gate(match->id)) { return false; }
+
   if (!autorepeat) {
     const QString id = match->id;
     QMetaObject::invokeMethod(

--- a/src/server/src/services/global-shortcuts/vicinae-hotkey-global-shortcut-backend.cpp
+++ b/src/server/src/services/global-shortcuts/vicinae-hotkey-global-shortcut-backend.cpp
@@ -134,7 +134,11 @@ void VicinaeHotkeyGlobalShortcutBackend::pressed(void *data, struct vicinae_hotk
                                                  uint32_t serial, uint32_t time) {
   auto self = static_cast<VicinaeHotkeyGlobalShortcutBackend *>(data);
 
-  if (auto bind = self->findHotkey(hotkey)) { emit self->shortcutActivated(bind->id, time); }
+  // The compositor grabs the hotkey itself, so a gated activation can only suppress our own
+  // action; the physical keystroke was already consumed before it reached us.
+  if (auto bind = self->findHotkey(hotkey); bind && !(self->m_gate && self->m_gate(bind->id))) {
+    emit self->shortcutActivated(bind->id, time);
+  }
 }
 
 void VicinaeHotkeyGlobalShortcutBackend::released(void *data, struct vicinae_hotkey_v1 *hotkey,

--- a/src/server/src/services/global-shortcuts/windows-global-shortcut-backend.cpp
+++ b/src/server/src/services/global-shortcuts/windows-global-shortcut-backend.cpp
@@ -188,6 +188,10 @@ bool WindowsGlobalShortcutBackend::dispatchKey(unsigned int vk, unsigned int mod
       continue;
     }
     if (mods == target.mods) {
+      // RegisterHotKey still reserves the combination, so gating can suppress our action but cannot
+      // guarantee that the focused app receives the physical keystroke.
+      if (m_gate && m_gate(target.id)) { continue; }
+
       if (!target.down) {
         target.down = true;
         QMetaObject::invokeMethod(

--- a/src/server/src/services/global-shortcuts/x11-global-shortcut-backend.cpp
+++ b/src/server/src/services/global-shortcuts/x11-global-shortcut-backend.cpp
@@ -201,7 +201,10 @@ void X11GlobalShortcutBackend::drainEvents() {
       uint16_t const mods = key->state & MODIFIER_BITS;
       auto it =
           std::ranges::find_if(m_binds, [&](auto &&b) { return b.keycode == key->detail && b.mods == mods; });
-      if (it != m_binds.end()) { emit shortcutActivated(it->id, key->time); }
+      // XGrabKey is an exclusive OS-level grab: the physical keystroke never reaches the focused
+      // app regardless, so a gated activation can only suppress our own action, not truly pass
+      // the key through.
+      if (it != m_binds.end() && !(m_gate && m_gate(it->id))) { emit shortcutActivated(it->id, key->time); }
       break;
     }
     case XCB_KEY_RELEASE: {

--- a/src/server/src/services/root-item-manager/root-item-manager.cpp
+++ b/src/server/src/services/root-item-manager/root-item-manager.cpp
@@ -272,6 +272,11 @@ bool RootItemManager::setItemEnabled(const EntrypointId &id, bool value) {
   return true;
 }
 
+bool RootItemManager::setItemHotkeyExcluded(const EntrypointId &id, bool value) {
+  m_cfg.mergeEntrypointWithUser(id, {.hotkeyExcluded = value});
+  return true;
+}
+
 bool RootItemManager::setProviderPreferenceValues(const QString &id, const QJsonObject &preferences) {
   auto provider = findProviderById(id);
 
@@ -659,12 +664,14 @@ void RootItemManager::mergeConfigWithMetadata(const config::ConfigValue &cfg) {
 
     meta.providerId = entrypointId.provider;
     meta.enabled = !item.item->isDefaultDisabled();
+    meta.hotkeyExcluded = false;
     meta.favorite = favoriteSet.contains(entrypointId);
     meta.fallback = fallbackSet.contains(entrypointId);
 
     if (itemConfig) {
       item.item->preferenceValuesChanged(getItemPreferenceValues(entrypointId));
       if (auto enabled = itemConfig->enabled) { meta.enabled = enabled.value(); }
+      if (auto hotkeyExcluded = itemConfig->hotkeyExcluded) { meta.hotkeyExcluded = hotkeyExcluded.value(); }
       if (auto alias = itemConfig->alias) { meta.alias = alias.value(); }
       if (auto shortcut = itemConfig->shortcut) { meta.shortcut = shortcut.value(); }
     }

--- a/src/server/src/services/root-item-manager/root-item-manager.hpp
+++ b/src/server/src/services/root-item-manager/root-item-manager.hpp
@@ -199,6 +199,7 @@ public:
 struct RootItemMetadata {
   int visitCount = 0;
   bool enabled = true;
+  bool hotkeyExcluded = false;
   bool favorite = false;
   bool fallback = false;
   std::optional<std::uint64_t> lastVisitedAt;
@@ -271,6 +272,7 @@ public:
   bool setProviderPreferenceValues(const QString &id, const QJsonObject &preferences);
 
   bool setItemEnabled(const EntrypointId &id, bool value);
+  bool setItemHotkeyExcluded(const EntrypointId &id, bool value);
   bool setItemPreferenceValues(const EntrypointId &id, const QJsonObject &preferences);
 
   void setPreferenceValues(const EntrypointId &id, const QJsonObject &preferences);

--- a/src/server/src/services/window-manager/abstract-window-manager.hpp
+++ b/src/server/src/services/window-manager/abstract-window-manager.hpp
@@ -156,6 +156,12 @@ public:
    */
   virtual std::shared_ptr<AbstractWindow> getFocusedWindowSync() const { return nullptr; }
 
+  virtual std::optional<QString> focusedApplicationId() const {
+    auto const window = getFocusedWindowSync();
+    if (!window) return std::nullopt;
+    return window->wmClass();
+  }
+
   /**
    * Whether the window manager is able to track what window is currently focused.
    * Note that a WM implementation can still implement `focusWindowSync` even if it

--- a/src/server/src/services/window-manager/macos/macos-window-manager.hpp
+++ b/src/server/src/services/window-manager/macos/macos-window-manager.hpp
@@ -31,6 +31,7 @@ public:
   WindowList listWindowsSync() const override;
   std::vector<Screen> listScreensSync(QWindow *activeWindow) const override;
   std::shared_ptr<AbstractWindow> getFocusedWindowSync() const override;
+  std::optional<QString> focusedApplicationId() const override;
   bool supportsFocusTracking() const override { return true; }
   void focusWindowSync(const AbstractWindow &window) const override;
   bool closeWindow(const AbstractWindow &window) const override;

--- a/src/server/src/services/window-manager/macos/macos-window-manager.mm
+++ b/src/server/src/services/window-manager/macos/macos-window-manager.mm
@@ -75,6 +75,29 @@ AXUIElementRef _AXUIElementCreateWithRemoteToken(CFDataRef token);
 
 namespace {
 
+struct FrontmostApplication {
+  pid_t pid;
+  QString bundleId;
+  QString name;
+};
+
+std::optional<FrontmostApplication> frontmostApplication() {
+  @autoreleasepool {
+    NSRunningApplication *application = NSWorkspace.sharedWorkspace.frontmostApplication;
+    if (!application || application.processIdentifier <= 0 || application.processIdentifier == getpid()) {
+      return std::nullopt;
+    }
+
+    QString bundleId =
+        application.bundleIdentifier ? QString::fromNSString(application.bundleIdentifier) : QString();
+    if (bundleId.isEmpty()) return std::nullopt;
+
+    QString name = application.localizedName ? QString::fromNSString(application.localizedName) : bundleId;
+    return FrontmostApplication{
+        .pid = application.processIdentifier, .bundleId = std::move(bundleId), .name = std::move(name)};
+  }
+}
+
 QString axCopyString(AXUIElementRef element, CFStringRef attribute) {
   CFTypeRef value = nullptr;
   if (AXUIElementCopyAttributeValue(element, attribute, &value) != kAXErrorSuccess || !value) return {};
@@ -426,28 +449,28 @@ AbstractWindowManager::WindowPtr MacosWindowManager::getFocusedWindowSync() cons
 
   WindowPtr result;
 
+  auto const application = frontmostApplication();
+  if (!application) return nullptr;
+
   @autoreleasepool {
-    NSRunningApplication *front = [[NSWorkspace sharedWorkspace] frontmostApplication];
-    if (!front) return nullptr;
-
-    pid_t pid = front.processIdentifier;
-    if (pid <= 0 || pid == getpid()) return nullptr;
-
-    QString bundleId = front.bundleIdentifier ? QString::fromNSString(front.bundleIdentifier) : QString();
-    QString appName = front.localizedName ? QString::fromNSString(front.localizedName) : bundleId;
-
-    AXUIElementRef appElement = AXUIElementCreateApplication(pid);
+    AXUIElementRef appElement = AXUIElementCreateApplication(application->pid);
     AXUIElementRef focused = nullptr;
     if (AXUIElementCopyAttributeValue(appElement, kAXFocusedWindowAttribute,
                                       reinterpret_cast<CFTypeRef *>(&focused)) == kAXErrorSuccess &&
         focused) {
-      result = buildWindow(focused, pid, bundleId, appName);
+      result = buildWindow(focused, application->pid, application->bundleId, application->name);
       CFRelease(focused);
     }
     CFRelease(appElement);
   }
 
   return result;
+}
+
+std::optional<QString> MacosWindowManager::focusedApplicationId() const {
+  auto const application = frontmostApplication();
+  if (!application) return std::nullopt;
+  return application->bundleId;
 }
 
 void MacosWindowManager::focusWindowSync(const AbstractWindow &window) const {

--- a/src/server/src/services/window-manager/window-manager.cpp
+++ b/src/server/src/services/window-manager/window-manager.cpp
@@ -64,6 +64,10 @@ AbstractWindowManager::WindowPtr WindowManager::getFocusedWindow() {
   return m_provider->getFocusedWindowSync();
 }
 
+std::optional<QString> WindowManager::focusedApplicationId() const {
+  return m_provider->focusedApplicationId();
+}
+
 const AbstractWindowManager::AbstractWindow *WindowManager::findWindowById(const QString &id) {
   auto pred = [&](auto &&win) { return win->id() == id; };
   if (auto it = std::ranges::find_if(m_windows, pred); it != m_windows.end()) { return it->get(); }

--- a/src/server/src/services/window-manager/window-manager.hpp
+++ b/src/server/src/services/window-manager/window-manager.hpp
@@ -15,6 +15,7 @@ public:
   AbstractWindowManager *provider() const;
   AbstractWindowManager::WindowList listWindowsSync();
   AbstractWindowManager::WindowPtr getFocusedWindow();
+  std::optional<QString> focusedApplicationId() const;
 
   AbstractWindowManager::WindowList findAppWindows(const AbstractApplication &app) const;
   const AbstractWindowManager::WindowList &listWindows() const;

--- a/src/server/tests/config/manager.cpp
+++ b/src/server/tests/config/manager.cpp
@@ -1,0 +1,55 @@
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <QTemporaryDir>
+#include <catch2/catch_test_macros.hpp>
+#include "config/config.hpp"
+
+namespace Omnicast {
+std::filesystem::path configDir() { return {}; }
+} // namespace Omnicast
+
+TEST_CASE("persists and prunes a standalone hotkey exclusion") {
+  QTemporaryDir const directory;
+  REQUIRE(directory.isValid());
+
+  std::filesystem::path const configPath =
+      std::filesystem::path{directory.path().toStdString()} / "settings.json";
+  EntrypointId const moonlight{"applications", "com.moonlight-stream.Moonlight"};
+
+  {
+    config::Manager manager{configPath};
+    REQUIRE(manager.mergeEntrypointWithUser(moonlight, {.hotkeyExcluded = true}));
+  }
+
+  {
+    std::ifstream configFile{configPath};
+    REQUIRE(configFile);
+    std::string const configText{std::istreambuf_iterator<char>{configFile},
+                                 std::istreambuf_iterator<char>{}};
+    REQUIRE(configText.contains("\"hotkey_excluded\""));
+    REQUIRE_FALSE(configText.contains("\"hotkeyExcluded\""));
+  }
+
+  {
+    config::Manager const reloaded{configPath};
+    auto const provider = reloaded.value().providers.find(moonlight.provider);
+    REQUIRE(provider != reloaded.value().providers.end());
+
+    auto const entrypoint = provider->second.entrypoints.find(moonlight.entrypoint);
+    REQUIRE(entrypoint != provider->second.entrypoints.end());
+    REQUIRE(entrypoint->second.hotkeyExcluded.value_or(false));
+  }
+
+  {
+    config::Manager manager{configPath};
+    REQUIRE(manager.mergeEntrypointWithUser(moonlight, {.hotkeyExcluded = false}));
+  }
+
+  std::ifstream configFile{configPath};
+  REQUIRE(configFile);
+  std::string const configText{std::istreambuf_iterator<char>{configFile}, std::istreambuf_iterator<char>{}};
+  REQUIRE_FALSE(configText.contains("hotkey_excluded"));
+  REQUIRE_FALSE(configText.contains(moonlight.entrypoint));
+}


### PR DESCRIPTION
Some applications need to receive the global toggle hotkey themselves, but Vicinae currently always opens. This adds a per-application exclusion so the hotkey is ignored while an excluded application is focused.