### PR TITLE
feat: add xdg-activation support

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -864,6 +864,7 @@ if (UNIX AND NOT APPLE)
 	list(APPEND SRCS
 		src/internal/wayland/output-tracker.cpp
 		src/internal/wayland/layer-shell.cpp
+		src/internal/wayland/xdg-activation.cpp
 		src/services/window-material/ext-background-effect-v1-manager.cpp
 		src/services/shortcut-inhibit/wayland-shortcut-inhibit-manager.cpp
 		src/services/clipboard/data-control/data-control-clipboard-server.hpp
@@ -935,6 +936,7 @@ if (UNIX AND NOT APPLE)
 			${CMAKE_SOURCE_DIR}/src/wayland-protocols/vicinae-hotkey-v1.xml
 			${CMAKE_SOURCE_DIR}/src/wayland-protocols/wlr-foreign-toplevel-management-unstable-v1.xml
 			${CMAKE_SOURCE_DIR}/src/wayland-protocols/wlr-layer-shell-unstable-v1.xml
+			${CMAKE_SOURCE_DIR}/src/wayland-protocols/xdg-activation-v1.xml
 	)
 endif()
 

--- a/src/server/src/internal/wayland/xdg-activation.cpp
+++ b/src/server/src/internal/wayland/xdg-activation.cpp
@@ -1,0 +1,112 @@
+#include "xdg-activation.hpp"
+#include <QGuiApplication>
+#include <QtWaylandClient/QWaylandClientExtension>
+#include <qlogging.h>
+#include <qwindow.h>
+#include <wayland-client-core.h>
+#include "qt-wayland-utils.hpp"
+#include "qwayland-xdg-activation-v1.h"
+
+namespace {
+
+class XdgActivationV1 : public QWaylandClientExtensionTemplate<XdgActivationV1>,
+                        public QtWayland::xdg_activation_v1 {
+public:
+  XdgActivationV1() : QWaylandClientExtensionTemplate(1) { initialize(); }
+};
+
+struct Token : QtWayland::xdg_activation_token_v1 {
+  using xdg_activation_token_v1::xdg_activation_token_v1;
+  ~Token() override {
+    if (isInitialized()) destroy();
+  }
+
+  std::optional<QString> value;
+
+protected:
+  void xdg_activation_token_v1_done(const QString &token) override { value = token; }
+};
+
+XdgActivationV1 *activation() {
+  if (QGuiApplication::platformName() != "wayland") return nullptr;
+
+  static XdgActivationV1 instance;
+  return instance.isActive() ? &instance : nullptr;
+}
+
+std::optional<std::uint32_t> g_pendingSerial;
+
+std::optional<QString> mintToken(XdgActivationV1 &activation, std::uint32_t serial, wl_seat *seat,
+                                 wl_surface *surface, const QString &appId) {
+  Token token(activation.get_activation_token());
+
+  if (seat) token.set_serial(serial, seat);
+  if (surface) token.set_surface(surface);
+  if (!appId.isEmpty()) token.set_app_id(appId);
+  token.commit();
+
+  auto *app = qApp->nativeInterface<QNativeInterface::QWaylandApplication>();
+  wl_display_roundtrip(app->display());
+
+  return token.value;
+}
+
+wl_seat *inputSeat(QNativeInterface::QWaylandApplication *app) {
+  if (auto *seat = app->lastInputSeat()) return seat;
+  return app->seat();
+}
+
+} // namespace
+
+namespace Wayland::XdgActivation {
+
+bool isSupported() { return activation() != nullptr; }
+
+std::optional<QString> requestLaunchToken(const QString &appId) {
+  auto *ext = activation();
+
+  if (!ext) return std::nullopt;
+
+  auto *app = qApp->nativeInterface<QNativeInterface::QWaylandApplication>();
+  auto *win = QGuiApplication::focusWindow();
+
+  if (!win) {
+    qWarning() << "xdg-activation: no focused window while requesting a launch token, was the launcher "
+                  "window closed before launching? The token will likely not grant focus.";
+  }
+
+  wl_surface *surface = win ? QtWaylandUtils::getWindowSurface(win) : nullptr;
+
+  return mintToken(*ext, app->lastInputSerial(), inputSeat(app), surface, appId);
+}
+
+void setPendingSerial(std::uint32_t serial) { g_pendingSerial = serial; }
+
+bool activateWindow(QWindow *window) {
+  auto *ext = activation();
+
+  if (!ext || !window) return false;
+
+  auto *surface = QtWaylandUtils::getWindowSurface(window);
+
+  if (!surface) {
+    qWarning() << "xdg-activation: no wl_surface for window" << window;
+    return false;
+  }
+
+  qDebug() << "activating window";
+
+  auto *app = qApp->nativeInterface<QNativeInterface::QWaylandApplication>();
+  auto serial = g_pendingSerial.value_or(app->lastInputSerial());
+
+  g_pendingSerial.reset();
+
+  auto token = mintToken(*ext, serial, inputSeat(app), surface, {});
+
+  if (!token) return false;
+
+  ext->activate(*token, surface);
+  return true;
+}
+
+} // namespace Wayland::XdgActivation

