### PR TITLE
feat: switch to native font rendering on macOS and Windows

### DIFF
--- a/extra/config.jsonc
+++ b/extra/config.jsonc
@@ -65,9 +65,11 @@
 
 	"font": {
 		// Text rendering backend used by Qt Quick text.
-		// "native": uses platform/fontconfig rendering (can have better dark-mode weight/clarity)
+		// "native": uses the platform rasterizer (CoreText/DirectWrite/fontconfig), matching how other apps on the system render text
 		// "qt": uses Qt distance-field rendering (typically better performance for heavy scaling/animation)
-		"rendering": "qt",
+		// NOTE: if unspecified, Vicinae picks the best backend for the current platform:
+		// "native" on macOS and Windows, "qt" on Linux (native rendering degrades under fractional scaling).
+		// "rendering": "qt",
 
 		// The font family to use for the general vicinae UI.
 		// "auto" (recommended): uses the bundled Inter font

--- a/src/server/src/config/config.hpp
+++ b/src/server/src/config/config.hpp
@@ -202,7 +202,11 @@ template <> struct Partial<WindowConfig> {
 };
 
 struct FontConfig {
+#if defined(Q_OS_MACOS) || defined(Q_OS_WIN)
+  std::string rendering = "native";
+#else
   std::string rendering = "qt";
+#endif
 
   struct FontSpec {
     std::string family = "auto";


### PR DESCRIPTION
Switch to native font rendering (CoreText on macOS, DirectWrite on Windows) by default. Linux still uses QT font rendering because native font rendering sucks with fractional scaling.

This can still be manually changed in the "Advanced" section of the settings (has been available for a while).