### PR TITLE
style: set base UI font weight to normal

### DIFF
--- a/src/server/src/qml/qml/ListItemDelegate.qml
+++ b/src/server/src/qml/qml/ListItemDelegate.qml
@@ -77,7 +77,7 @@ SelectableDelegate {
                 width: Math.min(implicitWidth, Math.max(0, textRow.availableForText - titleText.width - textRow.spacing))
                 text: root.itemSubtitle
                 color: root.selected ? Theme.listItemSecondarySelectionFg : root.hovered ? Theme.listItemSecondaryHoverFg : Theme.textMuted
-                font.pointSize: Theme.smallerFontSize
+                font.pointSize: Theme.regularFontSize
                 elide: Text.ElideRight
                 maximumLineCount: 1
             }

--- a/src/server/src/server.cpp
+++ b/src/server/src/server.cpp
@@ -162,7 +162,7 @@ static void applyTextRenderingMode(const config::FontConfig &fontConfig) {
   }
 }
 
-static constexpr QFont::Weight UI_FONT_WEIGHT = QFont::Medium;
+static constexpr QFont::Weight UI_FONT_WEIGHT = QFont::Normal;
 
 static QFont resolveAppFont(const config::FontConfig &fontConfig) {
   QFont font;


### PR DESCRIPTION
There was no practical reason to hardcode it to medium instead of normal.

Depending on what font is used, the difference may or may not be visible.