### PR TITLE
feat(linux): add command to configure default terminal

### DIFF
--- a/src/lib/xdgpp/CMakeLists.txt
+++ b/src/lib/xdgpp/CMakeLists.txt
@@ -53,7 +53,7 @@ if (BUILD_TESTS)
 	set(FIXTURE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/fixtures)
 	find_package(Catch2 3 REQUIRED)
 	add_compile_options(-g3)
-	add_executable(${TEST_TARGET} tests/main.cpp tests/entry.cpp tests/env.cpp tests/locale.cpp tests/mime.cpp tests/file.cpp tests/special.cpp)
+	add_executable(${TEST_TARGET} tests/main.cpp tests/entry.cpp tests/env.cpp tests/locale.cpp tests/mime.cpp tests/file.cpp tests/special.cpp tests/xdg-terminal-exec.cpp)
 	target_compile_definitions(${TEST_TARGET} PRIVATE
 		XDGPP_FIXTURE_DIR="${FIXTURE_DIR}"
 	)

--- a/src/lib/xdgpp/tests/xdg-terminal-exec.cpp
+++ b/src/lib/xdgpp/tests/xdg-terminal-exec.cpp
@@ -1,0 +1,42 @@
+#include "utils/utils.hpp"
+#include "xdg-terminal-exec/xdg-terminals-list.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <filesystem>
+#include <fstream>
+
+TEST_CASE("Should write the new terminal app ID to an empty file") {
+  const auto path = std::filesystem::temp_directory_path() / "xdg-terminals.list";
+  std::filesystem::remove(path);
+
+  REQUIRE(xdgpp::setDefaultTerminal("test", {}, path));
+  REQUIRE(slurp(path) == "# Configured by the Vicinae launcher\ntest\n");
+}
+
+TEST_CASE("Should write the new terminal app ID to an existing file, before all other entries") {
+  const auto path = std::filesystem::temp_directory_path() / "xdg-terminals.list";
+  std::filesystem::remove(path);
+
+  {
+    std::ofstream ofs{path};
+    ofs << "org.someone.something\n";
+  }
+
+  REQUIRE(xdgpp::setDefaultTerminal("test", {}, path));
+  REQUIRE(slurp(path) == "# Configured by the Vicinae launcher\ntest\norg.someone.something\n");
+}
+
+TEST_CASE("Should write the new terminal app ID to an already modified file") {
+  const auto path = std::filesystem::temp_directory_path() / "xdg-terminals.list";
+  std::filesystem::remove(path);
+
+  {
+    std::ofstream ofs{path};
+    ofs << "# Configured by the Vicinae launcher\n# This is some "
+           "comment\norg.someone.something\norg.somethingelse.unrelated\n";
+  }
+
+  REQUIRE(xdgpp::setDefaultTerminal("test", {}, path));
+  REQUIRE(
+      slurp(path) ==
+      "# Configured by the Vicinae launcher\n# This is some comment\ntest\norg.somethingelse.unrelated\n");
+}

--- a/src/lib/xdgpp/xdgpp/xdg-terminal-exec/xdg-terminals-list.hpp
+++ b/src/lib/xdgpp/xdgpp/xdg-terminal-exec/xdg-terminals-list.hpp
@@ -3,9 +3,14 @@
 #include <filesystem>
 #include <fstream>
 #include <functional>
+#include <iomanip>
+#include <iostream>
 #include <optional>
 #include <string>
+#include <string_view>
+#include <system_error>
 #include "../utils/utils.hpp"
+#include "xdgpp/env/env.hpp"
 
 namespace xdgpp {
 
@@ -45,6 +50,72 @@ parseXdgTerminalsList(const std::filesystem::path &path,
       cb({.entryId = raw}, state);
     }
   }
+}
+
+inline bool setDefaultTerminal(std::string_view appId, std::optional<std::string_view> actionId,
+                               const std::filesystem::path &path) {
+  constexpr auto HEADER = "# Configured by the Vicinae launcher";
+  std::string buf{};
+  bool inserted = false;
+
+  const auto insertAppId = [&]() {
+    inserted = true;
+    buf += appId;
+
+    if (actionId) {
+      buf += ':';
+      buf += actionId.value();
+    }
+
+    buf += "\n";
+  };
+
+  const auto insertHeader = [&]() {
+    if (!buf.empty()) buf += "\n";
+    buf += HEADER;
+    buf += "\n";
+  };
+
+  {
+    std::ifstream ifs{path};
+    std::string line{};
+    bool writeNext = false;
+
+    while (std::getline(ifs, line)) {
+      auto const entry = trim(line);
+
+      if (writeNext && !entry.empty() && !entry.starts_with("#")) {
+        writeNext = false;
+        insertAppId();
+        continue;
+      }
+
+      if (!inserted && !entry.empty() && (!entry.starts_with("#") || entry == HEADER)) {
+        if (entry == HEADER) {
+          writeNext = true; // replace the next non empty line with the new app id
+        } else {
+          insertHeader();
+          insertAppId();
+        }
+      }
+
+      buf += line + "\n";
+    }
+  }
+
+  if (!inserted) {
+    insertHeader();
+    insertAppId();
+  }
+
+  std::ofstream ofs{path};
+  ofs << buf;
+
+  return ofs.good();
+}
+
+inline bool setDefaultTerminal(std::string_view appId, std::optional<std::string_view> actionId) {
+  return setDefaultTerminal(appId, actionId, xdgpp::configHome() / "xdg-terminals.list");
 }
 
 }; // namespace xdgpp

--- a/src/server/src/extensions/system/system-extension.hpp
+++ b/src/server/src/extensions/system/system-extension.hpp
@@ -2,18 +2,22 @@
 #include "command-database.hpp"
 #include "common/context.hpp"
 #include "qml/browse-apps-view-host.hpp"