--- a/src/server/src/internal/wayland/xdg-activation.hpp
+++ b/src/server/src/internal/wayland/xdg-activation.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <QString>
+#include <cstdint>
+#include <optional>
+
+class QWindow;
+
+namespace Wayland::XdgActivation {
+
+bool isSupported();
+
+/**
+ * Token to pass to a launched app through XDG_ACTIVATION_TOKEN, allowing it to take focus.
+ * Uses the currently focused window and last input serial as provenance.
+ */
+std::optional<QString> requestLaunchToken(const QString &appId);
+
+/**
+ * Record the input serial of a compositor-forwarded trigger (e.g. a vicinae-hotkey press) so the
+ * next activateWindow() call can use it. Qt's own last input serial is stale in that situation
+ * because the compositor consumed the triggering key event.
+ */
+void setPendingSerial(std::uint32_t serial);
+
+/** Focus one of our own windows, consuming the pending trigger serial if any. */
+bool activateWindow(QWindow *window);
+
+} // namespace Wayland::XdgActivation

--- a/src/server/src/internal/wayland/xdg-activation.hpp
+++ b/src/server/src/internal/wayland/xdg-activation.hpp
@@ -7,23 +7,8 @@
 class QWindow;
 
 namespace Wayland::XdgActivation {
-
 bool isSupported();
-
-/**
- * Token to pass to a launched app through XDG_ACTIVATION_TOKEN, allowing it to take focus.
- * Uses the currently focused window and last input serial as provenance.
- */
 std::optional<QString> requestLaunchToken(const QString &appId);
-
-/**
- * Record the input serial of a compositor-forwarded trigger (e.g. a vicinae-hotkey press) so the
- * next activateWindow() call can use it. Qt's own last input serial is stale in that situation
- * because the compositor consumed the triggering key event.
- */
 void setPendingSerial(std::uint32_t serial);
-
-/** Focus one of our own windows, consuming the pending trigger serial if any. */
 bool activateWindow(QWindow *window);
-
 } // namespace Wayland::XdgActivation

