### PR TITLE
feat: add action to set global shortcut in root search

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -200,6 +200,8 @@ set(SRCS
 	src/ui/action-pannel/action-panel-view.hpp
 	src/ui/action-pannel/action-list-view.hpp
 	src/ui/action-pannel/action-list-view.cpp
+	src/ui/action-pannel/shortcut-recorder-panel-view.hpp
+	src/ui/action-pannel/shortcut-recorder-panel-view.cpp
 
 	
 	src/extension/extension-command.hpp
@@ -1074,6 +1076,8 @@ set(VICINAE_QML_FILES
 	src/qml/qml/ExtensionSettingsPage.qml
 	src/qml/qml/AboutSettingsPage.qml
 	src/qml/qml/ShortcutRecorderField.qml
+	src/qml/qml/ShortcutRecorderCapture.qml
+	src/qml/qml/ShortcutRecorderPanel.qml
 	src/qml/qml/ShortcutField.qml
 	src/qml/qml/PreferenceFormView.qml
 	src/qml/qml/SettingsPreferenceForm.qml

--- a/src/server/src/actions/root-search/root-search-actions.cpp
+++ b/src/server/src/actions/root-search/root-search-actions.cpp
@@ -1,5 +1,6 @@
 #include "actions/root-search/root-search-actions.hpp"
 #include "qml/alias-form-view-host.hpp"
+#include "ui/action-pannel/shortcut-recorder-panel-view.hpp"
 #include "ui/image/url.hpp"
 #include "service-registry.hpp"
 #include "ui/action-pannel/action.hpp"
@@ -116,4 +117,22 @@ void OpenItemPreferencesAction::execute(ApplicationContext *ctx) {
 
 void SetRootItemAliasAction::execute(ApplicationContext *ctx) {
   ctx->navigation->pushView(new AliasFormViewHost(m_id));
+}
+
+SetRootItemShortcutAction::SetRootItemShortcutAction(const EntrypointId &id, const QString &itemTitle,
+                                                     const ImageURL &itemIcon,
+                                                     const std::optional<std::string> &shortcut)
+    : SubmenuAction(tr("Set Global Shortcut"), ImageURL::builtin(BuiltinIcon::Keyboard)), m_id(id),
+      m_itemTitle(itemTitle), m_itemIcon(itemIcon),
+      m_shortcut(QString::fromStdString(shortcut.value_or(""))) {}
+
+ActionPanelView *SetRootItemShortcutAction::createView(ApplicationContext *ctx, QObject *parent) {
+  auto *view = new ShortcutRecorderPanelView(m_itemTitle, m_itemIcon, QString::fromStdString(m_id),
+                                             m_shortcut, parent);
+
+  view->setAcceptHandler([ctx, id = m_id](const QString &serialized) {
+    ctx->services->rootItemManager()->setShortcut(id, serialized.toStdString());
+  });
+
+  return view;
 }

--- a/src/server/src/actions/root-search/root-search-actions.hpp
+++ b/src/server/src/actions/root-search/root-search-actions.hpp
@@ -4,6 +4,7 @@
 #include "common/entrypoint.hpp"
 #include "services/root-item-manager/root-item-manager.hpp"
 #include "ui/action-pannel/action.hpp"
+#include "utils/capabilities.hpp"
 
 class DisableItemAction : public AbstractAction {
   Q_DECLARE_TR_FUNCTIONS(DisableItemAction)
@@ -96,10 +97,26 @@ public:
   }
   std::optional<ImageURL> icon() const override { return BuiltinIcon::Text; }
   void execute(ApplicationContext *context) override;
-  SetRootItemAliasAction(EntrypointId id) : m_id(id) { setShortcut(Keybind::EditSecondaryAction); }
+  SetRootItemAliasAction(EntrypointId id) : m_id(std::move(id)) { setShortcut(Keybind::EditSecondaryAction); }
 
 private:
   EntrypointId m_id;
+};
+
+class SetRootItemShortcutAction : public SubmenuAction {
+  Q_DECLARE_TR_FUNCTIONS(SetRootItemShortcutAction)
+
+public:
+  SetRootItemShortcutAction(const EntrypointId &id, const QString &itemTitle, const ImageURL &itemIcon,
+                            const std::optional<std::string> &shortcut);
+
+  ActionPanelView *createView(ApplicationContext *ctx, QObject *parent) override;
+
+private:
+  EntrypointId m_id;
+  QString m_itemTitle;
+  ImageURL m_itemIcon;
+  QString m_shortcut;
 };
 
 // common actions applicable to all root search items
@@ -120,6 +137,21 @@ public:
 
     disable->setShortcut(Keybind::RemoveAction);
 
-    return {copyDeeplink, resetRanking, markAsFavorite, setAlias, openPreferences, copyId, disable};
+    std::vector<AbstractAction *> actions;
+    actions.reserve(8);
+    actions.emplace_back(copyDeeplink);
+    actions.emplace_back(resetRanking);
+    actions.emplace_back(markAsFavorite);
+    actions.emplace_back(setAlias);
+    if (platform::supports(platform::Capability::GlobalShortcuts)) {
+      auto setGlobalShortcut =
+          new SetRootItemShortcutAction(id, item.title(), item.iconUrl(), metadata.shortcut);
+      actions.emplace_back(setGlobalShortcut);
+    }
+    actions.emplace_back(openPreferences);
+    actions.emplace_back(copyId);
+    actions.emplace_back(disable);
+
+    return actions;
   }
 };

