### PR TITLE
feat: remove raycast url schemes from Info.plist

### DIFF
--- a/extra/Info.plist.in
+++ b/extra/Info.plist.in
@@ -32,8 +32,6 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>vicinae</string>
-				<string>raycast</string>
-				<string>com.raycast</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
We remove the raycast url schemes from Info.plist as this can cause vicinae to override the reservation done by Raycast. On macOS there is no way to fix that problem at runtime (e.g behind a setting) so removing it is the best option.

The raycast compatible version of some of the deeplinks can still be leveraged by calling the `vicinae` binary directly: `vicinae raycast://<deeplink>`

fixes #1745 