### PR TITLE
feat: clipboard history drag and drop

### DIFF
--- a/src/lib/common/include/common/clipboard-formats.hpp
+++ b/src/lib/common/include/common/clipboard-formats.hpp
@@ -4,6 +4,7 @@ namespace Clipboard {
 
 inline constexpr const char *CONCEALED_MIME_TYPE = "vicinae/concealed";
 inline constexpr const char *PASSWORD_HINT_MIME_TYPE = "x-kde-passwordManagerHint";
+inline constexpr const char *URI_LIST = "text/uri-list";
 
 // Qt wraps native Windows clipboard formats it has no mime mapping for
 inline constexpr const char *WIN_NATIVE_MIME_PREFIX = "application/x-qt-windows-mime";

--- a/src/server/src/qml/clipboard-history-model.cpp
+++ b/src/server/src/qml/clipboard-history-model.cpp
@@ -45,6 +45,17 @@ ImageURL ClipboardHistorySection::iconForEntry(const ClipboardHistoryEntry &entr
   }
 }
 
+bool ClipboardHistorySection::isDraggable(int idx) const { return true; }
+
+std::unique_ptr<QMimeData> ClipboardHistorySection::dragMimeData(int idx) const {
+  auto clipman = scope().services()->clipman();
+  auto selection = clipman->retrieveSelectionById(m_entries[idx].id);
+
+  return selection
+      .transform([&](const auto &selection) { return clipman->dragMimeDataForSelection(selection); })
+      .value_or(nullptr);
+}
+
 std::unique_ptr<ActionPanelState> ClipboardHistorySection::actionPanel(int i) const {
   const auto &entry = m_entries[i];
   auto panel = std::make_unique<ListActionPanelState>();

--- a/src/server/src/qml/clipboard-history-model.hpp
+++ b/src/server/src/qml/clipboard-history-model.hpp
@@ -40,6 +40,8 @@ protected:
   QString itemSubtitle(int i) const override;
   std::optional<ImageURL> itemIcon(int i) const override;
   std::unique_ptr<ActionPanelState> actionPanel(int i) const override;
+  bool isDraggable(int) const override;
+  std::unique_ptr<QMimeData> dragMimeData(int) const override;
 
 private:
   ImageURL iconForEntry(const ClipboardHistoryEntry &entry) const;

--- a/src/server/src/qml/qml/ClipboardHistoryView.qml
+++ b/src/server/src/qml/qml/ClipboardHistoryView.qml
@@ -102,6 +102,7 @@ Item {
                 required property string iconSource
                 required property var itemAccessory
                 required property bool isPinned
+                required property bool isDraggable
 
                 sourceComponent: isSection ? sectionComponent : itemComponent
 
@@ -122,6 +123,11 @@ Item {
                         selected: listView.currentIndex === delegateLoader.index
                         onClicked: listView.currentIndex = delegateLoader.index
                         onActivated: listView.itemActivated(delegateLoader.index)
+                        draggable: delegateLoader.isDraggable
+                        onDragRequested: function (source) {
+                            listView.currentIndex = delegateLoader.index;
+                            root.host.listModel.startDrag(delegateLoader.index, source);
+                        }
 
                         RowLayout {
                             anchors.fill: parent

--- a/src/server/src/services/clipboard/clipboard-server.hpp
+++ b/src/server/src/services/clipboard/clipboard-server.hpp
@@ -86,7 +86,7 @@ public:
     return writeClipboard(data, options);
   }
 
-  AbstractClipboardServer() {}
+  AbstractClipboardServer() = default;
 
 signals:
   void selectionAdded(const ClipboardSelection &selection);

--- a/src/server/src/services/clipboard/clipboard-service.cpp
+++ b/src/server/src/services/clipboard/clipboard-service.cpp
@@ -4,6 +4,7 @@
 #include <filesystem>
 #include <numeric>
 #include <QGuiApplication>
+#include <qstandardpaths.h>
 #include "services/app-service/abstract-app-db.hpp"
 #ifdef Q_OS_LINUX
 #include "x11/x11-clipboard-server.hpp"
@@ -22,6 +23,7 @@
 #include <quuid.h>
 #include "services/app-service/app-service.hpp"
 #include "services/clipboard/clipboard-db.hpp"
+#include "services/clipboard/selection-mime-data.hpp"
 #include "services/clipboard/clipboard-encrypter.hpp"
 #include "services/clipboard/clipboard-mime.hpp"
 #include "services/clipboard/clipboard-server.hpp"
@@ -533,13 +535,8 @@ void ClipboardService::restoreClipboard() {
   m_lastSelection.reset();
 }
 
-bool ClipboardService::copySelection(const ClipboardSelection &selection,
-                                     const Clipboard::CopyOptions &options) {
-  if (selection.offers.empty()) {
-    qWarning() << "Not copying selection with no offers";
-    return false;
-  }
-
+std::unique_ptr<QMimeData>
+ClipboardService::mimeDataFromSelection(const ClipboardSelection &selection) const {
   QMimeData *mimeData = new QMimeData;
 
   for (const auto &offer : selection.offers) {
@@ -565,9 +562,27 @@ bool ClipboardService::copySelection(const ClipboardSelection &selection,
     }
   }
 
+  return std::unique_ptr<QMimeData>{mimeData};
+}
+
+std::unique_ptr<QMimeData>
+ClipboardService::dragMimeDataForSelection(const ClipboardSelection &selection) const {
+  return std::make_unique<DragAndDropSelectionMimeData>(selection);
+}
+
+bool ClipboardService::copySelection(const ClipboardSelection &selection,
+                                     const Clipboard::CopyOptions &options) {
+  if (selection.offers.empty()) {
+    qWarning() << "Not copying selection with no offers";
+    return false;
+  }
+
+  auto mimeData = mimeDataFromSelection(selection);
   auto enrichedOptions = options;
+
   if (!enrichedOptions.sourceApp) enrichedOptions.sourceApp = selection.sourceApp;
-  return copyQMimeData(mimeData, enrichedOptions);
+
+  return copyQMimeData(mimeData.release(), enrichedOptions);
 }
 
 bool ClipboardService::copySelectionRecord(const QString &id, const Clipboard::CopyOptions &options) {

--- a/src/server/src/services/clipboard/clipboard-service.hpp
+++ b/src/server/src/services/clipboard/clipboard-service.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include "common.hpp"
-#include "extensions/wm/wm-extension.hpp"
+#include "common/types.hpp"
 #include "services/clipboard/clipboard-content.hpp"
 #include "services/clipboard/clipboard-db.hpp"
 #include "services/clipboard/clipboard-encrypter.hpp"
@@ -9,10 +9,13 @@
 #include <expected>
 #include <filesystem>
 #include <QJsonObject>
+#include <qcontainerfwd.h>
 #include <qdir.h>
 #include <qfileinfo.h>
 #include <qfuture.h>
+#include <qimage.h>
 #include <qjsonobject.h>
+#include <qmimedata.h>
 #include <qmimedatabase.h>
 #include <qstringview.h>
 #include <QTimer>
@@ -72,6 +75,8 @@ public:
   ClipboardSelection retrieveSelection(int offset = 0);
   std::optional<ClipboardSelection> retrieveSelectionById(const QString &id);
   bool copySelectionRecord(const QString &id, const Clipboard::CopyOptions &options);
+  std::unique_ptr<QMimeData> mimeDataFromSelection(const ClipboardSelection &selection) const;
+  std::unique_ptr<QMimeData> dragMimeDataForSelection(const ClipboardSelection &selection) const;
   bool copySelection(const ClipboardSelection &selection, const Clipboard::CopyOptions &options);
   bool copyQMimeData(QMimeData *data, const Clipboard::CopyOptions &options = {});
 

--- a/src/server/src/services/clipboard/selection-mime-data.hpp
+++ b/src/server/src/services/clipboard/selection-mime-data.hpp
@@ -47,7 +47,7 @@ public:
     qDebug() << "retrieve format" << mimetype << preferredType;
 
     if (m_imageMimeType && mimetype == Clipboard::URI_LIST) {
-      auto path = QString::fromStdString(Omnicast::runtimeDir() / "vicinae-drag-image.png");
+      auto path = QString::fromStdString((Omnicast::runtimeDir() / "vicinae-drag-image.png").string());
 
       if (ensureImage(path)) { return QVariantList{QUrl::fromLocalFile(path)}; }
     }

--- a/src/server/src/services/clipboard/selection-mime-data.hpp
+++ b/src/server/src/services/clipboard/selection-mime-data.hpp
@@ -51,6 +51,7 @@ public:
 
       if (ensureImage(path)) {
         auto file = QUrl::fromLocalFile(path);
+        qDebug() << "Serving image data as file" << file;
         if (preferredType == QMetaType::fromType<QVariantList>()) return QVariantList{file};
         return file;
       }

--- a/src/server/src/services/clipboard/selection-mime-data.hpp
+++ b/src/server/src/services/clipboard/selection-mime-data.hpp
@@ -49,12 +49,7 @@ public:
     if (m_imageMimeType && mimetype == Clipboard::URI_LIST) {
       auto path = QString::fromStdString(Omnicast::runtimeDir() / "vicinae-drag-image.png");
 
-      if (ensureImage(path)) {
-        auto file = QUrl::fromLocalFile(path);
-        qDebug() << "Serving image data as file" << file;
-        if (preferredType == QMetaType::fromType<QVariantList>()) return QVariantList{file};
-        return file;
-      }
+      if (ensureImage(path)) { return QVariantList{QUrl::fromLocalFile(path)}; }
     }
 
     return QMimeData::retrieveData(mimetype, preferredType);

--- a/src/server/src/services/clipboard/selection-mime-data.hpp
+++ b/src/server/src/services/clipboard/selection-mime-data.hpp
@@ -1,0 +1,72 @@
+#include <algorithm>
+#include <filesystem>
+#include <QImage>
+#include <QMimeData>
+#include <QUrl>
+#include <system_error>
+#include "common/clipboard-formats.hpp"
+#include "services/clipboard/clipboard-server.hpp"
+
+/**
+ * QMimeData for a saved clipboard selection that is optimized for drag and drop.
+ * In particular, this one will automatically write raw image data to a file and
+ * advertise a file as one of the transferrable types. This is because unlike regular
+ * clipboard copy, drag and drop handlers rarely accept raw image data.
+ */
+class DragAndDropSelectionMimeData : public QMimeData {
+public:
+  DragAndDropSelectionMimeData(ClipboardSelection selection) : m_selection(std::move(selection)) {
+    auto fileIt = std::ranges::find_if(m_selection.offers, [](const ClipboardDataOffer &offer) {
+      return offer.mimeType == Clipboard::URI_LIST;
+    });
+
+    for (const auto &offer : m_selection.offers) {
+      // if we have raw image data and no file attached, then we
+      // probably want to convert the image to a file.
+      if (offer.mimeType.startsWith("image/")) {
+        if (fileIt == m_selection.offers.end()) {
+          m_formats << Clipboard::URI_LIST;
+          m_imageMimeType = offer.mimeType;
+        }
+      }
+      setData(offer.mimeType, std::move(offer.data));
+      m_formats << offer.mimeType;
+    }
+  }
+
+  QStringList formats() const override { return m_formats; }
+
+  bool hasFormat(const QString &mimetype) const override {
+    qDebug() << "has format" << mimetype << m_formats.contains(mimetype);
+    return m_formats.contains(mimetype);
+  }
+
+  QVariant retrieveData(const QString &mimetype, QMetaType preferredType) const override {
+    qDebug() << "retrieve format" << mimetype << preferredType;
+
+    if (m_imageMimeType && mimetype == Clipboard::URI_LIST) {
+      std::error_code ec;
+      auto path = QString::fromStdString(
+          (std::filesystem::temp_directory_path(ec) / "vicinae-drag-image.png").string());
+
+      if (!ec && ensureImage(path)) { return QUrl::fromLocalFile(path); }
+    }
+
+    return QMimeData::retrieveData(mimetype, preferredType);
+  }
+
+protected:
+  bool ensureImage(const QString &path) const {
+    if (!m_imageMimeType) return false;
+    if (imageLoaded) return true;
+
+    auto img = QImage::fromData(data(*m_imageMimeType));
+    return imageLoaded = img.save(path, "PNG");
+  }
+
+private:
+  mutable bool imageLoaded = false;
+  ClipboardSelection m_selection;
+  std::optional<QString> m_imageMimeType;
+  QStringList m_formats;
+};

--- a/src/server/src/services/clipboard/selection-mime-data.hpp
+++ b/src/server/src/services/clipboard/selection-mime-data.hpp
@@ -1,11 +1,14 @@
+#pragma once
 #include <algorithm>
 #include <filesystem>
 #include <QImage>
 #include <QMimeData>
 #include <QUrl>
-#include <system_error>
+#include <qcontainerfwd.h>
+#include <qlogging.h>
 #include "common/clipboard-formats.hpp"
 #include "services/clipboard/clipboard-server.hpp"
+#include "vicinae.hpp"
 
 /**
  * QMimeData for a saved clipboard selection that is optimized for drag and drop.
@@ -15,41 +18,42 @@
  */
 class DragAndDropSelectionMimeData : public QMimeData {
 public:
-  DragAndDropSelectionMimeData(ClipboardSelection selection) : m_selection(std::move(selection)) {
-    auto fileIt = std::ranges::find_if(m_selection.offers, [](const ClipboardDataOffer &offer) {
+  DragAndDropSelectionMimeData(ClipboardSelection selection) {
+    auto fileIt = std::ranges::find_if(selection.offers, [](const ClipboardDataOffer &offer) {
       return offer.mimeType == Clipboard::URI_LIST;
     });
 
-    for (const auto &offer : m_selection.offers) {
+    bool hasImage = false;
+
+    for (auto &offer : selection.offers) {
       // if we have raw image data and no file attached, then we
       // probably want to convert the image to a file.
-      if (offer.mimeType.startsWith("image/")) {
-        if (fileIt == m_selection.offers.end()) {
+      if (!hasImage && offer.mimeType.startsWith("image/")) {
+        if (fileIt == selection.offers.end()) {
+          hasImage = true;
           m_formats << Clipboard::URI_LIST;
           m_imageMimeType = offer.mimeType;
         }
       }
-      setData(offer.mimeType, std::move(offer.data));
+
       m_formats << offer.mimeType;
+      setData(offer.mimeType, std::move(offer.data));
     }
   }
 
   QStringList formats() const override { return m_formats; }
 
-  bool hasFormat(const QString &mimetype) const override {
-    qDebug() << "has format" << mimetype << m_formats.contains(mimetype);
-    return m_formats.contains(mimetype);
-  }
-
   QVariant retrieveData(const QString &mimetype, QMetaType preferredType) const override {
     qDebug() << "retrieve format" << mimetype << preferredType;
 
     if (m_imageMimeType && mimetype == Clipboard::URI_LIST) {
-      std::error_code ec;
-      auto path = QString::fromStdString(
-          (std::filesystem::temp_directory_path(ec) / "vicinae-drag-image.png").string());
+      auto path = QString::fromStdString(Omnicast::runtimeDir() / "vicinae-drag-image.png");
 
-      if (!ec && ensureImage(path)) { return QUrl::fromLocalFile(path); }
+      if (ensureImage(path)) {
+        auto file = QUrl::fromLocalFile(path);
+        if (preferredType == QMetaType::fromType<QVariantList>()) return QVariantList{file};
+        return file;
+      }
     }
 
     return QMimeData::retrieveData(mimetype, preferredType);
@@ -61,12 +65,15 @@ protected:
     if (imageLoaded) return true;
 
     auto img = QImage::fromData(data(*m_imageMimeType));
-    return imageLoaded = img.save(path, "PNG");
+    if (!img.save(path, "PNG")) {
+      qWarning() << "[DND] failed to save image data as PNG";
+      return false;
+    }
+    return imageLoaded = true;
   }
 
 private:
   mutable bool imageLoaded = false;
-  ClipboardSelection m_selection;
   std::optional<QString> m_imageMimeType;
   QStringList m_formats;
 };


### PR DESCRIPTION
Raw image data is generally not supported by most drag handlers, so we
subclass `QMimeData` to offer a file URL constructed on the fly if the
selection does not already contain a file.