### PR TITLE
feat: inhibit global shortcuts for specific frontmost apps

### DIFF
--- a/extra/config.jsonc
+++ b/extra/config.jsonc
@@ -179,6 +179,21 @@
 		}
 	},
 	
+	// Shortcuts that work system-wide, even when the vicinae window is closed.
+	"global_shortcuts": {
+		// The shortcut used to toggle the launcher window.
+		// Defaults to "alt+space" on macOS and Windows, "super+control+space" elsewhere.
+		// "toggle": "alt+space",
+
+		// While one of these applications is focused, all global shortcuts are released so that
+		// the keystrokes reach the application itself. Useful for virtual machines or remote
+		// desktops that need to receive every key.
+		// Values are application IDs:
+		// - macOS: the bundle identifier, e.g "com.vmware.fusion"
+		// - Linux: the desktop file ID, e.g "org.gnome.Boxes.desktop"
+		"inhibit_apps": []
+	},
+
 	// Keybinds are serialized using a custom format.
 	// It is recommended to edit them through the settings GUI, which will write them to this file.
 	// NOTE: here, "control" remaps to the "command" (⌘) key on macOS.

--- a/src/server/src/config/config.hpp
+++ b/src/server/src/config/config.hpp
@@ -278,10 +278,12 @@ struct GlobalShortcuts {
 #else
   std::optional<std::string> toggle = "super+control+space";
 #endif
+  std::vector<std::string> inhibitApps;
 };
 
 template <> struct Partial<GlobalShortcuts> {
   std::optional<std::string> toggle;
+  std::optional<std::vector<std::string>> inhibitApps;
 };
 
 struct ConfigValue {

--- a/src/server/src/server.cpp
+++ b/src/server/src/server.cpp
@@ -280,8 +280,8 @@ int startServer(const ServerLaunchOptions &launchOpts) {
                                                        std::move(platformPaste));
     auto fontService = std::make_unique<FontService>();
     auto rootItemManager = std::make_unique<RootItemManager>(*configService, *localStorage);
-    auto globalShortcutService = std::make_unique<GlobalShortcutService>(*configService, *rootItemManager,
-                                                                         createGlobalShortcutBackend());
+    auto globalShortcutService = std::make_unique<GlobalShortcutService>(
+        *configService, *rootItemManager, *appRuntime, createGlobalShortcutBackend());
     auto shortcutService =
         std::make_unique<ShortcutService>(Omnicast::dataDir() / "shortcuts" / "shortcuts.json", omniDb.get());
     auto toastService = std::make_unique<ToastService>();

--- a/src/server/src/services/global-shortcuts/global-shortcut-service.cpp
+++ b/src/server/src/services/global-shortcuts/global-shortcut-service.cpp
@@ -1,12 +1,16 @@
 #include "services/global-shortcuts/global-shortcut-service.hpp"
 #include "common/types.hpp"
 #include "config/config.hpp"
+#include "services/app-runtime/app-runtime.hpp"
 #include "services/root-item-manager/root-item-manager.hpp"
+#include <algorithm>
 #include <utility>
 
 GlobalShortcutService::GlobalShortcutService(config::Manager &config, RootItemManager &rootItemManager,
+                                             AppRuntime &appRuntime,
                                              std::unique_ptr<AbstractGlobalShortcutBackend> backend)
-    : m_config(config), m_rootItemManager(rootItemManager), m_backend(std::move(backend)) {
+    : m_config(config), m_rootItemManager(rootItemManager), m_appRuntime(appRuntime),
+      m_backend(std::move(backend)) {
   connect(m_backend.get(), &AbstractGlobalShortcutBackend::shortcutActivated, this,
           &GlobalShortcutService::onActivated);
   // `ready` may be re-emitted after a backend reset, in which case every binding is replayed
@@ -15,8 +19,13 @@ GlobalShortcutService::GlobalShortcutService(config::Manager &config, RootItemMa
     m_actions.clear();
     reconcile();
   });
-  connect(&m_config, &config::Manager::configChanged, this, [this] { reconcile(); });
+  connect(&m_config, &config::Manager::configChanged, this, [this] {
+    updateInhibition();
+    reconcile();
+  });
+  connect(&m_appRuntime, &AppRuntime::frontmostAppChanged, this, &GlobalShortcutService::updateInhibition);
 
+  m_inhibited = computeInhibited();
   m_backend->start();
   reconcile();
 }
@@ -35,7 +44,7 @@ void GlobalShortcutService::setCapturing(bool capturing) {
 }
 
 void GlobalShortcutService::reconcile() {
-  if (m_capturing) { return; }
+  if (m_capturing || m_inhibited) { return; }
   if (!isSupported()) { return; }
 
   const config::ConfigValue &cfg = m_config.value();
@@ -108,6 +117,33 @@ std::optional<QString> GlobalShortcutService::probeBind(const Keyboard::Shortcut
 QString GlobalShortcutService::describeCommand(const EntrypointId &id) const {
   if (auto meta = m_rootItemManager.itemMetadata(id); meta.item) { return meta.item->title(); }
   return QString::fromStdString(id);
+}
+
+void GlobalShortcutService::updateInhibition() {
+  const bool inhibited = computeInhibited();
+  if (inhibited == m_inhibited) { return; }
+
+  m_inhibited = inhibited;
+  if (m_capturing) { return; }
+
+  if (inhibited) {
+    m_backend->unbindAll();
+    m_appliedTriggers.clear();
+    m_actions.clear();
+  } else {
+    reconcile();
+  }
+}
+
+bool GlobalShortcutService::computeInhibited() const {
+  const auto &apps = m_config.value().globalShortcuts.inhibitApps;
+  if (apps.empty()) { return false; }
+
+  const auto app = m_appRuntime.frontmostApp();
+  if (!app) { return false; }
+
+  const std::string id = app->id().toStdString();
+  return std::ranges::contains(apps, id);
 }
 
 void GlobalShortcutService::onActivated(const QString &id, quint64 timestamp) {

--- a/src/server/src/services/global-shortcuts/global-shortcut-service.hpp
+++ b/src/server/src/services/global-shortcuts/global-shortcut-service.hpp
@@ -9,6 +9,7 @@ namespace config {
 class Manager;
 }
 
+class AppRuntime;
 class RootItemManager;
 
 /**
@@ -29,7 +30,7 @@ public:
   // Non-command global shortcuts are prefixed with '@' to avoid colliding with entrypoint ids.
   static constexpr const char *TOGGLE_ID = "@toggle-launcher";
 
-  GlobalShortcutService(config::Manager &config, RootItemManager &rootItemManager,
+  GlobalShortcutService(config::Manager &config, RootItemManager &rootItemManager, AppRuntime &appRuntime,
                         std::unique_ptr<AbstractGlobalShortcutBackend> backend);
 
   AbstractGlobalShortcutBackend *backend() const { return m_backend.get(); }
@@ -63,11 +64,15 @@ private:
   void reconcile();
   void onActivated(const QString &id, quint64 timestamp);
   QString describeCommand(const EntrypointId &id) const;
+  void updateInhibition();
+  bool computeInhibited() const;
 
   config::Manager &m_config;
   RootItemManager &m_rootItemManager;
+  AppRuntime &m_appRuntime;
   std::unique_ptr<AbstractGlobalShortcutBackend> m_backend;
   std::unordered_map<QString, Action> m_actions;
   std::unordered_map<QString, QString> m_appliedTriggers;
   bool m_capturing = false;
+  bool m_inhibited = false;
 };


### PR DESCRIPTION
Add a config file only setting to allow inhibition of global shortcuts when a specific app is in front.
Useful if dealing with a virtual machine or some sort of remote desktop software and you don't want vicinae to swallow keys.