### PR TITLE
build(nix): declare build inputs explicitly and fix dev shell env

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -87,9 +87,12 @@
             clang-tools
           ];
 
+          # qmlls discovers QML modules through these, so point them at the
+          # aggregate env: qtdeclarative alone hides LayerShellQt and the
+          # modules shipped by the other Qt packages.
           shellHook = ''
-            export QML2_IMPORT_PATH=${pkgs.qt6.qtdeclarative}/lib/qt-6/qml
-            export QML_IMPORT_PATH=${pkgs.qt6.qtdeclarative}/lib/qt-6/qml
+            export QML2_IMPORT_PATH=${qtEnv}/lib/qt-6/qml
+            export QML_IMPORT_PATH=${qtEnv}/lib/qt-6/qml
           '';
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -87,12 +87,7 @@
             clang-tools
           ];
 
-          shellHook = pkgs.lib.optionalString isLinux ''
-            export CC=${pkgs.gcc15}/bin/gcc
-            export CXX=${pkgs.gcc15}/bin/g++
-            export CMAKE_C_COMPILER=$CC
-            export CMAKE_CXX_COMPILER=$CXX
-
+          shellHook = ''
             export QML2_IMPORT_PATH=${pkgs.qt6.qtdeclarative}/lib/qt-6/qml
             export QML_IMPORT_PATH=${pkgs.qt6.qtdeclarative}/lib/qt-6/qml
           '';

--- a/nix/vicinae.nix
+++ b/nix/vicinae.nix
@@ -5,15 +5,23 @@
   kdePackages,
   lib,
   libqalculate,
+  libx11,
+  libxcb,
+  libxcb-keysyms,
+  libxkbcommon,
   llvmPackages_21,
   ninja,
   nodejs,
   npmHooks,
+  openssl,
   pkg-config,
   qt6,
   stdenv,
   gcc15Stdenv,
+  udev,
   wayland,
+  wayland-protocols,
+  wayland-scanner,
   glaze,
   swift ? null,
   apple-sdk ? null,
@@ -91,6 +99,9 @@ in
         qt6.qttools
         qt6.wrapQtAppsHook
       ]
+      ++ lib.optionals isLinux [
+        wayland-scanner
+      ]
       ++ lib.optionals isDarwin [
         swift
       ];