--- a/src/server/src/qml/action-panel-controller.cpp
+++ b/src/server/src/qml/action-panel-controller.cpp
@@ -183,6 +183,11 @@ bool ActionPanelController::tryShortcut(int key, int modifiers) {
   return model->activateByShortcut(key, modifiers);
 }
 
+bool ActionPanelController::capturesAllKeys() const {
+  if (!m_open || !m_currentPanel) return false;
+  return m_currentPanel->property("capturesAllKeys").toBool();
+}
+
 bool ActionPanelController::activateBoundAction(const QKeyEvent *event) {
   auto *root = activeRoot();
   if (!root) return false;

--- a/src/server/src/qml/action-panel-controller.hpp
+++ b/src/server/src/qml/action-panel-controller.hpp
@@ -61,6 +61,13 @@ public:
   Q_INVOKABLE bool tryShortcut(int key, int modifiers);
 
   /**
+   * Whether the currently displayed panel wants every keypress delivered to it
+   * (e.g. a shortcut recorder). Window-level key routing must not match bound
+   * actions or app keybinds while this is true.
+   */
+  bool capturesAllKeys() const;
+
+  /**
    * Activate the action the key event is bound to, if any: submenus are opened,
    * regular actions are executed. Enter/return uniformization is handled as part
    * of the shortcut matching.

--- a/src/server/src/qml/launcher-window.cpp
+++ b/src/server/src/qml/launcher-window.cpp
@@ -3,6 +3,7 @@
 #ifdef Q_OS_LINUX
 #include "internal/wayland/xdg-activation.hpp"
 #endif
+#include "global-shortcut-bridge.hpp"
 #include "hud-bridge.hpp"
 #include "keybind-bridge.hpp"
 #include "keyboard-bridge.hpp"
@@ -53,8 +54,8 @@ LauncherWindow::LauncherWindow(ApplicationContext &ctx, QObject *parent)
       m_footerPanel(new ActionPanelController(ctx, this)),
       m_alertModel(new AlertModel(*ctx.navigation, this)), m_configBridge(new ConfigBridge(this)),
       m_imgSource(new ImageSource(this)), m_keybindProxy(new KeybindBridge(this)),
-      m_keyboardBridge(new KeyboardBridge(this)), m_platformBridge(new PlatformBridge(this)),
-      m_themeBridge(new ThemeBridge(this)) {
+      m_keyboardBridge(new KeyboardBridge(this)), m_globalShortcutBridge(new GlobalShortcutBridge(this)),
+      m_platformBridge(new PlatformBridge(this)), m_themeBridge(new ThemeBridge(this)) {
 
 #ifndef Q_OS_MACOS
   // Ensure Wayland app_id / X11 WM_CLASS is "vicinae"
@@ -75,6 +76,7 @@ LauncherWindow::LauncherWindow(ApplicationContext &ctx, QObject *parent)
   rootCtx->setContextProperty(QStringLiteral("footerPanel"), m_footerPanel);
   rootCtx->setContextProperty(QStringLiteral("Keybinds"), m_keybindProxy);
   rootCtx->setContextProperty(QStringLiteral("Keyboard"), m_keyboardBridge);
+  rootCtx->setContextProperty(QStringLiteral("GlobalShortcuts"), m_globalShortcutBridge);
   rootCtx->setContextProperty(QStringLiteral("FileChooser"), ctx.services->fileChooserService());
 
   updateLayerShellProps();
@@ -214,10 +216,16 @@ LauncherWindow::LauncherWindow(ApplicationContext &ctx, QObject *parent)
   });
 
   connect(m_footerPanel, &ActionPanelController::openChanged, this, [this]() {
-    if (m_footerPanel->isOpen()) m_actionPanel->close();
+    if (m_footerPanel->isOpen()) {
+      setCompacted(false);
+      m_actionPanel->close();
+    }
   });
   connect(m_actionPanel, &ActionPanelController::openChanged, this, [this]() {
-    if (m_actionPanel->isOpen()) m_footerPanel->close();
+    if (m_actionPanel->isOpen()) {
+      setCompacted(false);
+      m_footerPanel->close();
+    }
   });
 
   connect(nav, &NavigationController::navigationStatusChanged, this,
@@ -472,6 +480,8 @@ void LauncherWindow::forwardSearchText(const QString &text) {
 }
 
 bool LauncherWindow::forwardKey(int key, int modifiers) {
+  if (m_actionPanel->capturesAllKeys()) return false;
+
   auto mods = static_cast<Qt::KeyboardModifiers>(modifiers);
   const bool isReturn = key == Qt::Key_Return || key == Qt::Key_Enter;
   const bool unmodified = (mods & ~Qt::KeypadModifier) == Qt::NoModifier;
@@ -622,7 +632,7 @@ void LauncherWindow::setCompacted(bool value) {
 void LauncherWindow::tryCompaction() {
   auto &cfg = m_ctx.services->config()->value().launcherWindow.compactMode;
 
-  setCompacted(!m_ctx.services->newsService()->hasUnreadNews() && cfg.enabled &&
+  setCompacted(!m_ctx.services->newsService()->hasUnreadNews() && cfg.enabled && !m_actionPanel->isOpen() &&
                m_ctx.navigation->searchText().isEmpty() && m_ctx.navigation->viewStackSize() == 1 &&
                !m_toastActive);
 }
@@ -649,8 +659,6 @@ void LauncherWindow::setExclusiveFocus(bool exclusive) {
 
 void LauncherWindow::applyWindowConfig() {
   if (!m_window) return;
-  auto &wcfg = m_ctx.services->config()->value().launcherWindow;
-
   updateLayerShellProps();
 }
 

--- a/src/server/src/qml/launcher-window.hpp
+++ b/src/server/src/qml/launcher-window.hpp
@@ -10,6 +10,7 @@
 class ActionPanelController;
 class AlertModel;
 class ConfigBridge;
+class GlobalShortcutBridge;
 class HudBridge;
 class ImageSource;
 class KeybindBridge;
@@ -147,6 +148,7 @@ private:
   ImageSource *m_imgSource;
   KeybindBridge *m_keybindProxy;
   KeyboardBridge *m_keyboardBridge;
+  GlobalShortcutBridge *m_globalShortcutBridge;
   PlatformBridge *m_platformBridge;
   ThemeBridge *m_themeBridge;
 

--- a/src/server/src/qml/qml/ShortcutRecorderCapture.qml
+++ b/src/server/src/qml/qml/ShortcutRecorderCapture.qml
@@ -1,0 +1,119 @@
+import QtQuick
+import QtQuick.Layouts
+
+// Shared key-capture core for shortcut recorders: key normalization, validation,
+// status feedback, and the capture lifecycle (global shortcut suspension +
+// compositor shortcut inhibition). Hosts decide where to embed it and when to close.
+FocusScope {
+    id: capture
+
+    // Returns a user-facing error string, or "" if the shortcut is acceptable.
+    property var validateShortcut: null
+    // Returns display tokens for a (key, modifiers) pair.
+    property var shortcutDisplayProvider: null
+    // Suspends global shortcuts and inhibits compositor ones while true.
+    property bool capturing: false
+    // Tokens shown before the first keypress (e.g. the currently assigned shortcut).
+    property var initialTokens: []
+
+    signal shortcutCaptured(int key, int modifiers)
+    // Escape or Backspace pressed bare; hosts decide whether that closes or clears.
+    signal dismissRequested(int key)
+    // Any keypress; hosts use this to interrupt pending auto-close timers.
+    signal activity
+
+    property var _currentShortcutTokens: []
+    property string _statusText: qsTr("Recording...")
+    property color _statusColor: Theme.foreground
+
+    readonly property var _visibleTokens: _currentShortcutTokens.length > 0 ? _currentShortcutTokens : initialTokens
+
+    implicitWidth: layout.implicitWidth
+    implicitHeight: layout.implicitHeight
+
+    function reset() {
+        _currentShortcutTokens = [];
+        _statusText = qsTr("Recording...");
+        _statusColor = Theme.foreground;
+    }
+
+    ShortcutInhibitor.enabled: capture.capturing
+
+    onCapturingChanged: GlobalShortcuts.setCapturing(capture.capturing)
+    Component.onCompleted: {
+        if (capturing)
+            GlobalShortcuts.setCapturing(true);
+    }
+    Component.onDestruction: GlobalShortcuts.setCapturing(false)
+
+    Keys.onPressed: event => {
+        event.accepted = true;
+        capture.activity();
+
+        const key = Keyboard.normalizeKey(event.key);
+        const mods = event.modifiers;
+
+        const isModKey = key === Qt.Key_Shift || key === Qt.Key_Control || key === Qt.Key_Alt || key === Qt.Key_Meta;
+        const isDismissKey = key === Qt.Key_Escape || key === Qt.Key_Backspace;
+
+        if (!isModKey && isDismissKey && mods === Qt.NoModifier) {
+            capture.dismissRequested(key);
+            return;
+        }
+
+        if (capture.shortcutDisplayProvider)
+            capture._currentShortcutTokens = capture.shortcutDisplayProvider(key, mods);
+
+        if (isModKey) {
+            capture._statusText = qsTr("Recording...");
+            capture._statusColor = Theme.foreground;
+            return;
+        }
+
+        if (capture.validateShortcut) {
+            const error = capture.validateShortcut(key, mods);
+            if (error !== "") {
+                capture._statusText = error;
+                capture._statusColor = Theme.danger;
+                return;
+            }
+        }
+
+        capture._statusText = qsTr("Keybind updated");
+        capture._statusColor = Theme.toastSuccess;
+        capture.shortcutCaptured(key, mods);
+    }
+
+    Item {
+        id: keyReceiver
+        focus: true
+    }
+
+    ColumnLayout {
+        id: layout
+        anchors.fill: parent
+        spacing: 5
+
+        Item {
+            Layout.alignment: Qt.AlignHCenter
+            Layout.preferredWidth: badge.width
+            Layout.preferredHeight: badge.height
+            visible: capture._visibleTokens.length > 0
+
+            ShortcutBadge {
+                id: badge
+                tokens: capture._visibleTokens
+            }
+        }
+
+        Text {
+            Layout.alignment: Qt.AlignHCenter
+            Layout.fillWidth: true
+            text: capture._statusText
+            color: capture._statusColor
+            font.pointSize: Theme.smallerFontSize
+            horizontalAlignment: Text.AlignHCenter
+            wrapMode: Text.Wrap
+        }
+    }
+}

--- a/src/server/src/qml/qml/ShortcutRecorderField.qml
+++ b/src/server/src/qml/qml/ShortcutRecorderField.qml
@@ -1,6 +1,5 @@
 import QtQuick
 import QtQuick.Controls
-import QtQuick.Layouts
 
 Popup {
     id: recorder
@@ -19,11 +18,6 @@ Popup {
     padding: 10
 
     property bool _below: false
-
-    property var _currentShortcutTokens: []
-    property string _statusText: qsTr("Recording...")
-    property color _statusColor: Theme.foreground
-
     property bool _justClosed: false
 
     Timer {
@@ -42,9 +36,7 @@ Popup {
         if (_justClosed)
             return false;
 
-        _currentShortcutTokens = [];
-        _statusText = qsTr("Recording...");
-        _statusColor = Theme.foreground;
+        capture.reset();
         closeTimer.stop();
 
         // Parent to the trigger so the native popup anchors to it; x/y only
@@ -57,19 +49,13 @@ Popup {
         return true;
     }
 
-    onOpened: {
-        GlobalShortcuts.setCapturing(true);
-        keyReceiver.forceActiveFocus();
-    }
+    onOpened: capture.forceActiveFocus()
     onAboutToHide: {
         _justClosed = true;
         reopenGuard.restart();
     }
-    onClosed: GlobalShortcuts.setCapturing(false)
     onActiveFocusChanged: if (!activeFocus && opened)
         close()
-
-    Component.onDestruction: GlobalShortcuts.setCapturing(false)
 
     background: Rectangle {
         readonly property bool csd: recorder.popupType === Popup.Item || Platform.supports("clientSideDecorations")
@@ -81,80 +67,18 @@ Popup {
         PopupMaterial {}
     }
 
-    contentItem: FocusScope {
+    contentItem: ShortcutRecorderCapture {
+        id: capture
         focus: true
+        capturing: recorder.opened
+        validateShortcut: recorder.validateShortcut
+        shortcutDisplayProvider: recorder.shortcutDisplayProvider
 
-        ShortcutInhibitor.enabled: recorder.opened
-
-        Keys.onPressed: event => {
-            event.accepted = true;
-            closeTimer.stop();
-
-            var key = Keyboard.normalizeKey(event.key);
-            var mods = event.modifiers;
-
-            var isModKey = key === Qt.Key_Shift || key === Qt.Key_Control || key === Qt.Key_Alt || key === Qt.Key_Meta;
-            var isCloseKey = key === Qt.Key_Escape || key === Qt.Key_Backspace;
-
-            if (!isModKey && isCloseKey && mods === Qt.NoModifier) {
-                recorder.close();
-                return;
-            }
-
-            if (recorder.shortcutDisplayProvider)
-                recorder._currentShortcutTokens = recorder.shortcutDisplayProvider(key, mods);
-
-            if (isModKey) {
-                recorder._statusText = qsTr("Recording...");
-                recorder._statusColor = Theme.foreground;
-                return;
-            }
-
-            if (recorder.validateShortcut) {
-                var error = recorder.validateShortcut(key, mods);
-                if (error !== "") {
-                    recorder._statusText = error;
-                    recorder._statusColor = Theme.danger;
-                    return;
-                }
-            }
-
-            recorder._statusText = qsTr("Keybind updated");
-            recorder._statusColor = Theme.toastSuccess;
+        onActivity: closeTimer.stop()
+        onDismissRequested: recorder.close()
+        onShortcutCaptured: (key, modifiers) => {
             closeTimer.start();
-            recorder.shortcutCaptured(key, mods);
-        }
-
-        Item {
-            id: keyReceiver
-            focus: true
-        }
-
-        ColumnLayout {
-            anchors.fill: parent
-            spacing: 5
-
-            Item {
-                Layout.alignment: Qt.AlignHCenter
-                Layout.preferredWidth: badge.width
-                Layout.preferredHeight: badge.height
-                visible: recorder._currentShortcutTokens.length > 0
-
-                ShortcutBadge {
-                    id: badge
-                    tokens: recorder._currentShortcutTokens
-                }
-            }
-
-            Text {
-                Layout.alignment: Qt.AlignHCenter
-                Layout.fillWidth: true
-                text: recorder._statusText
-                color: recorder._statusColor
-                font.pointSize: Theme.smallerFontSize
-                horizontalAlignment: Text.AlignHCenter
-                wrapMode: Text.Wrap
-            }
+            recorder.shortcutCaptured(key, modifiers);
         }
     }
 }

--- a/src/server/src/qml/qml/ShortcutRecorderPanel.qml
+++ b/src/server/src/qml/qml/ShortcutRecorderPanel.qml
@@ -1,0 +1,114 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+// Action panel page that records a shortcut in place. Backed by a
+// ShortcutRecorderPanelView exposed as `view`.
+Item {
+    id: root
+
+    required property var view
+    property var controller: actionPanel
+
+    // Tells the window-level key routing to deliver every keypress here
+    // instead of matching bound actions or app keybinds.
+    readonly property bool capturesAllKeys: true
+
+    signal navigateBack
+
+    readonly property int stripeHeight: 40
+    readonly property int captureAreaHeight: 130
+
+    implicitHeight: stripeHeight + 1 + captureAreaHeight
+
+    function focusFilter() {
+        capture.forceActiveFocus();
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 0
+
+        Item {
+            id: stripe
+            Layout.fillWidth: true
+            Layout.preferredHeight: root.stripeHeight
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.leftMargin: 12
+                anchors.rightMargin: 12
+                spacing: 8
+
+                ViciImage {
+                    source: root.view.icon
+                    sourceSize.width: 20
+                    sourceSize.height: 20
+                    Layout.preferredWidth: 20
+                    Layout.preferredHeight: 20
+                    Layout.alignment: Qt.AlignVCenter
+                }
+
+                Text {
+                    Layout.fillWidth: true
+                    text: root.view.title
+                    color: Theme.foreground
+                    font.pointSize: Theme.regularFontSize
+                    elide: Text.ElideRight
+                }
+            }
+        }
+
+        Rectangle {
+            id: divider
+            Layout.fillWidth: true
+            implicitHeight: 1
+            color: Theme.divider
+        }
+
+        Item {
+            id: captureArea
+            Layout.fillWidth: true
+            Layout.preferredHeight: root.captureAreaHeight
+
+            ShortcutRecorderCapture {
+                id: capture
+                anchors.centerIn: parent
+                width: parent.width - 32
+                focus: true
+                capturing: root.StackView.status === StackView.Active
+                initialTokens: Keyboard.tokensForString(root.view.currentShortcut)
+                validateShortcut: (key, mods) => GlobalShortcuts.validate(key, mods, root.view.shortcutId)
+                shortcutDisplayProvider: (key, mods) => Keyboard.tokens(key, mods)
+
+                onShortcutCaptured: (key, modifiers) => {
+                    root.view.accept(key, modifiers);
+                    root.view.requestClose();
+                }
+                onDismissRequested: key => {
+                    if (key === Qt.Key_Backspace && root.view.currentShortcut !== "") {
+                        root.view.clear();
+                        root.view.requestClose();
+                    } else {
+                        root.navigateBack();
+                    }
+                }
+            }
+
+            Text {
+                anchors.bottom: parent.bottom
+                anchors.bottomMargin: 10
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.leftMargin: 16
+                anchors.rightMargin: 16
+                visible: root.view.currentShortcut !== ""
+                text: qsTr("Press Backspace to remove the current shortcut")
+                color: Theme.textPlaceholder
+                font.pointSize: Theme.smallerFontSize
+                horizontalAlignment: Text.AlignHCenter
+                wrapMode: Text.Wrap
+            }
+        }
+    }
+}

--- a/src/server/src/ui/action-pannel/shortcut-recorder-panel-view.cpp
+++ b/src/server/src/ui/action-pannel/shortcut-recorder-panel-view.cpp
@@ -1,0 +1,35 @@
+#include "ui/action-pannel/shortcut-recorder-panel-view.hpp"
+#include "internal/keyboard/keyboard.hpp"
+
+ShortcutRecorderPanelView::ShortcutRecorderPanelView(const QString &title, const ImageURL &icon,
+                                                     const QString &shortcutId,
+                                                     const QString &currentShortcut, QObject *parent)
+    : ActionPanelView(parent), m_title(title), m_icon(icon), m_shortcutId(shortcutId),
+      m_currentShortcut(currentShortcut) {
+  setId(shortcutId);
+}
+
+QUrl ShortcutRecorderPanelView::componentUrl() const {
+  return QUrl(QStringLiteral("qrc:/Vicinae/ShortcutRecorderPanel.qml"));
+}
+
+QVariantMap ShortcutRecorderPanelView::componentProps() {
+  QVariantMap props;
+  props[QStringLiteral("view")] = QVariant::fromValue(static_cast<QObject *>(this));
+  return props;
+}
+
+void ShortcutRecorderPanelView::accept(int key, int modifiers) {
+  Keyboard::Shortcut const shortcut(static_cast<Qt::Key>(key), static_cast<Qt::KeyboardModifiers>(modifiers));
+  if (!shortcut.isValid()) return;
+
+  m_currentShortcut = shortcut.toString();
+  if (m_onAccept) m_onAccept(m_currentShortcut);
+}
+
+void ShortcutRecorderPanelView::clear() {
+  m_currentShortcut.clear();
+  if (m_onAccept) m_onAccept(QString());
+}
+
+void ShortcutRecorderPanelView::requestClose() { emit closeRequested(); }

--- a/src/server/src/ui/action-pannel/shortcut-recorder-panel-view.hpp
+++ b/src/server/src/ui/action-pannel/shortcut-recorder-panel-view.hpp
@@ -1,0 +1,45 @@
+#pragma once
+#include "qml/image-url.hpp"
+#include "ui/action-pannel/action-panel-view.hpp"
+#include "ui/image/url.hpp"
+#include <functional>
+
+/**
+ * Action panel view that records a keyboard shortcut inline, in place of the
+ * usual action list. The host provides persistence through the accept handler,
+ * which receives the serialized shortcut (empty when cleared).
+ */
+class ShortcutRecorderPanelView : public ActionPanelView {
+  Q_OBJECT
+  Q_PROPERTY(QString title READ title CONSTANT)
+  Q_PROPERTY(ImageUrl icon READ icon CONSTANT)
+  Q_PROPERTY(QString shortcutId READ shortcutId CONSTANT)
+  Q_PROPERTY(QString currentShortcut READ currentShortcut CONSTANT)
+
+public:
+  Q_INVOKABLE void accept(int key, int modifiers);
+  Q_INVOKABLE void clear();
+  Q_INVOKABLE void requestClose();
+
+  using AcceptHandler = std::function<void(const QString &serialized)>;
+
+  ShortcutRecorderPanelView(const QString &title, const ImageURL &icon, const QString &shortcutId,
+                            const QString &currentShortcut, QObject *parent = nullptr);
+
+  QString title() const { return m_title; }
+  ImageUrl icon() const { return ImageUrl(m_icon); }
+  QString shortcutId() const { return m_shortcutId; }
+  QString currentShortcut() const { return m_currentShortcut; }
+
+  void setAcceptHandler(AcceptHandler handler) { m_onAccept = std::move(handler); }
+
+  QUrl componentUrl() const override;
+  QVariantMap componentProps() override;
+
+private:
+  QString m_title;
+  ImageURL m_icon;
+  QString m_shortcutId;
+  QString m_currentShortcut;
+  AcceptHandler m_onAccept;
+};


### PR DESCRIPTION
Add an action to set the global shortcut for a given root search item, directly from the root search without having to go in the settings.

Only available on platforms that support global shortcuts of course.

fixes #1689


https://github.com/user-attachments/assets/23acb9d3-8cc7-4a5b-9975-1213e9c510b1




