### PR TITLE
feat: change form submission binding to ctrl+return

### DIFF
--- a/src/server/src/internal/keyboard/keyboard.hpp
+++ b/src/server/src/internal/keyboard/keyboard.hpp
@@ -27,7 +27,7 @@ public:
   static Shortcut osCopy() { return Shortcut(Qt::Key_C, Qt::ControlModifier); }
   static Shortcut osPaste() { return Shortcut(Qt::Key_V, Qt::ControlModifier); }
   static Shortcut enter() { return Qt::Key_Return; }
-  static Shortcut submit() { return enter().shifted(); }
+  static Shortcut submit() { return Shortcut(Qt::Key_Return, Qt::ControlModifier); }
 
   static Shortcut shiftPaste() { return osPaste().shifted(); }
   static Shortcut fromString(const QString &str) { return str; }


### PR DESCRIPTION
Long overdue, the `shift+return` is odd and I honestly don't know why I picked that.