@@ -111,8 +122,15 @@ in
       ]
       ++ lib.optionals isLinux [
         kdePackages.layer-shell-qt
+        libx11
+        libxcb
+        libxcb-keysyms
+        libxkbcommon
+        openssl
         qt6.qtwayland
+        udev
         wayland
+        wayland-protocols
       ]
       ++ lib.optionals isDarwin [
         apple-sdk

--- a/nix/vicinae.nix
+++ b/nix/vicinae.nix
@@ -73,6 +73,7 @@ in
       "VICINAE_GIT_TAG" = "v${finalAttrs.version}";
       "VICINAE_GIT_COMMIT_HASH" = manifestGet "short_rev";
       "VICINAE_PROVENANCE" = "nix";
+      "INSTALL_MODULES_LOAD_CONFIG" = "OFF";
       "INSTALL_NODE_MODULES" = "OFF";
       "USE_SYSTEM_CMARK_GFM" = "ON";
       "USE_SYSTEM_GLAZE" = "ON";


### PR DESCRIPTION
## Summary

I've been building Vicinae from the flake and working in `nix develop`, and went looking for why a couple of things behaved oddly in the dev shell. That turned into four small commits: two on the package, two on the dev shell. The only change to the built output is the removed (inert) `modules-load.d` file; every other installed byte is identical. The evidence is in the collapsed section at the bottom so you can reproduce it rather than take my word for it.

Each commit stands alone, so happy to split this, drop any part, or reshape it entirely.

| Commit     | File              | What                                                                                     |
| ---------- | ----------------- | ---------------------------------------------------------------------------------------- |
| `0ab07cfe` | `nix/vicinae.nix` | Declare eight dependencies the build uses but never listed                               |
| `5943d423` | `nix/vicinae.nix` | Stop installing `lib/modules-load.d/vicinae.conf`, which nothing reads from a store path |
| `441b65a4` | `flake.nix`       | Remove four `shellHook` exports that are duplicates or no-ops                            |
| `85521f69` | `flake.nix`       | Point the QML import paths at the `qtEnv` the shell already builds                       |

## 1. Undeclared dependencies (`0ab07cfe`)

`nix/vicinae.nix` sets `strictDeps = true`, so I expected `buildInputs` to be the complete picture. The CMake actually requires eight things that aren't in it: `wayland-scanner` and `wayland-protocols` (`cmake/Wayland.cmake`), OpenSSL (`src/lib/crypto`, `vendor/sqlcipher`), `X11::xcb` / `X11::xcb_keysyms` (`src/server`), and the bare `xkbcommon` / `udev` link names (`src/server`, `src/lib/linux-utils`, `src/snippet`). 

They resolve today because `qt6.qtbase` and `layer-shell-qt` propagate all eight transitively.

Nothing is broken. The reason to declare them anyway is that the arrangement is invisible exactly when it matters. Two cases from this repo, and neither is a criticism, they're the point:

- **#1578** added `find_package(OpenSSL REQUIRED)`, and _did_ update `nix/vicinae.nix` in the same change (`swift` / `apple-sdk` for Darwin), yet openssl still didn't get added, because propagation meant nothing ever failed.
- **#1753** made system `wayland-protocols` a hard configure-time requirement (`FATAL_ERROR` when absent). `nix/` wasn't touched, and stayed green because `layer-shell-qt` happened to carry it.

If a nixpkgs bump ever changes what Qt propagates, configure fails with `wayland-protocols not found` in a diff that has nothing to do with Wayland, and whoever bisects it has a bad afternoon. I read this as finishing what `strictDeps` already opted into, but if you'd rather deliberately lean on Qt's propagation and keep the list minimal, that's a fair call and I'll drop this commit.

## 2. `modules-load.d` (`5943d423`)

`INSTALL_MODULES_LOAD_CONFIG` defaults to `ON`, so the package installs `$out/lib/modules-load.d/vicinae.conf`. systemd only reads `modules-load.d` from `/etc`, `/run` and `/usr(/local)/lib`, and NixOS generates `/etc/modules-load.d` from `boot.kernelModules`, so in a store path the file is inert, and it reads as though the package handles loading `uinput` when it doesn't. Same shape of problem as **#1607** (a package manager wanting to own installed files, there for Gentoo); the two compose rather than conflict. That PR adds a coarse switch, and the Nix build wants the existing fine-grained one, since it does want the themes, desktop file and icon.

## 3. Dev shell (`441b65a4`, `85521f69`)

Both are artifacts of ordering rather than anything anyone got wrong.

**`441b65a4`**: #1129 added `export CC=${pkgs.gcc15}/bin/gcc` (and `CXX`) to get gcc 15 into the shell, which was the right fix at the time. #1545 later rebuilt the shell as `mkShell.override {stdenv = package.stdenv;}`, and since `gcc15Stdenv.cc` _is_ `pkgs.gcc15` (verified below), the exports became a second copy of what the stdenv already does. The two `CMAKE_*_COMPILER` exports were no-ops all along: CMake reads `CC`/`CXX` from the environment and never the `CMAKE_*_COMPILER` variables (verified below, and [documented](https://cmake.org/cmake/help/latest/envvar/CC.html)). With the compiler exports gone the hook only carries the QML import paths, so this commit also drops the `isLinux` guard on the `shellHook`: qmlls is equally useful on macOS. Say the word if you'd rather keep it guarded.

**`85521f69`**: #1189 introduced the aggregate `qtEnv`; #1636 later added the QML import paths so qmlls could see Nix-installed QML modules, but pointed them at `pkgs.qt6.qtdeclarative` rather than the `qtEnv` that already existed, so qmlls saw a subset of what the shell provides (`org.kde.layershell` and `QtWayland` were missing). This is really just finishing #1636.

<details>
<summary><b>Verification: how I checked nothing changed</b> (x86_64-linux, flake's pinned nixpkgs)</summary>

<br>

**Nothing new enters the build.** The `.drv` closures of `main` and this branch differ only in vicinae's own derivation, its source tree, and the two fixed-output `npm-deps` derivations (whose output hashes are pinned, so their outputs are identical):

```bash
# bash, from the branch checkout root, clean tree
diff <(nix-store -qR "$(nix eval --raw "git+file://$PWD?ref=main#packages.x86_64-linux.default.drvPath")" | sort) \
     <(nix-store -qR "$(nix eval --raw .#packages.x86_64-linux.default.drvPath)" | sort)
# -> 8 paths: one vicinae-0.24.0.drv and one *-source per side, two npm-deps.drv per side
```

All eight packages were already in main's build closure at identical versions: `systemd-minimal-libs-259` (nixpkgs' `udev`), `wayland-protocols-1.47`, `libxkbcommon-1.11.0`, `wayland-scanner-1.24.0`, `libxcb-1.17.0`, `libxcb-keysyms-0.4.1`, `libx11-1.8.12`, `openssl-3.6.1`. All but wayland-protocols are in `qt6.qtbase`'s `propagatedBuildInputs`; wayland-protocols is in `layer-shell-qt`'s.

**The installed tree is byte-identical.** I built both derivations and compared the outputs after replacing each output's self-referencing store hash with a fixed placeholder (the store paths necessarily differ, and the binaries embed their own `$out`). The only difference left is the `modules-load.d` removal:

```bash
main=$(nix build "git+file://$PWD?ref=main" --no-link --print-out-paths)  # full source build
branch=$(nix build . --no-link --print-out-paths)
tmp=$(mktemp -d)
cp -r "$main" "$tmp/main" && cp -r "$branch" "$tmp/branch" && chmod -R u+w "$tmp"
export LC_ALL=C  # sed must treat the ELF binaries as bytes, not UTF-8
find "$tmp/main"   -type f -exec sed -i "s/$(basename "$main"   | head -c32)/@self@/g" {} +
find "$tmp/branch" -type f -exec sed -i "s/$(basename "$branch" | head -c32)/@self@/g" {} +
diff -r "$tmp/main" "$tmp/branch"
# -> Only in .../main/lib: modules-load.d   (the intended removal; nothing else)
```

**The runtime closure holds one version of each** library. `openssl-3.6.1-bin`/`-dev` do appear, but `nix why-depends` shows they arrive through `nodejs` (the `bin/vicinae` wrapper's `PATH` -> `nodejs` -> `openssl-dev`), which predates this change.

**Package:** `nix build -L .#default` green; `lib/modules-load.d` gone; all six installed programs present (`bin/vicinae` plus five under `libexec/vicinae/`). The built launcher runs (`vicinae server --open` on Wayland/GNOME: window opens, app search and launch work).

**Dev shell:**

- `nix develop -c sh -c '$CC --version'` -> `gcc (GCC) 15.2.0`, unchanged.
- `gcc15Stdenv.cc == pkgs.gcc15` -> `true` (`nix eval` against the pinned nixpkgs).
- The CMake claim, tested empirically in the shell: `CMAKE_CXX_COMPILER=/nonexistent cmake ...` configures fine (env var ignored); `CXX=/nonexistent cmake ...` fails with `CMAKE_CXX_COMPILER not set` (env var read).
- `$QML_IMPORT_PATH` now resolves `org/kde/layershell/{qmldir,LayerShellQtQml.qmltypes}`, and the delta against plain qtdeclarative is exactly the two missing trees:

  ```console
  $ comm -13 <(ls $qtdeclarative/lib/qt-6/qml) <(ls $qtEnv/lib/qt-6/qml)
  org          # org.kde.layershell
  QtWayland
  ```

**Hygiene:** `alejandra --check .` clean. Eval is warning-free: the commit uses the top-level `libx11` / `libxcb` / `libxcb-keysyms` attributes because the pinned nixpkgs deprecates the `xorg.*` set ("The xorg package set has been deprecated", `pkgs/top-level/aliases.nix`). The package and dev shell also evaluate cleanly at each of the four commits, and still evaluate for `aarch64-darwin`.

**Not verified:** macOS beyond evaluation. The Linux-only additions sit inside the existing `lib.optionals isLinux` blocks, so the Darwin path should be untouched, but I'd appreciate a check from someone who can build it.

</details>

Happy to clarify any of these further.