+#include "set-default-terminal-view-host.hpp"
 #include "single-view-command-context.hpp"
 #include "qml/system-run-model.hpp"
 #include "qml/system-run-view-host.hpp"
+#include "theme/colors.hpp"
 #include "utils.hpp"
 #include "services/app-service/app-service.hpp"
 #include "services/audio-control/audio-control-service.hpp"
 #include "services/toast/toast-service.hpp"
 #include <QCoreApplication>
-#include <sstream>
 #ifndef Q_OS_WIN
 #include "xdgpp/desktop-entry/exec.hpp"
+#include "xdgpp/xdg-terminal-exec/xdg-terminals-list.hpp"
 #endif
+
+namespace {
 
 class SystemRunCommand : public BuiltinCallbackCommand {
   Q_DECLARE_TR_FUNCTIONS(SystemRunCommand)
@@ -253,6 +257,17 @@ class ToggleMuteCommand : public BuiltinCallbackCommand {
   }
 };
 
+class SetDefaultTerminal : public BuiltinViewCommand<SetDefaultTerminalViewHost> {
+  Q_DECLARE_TR_FUNCTIONS(SetDefaultTerminal)
+
+  QString id() const override { return "set-default-terminal"; }
+  QString name() const override { return tr("Set Default Terminal"); }
+  QString description() const override { return tr("Change the default system terminal"); }
+  std::vector<QString> keywords() const override { return {}; }
+  ImageURL iconUrl() const override { return ImageURL::symbol("$").setBackgroundTint(VOLUME_COMMAND_TINT); }
+};
+} // namespace
+
 class SystemExtension : public BuiltinCommandRepository {
   Q_DECLARE_TR_FUNCTIONS(SystemExtension)
 
@@ -275,6 +290,11 @@ public:
     registerCommand<SetVolumeCommand<25, BuiltinIcon::SpeakerLow>>();
     registerCommand<SetVolumeCommand<0, BuiltinIcon::SpeakerOff>>();
     registerCommand<ToggleMuteCommand>();
+
+#ifdef Q_OS_LINUX
+    // set default terminal using xdg-terminal-exec
+    registerCommand<SetDefaultTerminal>();
+#endif
   }
 
   std::vector<Preference> preferences() const override { return {}; }

--- a/src/server/src/extensions/system/system-extension.hpp
+++ b/src/server/src/extensions/system/system-extension.hpp
@@ -2,7 +2,6 @@
 #include "command-database.hpp"
 #include "common/context.hpp"
 #include "qml/browse-apps-view-host.hpp"
-#include "set-default-terminal-view-host.hpp"
 #include "single-view-command-context.hpp"
 #include "qml/system-run-model.hpp"
 #include "qml/system-run-view-host.hpp"
@@ -12,9 +11,10 @@
 #include "services/audio-control/audio-control-service.hpp"
 #include "services/toast/toast-service.hpp"
 #include <QCoreApplication>
+
 #ifndef Q_OS_WIN
 #include "xdgpp/desktop-entry/exec.hpp"
-#include "xdgpp/xdg-terminal-exec/xdg-terminals-list.hpp"
+#include "set-default-terminal-view-host.hpp"
 #endif
 
 namespace {
@@ -257,6 +257,7 @@ class ToggleMuteCommand : public BuiltinCallbackCommand {
   }
 };
 
+#ifdef Q_OS_LINUX
 class SetDefaultTerminal : public BuiltinViewCommand<SetDefaultTerminalViewHost> {
   Q_DECLARE_TR_FUNCTIONS(SetDefaultTerminal)
 
@@ -266,6 +267,8 @@ class SetDefaultTerminal : public BuiltinViewCommand<SetDefaultTerminalViewHost>
   std::vector<QString> keywords() const override { return {}; }
   ImageURL iconUrl() const override { return ImageURL::symbol("$").setBackgroundTint(VOLUME_COMMAND_TINT); }
 };
