### PR TITLE
fix: execute action before closing window for Wayland XDG activation

### DIFF
--- a/src/server/src/navigation-controller.cpp
+++ b/src/server/src/navigation-controller.cpp
@@ -446,9 +446,8 @@ void NavigationController::executeActionNow(AbstractAction *action) {
     }
   }
 
-  if (action->autoClose()) { closeWindow({.clearRootSearch = true}); }
-
   action->execute(&m_ctx);
+  if (action->autoClose()) { closeWindow({.clearRootSearch = true}); }
   closeActionPanel();
 }
 


### PR DESCRIPTION
Closing the launcher window before executing an action hides the window surface and resets QGuiApplication::focusWindow() to nullptr. As a result, when AppService attempts to request an XDG activation token, requestLaunchToken() lacks a focused window surface to bind to the activation token.

This seems to happen as a race condition that is particularly prevelent with applications that are slow to start (IntelliJ is a prime example).

Under compositors like Hyprland, an unauthenticated/unbound launch token fails to grant workspace focus to the newly spawned window, causing it to fall back to opening on workspace 1.

Executing the action prior to calling closeWindow() ensures the window surface and focus state remain valid when requesting the XDG activation token.

Closes #1697