--- a/src/server/src/qml/launcher-window.cpp
+++ b/src/server/src/qml/launcher-window.cpp
@@ -392,9 +392,7 @@ void LauncherWindow::handleVisibilityChanged(bool visible) {
     LauncherWindowPlatform::grantForeground();
     m_window->requestActivate();
 #ifdef Q_OS_LINUX
-    // Qt's own requestActivate uses a stale input serial when we are summoned by a global
-    // shortcut, as the triggering key event never reached us. Use the serial forwarded by the
-    // compositor instead. Layer shell surfaces get focus through keyboard interactivity.
+    // layer-shell has its own focus mechanism, we don't need a token
     if (!isLayerShellActive()) { Wayland::XdgActivation::activateWindow(m_window); }
 #endif
   } else {

--- a/src/server/src/qml/launcher-window.cpp
+++ b/src/server/src/qml/launcher-window.cpp
@@ -1,5 +1,8 @@
 #include "launcher-window.hpp"
 #include "launcher-window-platform.hpp"
+#ifdef Q_OS_LINUX
+#include "internal/wayland/xdg-activation.hpp"
+#endif
 #include "hud-bridge.hpp"
 #include "keybind-bridge.hpp"
 #include "keyboard-bridge.hpp"
@@ -388,6 +391,12 @@ void LauncherWindow::handleVisibilityChanged(bool visible) {
     m_window->raise();
     LauncherWindowPlatform::grantForeground();
     m_window->requestActivate();
+#ifdef Q_OS_LINUX
+    // Qt's own requestActivate uses a stale input serial when we are summoned by a global
+    // shortcut, as the triggering key event never reached us. Use the serial forwarded by the
+    // compositor instead. Layer shell surfaces get focus through keyboard interactivity.
+    if (!isLayerShellActive()) { Wayland::XdgActivation::activateWindow(m_window); }
+#endif
   } else {
     LauncherWindowPlatform::suppressHeldKeyReleases();
     m_window->hide();

--- a/src/server/src/services/app-service/xdg/xdg-app-database.cpp
+++ b/src/server/src/services/app-service/xdg/xdg-app-database.cpp
@@ -1,5 +1,6 @@
 #include "xdg-app-database.hpp"
 #include "environment.hpp"
+#include "internal/wayland/xdg-activation.hpp"
 #include "services/app-service/abstract-app-db.hpp"
 #include "services/app-service/xdg/xdg-app.hpp"
 #include "utils.hpp"
@@ -458,11 +459,12 @@ bool XdgAppDatabase::launchTerminalCommand(const std::vector<QString> &cmdline,
     argv << arg;
   }
 
-  return launchProcess(exec.front(), argv, xdgApp->data().workingDirectory());
+  return launchProcess(exec.front(), argv, xdgApp->data().workingDirectory(), opts.appId.value_or(QString()));
 }
 
 bool XdgAppDatabase::launchProcess(const QString &prog, const QStringList &args,
-                                   const std::optional<std::filesystem::path> &workingDirectory) const {
+                                   const std::optional<std::filesystem::path> &workingDirectory,
+                                   const QString &appId) const {
   QProcess process;
   process.setProgram(prog);
   process.setArguments(args);
@@ -470,6 +472,15 @@ bool XdgAppDatabase::launchProcess(const QString &prog, const QStringList &args,
   process.setStandardErrorFile(QProcess::nullDevice());
 
   if (workingDirectory) { process.setWorkingDirectory(workingDirectory->c_str()); }
+
+  if (auto token = Wayland::XdgActivation::requestLaunchToken(appId)) {
+    qDebug() << "Successfully minted xdg activation token for app" << appId;
+    auto env = QProcessEnvironment::systemEnvironment();
+    env.insert("XDG_ACTIVATION_TOKEN", *token);
+    process.setProcessEnvironment(env);
+  } else {
+    qWarning() << "Unable to mint xdg activation token to launch" << appId;
+  }
 
   QStringList cmdline;
   cmdline << prog << args;
@@ -520,7 +531,8 @@ bool XdgAppDatabase::launch(const AbstractApplication &app, const std::vector<QS
 
   auto argv = exec | std::views::drop(1) | std::ranges::to<QStringList>();
 
-  return launchProcess(exec.front(), argv, xdgApp.data().workingDirectory());
+  return launchProcess(exec.front(), argv, xdgApp.data().workingDirectory(),
+                       xdgApp.windowClass().value_or(xdgApp.id()));
 }
 
 QString XdgAppDatabase::mimeNameForTarget(const QString &target) const {

--- a/src/server/src/services/app-service/xdg/xdg-app-database.hpp
+++ b/src/server/src/services/app-service/xdg/xdg-app-database.hpp
@@ -43,7 +43,8 @@ public:
 
 private:
   bool launchProcess(const QString &prog, const QStringList &args,
-                     const std::optional<std::filesystem::path> &workingDirectory) const;
+                     const std::optional<std::filesystem::path> &workingDirectory,
+                     const QString &appId = {}) const;
 
   xdgpp::DesktopEntry::TerminalExec getTermExec(const XdgApplication &app) const;
   xdgpp::DesktopEntry::TerminalExec inferTermExec(const XdgApplication &app) const;

--- a/src/server/src/services/global-shortcuts/vicinae-hotkey-global-shortcut-backend.cpp
+++ b/src/server/src/services/global-shortcuts/vicinae-hotkey-global-shortcut-backend.cpp
@@ -1,4 +1,5 @@
 #include "vicinae-hotkey-global-shortcut-backend.hpp"
+#include "internal/wayland/xdg-activation.hpp"
 #include "services/global-shortcuts/abstract-global-shortcut-backend.hpp"
 #include "services/global-shortcuts/xkb-keysym.hpp"
 #include <algorithm>
@@ -56,6 +57,7 @@ void VicinaeHotkeyGlobalShortcutBackend::Hotkey::vicinae_hotkey_v1_revoked(uint3
 }
 
 void VicinaeHotkeyGlobalShortcutBackend::Hotkey::vicinae_hotkey_v1_pressed(uint32_t serial, uint32_t time) {
+  Wayland::XdgActivation::setPendingSerial(serial);
   emit m_backend->shortcutActivated(m_id, time);
 }
 
@@ -81,11 +83,11 @@ VicinaeHotkeyGlobalShortcutBackend::bindShortcut(const GlobalShortcutRequest &re
 
   auto *handle = m_manager.bind(keysym.value(), fromQtMods(request.trigger.mods()), nullptr,
                                 QStringLiteral("vicinae"), request.description);
-  auto &hotkey = m_binds.emplace_back(std::make_unique<Hotkey>(this, handle, request.id));
 
-  m_pendingBind = hotkey.get();
+  m_pendingBind = m_binds.emplace_back(std::make_unique<Hotkey>(this, handle, request.id)).get();
   m_pendingDeny.reset();
   wlRoundtrip();
+
   auto *bound = std::exchange(m_pendingBind, nullptr);
 
   if (m_pendingDeny) {

--- a/src/wayland-protocols/xdg-activation-v1.xml
+++ b/src/wayland-protocols/xdg-activation-v1.xml
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="xdg_activation_v1">
+
+  <copyright>
+    Copyright © 2020 Aleix Pol Gonzalez &lt;aleixpol@kde.org&gt;
+    Copyright © 2020 Carlos Garnacho &lt;carlosg@gnome.org&gt;
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="Protocol for requesting activation of surfaces">
+    The way for a client to pass focus to another toplevel is as follows.
+
+    The client that intends to activate another toplevel uses the
+    xdg_activation_v1.get_activation_token request to get an activation token.
+    This token is then forwarded to the client, which is supposed to activate
+    one of its surfaces, through a separate band of communication.
+
+    One established way of doing this is through the XDG_ACTIVATION_TOKEN
+    environment variable of a newly launched child process. The child process
+    should unset the environment variable again right after reading it out in
+    order to avoid propagating it to other child processes.
+
+    Another established way exists for Applications implementing the D-Bus
+    interface org.freedesktop.Application, which should get their token under
+    activation-token on their platform_data.
+
+    In general activation tokens may be transferred across clients through
+    means not described in this protocol.
+
+    The client to be activated will then pass the token
+    it received to the xdg_activation_v1.activate request. The compositor can
+    then use this token to decide how to react to the activation request.
+
+    The token the activating client gets may be ineffective either already at
+    the time it receives it, for example if it was not focused, for focus
+    stealing prevention. The activating client will have no way to discover
+    the validity of the token, and may still forward it to the to be activated
+    client.
+
+    The created activation token may optionally get information attached to it
+    that can be used by the compositor to identify the application that we
+    intend to activate. This can for example be used to display a visual hint
+    about what application is being started.
+
+    Warning! The protocol described in this file is currently in the testing
+    phase. Backward compatible changes may be added together with the
+    corresponding interface version bump. Backward incompatible changes can
+    only be done by creating a new major version of the extension.
+  </description>
+
+  <interface name="xdg_activation_v1" version="1">
+    <description summary="interface for activating surfaces">
+      A global interface used for informing the compositor about applications
+      being activated or started, or for applications to request to be
+      activated.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the xdg_activation object">
+        Notify the compositor that the xdg_activation object will no longer be
+        used.
+
+        The child objects created via this interface are unaffected and should
+        be destroyed separately.
+      </description>
+    </request>
+
+    <request name="get_activation_token">
+      <description summary="requests a token">
+        Creates an xdg_activation_token_v1 object that will provide
+        the initiating client with a unique token for this activation. This
+        token should be offered to the clients to be activated.
+      </description>
+
+      <arg name="id" type="new_id" interface="xdg_activation_token_v1"/>
+    </request>
+
+    <request name="activate">
+      <description summary="notify new interaction being available">
+        Requests surface activation. It's up to the compositor to display
+        this information as desired, for example by placing the surface above
+        the rest.
+
+        The compositor may know who requested this by checking the activation
+        token and might decide not to follow through with the activation if it's
+        considered unwanted.
+
+        Compositors can ignore unknown activation tokens when an invalid
+        token is passed.
+      </description>
+      <arg name="token" type="string" summary="the activation token of the initiating client"/>
+      <arg name="surface" type="object" interface="wl_surface"
+	   summary="the wl_surface to activate"/>
+    </request>
+  </interface>
+
+  <interface name="xdg_activation_token_v1" version="1">
+    <description summary="an exported activation handle">
+      An object for setting up a token and receiving a token handle that can
+      be passed as an activation token to another client.
+
+      The object is created using the xdg_activation_v1.get_activation_token
+      request. This object should then be populated with the app_id, surface
+      and serial information and committed. The compositor shall then issue a
+      done event with the token. In case the request's parameters are invalid,
+      the compositor will provide an invalid token.
+    </description>
+
+    <enum name="error">
+      <entry name="already_used" value="0"
+             summary="The token has already been used previously"/>
+    </enum>
+
+    <request name="set_serial">
+      <description summary="specifies the seat and serial of the activating event">
+        Provides information about the seat and serial event that requested the
+        token.
+
+        The serial can come from an input or focus event. For instance, if a
+        click triggers the launch of a third-party client, the launcher client
+        should send a set_serial request with the serial and seat from the
+        wl_pointer.button event.
+
+        Some compositors might refuse to activate toplevels when the token
+        doesn't have a valid and recent enough event serial.
+
+        Must be sent before commit. This information is optional.
+      </description>
+      <arg name="serial" type="uint"
+           summary="the serial of the event that triggered the activation"/>
+      <arg name="seat" type="object" interface="wl_seat"
+           summary="the wl_seat of the event"/>
+    </request>
+
+    <request name="set_app_id">
+      <description summary="specifies the application being activated">
+        The requesting client can specify an app_id to associate the token
+        being created with it.
+
+        Must be sent before commit. This information is optional.
+      </description>
+      <arg name="app_id" type="string"
+           summary="the application id of the client being activated."/>
+    </request>
+
+    <request name="set_surface">
+      <description summary="specifies the surface requesting activation">
+        This request sets the surface requesting the activation. Note, this is
+        different from the surface that will be activated.
+
+        Some compositors might refuse to activate toplevels when the token
+        doesn't have a requesting surface.
+
+        Must be sent before commit. This information is optional.
+      </description>
+      <arg name="surface" type="object" interface="wl_surface"
+	   summary="the requesting surface"/>
+    </request>
+
+    <request name="commit">
+      <description summary="issues the token request">
+        Requests an activation token based on the different parameters that
+        have been offered through set_serial, set_surface and set_app_id.
+      </description>
+    </request>
+
+    <event name="done">
+      <description summary="the exported activation token">
+        The 'done' event contains the unique token of this activation request
+        and notifies that the provider is done.
+      </description>
+      <arg name="token" type="string" summary="the exported activation token"/>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the xdg_activation_token_v1 object">
+        Notify the compositor that the xdg_activation_token_v1 object will no
+        longer be used. The received token stays valid.
+      </description>
+    </request>
+  </interface>
+</protocol>


### PR DESCRIPTION
We add proper `xdg-activation` support so that:

- every app launched from vicinae gets a freshly minted activation token, passed to the process through the `XDG_ACTIVATION_TOKEN` environment variable. Said app can then use it to steal focus, which it is often not able to do otherwise (may depend on the compositor and the strictness of the configuration).
- the vicinae launcher window itself can activate from e.g a global shortcut or similar. This only matters if the vicinae window is not a layer, which it is in almost all cases (except on Gnome).