+#endif
+
 } // namespace
 
 class SystemExtension : public BuiltinCommandRepository {

--- a/src/server/src/qml/mono-list-view-host.hpp
+++ b/src/server/src/qml/mono-list-view-host.hpp
@@ -1,0 +1,70 @@
+#pragma once
+#include "bridge-view.hpp"
+#include "fuzzy-section.hpp"
+#include "section-list-model.hpp"
+
+/**
+ * A list view with a single section.
+ * Does not require creating a separate model, much simpler way to create new views.
+ */
+template <typename T> class MonoListViewHost : public ViewHostBase, public FuzzySection<T> {
+  Q_PROPERTY(QObject *listModel READ listModel CONSTANT)
+
+public:
+  using ItemType = T;
+
+  virtual void onMount() { initialize(); }
+
+protected:
+  QString sectionName() const override { return ""; }
+
+  QString displayTitle(const T &e) const override = 0;
+  QString displaySubtitle(const T &e) const override = 0;
+  std::optional<ImageURL> displayIcon(const T &e) const override = 0;
+  AccessoryList displayAccessories(const T &e) const override = 0;
+  std::unique_ptr<ActionPanelState> buildActionPanel(const T &e) const override = 0;
+
+  void textChanged(const QString &text) override { m_model.setFilter(text); }
+  void onReactivated() override { m_model.refreshActionPanel(); }
+  void beforePop() override { m_model.beforePop(); }
+
+  SectionListModel m_model{this};
+
+private:
+  QUrl qmlComponentUrl() const final { return m_model.qmlComponentUrl(); }
+
+  QVariantMap qmlProperties() final {
+    return {{QStringLiteral("cmdModel"), QVariant::fromValue(static_cast<QObject *>(&m_model))}};
+  }
+
+  void initialize() final {
+    BaseView::initialize();
+    initModel();
+    onMount();
+  }
+
+  QObject *listModel() const { return const_cast<SectionListModel *>(&m_model); }
+
+  SectionListModel *model() { return &m_model; }
+
+  void initModel() {
+    m_model.setScope(ViewScope(context(), this));
+    m_model.addSource(this);
+
+    connect(&m_model, &SectionListModel::itemSelected, this, [this](SectionSource *source, int itemIdx) {
+      if (auto panel = source->actionPanel(itemIdx))
+        setActions(std::move(panel));
+      else
+        clearActions();
+    });
+
+    connect(&m_model, &SectionListModel::selectionCleared, this, [this]() {
+      if (auto panel = emptyActionPanel())
+        setActions(std::move(panel));
+      else
+        clearActions();
+    });
+  }
+
+  virtual std::unique_ptr<ActionPanelState> emptyActionPanel() { return nullptr; }
+};

--- a/src/server/src/qml/set-default-terminal-view-host.hpp
+++ b/src/server/src/qml/set-default-terminal-view-host.hpp
@@ -1,0 +1,84 @@
+#pragma once
+#include <memory>
+#include <ranges>
+#include "builtin_icon.hpp"
+#include "common/context.hpp"
+#include "mono-list-view-host.hpp"
+#include "services/app-service/abstract-app-db.hpp"
+#include "theme/colors.hpp"
+#include "ui/action-pannel/action-panel-state.hpp"
+#include "services/app-service/app-service.hpp"
+#include "ui/action-pannel/action.hpp"
+#include "ui/list-accessory/list-accessory.hpp"
+#include "xdgpp/xdg-terminal-exec/xdg-terminals-list.hpp"
+#include "services/toast/toast-service.hpp"
+
+class SetDefaultTerminalViewHost : public MonoListViewHost<std::shared_ptr<AbstractApplication>> {
+signals:
+  void defaultEmulatorChanged() const;
+
+public:
+  void onMount() override {
+    setSearchPlaceholderText("Select a terminal emulator...");
+    m_onChanged = [this]() { reloadItems(); };
+    reloadItems();
+  }
+
+  QString sectionName() const override { return "Available terminal emulators"; }
+
+  QString displayTitle(const ItemType &e) const override { return e->displayName(); }
+
+  QString displaySubtitle(const ItemType &e) const override { return e->description(); }
+
+  std::optional<ImageURL> displayIcon(const ItemType &e) const override { return e->iconUrl(); }
+
+  AccessoryList displayAccessories(const ItemType &e) const override {
+    if (auto &t = m_defaultTerminal; t && *t == e->id()) {
+      return {
+          ListAccessory{.icon = ImageURL::builtin(BuiltinIcon::CheckCircle).setFill(SemanticColor::Green)}};
+    }
+
+    return {};
+  }
+
+  std::unique_ptr<ActionPanelState> buildActionPanel(const ItemType &e) const override {
+    auto panel = std::make_unique<ListActionPanelState>();
+    auto main = panel->createSection();
+    auto setDefault = new StaticAction(
+        "Set as default terminal", ImageURL::symbol("$"), [this, appId = e->id()](ApplicationContext *ctx) {
+          if (xdgpp::setDefaultTerminal(appId.toStdString(), {})) {
+            m_onChanged();
+            ctx->navigation->showHud("Default terminal changed",
+                                     ImageURL::symbol("$").setFill(SemanticColor::Green));
+            ctx->navigation->popToRoot();
+          } else {
+            ctx->services->toastService()->failure("Failed to set default terminal");
+          }
+        });
+
+    main->addAction(setDefault);
+
+    return panel;
+  }
+
+private:
+  void reloadItems() {
+    auto appDb = context()->services->appDb();
+
+    if (auto app = appDb->terminalEmulator()) { m_defaultTerminal = app->id(); }
+
+    auto terminals =
+        appDb->list() |
+        std::views::filter([](auto &&app) { return app->displayable() && app->isTerminalEmulator(); }) |
+        std::ranges::to<std::vector>();
+    const auto isDefault = [&](auto &&app) { return m_defaultTerminal && *m_defaultTerminal == app->id(); };
+
+    std::ranges::sort(terminals, [&](auto &&a, auto &&b) { return isDefault(a) > isDefault(b); });
+
+    setItems(std::move(terminals));
+    notifyChanged();
+  }
+
+  std::optional<QString> m_defaultTerminal;
+  std::function<void()> m_onChanged;
+};

--- a/src/server/src/ui/image/image-renderer.cpp
+++ b/src/server/src/ui/image/image-renderer.cpp
@@ -42,98 +42,18 @@ QThreadPool &decodingPool() {
   return pool;
 }
 
-QImage renderBuiltinSvg(const QString &iconName, const QSize &size, const QColor &fg, const QColor &bg) {
+QImage renderBuiltinSvg(const QString &iconName, const QSize &size) {
   QString const iconPath = QStringLiteral(":icons/%1.svg").arg(iconName);
   QSvgRenderer renderer(iconPath);
   if (!renderer.isValid()) return {};
 
-  bool const hasBg = bg.isValid() && bg.alpha() > 0;
-  int const pad = hasBg ? 0 : AA_PAD;
-
-  // Theme tints are tuned for text on the app background, not as fills: their
-  // lightness varies per hue, which makes a row of tiles look uneven. Clamp
-  // every tile into one tonal band so the set reads as a family and always
-  // supports a light glyph.
-  QColor tile = bg;
-  if (hasBg) {
-    float h, s, l, a;
-    bg.getHslF(&h, &s, &l, &a);
-    if (h < 0.f) h = 0.f;
-    if (s > 0.05f) s = std::clamp(s, 0.55f, 0.8f);
-    l = std::clamp(l, 0.42f, 0.52f);
-    tile = QColor::fromHslF(h, s, l, a);
-  }
-
-  QImage canvas(size.width() + pad * 2, size.height() + pad * 2, QImage::Format_ARGB32_Premultiplied);
+  QImage canvas(size.width() + AA_PAD * 2, size.height() + AA_PAD * 2, QImage::Format_ARGB32_Premultiplied);
   canvas.fill(Qt::transparent);
   QPainter painter(&canvas);
   painter.setRenderHint(QPainter::Antialiasing, true);
   painter.setRenderHint(QPainter::SmoothPixmapTransform, true);
-
-  QRectF const contentRect(pad, pad, size.width(), size.height());
-  int margin = 0;
-
-  if (hasBg) {
-    int const side = qMin(size.width(), size.height());
-    qreal const radius = side * 0.25;
-    margin = qRound(side * 0.19);
-
-    auto shifted = [](const QColor &c, float dh, float ds, float dl) {
-      float h, s, l, a;
-      c.getHslF(&h, &s, &l, &a);
-      if (h < 0.f) h = 0.f;
-      h = std::fmod(h + dh + 1.f, 1.f);
-      s = std::clamp(s + ds, 0.f, 1.f);
-      l = std::clamp(l + dl, 0.f, 1.f);
-      return QColor::fromHslF(h, s, l, a);
-    };
-
-    QLinearGradient gradient(contentRect.topLeft(), contentRect.bottomLeft());
-    gradient.setColorAt(0, shifted(tile, 0.025f, -0.03f, 0.10f));
-    gradient.setColorAt(1, shifted(tile, -0.015f, 0.06f, -0.05f));
-    painter.setBrush(gradient);
-    painter.setPen(Qt::NoPen);
-    painter.drawRoundedRect(contentRect, radius, radius);
-
-    qreal const strokeWidth = std::max(1.0, side / 32.0);
-    painter.setBrush(Qt::NoBrush);
-    painter.setPen(QPen(QColor(255, 255, 255, 30), strokeWidth));
-    qreal const inset = strokeWidth / 2.0;
-    painter.drawRoundedRect(contentRect.adjusted(inset, inset, -inset, -inset), radius - inset,
-                            radius - inset);
-  }
-
-  QRectF const iconRect =
-      contentRect.marginsRemoved({qreal(margin), qreal(margin), qreal(margin), qreal(margin)});
-
-  QImage svgImage(iconRect.size().toSize(), QImage::Format_ARGB32_Premultiplied);
-  svgImage.fill(Qt::transparent);
-  {
-    QPainter svgPainter(&svgImage);
-    svgPainter.setRenderHint(QPainter::Antialiasing, true);
-    svgPainter.setRenderHint(QPainter::SmoothPixmapTransform, true);
-    renderer.setAspectRatioMode(Qt::KeepAspectRatio);
-    renderer.render(&svgPainter, svgImage.rect());
-
-    QColor fillColor = fg;
-    if (hasBg) fillColor = ContrastHelper::getTonalContrastColor(tile, 5, 0.1);
-
-    svgPainter.setCompositionMode(QPainter::CompositionMode_SourceIn);
-    svgPainter.fillRect(svgImage.rect(), fillColor);
-  }
-
-  if (hasBg) {
-    QImage shadow(svgImage.size(), QImage::Format_ARGB32_Premultiplied);
-    shadow.fill(Qt::transparent);
-    QPainter shadowPainter(&shadow);
-    shadowPainter.drawImage(0, 0, svgImage);
-    shadowPainter.setCompositionMode(QPainter::CompositionMode_SourceIn);
-    shadowPainter.fillRect(shadow.rect(), QColor(0, 0, 0, 70));
-    qreal const offset = qMin(size.width(), size.height()) * 0.035;
-    painter.drawImage(iconRect.translated(0, offset), shadow);
-  }
-
-  painter.drawImage(iconRect, svgImage);
+  renderer.setAspectRatioMode(Qt::KeepAspectRatio);
+  renderer.render(&painter, QRectF(AA_PAD, AA_PAD, size.width(), size.height()));
   return canvas;
 }
 
@@ -240,7 +160,7 @@ static void applyFillColor(QImage &image, const QColor &fg) {
   image = tinted;
 }
 
-QImage renderFileIcon(const QString &path, const QSize &size, const QColor &fg, const QColor &bg) {
+QImage renderFileIcon(const QString &path, const QSize &size, const QColor &fg) {
 #ifdef Q_OS_MACOS
   if (!fg.isValid()) {
     if (QImage native = renderMacFileIcon(path, size); !native.isNull()) { return native; }
@@ -268,7 +188,9 @@ QImage renderFileIcon(const QString &path, const QSize &size, const QColor &fg, 
                                   : QStringLiteral("blank-document");
   QColor const builtinFg =
       fg.isValid() ? fg : ThemeService::instance().theme().resolve(SemanticColor::Foreground);
-  return renderBuiltinSvg(builtinName, size, builtinFg, bg);
+  QImage builtin = renderBuiltinSvg(builtinName, size);
+  applyFillColor(builtin, builtinFg);
+  return builtin;
 }
 
 QImage decodeImageData(QIODevice *device, const QSize &size) {
@@ -341,9 +263,89 @@ void applySafetyMargins(QImage &image) {
   image = padded;
 }
 
-void applyPostTransforms(QImage &image, const QColor &fg, OmniPainter::ImageMaskType mask) {
+static bool hasBackdrop(const QColor &bg) { return bg.isValid() && bg.alpha() > 0; }
+
+QSize backdropContentSize(const QSize &size) {
+  int const margin = qRound(qMin(size.width(), size.height()) * 0.19);
+  return {std::max(1, size.width() - margin * 2), std::max(1, size.height() - margin * 2)};
+}
+
+// Theme tints are tuned for text on the app background, not as fills: their
+// lightness varies per hue, which makes a row of tiles look uneven. Clamp
+// every tile into one tonal band so the set reads as a family and always
+// supports a light glyph.
+static QColor clampTileTone(const QColor &bg) {
+  float h, s, l, a;
+  bg.getHslF(&h, &s, &l, &a);
+  if (h < 0.f) h = 0.f;
+  if (s > 0.05f) s = std::clamp(s, 0.55f, 0.8f);
+  l = std::clamp(l, 0.42f, 0.52f);
+  return QColor::fromHslF(h, s, l, a);
+}
+
+static void applyBackdrop(QImage &image, const QSize &size, const QColor &tile) {
+  QImage canvas(size, QImage::Format_ARGB32_Premultiplied);
+  canvas.fill(Qt::transparent);
+  QPainter painter(&canvas);
+  painter.setRenderHint(QPainter::Antialiasing, true);
+  painter.setRenderHint(QPainter::SmoothPixmapTransform, true);
+
+  QRectF const tileRect(0, 0, size.width(), size.height());
+  int const side = qMin(size.width(), size.height());
+  qreal const radius = side * 0.25;
+
+  auto shifted = [](const QColor &c, float dh, float ds, float dl) {
+    float h, s, l, a;
+    c.getHslF(&h, &s, &l, &a);
+    if (h < 0.f) h = 0.f;
+    h = std::fmod(h + dh + 1.f, 1.f);
+    s = std::clamp(s + ds, 0.f, 1.f);
+    l = std::clamp(l + dl, 0.f, 1.f);
+    return QColor::fromHslF(h, s, l, a);
+  };
+
+  QLinearGradient gradient(tileRect.topLeft(), tileRect.bottomLeft());
+  gradient.setColorAt(0, shifted(tile, 0.025f, -0.03f, 0.10f));
+  gradient.setColorAt(1, shifted(tile, -0.015f, 0.06f, -0.05f));
+  painter.setBrush(gradient);
+  painter.setPen(Qt::NoPen);
+  painter.drawRoundedRect(tileRect, radius, radius);
+
+  qreal const strokeWidth = std::max(1.0, side / 32.0);
+  painter.setBrush(Qt::NoBrush);
+  painter.setPen(QPen(QColor(255, 255, 255, 30), strokeWidth));
+  qreal const inset = strokeWidth / 2.0;
+  painter.drawRoundedRect(tileRect.adjusted(inset, inset, -inset, -inset), radius - inset, radius - inset);
+
+  QRectF const dest((size.width() - image.width()) / 2.0, (size.height() - image.height()) / 2.0,
+                    image.width(), image.height());
+
+  QImage shadow(image.size(), QImage::Format_ARGB32_Premultiplied);
+  shadow.fill(Qt::transparent);
+  {
+    QPainter shadowPainter(&shadow);
+    shadowPainter.drawImage(0, 0, image);
+    shadowPainter.setCompositionMode(QPainter::CompositionMode_SourceIn);
+    shadowPainter.fillRect(shadow.rect(), QColor(0, 0, 0, 70));
+  }
+  painter.drawImage(dest.translated(0, side * 0.035), shadow);
+  painter.drawImage(dest, image);
+  image = canvas;
+}
+
+void applyPostTransforms(QImage &image, const QColor &fg, const QColor &bg, const QSize &size,
+                         OmniPainter::ImageMaskType mask) {
   if (image.isNull()) return;
-  if (fg.isValid()) applyFillColor(image, fg);
+  bool const hasBg = hasBackdrop(bg) && size.isValid();
+  QColor const tile = hasBg ? clampTileTone(bg) : QColor();
+
+  // On a tile, tintable content gets a contrast-derived fill instead of the
+  // requested one; untinted content (emoji, raster) keeps its own colors.
+  QColor fill = fg;
+  if (hasBg && fg.isValid()) fill = ContrastHelper::getTonalContrastColor(tile, 5, 0.1);
+  if (fill.isValid()) applyFillColor(image, fill);
+  if (hasBg) applyBackdrop(image, size, tile);
+
   switch (mask) {
   case OmniPainter::CircleMask:
     applyCircleMask(image);
@@ -356,7 +358,7 @@ void applyPostTransforms(QImage &image, const QColor &fg, OmniPainter::ImageMask
   }
 }
 
-QFuture<QImage> renderFavicon(const QString &domain, const QSize &size, const QColor &fg,
+QFuture<QImage> renderFavicon(const QString &domain, const QSize &size, const QColor &fg, const QColor &bg,
                               OmniPainter::ImageMaskType mask) {
   auto promise = std::make_shared<QPromise<QImage>>();
   auto future = promise->future();
@@ -364,7 +366,7 @@ QFuture<QImage> renderFavicon(const QString &domain, const QSize &size, const QC
 
   QMetaObject::invokeMethod(
       qApp,
-      [promise, domain, size, fg, mask]() {
+      [promise, domain, size, fg, bg, mask]() {
         auto *svc = FaviconService::instance();
         if (!svc) {
           promise->addResult(QImage{});
@@ -373,18 +375,22 @@ QFuture<QImage> renderFavicon(const QString &domain, const QSize &size, const QC
         }
         auto faviconFuture = svc->makeRequest(domain);
         auto *watcher = new QFutureWatcher<FaviconService::FaviconResponse>;
-        QObject::connect(watcher, &QFutureWatcherBase::finished, qApp, [promise, watcher, size, fg, mask]() {
-          auto result = watcher->result();
-          if (result) {
-            QImage img = result.value().scaled(size, Qt::KeepAspectRatio, Qt::SmoothTransformation).toImage();
-            applyPostTransforms(img, fg, mask);
-            promise->addResult(std::move(img));
-          } else {
-            promise->addResult(QImage{});
-          }
-          promise->finish();
-          watcher->deleteLater();
-        });
+        QObject::connect(
+            watcher, &QFutureWatcherBase::finished, qApp, [promise, watcher, size, fg, bg, mask]() {
+              auto result = watcher->result();
+              if (result) {
+                QSize const contentSize = hasBackdrop(bg) ? backdropContentSize(size) : size;
+                QImage img = result.value()
+                                 .scaled(contentSize, Qt::KeepAspectRatio, Qt::SmoothTransformation)
+                                 .toImage();
+                applyPostTransforms(img, fg, bg, size, mask);
+                promise->addResult(std::move(img));
+              } else {
+                promise->addResult(QImage{});
+              }
+              promise->finish();
+              watcher->deleteLater();
+            });
         watcher->setFuture(faviconFuture);
       },
       Qt::QueuedConnection);
@@ -392,14 +398,15 @@ QFuture<QImage> renderFavicon(const QString &domain, const QSize &size, const QC
   return future;
 }
 
-QImage decodeAndTransform(const QByteArray &data, const QSize &size, const QColor &fg,
+QImage decodeAndTransform(const QByteArray &data, const QSize &size, const QColor &fg, const QColor &bg,
                           OmniPainter::ImageMaskType mask) {
+  QSize const contentSize = hasBackdrop(bg) ? backdropContentSize(size) : size;
   QImage img;
 
   if (data.trimmed().startsWith("<?xml") || data.trimmed().startsWith("<svg")) {
     QSvgRenderer renderer(data);
     if (renderer.isValid()) {
-      img = QImage(size, QImage::Format_ARGB32_Premultiplied);
+      img = QImage(contentSize, QImage::Format_ARGB32_Premultiplied);
       img.fill(Qt::transparent);
       QPainter painter(&img);
       painter.setRenderHint(QPainter::Antialiasing, true);
@@ -408,10 +415,10 @@ QImage decodeAndTransform(const QByteArray &data, const QSize &size, const QColo
       renderer.render(&painter, img.rect());
     }
   } else {
-    img = decodeImageData(data, size);
+    img = decodeImageData(data, contentSize);
   }
 
-  applyPostTransforms(img, fg, mask);
+  applyPostTransforms(img, fg, bg, size, mask);
   return img;
 }
 

--- a/src/server/src/ui/image/image-renderer.hpp
+++ b/src/server/src/ui/image/image-renderer.hpp
@@ -16,21 +16,26 @@ namespace ImageRendering {
 QFuture<QImage> renderFirstFrame(const ImageURL &url, const QSize &size, bool safetyMargins = false);
 std::optional<QImage> cachedFrame(const ImageURL &url);
 
-QImage renderBuiltinSvg(const QString &name, const QSize &size, const QColor &fg, const QColor &bg);
+QImage renderBuiltinSvg(const QString &name, const QSize &size);
 QImage renderEmoji(const QString &emoji, const QSize &size);
 QImage renderSymbol(const QString &symbol, const QSize &size);
 QImage renderFontPreview(const QString &spec, const QSize &size);
 QImage renderSystemIcon(const QString &name, const QSize &size);
-QImage renderFileIcon(const QString &path, const QSize &size, const QColor &fg, const QColor &bg);
-QFuture<QImage> renderFavicon(const QString &domain, const QSize &size, const QColor &fg,
+QImage renderFileIcon(const QString &path, const QSize &size, const QColor &fg);
+QFuture<QImage> renderFavicon(const QString &domain, const QSize &size, const QColor &fg, const QColor &bg,
                               OmniPainter::ImageMaskType mask);
 
 QImage decodeImageData(QIODevice *device, const QSize &size);
 QImage decodeImageData(const QByteArray &data, const QSize &size);
 QImage decodeAndTransform(const QByteArray &data, const QSize &size, const QColor &fg = {},
-                          OmniPainter::ImageMaskType mask = OmniPainter::NoMask);
+                          const QColor &bg = {}, OmniPainter::ImageMaskType mask = OmniPainter::NoMask);
 
-void applyPostTransforms(QImage &image, const QColor &fg, OmniPainter::ImageMaskType mask);
+// Size content should be rendered at when it will be composed onto a backdrop
+// tile of the given full size.
+QSize backdropContentSize(const QSize &size);
+
+void applyPostTransforms(QImage &image, const QColor &fg, const QColor &bg, const QSize &size,
+                         OmniPainter::ImageMaskType mask);
 void applySafetyMargins(QImage &image);
 
 QThreadPool &decodingPool();

--- a/src/server/src/ui/image/image-stream.cpp
+++ b/src/server/src/ui/image/image-stream.cpp
@@ -89,9 +89,18 @@ static bool isMultiFrameGif(const QByteArray &data) {
   return reader.imageCount() > 1;
 }
 
+static QColor resolveBackgroundTint(const ImageURL &url) {
+  if (auto bg = url.backgroundTint()) {
+    QColor const c = OmniPainter::resolveColor(*bg);
+    if (c.isValid() && c.alpha() > 0) return c;
+  }
+  return {};
+}
+
 ImageStream::ImageStream(const ImageURL &url, const QSize &size, ImageStreamOptions opts, QObject *parent)
     : QObject(parent), m_url(url.resolved()), m_size(size), m_opts(opts) {
   if (auto fill = m_url.fillColor()) m_fg = OmniPainter::resolveColor(*fill);
+  m_bg = resolveBackgroundTint(m_url);
   m_mask = m_url.mask();
   m_cacheKey = makeCacheKey(m_url, size, m_opts.safetyMargins);
   m_originalCacheKey = m_cacheKey;
@@ -147,6 +156,7 @@ void ImageStream::tryFallback() {
 
   m_fg = QColor();
   if (auto fill = m_url.fillColor()) m_fg = OmniPainter::resolveColor(*fill);
+  m_bg = resolveBackgroundTint(m_url);
   m_mask = m_url.mask();
   m_cacheKey = makeCacheKey(m_url, m_size, m_opts.safetyMargins);
   m_latestCacheKey = makeLatestCacheKey(m_url);
@@ -171,60 +181,58 @@ void ImageStream::handleStaticFuture(QFuture<QImage> future) {
 
 void ImageStream::startStatic() {
   const QString name = m_url.name();
-  QColor bg;
-  if (auto bgTint = m_url.backgroundTint()) bg = OmniPainter::resolveColor(*bgTint);
+  // With a backdrop, content renders at the inset size and the post stage
+  // composes it onto the full-size tile.
+  const QSize renderSize = m_bg.isValid() ? ImageRendering::backdropContentSize(m_size) : m_size;
 
   auto canceled = m_canceled;
   auto runInPool = [this, canceled](auto renderFn, const QColor &postFg) {
-    auto mask = m_mask;
-    handleStaticFuture(
-        QtConcurrent::run(&ImageRendering::decodingPool(),
-                          [renderFn = std::move(renderFn), postFg, mask, canceled]() -> QImage {
-                            if (canceled->load(std::memory_order_relaxed)) return {};
-                            QImage img = renderFn();
-                            ImageRendering::applyPostTransforms(img, postFg, mask);
-                            return img;
-                          }));
+    handleStaticFuture(QtConcurrent::run(&ImageRendering::decodingPool(),
+                                         [renderFn = std::move(renderFn), postFg, bg = m_bg, size = m_size,
+                                          mask = m_mask, canceled]() -> QImage {
+                                           if (canceled->load(std::memory_order_relaxed)) return {};
+                                           QImage img = renderFn();
+                                           ImageRendering::applyPostTransforms(img, postFg, bg, size, mask);
+                                           return img;
+                                         }));
   };
 
   switch (m_url.type()) {
   case ImageURLType::Builtin:
-    runInPool([name, size = m_size, fg = m_fg,
-               bg]() { return ImageRendering::renderBuiltinSvg(name, size, fg, bg); },
-              QColor());
+    runInPool([name, size = renderSize]() { return ImageRendering::renderBuiltinSvg(name, size); }, m_fg);
     break;
   case ImageURLType::Emoji:
-    runInPool([name, size = m_size]() { return ImageRendering::renderEmoji(name, size); }, m_fg);
+    runInPool([name, size = renderSize]() { return ImageRendering::renderEmoji(name, size); }, m_fg);
     break;
   case ImageURLType::Symbol:
-    runInPool([name, size = m_size]() { return ImageRendering::renderSymbol(name, size); }, m_fg);
+    runInPool([name, size = renderSize]() { return ImageRendering::renderSymbol(name, size); }, m_fg);
     break;
   case ImageURLType::FontPreview:
-    runInPool([name, size = m_size]() { return ImageRendering::renderFontPreview(name, size); }, m_fg);
+    runInPool([name, size = renderSize]() { return ImageRendering::renderFontPreview(name, size); }, m_fg);
     break;
   case ImageURLType::System:
-    runInPool([name, size = m_size]() { return ImageRendering::renderSystemIcon(name, size); }, m_fg);
+    runInPool([name, size = renderSize]() { return ImageRendering::renderSystemIcon(name, size); }, m_fg);
     break;
 #ifdef Q_OS_MACOS
   case ImageURLType::MacBundle:
-    runInPool([name, size = m_size]() { return renderMacFileIcon(name, size); }, m_fg);
+    runInPool([name, size = renderSize]() { return renderMacFileIcon(name, size); }, m_fg);
     break;
 #endif
 #ifdef Q_OS_WIN
   case ImageURLType::WinShellIcon:
-    runInPool([name, size = m_size]() { return renderWinShellIcon(name, size); }, m_fg);
+    runInPool([name, size = renderSize]() { return renderWinShellIcon(name, size); }, m_fg);
     break;
   case ImageURLType::WinStockIcon:
-    runInPool([name, size = m_size]() { return renderWinStockIcon(name.toInt(), size); }, m_fg);
+    runInPool([name, size = renderSize]() { return renderWinStockIcon(name.toInt(), size); }, m_fg);
     break;
 #endif
   case ImageURLType::FileIcon:
     runInPool(
-        [name, size = m_size, fg = m_fg, bg]() { return ImageRendering::renderFileIcon(name, size, fg, bg); },
+        [name, size = renderSize, fg = m_fg]() { return ImageRendering::renderFileIcon(name, size, fg); },
         QColor());
     break;
   case ImageURLType::Favicon:
-    handleStaticFuture(ImageRendering::renderFavicon(name, m_size, m_fg, m_mask));
+    handleStaticFuture(ImageRendering::renderFavicon(name, m_size, m_fg, m_bg, m_mask));
     break;
   default:
     tryFallback();
@@ -245,29 +253,30 @@ void ImageStream::startFetchable() {
 
   if (type == ImageURLType::Local) {
     auto canceled = m_canceled;
-    auto future =
-        QtConcurrent::run(&ImageRendering::decodingPool(),
-                          [name, canceled, size = m_size, fg = m_fg, mask = m_mask]() -> DecodeResult {
-                            if (canceled->load(std::memory_order_relaxed)) return QImage{};
-                            QFile f(name);
-                            if (!f.open(QIODevice::ReadOnly)) return QImage{};
+    auto future = QtConcurrent::run(
+        &ImageRendering::decodingPool(),
+        [name, canceled, size = m_size, fg = m_fg, bg = m_bg, mask = m_mask]() -> DecodeResult {
+          if (canceled->load(std::memory_order_relaxed)) return QImage{};
+          QFile f(name);
+          if (!f.open(QIODevice::ReadOnly)) return QImage{};
 
-                            // Animated GIFs need full bytes for QMovie; everything else streams.
-                            if (isGif(f.peek(6))) {
-                              QByteArray data = f.readAll();
-                              if (isMultiFrameGif(data)) return data;
-                              return ImageRendering::decodeAndTransform(data, size, fg, mask);
-                            }
+          // Animated GIFs need full bytes for QMovie; everything else streams.
+          if (isGif(f.peek(6))) {
+            QByteArray data = f.readAll();
+            if (isMultiFrameGif(data)) return data;
+            return ImageRendering::decodeAndTransform(data, size, fg, bg, mask);
+          }
 
-                            // SVG can't be read by QImageReader; fall back to the bytes path.
-                            if (name.endsWith(QStringLiteral(".svg"), Qt::CaseInsensitive))
-                              return ImageRendering::decodeAndTransform(f.readAll(), size, fg, mask);
+          // SVG can't be read by QImageReader; fall back to the bytes path.
+          if (name.endsWith(QStringLiteral(".svg"), Qt::CaseInsensitive))
+            return ImageRendering::decodeAndTransform(f.readAll(), size, fg, bg, mask);
 
-                            // Raster: stream-decode directly from the file (no intermediate QByteArray).
-                            QImage img = ImageRendering::decodeImageData(&f, size);
-                            ImageRendering::applyPostTransforms(img, fg, mask);
-                            return img;
-                          });
+          // Raster: stream-decode directly from the file (no intermediate QByteArray).
+          QSize const decodeSize = bg.isValid() ? ImageRendering::backdropContentSize(size) : size;
+          QImage img = ImageRendering::decodeImageData(&f, decodeSize);
+          ImageRendering::applyPostTransforms(img, fg, bg, size, mask);
+          return img;
+        });
     auto *watcher = new QFutureWatcher<DecodeResult>(this);
     connect(watcher, &QFutureWatcherBase::finished, this, [this, watcher]() {
       auto result = watcher->result();
@@ -329,13 +338,13 @@ void ImageStream::onDataReceived(const QByteArray &data) {
     bytesCache().insert(m_url.name(), new QByteArray(data), data.size());
 
   auto canceled = m_canceled;
-  auto future =
-      QtConcurrent::run(&ImageRendering::decodingPool(),
-                        [data, size = m_size, fg = m_fg, mask = m_mask, canceled]() -> DecodeResult {
-                          if (canceled->load(std::memory_order_relaxed)) return QImage{};
-                          if (isMultiFrameGif(data)) return data;
-                          return ImageRendering::decodeAndTransform(data, size, fg, mask);
-                        });
+  auto future = QtConcurrent::run(
+      &ImageRendering::decodingPool(),
+      [data, size = m_size, fg = m_fg, bg = m_bg, mask = m_mask, canceled]() -> DecodeResult {
+        if (canceled->load(std::memory_order_relaxed)) return QImage{};
+        if (isMultiFrameGif(data)) return data;
+        return ImageRendering::decodeAndTransform(data, size, fg, bg, mask);
+      });
   auto *watcher = new QFutureWatcher<DecodeResult>(this);
   connect(watcher, &QFutureWatcherBase::finished, this, [this, watcher]() {
     auto result = watcher->result();
@@ -351,11 +360,12 @@ void ImageStream::onDataReceived(const QByteArray &data) {
 
 void ImageStream::decodeStatic(const QByteArray &data) {
   auto canceled = m_canceled;
-  auto future = QtConcurrent::run(&ImageRendering::decodingPool(),
-                                  [data, size = m_size, fg = m_fg, mask = m_mask, canceled]() -> QImage {
-                                    if (canceled->load(std::memory_order_relaxed)) return {};
-                                    return ImageRendering::decodeAndTransform(data, size, fg, mask);
-                                  });
+  auto future =
+      QtConcurrent::run(&ImageRendering::decodingPool(),
+                        [data, size = m_size, fg = m_fg, bg = m_bg, mask = m_mask, canceled]() -> QImage {
+                          if (canceled->load(std::memory_order_relaxed)) return {};
+                          return ImageRendering::decodeAndTransform(data, size, fg, bg, mask);
+                        });
   auto *watcher = new QFutureWatcher<QImage>(this);
   connect(watcher, &QFutureWatcherBase::finished, this, [this, watcher]() {
     watcher->deleteLater();
@@ -413,7 +423,7 @@ void ImageStream::startAnimation(QByteArray data) {
     }
     QImage frame = movie->currentImage();
     if (frame.isNull()) return;
-    ImageRendering::applyPostTransforms(frame, QColor(), mask);
+    ImageRendering::applyPostTransforms(frame, QColor(), QColor(), QSize(), mask);
     if (safetyMargins) ImageRendering::applySafetyMargins(frame);
     emit worker->frameReady(frame);
   });

--- a/src/server/src/ui/image/image-stream.hpp
+++ b/src/server/src/ui/image/image-stream.hpp
@@ -48,6 +48,7 @@ private:
   ImageURL m_url;
   QSize m_size;
   QColor m_fg;
+  QColor m_bg;
   OmniPainter::ImageMaskType m_mask = OmniPainter::NoMask;
   QString m_cacheKey;
   QString m_originalCacheKey;


### PR DESCRIPTION
The user can use this command to pick one of the terminal emulators on the system and make it the default according to the [xdg-terminal-exec](https://github.com/Vladimir-csp/xdg-terminal-exec) specification.

As an aside, this PR also features a small change to the image rendering pipeline in order to support colored backdrops for glyphs as well, which we use for the icon of this command.

<img width="1183" height="738" alt="image" src="https://github.com/user-attachments/assets/f845cb57-5ad1-41cd-a55a-f2bbaa8c2169" />
