### PR TITLE
style: make status bar float over the content

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -975,6 +975,7 @@ set(VICINAE_QML_FILES
 	src/qml/qml/ViciPopover.qml
 	src/qml/qml/SearchBar.qml
 	src/qml/qml/GenericListView.qml
+	src/qml/qml/StatusBarInset.qml
 	src/qml/qml/HoverResetOnModelChange.qml
 	src/qml/qml/HoverResetOnShow.qml
 	src/qml/qml/RootSearchList.qml

--- a/src/server/src/qml/qml/DetailPanel.qml
+++ b/src/server/src/qml/qml/DetailPanel.qml
@@ -1,6 +1,5 @@
 import QtQuick
 import QtQuick.Layouts
-import QtQuick.Window
 
 /// Reusable detail panel with arbitrary content on top and optional metadata at the bottom.
 /// Place child items inside to fill the content area. Set `metadata` to show a MetadataBar.
@@ -12,9 +11,13 @@ Item {
 
     readonly property bool _hasMetadata: root.metadata.length > 0
 
+    StatusBarInset {
+        id: statusBarInset
+    }
+
     ColumnLayout {
         anchors.fill: parent
-        anchors.bottomMargin: root._hasMetadata ? (root.Window.window?.statusBarOverlap ?? 0) : 0
+        anchors.bottomMargin: root._hasMetadata ? statusBarInset.value : 0
         spacing: 0
 
         Item {

--- a/src/server/src/qml/qml/DetailPanel.qml
+++ b/src/server/src/qml/qml/DetailPanel.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Layouts
+import QtQuick.Window
 
 /// Reusable detail panel with arbitrary content on top and optional metadata at the bottom.
 /// Place child items inside to fill the content area. Set `metadata` to show a MetadataBar.
@@ -13,6 +14,7 @@ Item {
 
     ColumnLayout {
         anchors.fill: parent
+        anchors.bottomMargin: root._hasMetadata ? (root.Window.window?.statusBarOverlap ?? 0) : 0
         spacing: 0
 
         Item {

--- a/src/server/src/qml/qml/FooterButton.qml
+++ b/src/server/src/qml/qml/FooterButton.qml
@@ -17,11 +17,10 @@ Item {
     implicitWidth: row.implicitWidth + 2 * horizontalPadding
     implicitHeight: buttonHeight
 
-    SourceBlendRect {
+    Rectangle {
         anchors.fill: parent
         visible: root.hovered || root.backgrounded
         radius: 6
-        backgroundColor: Qt.rgba(Theme.statusBarBackground.r, Theme.statusBarBackground.g, Theme.statusBarBackground.b, Config.windowOpacity)
         color: Qt.rgba(Theme.listItemHoverBg.r, Theme.listItemHoverBg.g, Theme.listItemHoverBg.b, Config.windowOpacity)
     }
 

--- a/src/server/src/qml/qml/FormView.qml
+++ b/src/server/src/qml/qml/FormView.qml
@@ -8,12 +8,17 @@ Flickable {
     contentHeight: layout.implicitHeight
     clip: true
     boundsBehavior: Flickable.StopAtBounds
-    bottomMargin: root.padding
+    bottomMargin: root.padding + statusBarInset.value
     topMargin: root.padding
 
     default property alias contentData: layout.data
     property real padding: 16
     property real maxContentWidth: Infinity
+
+    StatusBarInset {
+        id: statusBarInset
+        target: root
+    }
 
     ViciWheelHandler {
         target: root
@@ -71,12 +76,12 @@ Flickable {
         let itemTop = mapped.y;
         let itemBottom = itemTop + item.height;
         let viewTop = root.contentY;
-        let viewBottom = viewTop + root.height;
+        let viewBottom = viewTop + root.height - statusBarInset.value;
 
         if (itemTop < viewTop) {
             root.contentY = Math.max(0, itemTop - 8);
         } else if (itemBottom > viewBottom) {
-            root.contentY = Math.min(root.contentHeight - root.height, itemBottom - root.height + 8);
+            root.contentY = Math.min(root.contentHeight - root.height + root.bottomMargin, itemBottom - root.height + statusBarInset.value + 8);
         }
     }
 }

--- a/src/server/src/qml/qml/GenericGridView.qml
+++ b/src/server/src/qml/qml/GenericGridView.qml
@@ -1,11 +1,14 @@
 import QtQuick
 import QtQuick.Controls
-import QtQuick.Window
 
 Item {
     id: root
 
-    readonly property real _bottomInset: Window.window?.statusBarOverlap ?? 0
+    readonly property real _bottomInset: _statusBarInset.value
+
+    StatusBarInset {
+        id: _statusBarInset
+    }
 
     // The backing model — must be a QAbstractListModel with roles:
     //   isSection, sectionName, rowSectionIdx, rowStartItem, rowItemCount

--- a/src/server/src/qml/qml/GenericGridView.qml
+++ b/src/server/src/qml/qml/GenericGridView.qml
@@ -1,8 +1,11 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Window
 
 Item {
     id: root
+
+    readonly property real _bottomInset: Window.window?.statusBarOverlap ?? 0
 
     // The backing model — must be a QAbstractListModel with roles:
     //   isSection, sectionName, rowSectionIdx, rowStartItem, rowItemCount
@@ -139,11 +142,25 @@ Item {
             return false;
 
         const viewportTop = listView.contentY;
-        const viewportBottom = viewportTop + listView.height;
+        const viewportBottom = viewportTop + listView.height - root._bottomInset;
         const itemTop = item.y;
         const itemBottom = item.y + item.height;
 
         return itemBottom > viewportTop && itemTop < viewportBottom;
+    }
+
+    // positionViewAtIndex ignores ListView margins, so Contain can leave the
+    // row within the band covered by the floating status bar.
+    function _liftAboveInset(row) {
+        if (root._bottomInset <= 0)
+            return;
+        const item = listView.itemAtIndex(row);
+        if (!item)
+            return;
+        const usable = listView.height - root._bottomInset;
+        const itemBottom = item.y + item.height;
+        if (listView.contentHeight > usable && itemBottom > listView.contentY + usable)
+            listView.contentY = itemBottom - usable;
     }
 
     ListView {
@@ -155,7 +172,7 @@ Item {
         interactive: false
         boundsBehavior: Flickable.StopAtBounds
         topMargin: root.cellSpacing
-        bottomMargin: root.cellSpacing
+        bottomMargin: root.cellSpacing + root._bottomInset
         spacing: root.cellSpacing
         reuseItems: true
         cacheBuffer: 200
@@ -409,6 +426,7 @@ Item {
                     mode = ListView.Beginning;
                 }
                 listView.positionViewAtIndex(row, mode);
+                root._liftAboveInset(row);
             }
         }
     }

--- a/src/server/src/qml/qml/GenericListView.qml
+++ b/src/server/src/qml/qml/GenericListView.qml
@@ -1,12 +1,15 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import QtQuick.Window
 
 Item {
     id: root
 
-    readonly property real _bottomInset: Window.window?.statusBarOverlap ?? 0
+    readonly property real _bottomInset: _statusBarInset.value
+
+    StatusBarInset {
+        id: _statusBarInset
+    }
 
     // The backing model — must have Q_INVOKABLE nextSelectableIndex(int, int)
     required property var listModel

--- a/src/server/src/qml/qml/GenericListView.qml
+++ b/src/server/src/qml/qml/GenericListView.qml
@@ -1,9 +1,12 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import QtQuick.Window
 
 Item {
     id: root
+
+    readonly property real _bottomInset: Window.window?.statusBarOverlap ?? 0
 
     // The backing model — must have Q_INVOKABLE nextSelectableIndex(int, int)
     required property var listModel
@@ -95,12 +98,27 @@ Item {
         return Math.abs(listView.contentY - previousContentY) > 0.5;
     }
 
+    // positionViewAtIndex ignores ListView margins, so Contain can leave the
+    // item within the band covered by the floating status bar.
+    function _liftAboveInset(index) {
+        if (root._bottomInset <= 0)
+            return;
+        const item = listView.itemAtIndex(index);
+        if (!item)
+            return;
+        const usable = listView.height - root._bottomInset;
+        const itemBottom = item.y + item.height;
+        if (listView.contentHeight > usable && itemBottom > listView.contentY + usable)
+            listView.contentY = itemBottom - usable;
+    }
+
     function moveDown() {
         const next = root.listModel.nextSelectableIndex(listView.currentIndex, 1);
         if (next !== listView.currentIndex) {
             listView.currentIndex = next;
             const scrollTarget = sectionScrollTarget(next, -1);
             listView.positionViewAtIndex(scrollTarget, ListView.Contain);
+            _liftAboveInset(next);
         }
         return true;
     }
@@ -114,6 +132,7 @@ Item {
             listView.currentIndex = next;
             const scrollTarget = sectionScrollTarget(next, -1);
             listView.positionViewAtIndex(scrollTarget, ListView.Contain);
+            _liftAboveInset(next);
         }
         return true;
     }
@@ -127,6 +146,7 @@ Item {
             listView.currentIndex = next;
             const scrollTarget = sectionScrollTarget(next, -1);
             listView.positionViewAtIndex(scrollTarget, ListView.Contain);
+            _liftAboveInset(next);
         }
         return true;
     }
@@ -143,6 +163,7 @@ Item {
             listView.currentIndex = next;
             const scrollTarget = sectionScrollTarget(next, -1);
             listView.positionViewAtIndex(scrollTarget, ListView.Contain);
+            _liftAboveInset(next);
         }
         return true;
     }
@@ -218,7 +239,7 @@ Item {
             highlightMoveDuration: 0
             currentIndex: -1
             topMargin: 4
-            bottomMargin: 4
+            bottomMargin: 4 + root._bottomInset
 
             property real _lastContentHeight: 0
 

--- a/src/server/src/qml/qml/LauncherWindow.qml
+++ b/src/server/src/qml/qml/LauncherWindow.qml
@@ -14,6 +14,7 @@ Window {
     property bool nativeChrome: false
     property bool autoPlaceOnShow: true
     readonly property int statusBarOverlap: floatingStatusBar.visible ? floatingStatusBar.height - Config.borderWidth : 0
+    readonly property real statusBarTop: shadowPadding + floatingStatusBar.y
     signal aboutToShow
     signal shown
 

--- a/src/server/src/qml/qml/LauncherWindow.qml
+++ b/src/server/src/qml/qml/LauncherWindow.qml
@@ -13,6 +13,7 @@ Window {
     property bool shadowEnabled: shadowPadding > 0
     property bool nativeChrome: false
     property bool autoPlaceOnShow: true
+    readonly property int statusBarOverlap: floatingStatusBar.visible ? floatingStatusBar.height - Config.borderWidth : 0
     signal aboutToShow
     signal shown
 
@@ -100,44 +101,12 @@ Window {
             borderWidth: Config.borderWidth
         }
 
-        Item {
+        Rectangle {
             visible: !launcher.compacted
-            anchors.fill: parent
-            anchors.bottomMargin: launcher.hasOverlay || !launcher.statusBarVisible ? 0 : footer.height + Config.borderWidth
-            clip: true
-
-            Rectangle {
-                width: _w
-                height: _h
-                radius: root.cornerRadius
-                color: Qt.rgba(Theme.background.r, Theme.background.g, Theme.background.b, Config.windowOpacity)
-            }
-        }
-
-        Item {
-            visible: !launcher.compacted && !launcher.hasOverlay && launcher.statusBarVisible
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.bottom: parent.bottom
-            height: footer.height + Config.borderWidth
-            clip: true
-
-            Rectangle {
-                width: _w
-                height: _h
-                anchors.bottom: parent.bottom
-                radius: root.cornerRadius
-                color: Qt.rgba(Theme.statusBarBackground.r, Theme.statusBarBackground.g, Theme.statusBarBackground.b, Config.windowOpacity)
-            }
-        }
-
-        SourceBlendRect {
-            visible: !launcher.compacted && !root.nativeChrome
-            anchors.fill: parent
+            width: _w
+            height: _h
             radius: root.cornerRadius
-            overlay: true
-            borderColor: Config.withAlpha(Theme.mainWindowBorder, Config.windowOpacity)
-            borderWidth: Config.borderWidth
+            color: Qt.rgba(Theme.background.r, Theme.background.g, Theme.background.b, Config.windowOpacity)
         }
 
         ColumnLayout {
@@ -162,29 +131,122 @@ Window {
             }
 
             Item {
-                id: contentArea
-                objectName: "contentArea"
+                id: contentViewport
                 Layout.fillWidth: true
                 Layout.fillHeight: true
 
-                StackView {
-                    id: commandStack
+                Item {
                     anchors.fill: parent
-                    visible: !launcher.compacted
+                    anchors.bottomMargin: floatingStatusBar.visible ? floatingStatusBar.height - Config.borderWidth : 0
+                    clip: true
+
+                    Item {
+                        id: contentArea
+                        objectName: "contentArea"
+                        width: contentViewport.width
+                        height: contentViewport.height
+
+                        StackView {
+                            id: commandStack
+                            anchors.fill: parent
+                            visible: !launcher.compacted
+                        }
+                    }
+                }
+            }
+        }
+
+        Item {
+            id: floatingStatusBar
+            visible: !launcher.compacted && !launcher.hasOverlay && launcher.statusBarVisible
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
+            height: 41 + Config.borderWidth
+            clip: true
+
+            readonly property int backdropPad: 64
+
+            ShaderEffectSource {
+                id: statusBarBackdrop
+                visible: false
+                sourceItem: contentArea
+                sourceRect: Qt.rect(-Config.borderWidth, contentArea.height - (floatingStatusBar.height - Config.borderWidth) - floatingStatusBar.backdropPad, floatingStatusBar.width, floatingStatusBar.height + floatingStatusBar.backdropPad)
+                textureSize: Qt.size(Math.max(1, Math.round(floatingStatusBar.width / 10)), Math.max(1, Math.round((floatingStatusBar.height + floatingStatusBar.backdropPad) / 10)))
+            }
+
+            MultiEffect {
+                y: -floatingStatusBar.backdropPad
+                width: floatingStatusBar.width
+                height: floatingStatusBar.height + floatingStatusBar.backdropPad
+                source: statusBarBackdrop
+                autoPaddingEnabled: false
+                blurEnabled: true
+                blur: 1.0
+                blurMax: 64
+
+                layer.enabled: true
+                layer.effect: MultiEffect {
+                    autoPaddingEnabled: false
+                    blurEnabled: true
+                    blur: 1.0
+                    blurMax: 64
+                    maskEnabled: true
+                    maskSource: statusBarBlurMask
                 }
             }
 
+            Rectangle {
+                width: _w
+                height: _h
+                anchors.bottom: parent.bottom
+                radius: root.cornerRadius
+                color: Config.withAlpha(Theme.statusBarBackground, 0.78)
+            }
+
             ViciDivider {
-                visible: !launcher.compacted && launcher.statusBarVisible
-                Layout.fillWidth: true
+                anchors.top: parent.top
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.leftMargin: Config.borderWidth
+                anchors.rightMargin: Config.borderWidth
             }
 
             Footer {
                 id: footer
-                visible: !launcher.compacted && launcher.statusBarVisible
-                Layout.fillWidth: true
-                Layout.preferredHeight: visible ? 40 : 0
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.bottom: parent.bottom
+                anchors.leftMargin: Config.borderWidth
+                anchors.rightMargin: Config.borderWidth
+                anchors.bottomMargin: Config.borderWidth
+                height: 40
             }
+        }
+
+        Item {
+            id: statusBarBlurMask
+            width: floatingStatusBar.width
+            height: floatingStatusBar.height + floatingStatusBar.backdropPad
+            visible: false
+            layer.enabled: true
+
+            Rectangle {
+                width: _w
+                height: _h
+                anchors.bottom: parent.bottom
+                radius: root.cornerRadius
+                color: "white"
+            }
+        }
+
+        SourceBlendRect {
+            visible: !launcher.compacted && !root.nativeChrome
+            anchors.fill: parent
+            radius: root.cornerRadius
+            overlay: true
+            borderColor: Config.withAlpha(Theme.mainWindowBorder, Config.windowOpacity)
+            borderWidth: Config.borderWidth
         }
 
         Loader {

--- a/src/server/src/qml/qml/MetadataBar.qml
+++ b/src/server/src/qml/qml/MetadataBar.qml
@@ -13,12 +13,17 @@ Item {
     property var model: []
     implicitHeight: column.implicitHeight + 20  // 2 * margins
 
+    StatusBarInset {
+        id: statusBarInset
+    }
+
     Flickable {
         id: flickable
         anchors.fill: parent
         contentHeight: column.implicitHeight + 20
         clip: true
         boundsBehavior: Flickable.StopAtBounds
+        bottomMargin: statusBarInset.value
 
         ViciWheelHandler {
             target: flickable

--- a/src/server/src/qml/qml/ScriptOutputText.qml
+++ b/src/server/src/qml/qml/ScriptOutputText.qml
@@ -8,6 +8,17 @@ ScrollView {
 
     Component.onCompleted: contentItem.boundsBehavior = Flickable.StopAtBounds
 
+    StatusBarInset {
+        id: statusBarInset
+        target: root
+    }
+
+    Binding {
+        target: root.contentItem
+        property: "bottomMargin"
+        value: statusBarInset.value
+    }
+
     ViciWheelHandler {
         target: root.contentItem
     }
@@ -16,7 +27,7 @@ ScrollView {
         contentItem.contentY = Math.max(0, contentItem.contentY - 40);
     }
     function moveDown() {
-        contentItem.contentY = Math.min(contentItem.contentHeight - height, contentItem.contentY + 40);
+        contentItem.contentY = Math.min(contentItem.contentHeight - height + contentItem.bottomMargin, contentItem.contentY + 40);
     }
     function moveSectionUp() {
         moveUp();
@@ -29,7 +40,7 @@ ScrollView {
     }
     function scrollToBottom() {
         let flick = contentItem;
-        flick.contentY = Math.max(0, flick.contentHeight - root.height);
+        flick.contentY = Math.max(0, flick.contentHeight - root.height + flick.bottomMargin);
     }
 
     TextArea {

--- a/src/server/src/qml/qml/StatusBarInset.qml
+++ b/src/server/src/qml/qml/StatusBarInset.qml
@@ -1,0 +1,19 @@
+import QtQuick
+import QtQuick.Window
+
+/// Measures how much of `target`'s bottom edge is covered by the window's
+/// floating status bar. Bind the result to a Flickable's bottomMargin so
+/// content can scroll clear of the glass. Yields 0 when the bar is hidden or
+/// the target already ends above it.
+Item {
+    property Item target: parent
+    visible: false
+
+    readonly property real value: {
+        const win = Window.window;
+        if (!win || !(win.statusBarOverlap > 0) || !target || target.height <= 0)
+            return 0;
+        const bottom = target.mapToItem(null, 0, target.height).y;
+        return Math.max(0, Math.min(win.statusBarOverlap, bottom - win.statusBarTop));
+    }
+}

--- a/src/server/src/qml/qml/StoreDetailView.qml
+++ b/src/server/src/qml/qml/StoreDetailView.qml
@@ -48,6 +48,10 @@ Item {
         font.pointSize: Theme.smallerFontSize
     }
 
+    StatusBarInset {
+        id: statusBarInset
+    }
+
     Flickable {
         id: flickable
         anchors.fill: parent
@@ -56,6 +60,7 @@ Item {
         clip: true
         flickableDirection: Flickable.VerticalFlick
         boundsBehavior: Flickable.StopAtBounds
+        bottomMargin: statusBarInset.value
         visible: root.host.isReady
 
         ViciWheelHandler {

--- a/src/server/src/qml/qml/TextViewer.qml
+++ b/src/server/src/qml/qml/TextViewer.qml
@@ -12,6 +12,17 @@ ScrollView {
 
     Component.onCompleted: contentItem.boundsBehavior = Flickable.StopAtBounds
 
+    StatusBarInset {
+        id: statusBarInset
+        target: root
+    }
+
+    Binding {
+        target: root.contentItem
+        property: "bottomMargin"
+        value: statusBarInset.value
+    }
+
     ViciWheelHandler {
         target: root.contentItem
     }

--- a/src/server/src/qml/qml/ViciScrollBar.qml
+++ b/src/server/src/qml/qml/ViciScrollBar.qml
@@ -6,6 +6,13 @@ ScrollBar {
 
     property bool _recentlyScrolled: false
 
+    bottomPadding: control.orientation === Qt.Vertical ? statusBarInset.value : 0
+
+    StatusBarInset {
+        id: statusBarInset
+        target: control
+    }
+
     function revealOnScroll() {
         _recentlyScrolled = true;
         scrollActivityTimer.restart();

--- a/src/server/src/qml/qml/markdown/MarkdownView.qml
+++ b/src/server/src/qml/qml/markdown/MarkdownView.qml
@@ -46,6 +46,10 @@ Item {
         mdModel: root.model
     }
 
+    StatusBarInset {
+        id: statusBarInset
+    }
+
     // Cursor-only MouseArea below Flickable — sets I-beam for non-interactive gaps.
     // Interactive children (copy button) override with their own cursor.
     MouseArea {
@@ -66,6 +70,7 @@ Item {
         contentHeight: col.implicitHeight + root.topPadding + root.contentPadding
         clip: true
         boundsBehavior: Flickable.StopAtBounds
+        bottomMargin: statusBarInset.value
 
         ViciWheelHandler {
             target: flickable
@@ -74,7 +79,7 @@ Item {
         onContentHeightChanged: {
             if (root._autoScroll) {
                 root._autoScroll = false;
-                contentY = Math.max(0, contentHeight - height);
+                contentY = Math.max(0, contentHeight - height + bottomMargin);
             }
         }
 


### PR DESCRIPTION
Since the beginning we've treated the status bar as a distinct part of the layout with no relationship to the content. Now it floats on top of the main content, which is slightly visible under it (blurred).

<img width="1185" height="150" alt="image" src="https://github.com/user-attachments/assets/361634bd-a319-4148-91e7-680c2c3b3b78" />
