### PR TITLE
fix: pass proper shadow blur size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ if (APPLE OR WIN32)
 endif()
 
 # the Qt deploy API registers its support files on the first Qt6::Core scope seen
-find_package(Qt6 6.8 REQUIRED COMPONENTS Core Qml)
+find_package(Qt6 6.9 REQUIRED COMPONENTS Core Qml)
 
 if (NOT USE_SYSTEM_GLAZE)
 	include(Glaze)

--- a/src/server/src/qml/qml/LauncherWindow.qml
+++ b/src/server/src/qml/qml/LauncherWindow.qml
@@ -57,22 +57,18 @@ Window {
         anchors.fill: parent
         visible: root.shadowEnabled && !root.nativeChrome
 
-        Rectangle {
+        RectangularShadow {
             x: root.shadowPadding
             y: root.shadowPadding
             width: _w
             height: _contentH
             radius: root.cornerRadius
-            color: "black"
+            blur: root.shadowPadding
+            color: Qt.rgba(0, 0, 0, 0.3)
         }
 
         layer.enabled: root.shadowEnabled && !root.nativeChrome
         layer.effect: MultiEffect {
-            autoPaddingEnabled: false
-            shadowEnabled: true
-            shadowBlur: 0.5
-            shadowVerticalOffset: 3
-            shadowColor: Qt.rgba(0, 0, 0, 0.3)
             maskEnabled: true
             maskInverted: true
             maskSource: shadowMask


### PR DESCRIPTION
Also migrate to the newer and simpler `RectangularShadow` which requires a minimum QT version bump (6.9).

fixes #1754 