### PR TITLE
fix(nix): copy Raycast extension output from $HOME, not /build

### DIFF
--- a/nix/mkRayCastExtension.nix
+++ b/nix/mkRayCastExtension.nix
@@ -41,7 +41,7 @@ lib.extendMkDerivation {
         runHook preInstall
 
         mkdir -p $out
-        cp -r /build/.config/raycast/extensions/${name}/* $out/
+        cp -r "$HOME/.config/raycast/extensions/"*/. $out/
 
         runHook postInstall
       '';


### PR DESCRIPTION
Fixes #1782.

`/build` only exists in the Linux sandbox. The npm hooks set `HOME` to the
build directory on every platform and `ray build` writes its output under
`$HOME/.config/raycast/extensions/`, so copy from there instead. On Linux
nothing changes (`$HOME` is `/build`); on darwin this fixes the
`cp: missing destination file operand` failure.

Tested on `aarch64-darwin` (Determinate Nix): building the `uuid-generator`
Raycast extension fails with the stock helper and succeeds with this change.
