### PR TITLE
feat(dmenu): add index output format

### DIFF
--- a/figura/ipc.fig
+++ b/figura/ipc.fig
@@ -50,10 +50,16 @@ struct ListCommandsResponse {
   commands: CommandInfo[];
 };
 
+enum DMenuOutputFormat {
+  Data,
+  Index
+};
+
 struct DMenuRequest {
   rawContent: string;
   navigationTitle?: string;
   placeholder?: string;
+  format: DMenuOutputFormat;
   sectionTitle?: string;
   noSection: bool;
   noQuickLook: bool;

--- a/src/cli/src/cli.cpp
+++ b/src/cli/src/cli.cpp
@@ -1,8 +1,11 @@
 #include <filesystem>
 #include <glaze/core/opts.hpp>
 #include <glaze/core/reflect.hpp>
+#include <ranges>
 #include <system_error>
+#include <unordered_map>
 #include "cli.hpp"
+#include "CLI11/CLI11.hpp"
 #include "config.hpp"
 #include "fs.hpp"
 #include "rang/rang.hpp"
@@ -343,10 +346,22 @@ class DMenuCommand : public AbstractCommandLineCommand {
   std::string description() const override { return "Render a list view from stdin"; }
 
   void setup(CLI::App *app) override {
+    const std::unordered_map<std::string, ipc::DMenuOutputFormat> formatMap{
+        {"data", ipc::DMenuOutputFormat::Data},
+        {"index", ipc::DMenuOutputFormat::Index},
+    };
+
+    const auto formatChoices = formatMap | std::views::transform([](auto &&pair) { return pair.first; }) |
+                               std::views::join_with(',') | std::ranges::to<std::string>();
+
     app->add_option("-n,--navigation-title", m_req.navigationTitle, "Set the navigation title");
     app->add_option(
         "-s,--section-title", m_req.sectionTitle,
         "Set the title of the main section. Use the {count} placeholder to render the current count.");
+    app->add_option("-f,--format", m_req.format,
+                    std::format("Control the format of the output ({})", formatChoices))
+        ->transform(CLI::CheckedTransformer(formatMap, CLI::ignore_case))
+        ->default_val(ipc::DMenuOutputFormat::Data);
     app->add_option("-p,--placeholder", m_req.placeholder, "Placeholder text to use in the search bar");
     app->add_option("-q,--query", m_req.query, "Initial search query");
     app->add_option("-W,--width", m_req.width, "Window width in pixels");

--- a/src/server/src/qml/dmenu-model.cpp
+++ b/src/server/src/qml/dmenu-model.cpp
@@ -1,21 +1,23 @@
 #include "dmenu-model.hpp"
-#include "clipboard-actions.hpp"
+#include "common/enumerate.hpp"
 #include "fuzzy/fzf.hpp"
-#include "navigation-controller.hpp"
+#include "generated/ipc-client.hpp"
 #include "service-registry.hpp"
 #include "template-engine/template-engine.hpp"
+#include "services/clipboard/clipboard-service.hpp"
 #include "ui/action-pannel/action.hpp"
 #include "utils/utils.hpp"
 #include <algorithm>
 #include <filesystem>
+#include <qhashfunctions.h>
 #include <ranges>
 #include <utility>
 
 void DMenuSection::setRawEntries(std::vector<std::string_view> entries) {
   m_entries = std::move(entries);
   m_filtered.clear();
-  for (auto e : m_entries) {
-    m_filtered.push_back({e, 0});
+  for (auto [idx, e] : vicinae::enumerate(m_entries)) {
+    m_filtered.push_back({{e, idx}, 0});
   }
   notifyChanged();
 }
@@ -25,9 +27,9 @@ void DMenuSection::setFilter(std::string_view query) {
   m_currentSearchText = QString::fromUtf8(query.data(), query.size());
 
   m_filtered.clear();
-  for (auto e : m_entries) {
+  for (auto [idx, e] : vicinae::enumerate(m_entries)) {
     int const score = fzf::threadLocalMatcher().fuzzy_match_v2_score_query(e, queryStr);
-    if (queryStr.empty() || score > 0) { m_filtered.push_back({e, score}); }
+    if (queryStr.empty() || score > 0) { m_filtered.push_back({{e, idx}, score}); }
   }
   std::ranges::stable_sort(m_filtered, std::greater{});
 }
@@ -43,13 +45,13 @@ QString DMenuSection::expandSectionName(size_t count) const {
   return engine.build(QString::fromUtf8(m_sectionTemplate.data(), m_sectionTemplate.size()));
 }
 
-std::string_view DMenuSection::entryAt(int i) const {
+DMenuSection::IndexedData DMenuSection::entryAt(int i) const {
   if (i < 0 || std::cmp_greater_equal(i, m_filtered.size())) return {};
   return m_filtered[i].data;
 }
 
 QString DMenuSection::itemTitle(int i) const {
-  auto entry = entryAt(i);
+  auto entry = entryAt(i).first;
   if (entry.starts_with('/')) {
     return QString::fromStdString(getLastPathComponent(std::filesystem::path(entry)));
   }
@@ -58,7 +60,7 @@ QString DMenuSection::itemTitle(int i) const {
 
 QString DMenuSection::itemSubtitle(int i) const {
   if (!m_noQuickLook) return {};
-  auto entry = entryAt(i);
+  auto entry = entryAt(i).first;
   if (entry.starts_with('/')) {
     std::error_code ec;
     if (std::filesystem::exists(entry, ec)) {
@@ -69,7 +71,7 @@ QString DMenuSection::itemSubtitle(int i) const {
 }
 
 std::optional<ImageURL> DMenuSection::itemIcon(int i) const {
-  auto entry = entryAt(i);
+  auto entry = entryAt(i).first;
   if (entry.starts_with('/')) {
     std::error_code ec;
     if (std::filesystem::exists(entry, ec)) { return ImageURL::fileIcon(entry); }
@@ -83,15 +85,28 @@ void DMenuSection::selectEntry(const QString &text) const {
 }
 
 std::unique_ptr<ActionPanelState> DMenuSection::actionPanel(int i) const {
-  auto entry = entryAt(i);
+  auto [entry, idx] = entryAt(i);
   if (entry.empty()) return nullptr;
 
   auto text = QString::fromUtf8(entry.data(), entry.size());
   auto panel = std::make_unique<ListActionPanelState>();
   auto *main = panel->createSection();
 
-  main->addAction(new StaticAction(tr("Select entry"), ImageURL::builtin(BuiltinIcon::SaveDocument),
-                                   [this, text](ApplicationContext *) { selectEntry(text); }));
+  using Format = ipc_gen::DMenuOutputFormat;
+
+  auto selectEntryLabel = m_outputFormat == Format::Data ? tr("Select entry") : tr("Select entry (index)");
+
+  main->addAction(new StaticAction(selectEntryLabel, ImageURL::builtin(BuiltinIcon::SaveDocument),
+                                   [this, text, idx](ApplicationContext *) {
+                                     switch (m_outputFormat) {
+                                     case Format::Data:
+                                       selectEntry(text);
+                                       break;
+                                     case Format::Index:
+                                       selectEntry(QString::number(idx));
+                                       break;
+                                     }
+                                   }));
 
   main->addAction(new StaticAction(tr("Pass search text"), ImageURL::builtin(BuiltinIcon::SaveDocument),
                                    [this](ApplicationContext *) { selectEntry(m_currentSearchText); }));
@@ -109,7 +124,7 @@ std::unique_ptr<ActionPanelState> DMenuSection::actionPanel(int i) const {
 }
 
 void DMenuSection::onSelected(int i) {
-  auto entry = entryAt(i);
+  auto entry = entryAt(i).first;
   if (!entry.empty()) {
     std::error_code ec;
     if (entry.starts_with('/') && std::filesystem::exists(entry, ec)) {

--- a/src/server/src/qml/dmenu-model.cpp
+++ b/src/server/src/qml/dmenu-model.cpp
@@ -1,7 +1,6 @@
 #include "dmenu-model.hpp"
 #include "common/enumerate.hpp"
 #include "fuzzy/fzf.hpp"
-#include "generated/ipc-client.hpp"
 #include "service-registry.hpp"
 #include "template-engine/template-engine.hpp"
 #include "services/clipboard/clipboard-service.hpp"
@@ -9,7 +8,6 @@
 #include "utils/utils.hpp"
 #include <algorithm>
 #include <filesystem>
-#include <qhashfunctions.h>
 #include <ranges>
 #include <utility>
 

--- a/src/server/src/qml/dmenu-model.hpp
+++ b/src/server/src/qml/dmenu-model.hpp
@@ -1,19 +1,22 @@
 #pragma once
 #include "fuzzy/scored.hpp"
+#include "generated/ipc-server.hpp"
 #include "section-source.hpp"
 #include <QCoreApplication>
+#include <cstddef>
 #include <functional>
-#include <string>
 #include <string_view>
 #include <vector>
 
 class DMenuSection : public SectionSource {
   Q_DECLARE_TR_FUNCTIONS(DMenuSection)
+
 public:
   void setRawEntries(std::vector<std::string_view> entries);
   void setSectionTemplate(std::string_view tpl) { m_sectionTemplate = tpl; }
   void setNoSection(bool v) { m_noSection = v; }
   void setNoQuickLook(bool v) { m_noQuickLook = v; }
+  void setOutputFormat(ipc_gen::DMenuOutputFormat format) { m_outputFormat = format; }
   void setFilter(std::string_view query) override;
 
   QString sectionName() const override;
@@ -31,16 +34,19 @@ protected:
   std::unique_ptr<ActionPanelState> actionPanel(int i) const override;
 
 private:
-  std::string_view entryAt(int i) const;
+  using IndexedData = std::pair<std::string_view, std::size_t>;
+
+  IndexedData entryAt(int i) const;
   QString expandSectionName(size_t count) const;
   void selectEntry(const QString &text) const;
 
   std::vector<std::string_view> m_entries;
-  std::vector<Scored<std::string_view>> m_filtered;
+  std::vector<Scored<IndexedData>> m_filtered;
   std::string_view m_sectionTemplate = "Entries ({count})";
   QString m_currentSearchText;
   bool m_noSection = false;
   bool m_noQuickLook = false;
+  ipc_gen::DMenuOutputFormat m_outputFormat = ipc_gen::DMenuOutputFormat::Data;
 
   std::function<void(const QString &)> m_onEntryChosen;
   std::function<void(std::string_view)> m_onFileHighlighted;

--- a/src/server/src/qml/dmenu-view-host.cpp
+++ b/src/server/src/qml/dmenu-view-host.cpp
@@ -24,6 +24,7 @@ void DMenuViewHost::initialize() {
   BaseView::initialize();
   initModel();
 
+  m_section.setOutputFormat(m_data.format);
   if (m_data.noQuickLook) m_section.setNoQuickLook(true);
   if (m_data.noSection) m_section.setNoSection(true);
   if (m_data.sectionTitle) m_section.setSectionTemplate(*m_data.sectionTitle);

--- a/src/typescript/api/src/proto/ipc.ts
+++ b/src/typescript/api/src/proto/ipc.ts
@@ -78,6 +78,8 @@ export class RpcTransport {
 	private handlers = new Map<string, Array<(result: any) => void>>;
 };
 
+export type DMenuOutputFormat = 'Data' | 'Index';
+
 export type PingResponse = {
 	version: string;
 	pid: number;
@@ -131,6 +133,7 @@ export type DMenuRequest = {
 	rawContent: string;
 	navigationTitle?: string;
 	placeholder?: string;
+	format: DMenuOutputFormat;
 	sectionTitle?: string;
 	noSection: boolean;
 	noQuickLook: boolean;


### PR DESCRIPTION
Add a new `--format` flag that can be used to control the output format of the default dmenu action. Supports `data` (current) and `index` (index of the selected item in the list)

fixes #1605