### PR TITLE
feat(macOS): use Carbon API when accessibility is not granted

### DIFF
--- a/src/server/src/qml/onboarding-window.cpp
+++ b/src/server/src/qml/onboarding-window.cpp
@@ -19,7 +19,6 @@
 #include "macos-chrome-attached.hpp"
 #include "services/autostart/macos-login-item.hpp"
 #include "services/permissions/macos-permission-service.hpp"
-#include <ApplicationServices/ApplicationServices.h>
 #endif
 
 struct OnboardingState {
@@ -46,9 +45,7 @@ OnboardingWindow::OnboardingWindow(ApplicationContext &ctx, QObject *parent) : Q
 
 bool OnboardingWindow::shouldShow() {
 #if defined(Q_OS_MACOS) && defined(ENABLE_ONBOARDING)
-  // Accessibility is a hard requirement (global shortcuts, paste, snippets); if it was revoked we
-  // run the onboarding again until it's back.
-  return completedVersion() < ONBOARDING_VERSION || !AXIsProcessTrusted();
+  return completedVersion() < ONBOARDING_VERSION;
 #else
   return false;
 #endif
@@ -85,10 +82,6 @@ void OnboardingWindow::openUrl(const QString &url) { m_ctx.services->appDb()->op
 void OnboardingWindow::show() {
   ensureInitialized();
   if (!m_window) return;
-
-  // Returning users only ever land here because accessibility went missing: skip the intro.
-  constexpr int PERMISSION_STEP = 1;
-  if (completedVersion() >= ONBOARDING_VERSION) { m_window->setProperty("step", PERMISSION_STEP); }
 
   m_window->show();
   m_window->raise();

--- a/src/server/src/qml/qml/OnboardingWindow.qml
+++ b/src/server/src/qml/qml/OnboardingWindow.qml
@@ -6,12 +6,9 @@ Window {
 
     property int step: 0
     readonly property int stepCount: 4
-    readonly property bool onPermissionStep: root.step === 1
     readonly property bool accessibilityGranted: Permissions.accessibilityGranted
 
     function advance() {
-        if (root.onPermissionStep && !root.accessibilityGranted)
-            return;
         if (root.step === root.stepCount - 1) {
             onboarding.finish();
             return;
@@ -184,7 +181,7 @@ Window {
 
                         Text {
                             visible: !root.accessibilityGranted || !Permissions.fullDiskAccessGranted
-                            text: !root.accessibilityGranted ? qsTr("Accessibility is required: global shortcuts, paste, and snippet expansion cannot work without it.") : qsTr("Full disk access needs to be explicitly enabled if you want file search to cover all your files.")
+                            text: !root.accessibilityGranted ? qsTr("Without accessibility access, paste, snippet expansion, and window management are unavailable.") : qsTr("Full disk access needs to be explicitly enabled if you want file search to cover all your files.")
                             color: Theme.textMuted
                             font.pointSize: Theme.smallerFontSize
                             wrapMode: Text.Wrap
@@ -359,11 +356,7 @@ Window {
                                 anchors.margins: -5
                                 hoverEnabled: true
                                 cursorShape: Qt.PointingHandCursor
-                                onClicked: {
-                                    if (index > 1 && !root.accessibilityGranted)
-                                        return;
-                                    root.step = index;
-                                }
+                                onClicked: root.step = index
                             }
                         }
                     }
@@ -373,8 +366,6 @@ Window {
                     id: nextButton
                     anchors.right: parent.right
                     anchors.verticalCenter: parent.verticalCenter
-                    enabled: !root.onPermissionStep || root.accessibilityGranted
-                    opacity: enabled ? 1 : 0.4
                     variant: "accent"
                     text: {
                         if (root.step === root.stepCount - 1)

--- a/src/server/src/services/global-shortcuts/global-shortcut-service.cpp
+++ b/src/server/src/services/global-shortcuts/global-shortcut-service.cpp
@@ -9,7 +9,12 @@ GlobalShortcutService::GlobalShortcutService(config::Manager &config, RootItemMa
     : m_config(config), m_rootItemManager(rootItemManager), m_backend(std::move(backend)) {
   connect(m_backend.get(), &AbstractGlobalShortcutBackend::shortcutActivated, this,
           &GlobalShortcutService::onActivated);
-  connect(m_backend.get(), &AbstractGlobalShortcutBackend::ready, this, &GlobalShortcutService::reconcile);
+  // `ready` may be re-emitted after a backend reset, in which case every binding is replayed
+  connect(m_backend.get(), &AbstractGlobalShortcutBackend::ready, this, [this] {
+    m_appliedTriggers.clear();
+    m_actions.clear();
+    reconcile();
+  });
   connect(&m_config, &config::Manager::configChanged, this, [this] { reconcile(); });
 
   m_backend->start();

--- a/src/server/src/services/global-shortcuts/macos-global-shortcut-backend.cpp
+++ b/src/server/src/services/global-shortcuts/macos-global-shortcut-backend.cpp
@@ -10,7 +10,9 @@ namespace {
 
 constexpr uint64_t MODIFIER_MASK =
     kCGEventFlagMaskCommand | kCGEventFlagMaskControl | kCGEventFlagMaskAlternate | kCGEventFlagMaskShift;
-constexpr int PERMISSION_RETRY_INTERVAL_MS = 2000;
+constexpr int PERMISSION_POLL_INTERVAL_MS = 2000;
+constexpr OSType HOT_KEY_SIGNATURE = 'vici';
+constexpr uint32_t MAX_LAYOUT_KEYCODE = 128;
 
 std::optional<uint32_t> staticKeycodeForQtKey(Qt::Key key) {
   switch (key) {
@@ -99,6 +101,28 @@ uint64_t cgFlagsForQtModifiers(Qt::KeyboardModifiers mods) {
   return flags;
 }
 
+uint32_t carbonModifiersFromCGFlags(uint64_t flags) {
+  uint32_t carbon = 0;
+  if (flags & kCGEventFlagMaskCommand) { carbon |= cmdKey; }
+  if (flags & kCGEventFlagMaskControl) { carbon |= controlKey; }
+  if (flags & kCGEventFlagMaskAlternate) { carbon |= optionKey; }
+  if (flags & kCGEventFlagMaskShift) { carbon |= shiftKey; }
+  return carbon;
+}
+
+OSStatus hotKeyHandler(EventHandlerCallRef, EventRef event, void *userData) {
+  EventHotKeyID hotKeyId{};
+  if (GetEventParameter(event, kEventParamDirectObject, typeEventHotKeyID, nullptr, sizeof(hotKeyId), nullptr,
+                        &hotKeyId) != noErr) {
+    return eventNotHandledErr;
+  }
+  if (hotKeyId.signature != HOT_KEY_SIGNATURE) { return eventNotHandledErr; }
+
+  const auto timestamp = static_cast<quint64>(GetEventTime(event) * 1000.0);
+  static_cast<MacOSGlobalShortcutBackend *>(userData)->handleHotKey(hotKeyId.id, timestamp);
+  return noErr;
+}
+
 CGEventRef tapCallback(CGEventTapProxy, CGEventType type, CGEventRef event, void *refcon) {
   auto *self = static_cast<MacOSGlobalShortcutBackend *>(refcon);
 
@@ -129,8 +153,8 @@ MacOSGlobalShortcutBackend::~MacOSGlobalShortcutBackend() {
   CFNotificationCenterRemoveObserver(CFNotificationCenterGetDistributedCenter(), this,
                                      kTISNotifySelectedKeyboardInputSourceChanged, nullptr);
 
-  if (void *loop = m_runLoop.load()) { CFRunLoopStop(static_cast<CFRunLoopRef>(loop)); }
-  if (m_thread.joinable()) { m_thread.join(); }
+  teardownCarbon();
+  stopTapThread();
 
   std::lock_guard lock(m_mutex);
   if (m_layoutData) {
@@ -150,25 +174,48 @@ bool MacOSGlobalShortcutBackend::start() {
   CFNotificationCenterAddObserver(CFNotificationCenterGetDistributedCenter(), this, &layoutChangedCallback,
                                   kTISNotifySelectedKeyboardInputSourceChanged, nullptr,
                                   CFNotificationSuspensionBehaviorDeliverImmediately);
-  startTapThread();
 
-  if (!AXIsProcessTrusted()) {
-    m_permissionRetryTimer.setInterval(PERMISSION_RETRY_INTERVAL_MS);
-    connect(&m_permissionRetryTimer, &QTimer::timeout, this, [this]() {
-      if (!AXIsProcessTrusted()) return;
-      m_permissionRetryTimer.stop();
-      ensureTapRunning();
-    });
-    m_permissionRetryTimer.start();
+  m_trusted = AXIsProcessTrusted();
+  if (m_trusted) {
+    startTapThread();
+  } else {
+    startCarbonHandler();
   }
+
+  m_permissionTimer.setInterval(PERMISSION_POLL_INTERVAL_MS);
+  connect(&m_permissionTimer, &QTimer::timeout, this, &MacOSGlobalShortcutBackend::syncPermissionState);
+  m_permissionTimer.start();
 
   m_started = true;
   emit ready();
   return true;
 }
 
+void MacOSGlobalShortcutBackend::syncPermissionState() {
+  const bool trusted = AXIsProcessTrusted();
+
+  if (trusted == m_trusted) {
+    if (trusted) { ensureTapRunning(); }
+    return;
+  }
+
+  m_trusted = trusted;
+  if (trusted) {
+    unbindAll();
+    teardownCarbon();
+    startTapThread();
+  } else {
+    stopTapThread();
+    unbindAll();
+    startCarbonHandler();
+  }
+
+  emit ready();
+}
+
 // The tap gets its own run loop thread so a busy Qt main loop can't get it disabled by timeout.
 void MacOSGlobalShortcutBackend::startTapThread() {
+  if (m_thread.joinable()) { m_thread.join(); }
   m_tapThreadDone = false;
   m_thread = std::thread([this]() {
     runTap();
@@ -176,9 +223,13 @@ void MacOSGlobalShortcutBackend::startTapThread() {
   });
 }
 
+void MacOSGlobalShortcutBackend::stopTapThread() {
+  if (void *loop = m_runLoop.load()) { CFRunLoopStop(static_cast<CFRunLoopRef>(loop)); }
+  if (m_thread.joinable()) { m_thread.join(); }
+}
+
 void MacOSGlobalShortcutBackend::ensureTapRunning() {
   if (!m_tapThreadDone) return;
-  if (m_thread.joinable()) m_thread.join();
   startTapThread();
 }
 
@@ -223,6 +274,113 @@ void MacOSGlobalShortcutBackend::refreshLayout() {
   m_kbdType = LMGetKbdType();
 
   if (!m_qwertyLayoutData) { m_qwertyLayoutData = Keyboard::macos::copyQwertyLayoutData(); }
+
+  if (m_hotKeyHandler) {
+    for (auto &binding : m_bindings) {
+      if (binding.character.isEmpty()) { continue; }
+      unregisterCarbonHotKey(binding);
+      if (auto registered = registerCarbonHotKey(binding); !registered) {
+        qWarning() << "MacOSGlobalShortcutBackend: failed to rebind" << binding.id
+                   << "after layout change:" << registered.error();
+      }
+    }
+  }
+}
+
+bool MacOSGlobalShortcutBackend::startCarbonHandler() {
+  if (m_hotKeyHandler) { return true; }
+
+  const EventTypeSpec spec{.eventClass = kEventClassKeyboard, .eventKind = kEventHotKeyPressed};
+  EventHandlerRef handler = nullptr;
+  if (InstallApplicationEventHandler(&hotKeyHandler, 1, &spec, this, &handler) != noErr) {
+    qWarning() << "MacOSGlobalShortcutBackend: failed to install Carbon hot key handler";
+    return false;
+  }
+
+  m_hotKeyHandler = handler;
+  return true;
+}
+
+void MacOSGlobalShortcutBackend::teardownCarbon() {
+  {
+    std::lock_guard lock(m_mutex);
+    for (auto &binding : m_bindings) {
+      unregisterCarbonHotKey(binding);
+    }
+  }
+
+  if (m_hotKeyHandler) {
+    RemoveEventHandler(static_cast<EventHandlerRef>(m_hotKeyHandler));
+    m_hotKeyHandler = nullptr;
+  }
+}
+
+// requires m_mutex to be held
+std::optional<uint32_t> MacOSGlobalShortcutBackend::resolveCarbonKeycode(const Binding &binding) const {
+  if (binding.keycode) { return binding.keycode; }
+
+  const auto active = static_cast<CFDataRef>(m_layoutData);
+  const auto qwerty = static_cast<CFDataRef>(m_qwertyLayoutData);
+  const bool shift = (binding.flags & kCGEventFlagMaskShift) != 0;
+
+  const auto findIn = [&](CFDataRef layout, bool shifted) -> std::optional<uint32_t> {
+    if (!layout) { return std::nullopt; }
+    for (uint32_t keycode = 0; keycode < MAX_LAYOUT_KEYCODE; ++keycode) {
+      const QString character =
+          Keyboard::macos::translateKeycode(layout, static_cast<uint16_t>(keycode), shifted, m_kbdType);
+      if (!character.isEmpty() && character == binding.character) { return keycode; }
+    }
+    return std::nullopt;
+  };
+
+  if (const auto keycode = findIn(active, false)) { return keycode; }
+  if (shift) {
+    if (const auto keycode = findIn(active, true)) { return keycode; }
+  }
+  if (const auto keycode = findIn(qwerty, false)) { return keycode; }
+  if (shift) {
+    if (const auto keycode = findIn(qwerty, true)) { return keycode; }
+  }
+  return std::nullopt;
+}
+
+// requires m_mutex to be held
+std::expected<void, QString> MacOSGlobalShortcutBackend::registerCarbonHotKey(Binding &binding) {
+  const auto keycode = resolveCarbonKeycode(binding);
+  if (!keycode) { return std::unexpected(tr("unsupported or invalid trigger")); }
+
+  const uint32_t carbonId = binding.carbonId != 0 ? binding.carbonId : m_nextCarbonId++;
+  const EventHotKeyID hotKeyId{.signature = HOT_KEY_SIGNATURE, .id = carbonId};
+  EventHotKeyRef ref = nullptr;
+  const OSStatus status = RegisterEventHotKey(*keycode, carbonModifiersFromCGFlags(binding.flags), hotKeyId,
+                                              GetApplicationEventTarget(), 0, &ref);
+
+  if (status != noErr || !ref) { return std::unexpected(tr("failed to register hot key (%1)").arg(status)); }
+
+  binding.hotKeyRef = ref;
+  binding.carbonId = carbonId;
+  return {};
+}
+
+void MacOSGlobalShortcutBackend::unregisterCarbonHotKey(Binding &binding) {
+  if (!binding.hotKeyRef) { return; }
+  UnregisterEventHotKey(static_cast<EventHotKeyRef>(binding.hotKeyRef));
+  binding.hotKeyRef = nullptr;
+}
+
+void MacOSGlobalShortcutBackend::handleHotKey(uint32_t carbonId, quint64 timestamp) {
+  QString id;
+
+  {
+    std::lock_guard lock(m_mutex);
+    const auto it = std::ranges::find_if(m_bindings, [&](const Binding &binding) {
+      return binding.carbonId == carbonId && binding.hotKeyRef != nullptr;
+    });
+    if (it == m_bindings.end()) { return; }
+    id = it->id;
+  }
+
+  emit shortcutActivated(id, timestamp);
 }
 
 std::expected<void, QString> MacOSGlobalShortcutBackend::bindShortcut(const GlobalShortcutRequest &request) {
@@ -239,17 +397,26 @@ std::expected<void, QString> MacOSGlobalShortcutBackend::bindShortcut(const Glob
   }
 
   std::lock_guard lock(m_mutex);
+  if (m_hotKeyHandler) {
+    if (auto registered = registerCarbonHotKey(binding); !registered) { return registered; }
+  }
   m_bindings.emplace_back(std::move(binding));
   return {};
 }
 
 void MacOSGlobalShortcutBackend::unbindShortcut(const QString &id) {
   std::lock_guard lock(m_mutex);
+  for (auto &binding : m_bindings) {
+    if (binding.id == id) { unregisterCarbonHotKey(binding); }
+  }
   std::erase_if(m_bindings, [&](const Binding &binding) { return binding.id == id; });
 }
 
 void MacOSGlobalShortcutBackend::unbindAll() {
   std::lock_guard lock(m_mutex);
+  for (auto &binding : m_bindings) {
+    unregisterCarbonHotKey(binding);
+  }
   m_bindings.clear();
 }
 

--- a/src/server/src/services/global-shortcuts/macos-global-shortcut-backend.hpp
+++ b/src/server/src/services/global-shortcuts/macos-global-shortcut-backend.hpp
@@ -10,8 +10,9 @@
 #include "services/global-shortcuts/abstract-global-shortcut-backend.hpp"
 
 // Global shortcuts on macOS via a CGEventTap. Character keys are matched by translating the incoming
-// keycode through the active layout, so shortcuts follow the character across layouts. CF/CG types
-// stay out of this header (opaque void *) so plain C++ translation units can include it.
+// keycode through the active layout, so shortcuts follow the character across layouts. Without the
+// accessibility permission, a Carbon RegisterEventHotKey fallback is used instead. CF/CG types stay
+// out of this header (opaque void *) so plain C++ translation units can include it.
 class MacOSGlobalShortcutBackend : public AbstractGlobalShortcutBackend {
   Q_OBJECT
 
@@ -30,6 +31,9 @@ public:
   bool handleKeyDown(uint32_t keycode, uint64_t flags, bool autorepeat, quint64 timestamp);
   void reenableTap();
 
+  // called on the main thread by the Carbon hot key handler
+  void handleHotKey(uint32_t carbonId, quint64 timestamp);
+
   // called on the main thread when the keyboard layout changes
   void refreshLayout();
 
@@ -39,11 +43,21 @@ private:
     std::optional<uint32_t> keycode;
     QString character;
     uint64_t flags = 0;
+    void *hotKeyRef = nullptr; // EventHotKeyRef
+    uint32_t carbonId = 0;
   };
 
   void startTapThread();
+  void stopTapThread();
   void ensureTapRunning();
   void runTap();
+
+  void syncPermissionState();
+  bool startCarbonHandler();
+  void teardownCarbon();
+  std::expected<void, QString> registerCarbonHotKey(Binding &binding);
+  void unregisterCarbonHotKey(Binding &binding);
+  std::optional<uint32_t> resolveCarbonKeycode(const Binding &binding) const;
 
   std::vector<Binding> m_bindings;          // guarded by m_mutex
   const void *m_layoutData = nullptr;       // CFDataRef, guarded by m_mutex
@@ -55,6 +69,11 @@ private:
   std::atomic<void *> m_runLoop = nullptr;
   std::atomic<bool> m_tapThreadDone = false;
   void *m_tap = nullptr; // CFMachPortRef, tap thread only
-  QTimer m_permissionRetryTimer;
+
+  void *m_hotKeyHandler = nullptr; // EventHandlerRef, main thread only
+  uint32_t m_nextCarbonId = 1;
+
+  QTimer m_permissionTimer;
+  bool m_trusted = false;
   bool m_started = false;
 };


### PR DESCRIPTION
#1709 made the accessibility permission mandatory which is actually not that nice as some people cannot grant this permission in corporate contexts.

This reverts that, and makes use of the Carbon API to register hotkeys instead of the tap when the accessibility permission is not granted.

fixes #1735