### PR TITLE
refactor: use proper models for dropdowns

### DIFF
--- a/src/server/src/qml/app-selector-model.cpp
+++ b/src/server/src/qml/app-selector-model.cpp
@@ -10,43 +10,28 @@ AppSelectorModel::AppSelectorModel(QObject *parent)
 }
 
 void AppSelectorModel::buildItems() {
-  m_items.clear();
-
   QVariantList allApps;
 
   if (auto browser = m_appDb->webBrowser()) {
-    m_defaultEntry = QVariantMap{
-        {QStringLiteral("id"), QStringLiteral("default")},
-        {QStringLiteral("displayName"), tr("%1 (Default)").arg(browser->fullyQualifiedName())},
-        {QStringLiteral("iconSource"), qml::imageSourceFor(browser->iconUrl())},
-    };
+    m_defaultEntry = qml::makeDropdownItem(QStringLiteral("default"),
+                                           tr("%1 (Default)").arg(browser->fullyQualifiedName()),
+                                           qml::imageSourceFor(browser->iconUrl()));
     allApps.append(m_defaultEntry);
   }
 
   for (const auto &app : m_appDb->list()) {
     if (!app->displayable()) continue;
 
-    allApps.append(QVariantMap{
-        {QStringLiteral("id"), app->id()},
-        {QStringLiteral("displayName"), app->fullyQualifiedName()},
-        {QStringLiteral("iconSource"), qml::imageSourceFor(app->iconUrl())},
-    });
+    allApps.append(qml::makeDropdownItem(app->id(), app->fullyQualifiedName(),
+                                         qml::imageSourceFor(app->iconUrl())));
 
     for (const auto &action : app->actions()) {
-      allApps.append(QVariantMap{
-          {QStringLiteral("id"), action->id()},
-          {QStringLiteral("displayName"), action->fullyQualifiedName()},
-          {QStringLiteral("iconSource"), qml::imageSourceFor(action->iconUrl())},
-      });
+      allApps.append(qml::makeDropdownItem(action->id(), action->fullyQualifiedName(),
+                                           qml::imageSourceFor(action->iconUrl())));
     }
   }
 
-  QVariantMap section;
-  section[QStringLiteral("title")] = QString();
-  section[QStringLiteral("items")] = allApps;
-  m_items.append(section);
-
-  emit itemsChanged();
+  m_model.setItems(allApps);
 }
 
 void AppSelectorModel::select(const QVariantMap &item) {
@@ -63,42 +48,19 @@ void AppSelectorModel::selectById(const QString &id) {
     return;
   }
 
-  for (const auto &sectionVar : m_items) {
-    auto section = sectionVar.toMap();
-    auto items = section[QStringLiteral("items")].toList();
-    for (const auto &itemVar : items) {
-      auto item = itemVar.toMap();
-      if (item[QStringLiteral("id")].toString() == id) {
-        m_currentItem = item;
-        emit currentItemChanged();
-        return;
-      }
-    }
+  if (auto item = m_model.itemDataById(id); !item.isEmpty()) {
+    m_currentItem = item;
+    emit currentItemChanged();
   }
 }
 
 void AppSelectorModel::updateDefaultApp(const std::shared_ptr<AbstractApplication> &app) {
   if (!app) return;
 
-  m_defaultEntry = QVariantMap{
-      {QStringLiteral("id"), QStringLiteral("default")},
-      {QStringLiteral("displayName"), tr("%1 (Default)").arg(app->fullyQualifiedName())},
-      {QStringLiteral("iconSource"), qml::imageSourceFor(app->iconUrl())},
-  };
-
-  if (!m_items.isEmpty()) {
-    auto section = m_items[0].toMap();
-    auto items = section[QStringLiteral("items")].toList();
-    if (!items.isEmpty()) {
-      auto first = items[0].toMap();
-      if (first[QStringLiteral("id")].toString() == QStringLiteral("default")) {
-        items[0] = m_defaultEntry;
-        section[QStringLiteral("items")] = items;
-        m_items[0] = section;
-        emit itemsChanged();
-      }
-    }
-  }
+  m_defaultEntry =
+      qml::makeDropdownItem(QStringLiteral("default"), tr("%1 (Default)").arg(app->fullyQualifiedName()),
+                            qml::imageSourceFor(app->iconUrl()));
+  m_model.updateItem(m_defaultEntry);
 
   if (m_currentItem[QStringLiteral("id")].toString() == QStringLiteral("default")) {
     m_currentItem = m_defaultEntry;

--- a/src/server/src/qml/app-selector-model.cpp
+++ b/src/server/src/qml/app-selector-model.cpp
@@ -22,8 +22,8 @@ void AppSelectorModel::buildItems() {
   for (const auto &app : m_appDb->list()) {
     if (!app->displayable()) continue;
 
-    allApps.append(qml::makeDropdownItem(app->id(), app->fullyQualifiedName(),
-                                         qml::imageSourceFor(app->iconUrl())));
+    allApps.append(
+        qml::makeDropdownItem(app->id(), app->fullyQualifiedName(), qml::imageSourceFor(app->iconUrl())));
 
     for (const auto &action : app->actions()) {
       allApps.append(qml::makeDropdownItem(action->id(), action->fullyQualifiedName(),

--- a/src/server/src/qml/app-selector-model.hpp
+++ b/src/server/src/qml/app-selector-model.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "completion-model.hpp"
 #include <QObject>
 #include <QVariantList>
 #include <QVariantMap>
@@ -9,13 +10,13 @@ class AppService;
 
 class AppSelectorModel : public QObject {
   Q_OBJECT
-  Q_PROPERTY(QVariantList items READ items NOTIFY itemsChanged)
+  Q_PROPERTY(CompletionModel *model READ model CONSTANT)
   Q_PROPERTY(QVariantMap currentItem READ currentItem NOTIFY currentItemChanged)
 
 public:
   explicit AppSelectorModel(QObject *parent = nullptr);
 
-  QVariantList items() const { return m_items; }
+  CompletionModel *model() { return &m_model; }
   QVariantMap currentItem() const { return m_currentItem; }
 
   Q_INVOKABLE void select(const QVariantMap &item);
@@ -24,14 +25,13 @@ public:
   void updateDefaultApp(const std::shared_ptr<AbstractApplication> &app);
 
 signals:
-  void itemsChanged();
   void currentItemChanged();
 
 private:
   void buildItems();
 
   AppService *m_appDb = nullptr;
-  QVariantList m_items;
+  CompletionModel m_model{this};
   QVariantMap m_currentItem;
   QVariantMap m_defaultEntry;
 };

--- a/src/server/src/qml/clipboard-history-view-host.cpp
+++ b/src/server/src/qml/clipboard-history-view-host.cpp
@@ -68,7 +68,9 @@ static const std::unordered_map<QString, ClipboardOfferKind> savedFilterToKind{
 
 static const char *filterIndexToSavedValue[] = {"all", "text", "image", "link", "file"};
 
-ClipboardHistoryViewHost::ClipboardHistoryViewHost() : ViewHostBase() {}
+ClipboardHistoryViewHost::ClipboardHistoryViewHost() : ViewHostBase() {
+  m_kindFilterModel.setStringOptions({tr("All"), tr("Text"), tr("Images"), tr("Links"), tr("Files")});
+}
 
 QUrl ClipboardHistoryViewHost::qmlComponentUrl() const {
   return QUrl(QStringLiteral("qrc:/Vicinae/ClipboardHistoryView.qml"));

--- a/src/server/src/qml/clipboard-history-view-host.hpp
+++ b/src/server/src/qml/clipboard-history-view-host.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "clipboard-history-model.hpp"
 #include "bridge-view.hpp"
+#include "completion-model.hpp"
 #include "section-list-model.hpp"
 #include "services/clipboard/clipboard-db.hpp"
 #include "view-utils.hpp"
@@ -15,6 +16,7 @@ class ClipboardHistoryViewHost : public ViewHostBase {
   Q_PROPERTY(QString clipboardStatusText READ clipboardStatusText NOTIFY clipboardStatusChanged)
   Q_PROPERTY(QString clipboardStatusIcon READ clipboardStatusIcon NOTIFY clipboardStatusChanged)
   Q_PROPERTY(bool canToggleMonitoring READ canToggleMonitoring CONSTANT)
+  Q_PROPERTY(CompletionModel *kindFilterModel READ kindFilterModel CONSTANT)
   Q_PROPERTY(int currentKindFilter READ currentKindFilter NOTIFY currentKindFilterChanged)
   Q_PROPERTY(bool hasDetail READ hasDetail NOTIFY detailChanged)
   Q_PROPERTY(bool hasDetailError READ hasDetailError NOTIFY detailChanged)
@@ -44,6 +46,7 @@ public:
   Q_INVOKABLE void setKindFilter(int kind);
 
   QObject *listModel() const { return const_cast<SectionListModel *>(&m_model); }
+  CompletionModel *kindFilterModel() { return &m_kindFilterModel; }
   QString itemCountText() const { return m_itemCountText; }
   QString clipboardStatusText() const { return m_clipboardStatusText; }
   QString clipboardStatusIcon() const { return m_clipboardStatusIcon; }
@@ -76,6 +79,7 @@ private:
   std::optional<QString> getSavedDropdownFilter();
 
   SectionListModel m_model{this};
+  CompletionModel m_kindFilterModel{this};
   ClipboardHistorySection m_section;
   ClipboardHistoryController *m_controller = nullptr;
   ClipboardService *m_clipman = nullptr;

--- a/src/server/src/qml/completion-model.cpp
+++ b/src/server/src/qml/completion-model.cpp
@@ -65,6 +65,56 @@ void CompletionModel::setSections(const QVariantList &sections) {
   emit countChanged();
 }
 
+void CompletionModel::updateItem(const QVariantMap &item) {
+  const auto id = item.value(QStringLiteral("id")).toString();
+  if (id.isEmpty()) return;
+
+  for (int s = 0; std::cmp_less(s, m_sections.size()); ++s) {
+    auto &items = m_sections[s].items;
+    for (int i = 0; std::cmp_less(i, items.size()); ++i) {
+      if (items[i].data.value(QStringLiteral("id")).toString() != id) continue;
+
+      auto title = item.value(QStringLiteral("title")).toString();
+      if (title.isEmpty()) title = item.value(QStringLiteral("displayName")).toString();
+      items[i] = {
+          .title = title.toStdString(),
+          .iconSource = item.value(QStringLiteral("iconSource")).toString(),
+          .data = item,
+      };
+
+      for (int f = 0; std::cmp_less(f, m_flat.size()); ++f) {
+        const auto &fi = m_flat[f];
+        if (fi.kind == FlatItem::Entry && fi.sectionIdx == s && fi.itemIdx == i) {
+          const auto idx = index(f);
+          emit dataChanged(idx, idx);
+          break;
+        }
+      }
+      return;
+    }
+  }
+}
+
+QVariantMap CompletionModel::itemDataById(const QString &id) const {
+  for (const auto &section : m_sections) {
+    for (const auto &item : section.items) {
+      if (item.data.value(QStringLiteral("id")).toString() == id) return item.data;
+    }
+  }
+  return {};
+}
+
+void CompletionModel::setStringOptions(const QStringList &options) {
+  QVariantList items;
+  for (qsizetype i = 0; i < options.size(); ++i) {
+    items.append(QVariantMap{
+        {QStringLiteral("id"), QString::number(i)},
+        {QStringLiteral("displayName"), options[i]},
+    });
+  }
+  setItems(items);
+}
+
 void CompletionModel::setFilter(const QString &query) {
   auto q = query.toStdString();
   if (m_filterQuery == q) return;

--- a/src/server/src/qml/completion-model.hpp
+++ b/src/server/src/qml/completion-model.hpp
@@ -24,6 +24,10 @@ public:
 
   Q_INVOKABLE void setItems(const QVariantList &items);
   Q_INVOKABLE void setSections(const QVariantList &sections);
+  Q_INVOKABLE void updateItem(const QVariantMap &item);
+  Q_INVOKABLE QVariantMap itemDataById(const QString &id) const;
+
+  void setStringOptions(const QStringList &options);
   Q_INVOKABLE void setFilter(const QString &query);
   Q_INVOKABLE int nextSelectableIndex(int from, int direction) const;
   Q_INVOKABLE int indexOfItemId(const QString &id) const;

--- a/src/server/src/qml/create-extension-view-host.cpp
+++ b/src/server/src/qml/create-extension-view-host.cpp
@@ -1,5 +1,6 @@
 #include "create-extension-view-host.hpp"
 #include "create-extension-success-view-host.hpp"
+#include "view-utils.hpp"
 #include "navigation-controller.hpp"
 #include "service-registry.hpp"
 #include "services/extension-boilerplate-generator/extension-boilerplate-generator.hpp"
@@ -25,16 +26,9 @@ void CreateExtensionViewHost::initialize() {
   ExtensionBoilerplateGenerator const gen;
   QVariantList items;
   for (const auto &tmpl : gen.commandBoilerplates()) {
-    items.append(QVariantMap{
-        {QStringLiteral("id"), tmpl.resource},
-        {QStringLiteral("displayName"), tmpl.name},
-    });
+    items.append(qml::makeDropdownItem(tmpl.resource, tmpl.name));
   }
-
-  QVariantMap section;
-  section[QStringLiteral("title")] = QString();
-  section[QStringLiteral("items")] = items;
-  m_templateItems.append(section);
+  m_templateModel.setItems(items);
 
   if (!items.isEmpty()) { m_selectedTemplate = items.first().toMap(); }
 

--- a/src/server/src/qml/create-extension-view-host.hpp
+++ b/src/server/src/qml/create-extension-view-host.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "bridge-view.hpp"
+#include "completion-model.hpp"
 #include <QVariantList>
 #include <QVariantMap>
 
@@ -17,7 +18,7 @@ class CreateExtensionViewHost : public FormViewBase {
       QString commandDescription READ commandDescription WRITE setCommandDescription NOTIFY formChanged)
   Q_PROPERTY(QVariantMap selectedTemplate READ selectedTemplate NOTIFY formChanged)
 
-  Q_PROPERTY(QVariantList templateItems READ templateItems CONSTANT)
+  Q_PROPERTY(CompletionModel *templateModel READ templateModel CONSTANT)
 
   Q_PROPERTY(QString authorError READ authorError NOTIFY errorsChanged)
   Q_PROPERTY(QString titleError READ titleError NOTIFY errorsChanged)
@@ -44,7 +45,7 @@ public:
   QString commandDescription() const { return m_commandDescription; }
   QVariantMap selectedTemplate() const { return m_selectedTemplate; }
 
-  QVariantList templateItems() const { return m_templateItems; }
+  CompletionModel *templateModel() { return &m_templateModel; }
 
   QString authorError() const { return m_authorError; }
   QString titleError() const { return m_titleError; }
@@ -116,7 +117,7 @@ private:
   QString m_commandDescription;
   QVariantMap m_selectedTemplate;
 
-  QVariantList m_templateItems;
+  CompletionModel m_templateModel{this};
 
   QString m_authorError;
   QString m_titleError;

--- a/src/server/src/qml/emoji-grid-view-host.hpp
+++ b/src/server/src/qml/emoji-grid-view-host.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "bridge-view.hpp"
+#include "completion-model.hpp"
 #include "emoji-grid-model.hpp"
 #include "glyph/glyph.hpp"
 #include <QCoreApplication>
@@ -8,7 +9,7 @@
 class EmojiGridViewHost : public ViewHostBase {
   Q_OBJECT
   Q_PROPERTY(QObject *listModel READ listModel CONSTANT)
-  Q_PROPERTY(QStringList categoryFilterOptions READ categoryFilterOptions CONSTANT)
+  Q_PROPERTY(CompletionModel *categoryFilterModel READ categoryFilterModel CONSTANT)
   Q_PROPERTY(int currentCategoryFilter READ currentCategoryFilter NOTIFY currentCategoryFilterChanged)
 
 public:
@@ -26,6 +27,7 @@ public:
     m_model.setScope(ViewScope(context(), this));
     m_model.initialize();
     setSearchPlaceholderText(m_model.searchPlaceholder());
+    m_categoryFilterModel.setStringOptions(categoryFilterOptions());
     restoreCategoryFilter();
   }
 
@@ -36,14 +38,7 @@ public:
 
   QObject *listModel() const { return const_cast<EmojiGridModel *>(&m_model); }
 
-  QStringList categoryFilterOptions() const {
-    QStringList options{tr("All")};
-    for (const auto &section : glyph::sections()) {
-      const QByteArray label(section.label.data(), static_cast<qsizetype>(section.label.size()));
-      options.append(QCoreApplication::translate("emoji-categories", label.constData()));
-    }
-    return options;
-  }
+  CompletionModel *categoryFilterModel() { return &m_categoryFilterModel; }
 
   int currentCategoryFilter() const { return m_currentCategoryFilter; }
 
@@ -65,6 +60,15 @@ signals:
   void currentCategoryFilterChanged();
 
 private:
+  QStringList categoryFilterOptions() const {
+    QStringList options{tr("All")};
+    for (const auto &section : glyph::sections()) {
+      const QByteArray label(section.label.data(), static_cast<qsizetype>(section.label.size()));
+      options.append(QCoreApplication::translate("emoji-categories", label.constData()));
+    }
+    return options;
+  }
+
   static QString categoryKey(glyph::Category category) {
     const auto label = glyph::categoryLabel(category);
     return QString::fromUtf8(label.data(), label.size());
@@ -84,5 +88,6 @@ private:
   }
 
   EmojiGridModel m_model{this};
+  CompletionModel m_categoryFilterModel{this};
   int m_currentCategoryFilter = 0;
 };

--- a/src/server/src/qml/extension-form-model.cpp
+++ b/src/server/src/qml/extension-form-model.cpp
@@ -46,11 +46,11 @@ QVariant ExtensionFormModel::data(const QModelIndex &index, int role) const {
     return item.autoFocus;
   case FieldDataRole:
     return item.fieldData;
-  case OptionsModelRole:
-    return QVariant::fromValue(static_cast<QObject *>(item.optionsModel));
-  case CurrentOptionRole: {
-    if (!item.optionsModel) return {};
-    auto option = item.optionsModel->itemDataById(item.effectiveValue().toString());
+  case DropdownModelRole:
+    return QVariant::fromValue(static_cast<QObject *>(item.dropdownModel));
+  case CurrentDropdownItemRole: {
+    if (!item.dropdownModel) return {};
+    auto option = item.dropdownModel->itemDataById(item.effectiveValue().toString());
     return option.isEmpty() ? QVariant{} : QVariant(option);
   }
   default:
@@ -69,8 +69,8 @@ QHash<int, QByteArray> ExtensionFormModel::roleNames() const {
       {ValueRole, "value"},
       {AutoFocusRole, "autoFocus"},
       {FieldDataRole, "fieldData"},
-      {OptionsModelRole, "optionsModel"},
-      {CurrentOptionRole, "currentOption"},
+      {DropdownModelRole, "dropdownModel"},
+      {CurrentDropdownItemRole, "currentDropdownItem"},
   };
 }
 
@@ -82,7 +82,7 @@ void ExtensionFormModel::setFieldValue(int index, const QVariant &value) {
   item.userValue = QJsonValue::fromVariant(value);
   item.hasUserValue = true;
   ++item.eventCount;
-  emit dataChanged(createIndex(index, 0), createIndex(index, 0), {ValueRole, CurrentOptionRole});
+  emit dataChanged(createIndex(index, 0), createIndex(index, 0), {ValueRole, CurrentDropdownItemRole});
 
   if (item.onChange) {
     m_notify(toQ(*item.onChange), QJsonArray{item.userValue, static_cast<int>(item.eventCount)});
@@ -159,7 +159,7 @@ void ExtensionFormModel::setFormData(const FormModel &model) {
   if (oldCount > newCount) {
     beginRemoveRows({}, newCount, oldCount - 1);
     for (int i = newCount; i < oldCount; ++i) {
-      if (m_items[i].optionsModel) m_items[i].optionsModel->deleteLater();
+      if (m_items[i].dropdownModel) m_items[i].dropdownModel->deleteLater();
     }
     m_items.resize(newCount);
     endRemoveRows();
@@ -186,7 +186,7 @@ void ExtensionFormModel::setFormData(const FormModel &model) {
           newData.hasUserValue = true;
         }
       }
-      if (m_items[i].optionsModel) m_items[i].optionsModel->deleteLater();
+      if (m_items[i].dropdownModel) m_items[i].dropdownModel->deleteLater();
       m_items[i] = std::move(newData);
     } else {
       updateItem(m_items[i], newItem);
@@ -264,8 +264,8 @@ ExtensionFormModel::FormItemData ExtensionFormModel::createItem(const FormModel:
 
     if (auto *dd = std::get_if<FormModel::DropdownField>(fieldPtr)) {
       data.dropdownItems = qml::convertDropdownChildren(dd->items);
-      data.optionsModel = new CompletionModel(this);
-      data.optionsModel->setSections(data.dropdownItems);
+      data.dropdownModel = new CompletionModel(this);
+      data.dropdownModel->setSections(data.dropdownItems);
     }
 
     if (base.value) {
@@ -296,11 +296,11 @@ void ExtensionFormModel::updateItem(FormItemData &existing, const FormModel::Ite
     existing.fieldData = buildFieldData(*fieldPtr);
 
     if (auto *dd = std::get_if<FormModel::DropdownField>(fieldPtr);
-        dd && existing.type == FormItemData::Type::Dropdown && existing.optionsModel) {
+        dd && existing.type == FormItemData::Type::Dropdown && existing.dropdownModel) {
       auto items = qml::convertDropdownChildren(dd->items);
       if (items != existing.dropdownItems) {
         existing.dropdownItems = std::move(items);
-        existing.optionsModel->setSections(existing.dropdownItems);
+        existing.dropdownModel->setSections(existing.dropdownItems);
       }
     }
 

--- a/src/server/src/qml/extension-form-model.cpp
+++ b/src/server/src/qml/extension-form-model.cpp
@@ -46,6 +46,13 @@ QVariant ExtensionFormModel::data(const QModelIndex &index, int role) const {
     return item.autoFocus;
   case FieldDataRole:
     return item.fieldData;
+  case OptionsModelRole:
+    return QVariant::fromValue(static_cast<QObject *>(item.optionsModel));
+  case CurrentOptionRole: {
+    if (!item.optionsModel) return {};
+    auto option = item.optionsModel->itemDataById(item.effectiveValue().toString());
+    return option.isEmpty() ? QVariant{} : QVariant(option);
+  }
   default:
     return {};
   }
@@ -56,6 +63,7 @@ QHash<int, QByteArray> ExtensionFormModel::roleNames() const {
       {TypeRole, "type"},   {FieldIdRole, "fieldId"},     {LabelRole, "label"},
       {ErrorRole, "error"}, {InfoRole, "info"},           {PlaceholderRole, "placeholder"},
       {ValueRole, "value"}, {AutoFocusRole, "autoFocus"}, {FieldDataRole, "fieldData"},
+      {OptionsModelRole, "optionsModel"}, {CurrentOptionRole, "currentOption"},
   };
 }
 
@@ -67,7 +75,7 @@ void ExtensionFormModel::setFieldValue(int index, const QVariant &value) {
   item.userValue = QJsonValue::fromVariant(value);
   item.hasUserValue = true;
   ++item.eventCount;
-  emit dataChanged(createIndex(index, 0), createIndex(index, 0), {ValueRole});
+  emit dataChanged(createIndex(index, 0), createIndex(index, 0), {ValueRole, CurrentOptionRole});
 
   if (item.onChange) {
     m_notify(toQ(*item.onChange), QJsonArray{item.userValue, static_cast<int>(item.eventCount)});
@@ -143,16 +151,27 @@ void ExtensionFormModel::setFormData(const FormModel &model) {
 
   if (oldCount > newCount) {
     beginRemoveRows({}, newCount, oldCount - 1);
+    for (int i = newCount; i < oldCount; ++i) {
+      if (m_items[i].optionsModel) m_items[i].optionsModel->deleteLater();
+    }
     m_items.resize(newCount);
     endRemoveRows();
   }
 
   int const updateCount = std::min(oldCount, newCount);
   for (int i = 0; i < updateCount; ++i) {
-    updateItem(m_items[i], model.items[i]);
+    const auto &newItem = model.items[i];
+    auto newType = FormItemData::Type::Separator;
+    QString newFieldId;
+    if (auto *fieldPtr = std::get_if<FormModel::Field>(&newItem)) {
+      newType = fieldType(*fieldPtr);
+      newFieldId = toQ(getBase(*fieldPtr).id);
+    } else if (std::holds_alternative<FormModel::Description>(newItem)) {
+      newType = FormItemData::Type::Description;
+    }
 
-    auto newData = createItem(model.items[i]);
-    if (m_items[i].type != newData.type || m_items[i].fieldId != newData.fieldId) {
+    if (m_items[i].type != newType || m_items[i].fieldId != newFieldId) {
+      auto newData = createItem(newItem);
       if (newData.isField() && !newData.hasUserValue) {
         auto it = savedValues.find(newData.fieldId);
         if (it != savedValues.end()) {
@@ -160,7 +179,10 @@ void ExtensionFormModel::setFormData(const FormModel &model) {
           newData.hasUserValue = true;
         }
       }
+      if (m_items[i].optionsModel) m_items[i].optionsModel->deleteLater();
       m_items[i] = std::move(newData);
+    } else {
+      updateItem(m_items[i], newItem);
     }
   }
   if (updateCount > 0) { emit dataChanged(createIndex(0, 0), createIndex(updateCount - 1, 0)); }
@@ -207,7 +229,7 @@ const FormModel::FieldBase &ExtensionFormModel::getBase(const FormModel::Field &
   return std::visit([](const auto &f) -> const FormModel::FieldBase & { return f.base; }, field);
 }
 
-ExtensionFormModel::FormItemData ExtensionFormModel::createItem(const FormModel::Item &item) const {
+ExtensionFormModel::FormItemData ExtensionFormModel::createItem(const FormModel::Item &item) {
   FormItemData data{};
 
   if (auto *fieldPtr = std::get_if<FormModel::Field>(&item)) {
@@ -232,6 +254,12 @@ ExtensionFormModel::FormItemData ExtensionFormModel::createItem(const FormModel:
                                       [](const auto &) { return QString(); },
                                   },
                                   *fieldPtr);
+
+    if (auto *dd = std::get_if<FormModel::DropdownField>(fieldPtr)) {
+      data.dropdownItems = qml::convertDropdownChildren(dd->items);
+      data.optionsModel = new CompletionModel(this);
+      data.optionsModel->setSections(data.dropdownItems);
+    }
 
     if (base.value) {
       data.modelValue = base.value->value;
@@ -259,6 +287,15 @@ void ExtensionFormModel::updateItem(FormItemData &existing, const FormModel::Ite
     existing.onBlur = base.onBlur;
     existing.onFocus = base.onFocus;
     existing.fieldData = buildFieldData(*fieldPtr);
+
+    if (auto *dd = std::get_if<FormModel::DropdownField>(fieldPtr);
+        dd && existing.type == FormItemData::Type::Dropdown && existing.optionsModel) {
+      auto items = qml::convertDropdownChildren(dd->items);
+      if (items != existing.dropdownItems) {
+        existing.dropdownItems = std::move(items);
+        existing.optionsModel->setSections(existing.dropdownItems);
+      }
+    }
 
     existing.placeholder =
         std::visit(overloaded{
@@ -302,7 +339,6 @@ QVariantMap ExtensionFormModel::buildFieldData(const FormModel::Field &field) {
                    if (f.label) data["label"] = toQ(*f.label);
                  },
                  [&](const FormModel::DropdownField &f) {
-                   data["items"] = qml::convertDropdownChildren(f.items);
                    data["isLoading"] = f.isLoading;
                    data["filtering"] = f.filtering;
                    data["hasRemoteSearch"] = f.onSearchTextChange.has_value();

--- a/src/server/src/qml/extension-form-model.cpp
+++ b/src/server/src/qml/extension-form-model.cpp
@@ -60,10 +60,17 @@ QVariant ExtensionFormModel::data(const QModelIndex &index, int role) const {
 
 QHash<int, QByteArray> ExtensionFormModel::roleNames() const {
   return {
-      {TypeRole, "type"},   {FieldIdRole, "fieldId"},     {LabelRole, "label"},
-      {ErrorRole, "error"}, {InfoRole, "info"},           {PlaceholderRole, "placeholder"},
-      {ValueRole, "value"}, {AutoFocusRole, "autoFocus"}, {FieldDataRole, "fieldData"},
-      {OptionsModelRole, "optionsModel"}, {CurrentOptionRole, "currentOption"},
+      {TypeRole, "type"},
+      {FieldIdRole, "fieldId"},
+      {LabelRole, "label"},
+      {ErrorRole, "error"},
+      {InfoRole, "info"},
+      {PlaceholderRole, "placeholder"},
+      {ValueRole, "value"},
+      {AutoFocusRole, "autoFocus"},
+      {FieldDataRole, "fieldData"},
+      {OptionsModelRole, "optionsModel"},
+      {CurrentOptionRole, "currentOption"},
   };
 }
 

--- a/src/server/src/qml/extension-form-model.hpp
+++ b/src/server/src/qml/extension-form-model.hpp
@@ -29,8 +29,8 @@ public:
     ValueRole,
     AutoFocusRole,
     FieldDataRole,
-    OptionsModelRole,
-    CurrentOptionRole,
+    DropdownModelRole,
+    CurrentDropdownItemRole,
   };
 
   explicit ExtensionFormModel(NotifyFn notify, QObject *parent = nullptr);
@@ -85,7 +85,7 @@ private:
 
     QVariantMap fieldData;
     QVariantList dropdownItems;
-    CompletionModel *optionsModel = nullptr;
+    CompletionModel *dropdownModel = nullptr;
 
     QJsonValue effectiveValue() const { return hasUserValue ? userValue : modelValue; }
     QString typeString() const;

--- a/src/server/src/qml/extension-form-model.hpp
+++ b/src/server/src/qml/extension-form-model.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "completion-model.hpp"
 #include "extend/form-model.hpp"
 #include "services/file-chooser/abstract-file-chooser.hpp"
 #include <QAbstractListModel>
@@ -28,6 +29,8 @@ public:
     ValueRole,
     AutoFocusRole,
     FieldDataRole,
+    OptionsModelRole,
+    CurrentOptionRole,
   };
 
   explicit ExtensionFormModel(NotifyFn notify, QObject *parent = nullptr);
@@ -81,13 +84,15 @@ private:
     std::optional<std::string> onFocus;
 
     QVariantMap fieldData;
+    QVariantList dropdownItems;
+    CompletionModel *optionsModel = nullptr;
 
     QJsonValue effectiveValue() const { return hasUserValue ? userValue : modelValue; }
     QString typeString() const;
     bool isField() const { return type != Type::Description && type != Type::Separator; }
   };
 
-  FormItemData createItem(const FormModel::Item &item) const;
+  FormItemData createItem(const FormModel::Item &item);
   void updateItem(FormItemData &existing, const FormModel::Item &newItem);
 
   static FormItemData::Type fieldType(const FormModel::Field &field);

--- a/src/server/src/qml/extension-view-host.cpp
+++ b/src/server/src/qml/extension-view-host.cpp
@@ -17,7 +17,8 @@ QUrl ExtensionViewHost::qmlComponentUrl() const {
 }
 
 QUrl ExtensionViewHost::qmlSearchAccessoryUrl() const {
-  if (!m_dropdownItems.isEmpty()) return QUrl(QStringLiteral("qrc:/Vicinae/ExtensionDropdownAccessory.qml"));
+  if (m_dropdownModel.rowCount() > 0)
+    return QUrl(QStringLiteral("qrc:/Vicinae/ExtensionDropdownAccessory.qml"));
   if (!m_linkAccessoryText.isEmpty()) return QUrl(QStringLiteral("qrc:/Vicinae/FormLinkAccessory.qml"));
   return {};
 }
@@ -376,11 +377,11 @@ void ExtensionViewHost::renderForm(const FormModel &model) {
 }
 
 void ExtensionViewHost::updateDropdown(const DropdownModel *dropdown) {
-  bool const hadDropdown = !m_dropdownItems.isEmpty();
+  bool const hadDropdown = m_dropdownModel.rowCount() > 0;
 
   if (!dropdown) {
     if (hadDropdown) {
-      m_dropdownItems.clear();
+      m_dropdownModel.setSections({});
       m_dropdownCurrentItem.clear();
       m_dropdownPlaceholder.clear();
       m_dropdownOnChange.reset();
@@ -393,7 +394,7 @@ void ExtensionViewHost::updateDropdown(const DropdownModel *dropdown) {
   m_dropdownOnChange = dropdown->onChange;
   m_dropdownPlaceholder = dropdown->placeholder ? QString::fromStdString(*dropdown->placeholder) : QString();
 
-  if (dropdown->dirty) { m_dropdownItems = qml::convertDropdownChildren(dropdown->children); }
+  if (dropdown->dirty) { m_dropdownModel.setSections(qml::convertDropdownChildren(dropdown->children)); }
 
   QString resolvedValue;
   if (dropdown->value) {
@@ -409,23 +410,11 @@ void ExtensionViewHost::updateDropdown(const DropdownModel *dropdown) {
 
   m_dropdownValue = resolvedValue;
 
-  QVariant newCurrentItem;
-  for (const auto &section : m_dropdownItems) {
-    auto sectionMap = section.toMap();
-    auto items = sectionMap["items"].toList();
-    for (const auto &item : items) {
-      auto itemMap = item.toMap();
-      if (itemMap["id"].toString() == resolvedValue) {
-        newCurrentItem = item;
-        break;
-      }
-    }
-    if (newCurrentItem.isValid()) break;
-  }
-  m_dropdownCurrentItem = newCurrentItem;
+  auto newCurrentItem = m_dropdownModel.itemDataById(resolvedValue);
+  m_dropdownCurrentItem = newCurrentItem.isEmpty() ? QVariant{} : QVariant(newCurrentItem);
 
   emit dropdownChanged();
-  if (hadDropdown != !m_dropdownItems.isEmpty()) { emit searchAccessoryUrlChanged(); }
+  if (hadDropdown != (m_dropdownModel.rowCount() > 0)) { emit searchAccessoryUrlChanged(); }
 
   if (!hadDropdown && !resolvedValue.isEmpty() && m_dropdownOnChange) {
     notifyExtension(QString::fromStdString(*m_dropdownOnChange), {resolvedValue});
@@ -435,19 +424,12 @@ void ExtensionViewHost::updateDropdown(const DropdownModel *dropdown) {
 void ExtensionViewHost::setDropdownValue(const QString &value) {
   m_dropdownValue = value;
 
-  for (const auto &section : m_dropdownItems) {
-    auto sectionMap = section.toMap();
-    auto items = sectionMap["items"].toList();
-    for (const auto &item : items) {
-      auto itemMap = item.toMap();
-      if (itemMap["id"].toString() == value) {
-        m_dropdownCurrentItem = item;
-        emit dropdownChanged();
-        if (m_dropdownOnChange) { notifyExtension(QString::fromStdString(*m_dropdownOnChange), {value}); }
-        return;
-      }
-    }
-  }
+  auto item = m_dropdownModel.itemDataById(value);
+  if (item.isEmpty()) return;
+
+  m_dropdownCurrentItem = item;
+  emit dropdownChanged();
+  if (m_dropdownOnChange) { notifyExtension(QString::fromStdString(*m_dropdownOnChange), {value}); }
 }
 
 void ExtensionViewHost::notifyExtension(const QString &handler, const QJsonArray &args) {

--- a/src/server/src/qml/extension-view-host.hpp
+++ b/src/server/src/qml/extension-view-host.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "completion-model.hpp"
 #include "extend/model-parser.hpp"
 #include "extend/pagination-model.hpp"
 #include "extension/extension-action-panel-builder.hpp"
@@ -21,7 +22,7 @@ class ExtensionViewHost : public ViewHostBase {
   Q_PROPERTY(bool suppressEmptyView READ suppressEmptyView NOTIFY suppressEmptyViewChanged)
   Q_PROPERTY(QString linkAccessoryText READ linkAccessoryText NOTIFY linkAccessoryChanged)
   Q_PROPERTY(QString linkAccessoryHref READ linkAccessoryHref NOTIFY linkAccessoryChanged)
-  Q_PROPERTY(QVariantList dropdownItems READ dropdownItems NOTIFY dropdownChanged)
+  Q_PROPERTY(CompletionModel *dropdownModel READ dropdownModel CONSTANT)
   Q_PROPERTY(QVariant dropdownCurrentItem READ dropdownCurrentItem NOTIFY dropdownChanged)
   Q_PROPERTY(QString dropdownPlaceholder READ dropdownPlaceholder NOTIFY dropdownChanged)
   Q_PROPERTY(bool hasMorePages READ hasMorePages NOTIFY paginationChanged)
@@ -51,7 +52,7 @@ public:
   bool suppressEmptyView() const { return m_isLoading && !m_hasSearchText; }
   QString linkAccessoryText() const;
   QString linkAccessoryHref() const;
-  QVariantList dropdownItems() const { return m_dropdownItems; }
+  CompletionModel *dropdownModel() { return &m_dropdownModel; }
   QVariant dropdownCurrentItem() const { return m_dropdownCurrentItem; }
   QString dropdownPlaceholder() const { return m_dropdownPlaceholder; }
 
@@ -117,7 +118,7 @@ private:
   QString m_linkAccessoryText;
   QString m_linkAccessoryHref;
 
-  QVariantList m_dropdownItems;
+  CompletionModel m_dropdownModel{this};
   QVariant m_dropdownCurrentItem;
   QString m_dropdownValue;
   QString m_dropdownPlaceholder;

--- a/src/server/src/qml/font-browser-view-host.hpp
+++ b/src/server/src/qml/font-browser-view-host.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "bridge-view.hpp"
+#include "completion-model.hpp"
 #include "font-grid-model.hpp"
 #include "view-scope.hpp"
 #include <QCoreApplication>
@@ -7,7 +8,7 @@
 
 class FontBrowserViewHost : public ViewHostBase {
   Q_OBJECT
-  Q_PROPERTY(QStringList categoryFilterOptions READ categoryFilterOptions CONSTANT)
+  Q_PROPERTY(CompletionModel *categoryFilterModel READ categoryFilterModel CONSTANT)
   Q_PROPERTY(int currentCategoryFilter READ currentCategoryFilter NOTIFY currentCategoryFilterChanged)
 
 signals:
@@ -28,19 +29,14 @@ public:
     m_model.setScope(ViewScope(context(), this));
     m_model.initialize();
     setSearchPlaceholderText(m_model.searchPlaceholder());
+    m_categoryFilterModel.setStringOptions(categoryFilterOptions());
     restoreCategoryFilter();
   }
 
   void textChanged(const QString &text) override { m_model.setFilter(text); }
   void loadInitialData() override { m_model.setFilter(searchText()); }
 
-  QStringList categoryFilterOptions() const {
-    QStringList options{tr("All")};
-    for (const auto &name : m_model.categoryNames()) {
-      options << QCoreApplication::translate("font-categories", qPrintable(name));
-    }
-    return options;
-  }
+  CompletionModel *categoryFilterModel() { return &m_categoryFilterModel; }
 
   int currentCategoryFilter() const { return m_currentCategoryFilter; }
 
@@ -56,6 +52,14 @@ public:
   }
 
 private:
+  QStringList categoryFilterOptions() const {
+    QStringList options{tr("All")};
+    for (const auto &name : m_model.categoryNames()) {
+      options << QCoreApplication::translate("font-categories", qPrintable(name));
+    }
+    return options;
+  }
+
   QStringList categoryFilterKeys() const {
     QStringList keys{QStringLiteral("All")};
     keys << m_model.categoryNames();
@@ -70,5 +74,6 @@ private:
   }
 
   FontGridModel m_model{this};
+  CompletionModel m_categoryFilterModel{this};
   int m_currentCategoryFilter = 0;
 };

--- a/src/server/src/qml/general-settings-model.cpp
+++ b/src/server/src/qml/general-settings-model.cpp
@@ -16,8 +16,28 @@
 #include <QLocale>
 
 GeneralSettingsModel::GeneralSettingsModel(QObject *parent) : QObject(parent) {
-  connect(ServiceRegistry::instance()->config(), &config::Manager::configChanged, this,
-          &GeneralSettingsModel::configChanged);
+  m_windowMaterialModel.setSections(windowMaterialItems());
+  m_fontModel.setSections(fontItems());
+  m_faviconServiceModel.setSections(faviconServiceItems());
+  m_keybindingSchemeModel.setSections(keybindingSchemeItems());
+  m_languageModel.setSections(languageItems());
+  refreshDynamicModels();
+
+  connect(ServiceRegistry::instance()->config(), &config::Manager::configChanged, this, [this]() {
+    refreshDynamicModels();
+    emit configChanged();
+  });
+}
+
+void GeneralSettingsModel::refreshDynamicModels() {
+  if (auto items = themeItems(); items != m_themeItems) {
+    m_themeItems = items;
+    m_themeModel.setSections(items);
+  }
+  if (auto items = iconThemeItems(); items != m_iconThemeItems) {
+    m_iconThemeItems = items;
+    m_iconThemeModel.setSections(items);
+  }
 }
 
 const config::ConfigValue &GeneralSettingsModel::cfg() const {
@@ -155,14 +175,7 @@ void GeneralSettingsModel::setFontSize(const QString &v) {
   if (ok) cfgManager().mergeWithUser({.font = config::Partial<config::FontConfig>{.normal{.size = val}}});
 }
 
-static QVariantMap makeDropdownItem(const QString &id, const QString &displayName,
-                                    const QString &iconSource = {}) {
-  QVariantMap m;
-  m[QStringLiteral("id")] = id;
-  m[QStringLiteral("displayName")] = displayName;
-  if (!iconSource.isEmpty()) m[QStringLiteral("iconSource")] = iconSource;
-  return m;
-}
+using qml::makeDropdownItem;
 
 static QVariantList wrapSection(const QString &title, const QVariantList &items) {
   QVariantMap section;
@@ -213,14 +226,11 @@ QVariant GeneralSettingsModel::currentTheme() const {
 }
 
 QVariantList GeneralSettingsModel::fontItems() const {
-  if (m_fontItems.isEmpty()) {
-    QVariantList items;
-    for (const auto &family : ServiceRegistry::instance()->fontService()->families()) {
-      items.append(makeDropdownItem(family, family));
-    }
-    m_fontItems = wrapSection(tr("Fonts"), items);
+  QVariantList items;
+  for (const auto &family : ServiceRegistry::instance()->fontService()->families()) {
+    items.append(makeDropdownItem(family, family));
   }
-  return m_fontItems;
+  return wrapSection(tr("Fonts"), items);
 }
 
 QVariant GeneralSettingsModel::currentFont() const {

--- a/src/server/src/qml/general-settings-model.hpp
+++ b/src/server/src/qml/general-settings-model.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "completion-model.hpp"
 #include "config/config.hpp"
 #include "service-registry.hpp"
 #include <QObject>
@@ -32,14 +33,14 @@ class GeneralSettingsModel : public QObject {
   Q_PROPERTY(
       bool nativeTextRendering READ nativeTextRendering WRITE setNativeTextRendering NOTIFY configChanged)
   Q_PROPERTY(QString fontSize READ fontSize WRITE setFontSize NOTIFY configChanged)
-  Q_PROPERTY(QVariantList windowMaterialItems READ windowMaterialItems CONSTANT)
+  Q_PROPERTY(CompletionModel *windowMaterialModel READ windowMaterialModel CONSTANT)
   Q_PROPERTY(QVariant currentWindowMaterial READ currentWindowMaterial NOTIFY configChanged)
-  Q_PROPERTY(QVariantList themeItems READ themeItems NOTIFY configChanged)
-  Q_PROPERTY(QVariantList fontItems READ fontItems CONSTANT)
-  Q_PROPERTY(QVariantList iconThemeItems READ iconThemeItems NOTIFY configChanged)
-  Q_PROPERTY(QVariantList faviconServiceItems READ faviconServiceItems NOTIFY configChanged)
-  Q_PROPERTY(QVariantList keybindingSchemeItems READ keybindingSchemeItems NOTIFY configChanged)
-  Q_PROPERTY(QVariantList languageItems READ languageItems CONSTANT)
+  Q_PROPERTY(CompletionModel *themeModel READ themeModel CONSTANT)
+  Q_PROPERTY(CompletionModel *fontModel READ fontModel CONSTANT)
+  Q_PROPERTY(CompletionModel *iconThemeModel READ iconThemeModel CONSTANT)
+  Q_PROPERTY(CompletionModel *faviconServiceModel READ faviconServiceModel CONSTANT)
+  Q_PROPERTY(CompletionModel *keybindingSchemeModel READ keybindingSchemeModel CONSTANT)
+  Q_PROPERTY(CompletionModel *languageModel READ languageModel CONSTANT)
   Q_PROPERTY(QVariant currentLanguage READ currentLanguage NOTIFY configChanged)
   Q_PROPERTY(QVariant currentTheme READ currentTheme NOTIFY configChanged)
   Q_PROPERTY(QVariant currentFont READ currentFont NOTIFY configChanged)
@@ -95,16 +96,17 @@ public:
   QString fontSize() const;
   void setFontSize(const QString &v);
 
-  QVariantList windowMaterialItems() const;
+  CompletionModel *windowMaterialModel() { return &m_windowMaterialModel; }
+  CompletionModel *themeModel() { return &m_themeModel; }
+  CompletionModel *fontModel() { return &m_fontModel; }
+  CompletionModel *iconThemeModel() { return &m_iconThemeModel; }
+  CompletionModel *faviconServiceModel() { return &m_faviconServiceModel; }
+  CompletionModel *keybindingSchemeModel() { return &m_keybindingSchemeModel; }
+  CompletionModel *languageModel() { return &m_languageModel; }
+
   QVariant currentWindowMaterial() const;
   Q_INVOKABLE void selectWindowMaterial(const QString &id);
 
-  QVariantList themeItems() const;
-  QVariantList fontItems() const;
-  QVariantList iconThemeItems() const;
-  QVariantList faviconServiceItems() const;
-  QVariantList keybindingSchemeItems() const;
-  QVariantList languageItems() const;
   QVariant currentLanguage() const;
   QVariant currentTheme() const;
   QVariant currentFont() const;
@@ -126,5 +128,22 @@ private:
   const config::ConfigValue &cfg() const;
   config::Manager &cfgManager() const;
 
-  mutable QVariantList m_fontItems;
+  QVariantList windowMaterialItems() const;
+  QVariantList themeItems() const;
+  QVariantList fontItems() const;
+  QVariantList iconThemeItems() const;
+  QVariantList faviconServiceItems() const;
+  QVariantList keybindingSchemeItems() const;
+  QVariantList languageItems() const;
+  void refreshDynamicModels();
+
+  CompletionModel m_windowMaterialModel{this};
+  CompletionModel m_themeModel{this};
+  CompletionModel m_fontModel{this};
+  CompletionModel m_iconThemeModel{this};
+  CompletionModel m_faviconServiceModel{this};
+  CompletionModel m_keybindingSchemeModel{this};
+  CompletionModel m_languageModel{this};
+  QVariantList m_themeItems;
+  QVariantList m_iconThemeItems;
 };

--- a/src/server/src/qml/missing-preference-view-host.cpp
+++ b/src/server/src/qml/missing-preference-view-host.cpp
@@ -38,10 +38,9 @@ static QVariantList dropdownOptions(const Preference &p) {
   if (auto *dd = std::get_if<Preference::DropdownData>(&d)) {
     QVariantList items;
     for (const auto &opt : dd->options) {
-      items.append(
-          QVariantMap{{QStringLiteral("id"), opt.value}, {QStringLiteral("displayName"), opt.title}});
+      items.append(qml::makeDropdownItem(opt.value, opt.title));
     }
-    return {QVariantMap{{QStringLiteral("title"), QString()}, {QStringLiteral("items"), items}}};
+    return items;
   }
   return {};
 }
@@ -91,8 +90,13 @@ QVariant MissingPreferenceFormModel::data(const QModelIndex &index, int role) co
     return f.placeholder;
   case ValueRole:
     return f.value;
-  case OptionsRole:
-    return f.options;
+  case OptionsModelRole:
+    return QVariant::fromValue(static_cast<QObject *>(f.optionsModel));
+  case CurrentOptionRole: {
+    if (!f.optionsModel) return {};
+    auto option = f.optionsModel->itemDataById(f.value.toString());
+    return option.isEmpty() ? QVariant{} : QVariant(option);
+  }
   case ReadOnlyRole:
     return false;
   case MultipleRole:
@@ -114,7 +118,8 @@ QHash<int, QByteArray> MissingPreferenceFormModel::roleNames() const {
           {DescriptionRole, "description"},
           {PlaceholderRole, "placeholder"},
           {ValueRole, "value"},
-          {OptionsRole, "options"},
+          {OptionsModelRole, "optionsModel"},
+          {CurrentOptionRole, "currentOption"},
           {ReadOnlyRole, "readOnly"},
           {MultipleRole, "multiple"},
           {CanChooseFilesRole, "canChooseFiles"},
@@ -124,6 +129,9 @@ QHash<int, QByteArray> MissingPreferenceFormModel::roleNames() const {
 void MissingPreferenceFormModel::load(const std::vector<Preference> &preferences,
                                       const QJsonObject &existingValues) {
   beginResetModel();
+  for (const auto &f : m_fields) {
+    if (f.optionsModel) f.optionsModel->deleteLater();
+  }
   m_fields.clear();
   m_values = QJsonObject{};
 
@@ -142,7 +150,10 @@ void MissingPreferenceFormModel::load(const std::vector<Preference> &preferences
     f.checkboxLabel = checkboxLabel(pref);
     f.description = pref.description();
     f.placeholder = pref.placeholder();
-    f.options = dropdownOptions(pref);
+    if (auto options = dropdownOptions(pref); !options.isEmpty()) {
+      f.optionsModel = new CompletionModel(this);
+      f.optionsModel->setItems(options);
+    }
     applyPickerFlags(pref, f.multiple, f.canChooseFiles, f.canChooseDirectories);
 
     if (f.type == QStringLiteral("checkbox")) {
@@ -160,7 +171,7 @@ void MissingPreferenceFormModel::setFieldValue(int row, const QVariant &value) {
   m_fields[row].value = value;
   m_values[m_fields[row].id] = QJsonValue::fromVariant(value);
   auto idx = index(row);
-  emit dataChanged(idx, idx, {ValueRole});
+  emit dataChanged(idx, idx, {ValueRole, CurrentOptionRole});
 }
 
 static bool isEmptyPreferenceValue(const QJsonValue &v) {

--- a/src/server/src/qml/missing-preference-view-host.cpp
+++ b/src/server/src/qml/missing-preference-view-host.cpp
@@ -90,11 +90,11 @@ QVariant MissingPreferenceFormModel::data(const QModelIndex &index, int role) co
     return f.placeholder;
   case ValueRole:
     return f.value;
-  case OptionsModelRole:
-    return QVariant::fromValue(static_cast<QObject *>(f.optionsModel));
-  case CurrentOptionRole: {
-    if (!f.optionsModel) return {};
-    auto option = f.optionsModel->itemDataById(f.value.toString());
+  case DropdownModelRole:
+    return QVariant::fromValue(static_cast<QObject *>(f.dropdownModel));
+  case CurrentDropdownItemRole: {
+    if (!f.dropdownModel) return {};
+    auto option = f.dropdownModel->itemDataById(f.value.toString());
     return option.isEmpty() ? QVariant{} : QVariant(option);
   }
   case ReadOnlyRole:
@@ -118,8 +118,8 @@ QHash<int, QByteArray> MissingPreferenceFormModel::roleNames() const {
           {DescriptionRole, "description"},
           {PlaceholderRole, "placeholder"},
           {ValueRole, "value"},
-          {OptionsModelRole, "optionsModel"},
-          {CurrentOptionRole, "currentOption"},
+          {DropdownModelRole, "dropdownModel"},
+          {CurrentDropdownItemRole, "currentDropdownItem"},
           {ReadOnlyRole, "readOnly"},
           {MultipleRole, "multiple"},
           {CanChooseFilesRole, "canChooseFiles"},
@@ -130,7 +130,7 @@ void MissingPreferenceFormModel::load(const std::vector<Preference> &preferences
                                       const QJsonObject &existingValues) {
   beginResetModel();
   for (const auto &f : m_fields) {
-    if (f.optionsModel) f.optionsModel->deleteLater();
+    if (f.dropdownModel) f.dropdownModel->deleteLater();
   }
   m_fields.clear();
   m_values = QJsonObject{};
@@ -151,8 +151,8 @@ void MissingPreferenceFormModel::load(const std::vector<Preference> &preferences
     f.description = pref.description();
     f.placeholder = pref.placeholder();
     if (auto options = dropdownOptions(pref); !options.isEmpty()) {
-      f.optionsModel = new CompletionModel(this);
-      f.optionsModel->setItems(options);
+      f.dropdownModel = new CompletionModel(this);
+      f.dropdownModel->setItems(options);
     }
     applyPickerFlags(pref, f.multiple, f.canChooseFiles, f.canChooseDirectories);
 
@@ -171,7 +171,7 @@ void MissingPreferenceFormModel::setFieldValue(int row, const QVariant &value) {
   m_fields[row].value = value;
   m_values[m_fields[row].id] = QJsonValue::fromVariant(value);
   auto idx = index(row);
-  emit dataChanged(idx, idx, {ValueRole, CurrentOptionRole});
+  emit dataChanged(idx, idx, {ValueRole, CurrentDropdownItemRole});
 }
 
 static bool isEmptyPreferenceValue(const QJsonValue &v) {

--- a/src/server/src/qml/missing-preference-view-host.hpp
+++ b/src/server/src/qml/missing-preference-view-host.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "common/entrypoint.hpp"
+#include "completion-model.hpp"
 #include "preference.hpp"
 #include "bridge-view.hpp"
 #include <QAbstractListModel>
@@ -21,7 +22,8 @@ public:
     DescriptionRole,
     PlaceholderRole,
     ValueRole,
-    OptionsRole,
+    OptionsModelRole,
+    CurrentOptionRole,
     ReadOnlyRole,
     MultipleRole,
     CanChooseFilesRole,
@@ -58,7 +60,7 @@ private:
     QString description;
     QString placeholder;
     QVariant value;
-    QVariantList options;
+    CompletionModel *optionsModel = nullptr;
     bool multiple = false;
     bool canChooseFiles = true;
     bool canChooseDirectories = false;

--- a/src/server/src/qml/missing-preference-view-host.hpp
+++ b/src/server/src/qml/missing-preference-view-host.hpp
@@ -22,8 +22,8 @@ public:
     DescriptionRole,
     PlaceholderRole,
     ValueRole,
-    OptionsModelRole,
-    CurrentOptionRole,
+    DropdownModelRole,
+    CurrentDropdownItemRole,
     ReadOnlyRole,
     MultipleRole,
     CanChooseFilesRole,
@@ -60,7 +60,7 @@ private:
     QString description;
     QString placeholder;
     QVariant value;
-    CompletionModel *optionsModel = nullptr;
+    CompletionModel *dropdownModel = nullptr;
     bool multiple = false;
     bool canChooseFiles = true;
     bool canChooseDirectories = false;

--- a/src/server/src/qml/preference-form-model.cpp
+++ b/src/server/src/qml/preference-form-model.cpp
@@ -1,5 +1,6 @@
 #include "preference-form-model.hpp"
 
+#include "view-utils.hpp"
 #include <QJSValue>
 #include <utility>
 #include "service-registry.hpp"
@@ -37,8 +38,10 @@ QVariant PreferenceFormModel::data(const QModelIndex &index, int role) const {
     return f.placeholder;
   case ValueRole:
     return f.value;
-  case OptionsRole:
-    return f.options;
+  case OptionsModelRole:
+    return QVariant::fromValue(static_cast<QObject *>(f.optionsModel));
+  case CurrentOptionRole:
+    return currentOption(f);
   case ReadOnlyRole:
     return f.readOnly;
   case MultipleRole:
@@ -62,7 +65,8 @@ QHash<int, QByteArray> PreferenceFormModel::roleNames() const {
           {DescriptionRole, "description"},
           {PlaceholderRole, "placeholder"},
           {ValueRole, "value"},
-          {OptionsRole, "options"},
+          {OptionsModelRole, "optionsModel"},
+          {CurrentOptionRole, "currentOption"},
           {ReadOnlyRole, "readOnly"},
           {MultipleRole, "multiple"},
           {CanChooseFilesRole, "canChooseFiles"},
@@ -97,10 +101,9 @@ static QVariantList dropdownOptions(const Preference &p) {
   if (auto *dd = std::get_if<Preference::DropdownData>(&d)) {
     QVariantList items;
     for (const auto &opt : dd->options) {
-      items.append(
-          QVariantMap{{QStringLiteral("id"), opt.value}, {QStringLiteral("displayName"), opt.title}});
+      items.append(qml::makeDropdownItem(opt.value, opt.title));
     }
-    return {QVariantMap{{QStringLiteral("title"), QString()}, {QStringLiteral("items"), items}}};
+    return items;
   }
   return {};
 }
@@ -142,34 +145,55 @@ static QString checkboxLabel(const Preference &p) {
   return {};
 }
 
+QVariant PreferenceFormModel::currentOption(const Field &f) {
+  if (!f.optionsModel) return {};
+  auto option = f.optionsModel->itemDataById(f.value.toString());
+  return option.isEmpty() ? QVariant{} : QVariant(option);
+}
+
+void PreferenceFormModel::clearFields() {
+  for (const auto &f : m_fields) {
+    if (f.optionsModel) f.optionsModel->deleteLater();
+  }
+  m_fields.clear();
+}
+
+PreferenceFormModel::Field PreferenceFormModel::createField(const Preference &pref) {
+  Field f;
+  f.type = preferenceType(pref);
+  f.id = pref.name();
+  f.label = pref.title();
+  f.checkboxLabel = checkboxLabel(pref);
+  f.description = pref.description();
+  f.placeholder = pref.placeholder();
+  f.readOnly = pref.isReadOnly();
+
+  if (auto options = dropdownOptions(pref); !options.isEmpty()) {
+    f.optionsModel = new CompletionModel(this);
+    f.optionsModel->setItems(options);
+  }
+
+  applyPickerFlags(pref, f.multiple, f.canChooseFiles, f.canChooseDirectories, f.lockedPaths);
+
+  QJsonValue raw = m_values.contains(pref.name()) ? m_values.value(pref.name()) : pref.defaultValue();
+  if (isFilePickerType(pref)) raw = normalizeFilePickerValue(raw);
+  f.value = raw.toVariant();
+
+  return f;
+}
+
 void PreferenceFormModel::load(const EntrypointId &id, const std::vector<Preference> &preferences) {
   if (m_saveTimer.isActive()) save();
   beginResetModel();
   m_itemId = id;
   m_isProvider = false;
-  m_fields.clear();
+  clearFields();
 
   auto *manager = ServiceRegistry::instance()->rootItemManager();
   m_values = manager->getItemPreferenceValues(id);
 
   for (const auto &pref : preferences) {
-    Field f;
-    f.type = preferenceType(pref);
-    f.id = pref.name();
-    f.label = pref.title();
-    f.checkboxLabel = checkboxLabel(pref);
-    f.description = pref.description();
-    f.placeholder = pref.placeholder();
-    f.readOnly = pref.isReadOnly();
-    f.options = dropdownOptions(pref);
-
-    applyPickerFlags(pref, f.multiple, f.canChooseFiles, f.canChooseDirectories, f.lockedPaths);
-
-    QJsonValue raw = m_values.contains(pref.name()) ? m_values.value(pref.name()) : pref.defaultValue();
-    if (isFilePickerType(pref)) raw = normalizeFilePickerValue(raw);
-    f.value = raw.toVariant();
-
-    m_fields.push_back(std::move(f));
+    m_fields.push_back(createField(pref));
   }
   endResetModel();
 }
@@ -180,29 +204,13 @@ void PreferenceFormModel::loadProvider(const QString &providerId,
   beginResetModel();
   m_providerId = providerId;
   m_isProvider = true;
-  m_fields.clear();
+  clearFields();
 
   auto *manager = ServiceRegistry::instance()->rootItemManager();
   m_values = manager->getProviderPreferenceValues(providerId);
 
   for (const auto &pref : preferences) {
-    Field f;
-    f.type = preferenceType(pref);
-    f.id = pref.name();
-    f.label = pref.title();
-    f.checkboxLabel = checkboxLabel(pref);
-    f.description = pref.description();
-    f.placeholder = pref.placeholder();
-    f.readOnly = pref.isReadOnly();
-    f.options = dropdownOptions(pref);
-
-    applyPickerFlags(pref, f.multiple, f.canChooseFiles, f.canChooseDirectories, f.lockedPaths);
-
-    QJsonValue raw = m_values.contains(pref.name()) ? m_values.value(pref.name()) : pref.defaultValue();
-    if (isFilePickerType(pref)) raw = normalizeFilePickerValue(raw);
-    f.value = raw.toVariant();
-
-    m_fields.push_back(std::move(f));
+    m_fields.push_back(createField(pref));
   }
   endResetModel();
 }
@@ -214,7 +222,7 @@ void PreferenceFormModel::setFieldValue(int row, const QVariant &value) {
   m_fields[row].value = resolved;
   m_values[m_fields[row].id] = QJsonValue::fromVariant(resolved);
   auto idx = index(row);
-  emit dataChanged(idx, idx, {ValueRole});
+  emit dataChanged(idx, idx, {ValueRole, CurrentOptionRole});
   m_saveTimer.start();
 }
 

--- a/src/server/src/qml/preference-form-model.cpp
+++ b/src/server/src/qml/preference-form-model.cpp
@@ -38,10 +38,10 @@ QVariant PreferenceFormModel::data(const QModelIndex &index, int role) const {
     return f.placeholder;
   case ValueRole:
     return f.value;
-  case OptionsModelRole:
-    return QVariant::fromValue(static_cast<QObject *>(f.optionsModel));
-  case CurrentOptionRole:
-    return currentOption(f);
+  case DropdownModelRole:
+    return QVariant::fromValue(static_cast<QObject *>(f.dropdownModel));
+  case CurrentDropdownItemRole:
+    return currentDropdownItem(f);
   case ReadOnlyRole:
     return f.readOnly;
   case MultipleRole:
@@ -65,8 +65,8 @@ QHash<int, QByteArray> PreferenceFormModel::roleNames() const {
           {DescriptionRole, "description"},
           {PlaceholderRole, "placeholder"},
           {ValueRole, "value"},
-          {OptionsModelRole, "optionsModel"},
-          {CurrentOptionRole, "currentOption"},
+          {DropdownModelRole, "dropdownModel"},
+          {CurrentDropdownItemRole, "currentDropdownItem"},
           {ReadOnlyRole, "readOnly"},
           {MultipleRole, "multiple"},
           {CanChooseFilesRole, "canChooseFiles"},
@@ -145,15 +145,15 @@ static QString checkboxLabel(const Preference &p) {
   return {};
 }
 
-QVariant PreferenceFormModel::currentOption(const Field &f) {
-  if (!f.optionsModel) return {};
-  auto option = f.optionsModel->itemDataById(f.value.toString());
+QVariant PreferenceFormModel::currentDropdownItem(const Field &f) {
+  if (!f.dropdownModel) return {};
+  auto option = f.dropdownModel->itemDataById(f.value.toString());
   return option.isEmpty() ? QVariant{} : QVariant(option);
 }
 
 void PreferenceFormModel::clearFields() {
   for (const auto &f : m_fields) {
-    if (f.optionsModel) f.optionsModel->deleteLater();
+    if (f.dropdownModel) f.dropdownModel->deleteLater();
   }
   m_fields.clear();
 }
@@ -169,8 +169,8 @@ PreferenceFormModel::Field PreferenceFormModel::createField(const Preference &pr
   f.readOnly = pref.isReadOnly();
 
   if (auto options = dropdownOptions(pref); !options.isEmpty()) {
-    f.optionsModel = new CompletionModel(this);
-    f.optionsModel->setItems(options);
+    f.dropdownModel = new CompletionModel(this);
+    f.dropdownModel->setItems(options);
   }
 
   applyPickerFlags(pref, f.multiple, f.canChooseFiles, f.canChooseDirectories, f.lockedPaths);
@@ -222,7 +222,7 @@ void PreferenceFormModel::setFieldValue(int row, const QVariant &value) {
   m_fields[row].value = resolved;
   m_values[m_fields[row].id] = QJsonValue::fromVariant(resolved);
   auto idx = index(row);
-  emit dataChanged(idx, idx, {ValueRole, CurrentOptionRole});
+  emit dataChanged(idx, idx, {ValueRole, CurrentDropdownItemRole});
   m_saveTimer.start();
 }
 

--- a/src/server/src/qml/preference-form-model.hpp
+++ b/src/server/src/qml/preference-form-model.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "completion-model.hpp"
 #include "preference.hpp"
 #include "common/entrypoint.hpp"
 #include <QAbstractListModel>
@@ -18,7 +19,8 @@ public:
     DescriptionRole,
     PlaceholderRole,
     ValueRole,
-    OptionsRole,
+    OptionsModelRole,
+    CurrentOptionRole,
     ReadOnlyRole,
     MultipleRole,
     CanChooseFilesRole,
@@ -49,13 +51,17 @@ private:
     QString description;
     QString placeholder;
     QVariant value;
-    QVariantList options;
+    CompletionModel *optionsModel = nullptr;
     bool readOnly = false;
     bool multiple = false;
     bool canChooseFiles = true;
     bool canChooseDirectories = false;
     QStringList lockedPaths;
   };
+
+  Field createField(const Preference &pref);
+  void clearFields();
+  static QVariant currentOption(const Field &f);
 
   std::vector<Field> m_fields;
   QJsonObject m_values;

--- a/src/server/src/qml/preference-form-model.hpp
+++ b/src/server/src/qml/preference-form-model.hpp
@@ -19,8 +19,8 @@ public:
     DescriptionRole,
     PlaceholderRole,
     ValueRole,
-    OptionsModelRole,
-    CurrentOptionRole,
+    DropdownModelRole,
+    CurrentDropdownItemRole,
     ReadOnlyRole,
     MultipleRole,
     CanChooseFilesRole,
@@ -51,7 +51,7 @@ private:
     QString description;
     QString placeholder;
     QVariant value;
-    CompletionModel *optionsModel = nullptr;
+    CompletionModel *dropdownModel = nullptr;
     bool readOnly = false;
     bool multiple = false;
     bool canChooseFiles = true;
@@ -61,7 +61,7 @@ private:
 
   Field createField(const Preference &pref);
   void clearFields();
-  static QVariant currentOption(const Field &f);
+  static QVariant currentDropdownItem(const Field &f);
 
   std::vector<Field> m_fields;
   QJsonObject m_values;

--- a/src/server/src/qml/qml/AdvancedSettingsPage.qml
+++ b/src/server/src/qml/qml/AdvancedSettingsPage.qml
@@ -78,7 +78,7 @@ Flickable {
                 showSeparator: false
                 SearchableDropdown {
                     width: parent.width
-                    items: root.model.keybindingSchemeItems
+                    model: root.model.keybindingSchemeModel
                     currentItem: root.model.currentKeybindingScheme
                     onActivated: item => root.model.selectKeybindingScheme(item.id)
                 }
@@ -107,7 +107,7 @@ Flickable {
                 showSeparator: false
                 SearchableDropdown {
                     width: parent.width
-                    items: root.model.faviconServiceItems
+                    model: root.model.faviconServiceModel
                     currentItem: root.model.currentFaviconService
                     onActivated: item => root.model.selectFaviconService(item.id)
                 }

--- a/src/server/src/qml/qml/AppearanceSettingsPage.qml
+++ b/src/server/src/qml/qml/AppearanceSettingsPage.qml
@@ -40,7 +40,7 @@ Flickable {
                 label: qsTr("Theme")
                 SearchableDropdown {
                     width: parent.width
-                    items: root.model.themeItems
+                    model: root.model.themeModel
                     currentItem: root.model.currentTheme
                     onActivated: item => root.model.selectTheme(item.id)
                 }
@@ -50,7 +50,7 @@ Flickable {
                 label: qsTr("Font")
                 SearchableDropdown {
                     width: parent.width
-                    items: root.model.fontItems
+                    model: root.model.fontModel
                     currentItem: root.model.currentFont
                     onActivated: item => root.model.selectFont(item.id)
                 }
@@ -80,7 +80,7 @@ Flickable {
                 showSeparator: false
                 SearchableDropdown {
                     width: parent.width
-                    items: root.model.iconThemeItems
+                    model: root.model.iconThemeModel
                     currentItem: root.model.currentIconTheme
                     onActivated: item => root.model.selectIconTheme(item.id)
                 }
@@ -100,7 +100,7 @@ Flickable {
                 description: qsTr("Background material applied to the launcher window. Lower the window opacity to see it.")
                 SearchableDropdown {
                     width: parent.width
-                    items: root.model.windowMaterialItems
+                    model: root.model.windowMaterialModel
                     currentItem: root.model.currentWindowMaterial
                     onActivated: item => root.model.selectWindowMaterial(item.id)
                 }

--- a/src/server/src/qml/qml/CategoryFilterAccessory.qml
+++ b/src/server/src/qml/qml/CategoryFilterAccessory.qml
@@ -5,24 +5,13 @@ SearchableDropdown {
     compact: true
     minimumWidth: 100
 
-    readonly property var _options: launcher.commandViewHost ? launcher.commandViewHost.categoryFilterOptions : [qsTr("All")]
-
-    items: [
-        {
-            title: "",
-            items: _options?.map((name, i) => ({
-                        id: i.toString(),
-                        displayName: name
-                    })) ?? []
-        }
-    ]
+    model: launcher.commandViewHost ? launcher.commandViewHost.categoryFilterModel : null
 
     currentItem: {
-        var idx = launcher.commandViewHost ? launcher.commandViewHost.currentCategoryFilter : 0;
-        return {
-            id: idx?.toString() ?? 'unknown',
-            displayName: _options?.[idx] ?? ''
-        };
+        const host = launcher.commandViewHost;
+        if (!host)
+            return null;
+        return host.categoryFilterModel.itemDataById(host.currentCategoryFilter.toString());
     }
 
     onActivated: item => {

--- a/src/server/src/qml/qml/CategoryFilterAccessory.qml
+++ b/src/server/src/qml/qml/CategoryFilterAccessory.qml
@@ -5,17 +5,20 @@ SearchableDropdown {
     compact: true
     minimumWidth: 100
 
-    model: launcher.commandViewHost ? launcher.commandViewHost.categoryFilterModel : null
+    readonly property var _host: launcher.commandViewHost
+
+    model: _host?.categoryFilterModel ?? null
 
     currentItem: {
-        const host = launcher.commandViewHost;
-        if (!host)
+        const m = _host?.categoryFilterModel;
+        const idx = _host?.currentCategoryFilter;
+        if (!m || idx === undefined)
             return null;
-        return host.categoryFilterModel.itemDataById(host.currentCategoryFilter.toString());
+        return m.itemDataById(idx.toString());
     }
 
     onActivated: item => {
-        if (launcher.commandViewHost)
-            launcher.commandViewHost.setCategoryFilter(parseInt(item.id));
+        if (root._host)
+            root._host.setCategoryFilter(parseInt(item.id));
     }
 }

--- a/src/server/src/qml/qml/ClipboardFilterAccessory.qml
+++ b/src/server/src/qml/qml/ClipboardFilterAccessory.qml
@@ -5,17 +5,20 @@ SearchableDropdown {
     compact: true
     minimumWidth: 100
 
-    model: launcher.commandViewHost ? launcher.commandViewHost.kindFilterModel : null
+    readonly property var _host: launcher.commandViewHost
+
+    model: _host?.kindFilterModel ?? null
 
     currentItem: {
-        const host = launcher.commandViewHost;
-        if (!host)
+        const m = _host?.kindFilterModel;
+        const idx = _host?.currentKindFilter;
+        if (!m || idx === undefined)
             return null;
-        return host.kindFilterModel.itemDataById(host.currentKindFilter.toString());
+        return m.itemDataById(idx.toString());
     }
 
     onActivated: item => {
-        if (launcher.commandViewHost)
-            launcher.commandViewHost.setKindFilter(parseInt(item.id));
+        if (root._host)
+            root._host.setKindFilter(parseInt(item.id));
     }
 }

--- a/src/server/src/qml/qml/ClipboardFilterAccessory.qml
+++ b/src/server/src/qml/qml/ClipboardFilterAccessory.qml
@@ -5,24 +5,13 @@ SearchableDropdown {
     compact: true
     minimumWidth: 100
 
-    readonly property var _options: [qsTr("All"), qsTr("Text"), qsTr("Images"), qsTr("Links"), qsTr("Files")]
-
-    items: [
-        {
-            title: "",
-            items: _options.map((name, i) => ({
-                        id: i.toString(),
-                        displayName: name
-                    }))
-        }
-    ]
+    model: launcher.commandViewHost ? launcher.commandViewHost.kindFilterModel : null
 
     currentItem: {
-        var idx = launcher.commandViewHost ? launcher.commandViewHost.currentKindFilter : 0;
-        return {
-            id: idx?.toString() ?? 'unknown',
-            displayName: _options[idx]
-        };
+        const host = launcher.commandViewHost;
+        if (!host)
+            return null;
+        return host.kindFilterModel.itemDataById(host.currentKindFilter.toString());
     }
 
     onActivated: item => {

--- a/src/server/src/qml/qml/CompletionPopup.qml
+++ b/src/server/src/qml/qml/CompletionPopup.qml
@@ -7,6 +7,8 @@ Popup {
 
     property var items: []
     property var sections: []
+    property CompletionModel model: null
+    readonly property CompletionModel _model: model ?? internalModel
     property bool showFilter: false
     property string filterPlaceholder: qsTr("Filter...")
     property string currentItemId: ""
@@ -17,8 +19,13 @@ Popup {
 
     popupType: nativePanel && Platform.supports("nativePanels") ? Popup.Window : Popup.Item
 
-    readonly property int count: completionModel.count
+    readonly property int count: _model.count
     readonly property bool hasSelection: _highlightedIndex >= 0
+
+    onCountChanged: {
+        if (_highlightedIndex >= count)
+            _highlightedIndex = -1;
+    }
 
     readonly property real _bgOpacity: popupType === Popup.Window ? Config.popupOpacity : 0
     readonly property real _fillOpacity: Config.popupSurfaceOpacity
@@ -40,14 +47,14 @@ Popup {
     }
 
     onItemsChanged: if (items.length > 0)
-        completionModel.setItems(items)
+        internalModel.setItems(items)
     onSectionsChanged: if (sections.length > 0)
-        completionModel.setSections(sections)
+        internalModel.setSections(sections)
 
     onOpened: {
         if (showFilter) {
             filterField.text = "";
-            completionModel.setFilter("");
+            _model.setFilter("");
             _highlightCurrentOrFirst();
             filterField.forceActiveFocus();
         }
@@ -59,34 +66,34 @@ Popup {
 
     function _highlightCurrentOrFirst() {
         if (currentItemId !== "") {
-            const idx = completionModel.indexOfItemId(currentItemId);
+            const idx = _model.indexOfItemId(currentItemId);
             if (idx >= 0) {
                 _highlightedIndex = idx;
                 return;
             }
         }
-        const first = completionModel.nextSelectableIndex(-1, 1);
+        const first = _model.nextSelectableIndex(-1, 1);
         _highlightedIndex = first >= 0 ? first : -1;
     }
 
     function filter(query) {
-        completionModel.setFilter(query);
-        const first = completionModel.nextSelectableIndex(-1, 1);
+        _model.setFilter(query);
+        const first = _model.nextSelectableIndex(-1, 1);
         _highlightedIndex = first >= 0 ? first : -1;
     }
 
     function moveUp() {
-        _highlightedIndex = completionModel.nextSelectableIndex(_highlightedIndex, -1);
+        _highlightedIndex = _model.nextSelectableIndex(_highlightedIndex, -1);
     }
 
     function moveDown() {
-        _highlightedIndex = completionModel.nextSelectableIndex(_highlightedIndex, 1);
+        _highlightedIndex = _model.nextSelectableIndex(_highlightedIndex, 1);
     }
 
     function acceptHighlighted() {
         if (_highlightedIndex < 0)
             return;
-        const data = completionModel.itemDataAt(_highlightedIndex);
+        const data = _model.itemDataAt(_highlightedIndex);
         if (Object.keys(data).length > 0) {
             itemAccepted(data);
             close();
@@ -94,15 +101,11 @@ Popup {
     }
 
     CompletionModel {
-        id: completionModel
-        onCountChanged: {
-            if (root._highlightedIndex >= count)
-                root._highlightedIndex = -1;
-        }
+        id: internalModel
     }
 
     HoverResetOnModelChange {
-        target: completionModel
+        target: root._model
     }
 
     background: PopoverBackground {
@@ -194,7 +197,7 @@ Popup {
             id: completionList
             Layout.fillWidth: true
             Layout.preferredHeight: Math.min(contentHeight, root.showFilter ? 300 : 200)
-            model: completionModel
+            model: root._model
             clip: true
             boundsBehavior: Flickable.StopAtBounds
 

--- a/src/server/src/qml/qml/CreateExtensionFormView.qml
+++ b/src/server/src/qml/qml/CreateExtensionFormView.qml
@@ -99,7 +99,7 @@ Item {
             label: qsTr("Template")
 
             SearchableDropdown {
-                items: root.host.templateItems
+                model: root.host.templateModel
                 currentItem: root.host.selectedTemplate
                 onActivated: item => root.host.selectTemplate(item)
             }

--- a/src/server/src/qml/qml/EmojiCategoryFilterAccessory.qml
+++ b/src/server/src/qml/qml/EmojiCategoryFilterAccessory.qml
@@ -5,24 +5,13 @@ SearchableDropdown {
     compact: true
     minimumWidth: 100
 
-    readonly property var _options: launcher.commandViewHost ? launcher.commandViewHost.categoryFilterOptions : [qsTr("All")]
-
-    items: [
-        {
-            title: "",
-            items: _options?.map((name, i) => ({
-                        id: i.toString(),
-                        displayName: name
-                    })) ?? []
-        }
-    ]
+    model: launcher.commandViewHost ? launcher.commandViewHost.categoryFilterModel : null
 
     currentItem: {
-        var idx = launcher.commandViewHost ? launcher.commandViewHost.currentCategoryFilter : 0;
-        return {
-            id: idx?.toString() ?? 'unknown',
-            displayName: _options?.[idx] ?? ''
-        };
+        const host = launcher.commandViewHost;
+        if (!host)
+            return null;
+        return host.categoryFilterModel.itemDataById(host.currentCategoryFilter.toString());
     }
 
     onActivated: item => {

--- a/src/server/src/qml/qml/EmojiCategoryFilterAccessory.qml
+++ b/src/server/src/qml/qml/EmojiCategoryFilterAccessory.qml
@@ -5,17 +5,20 @@ SearchableDropdown {
     compact: true
     minimumWidth: 100
 
-    model: launcher.commandViewHost ? launcher.commandViewHost.categoryFilterModel : null
+    readonly property var _host: launcher.commandViewHost
+
+    model: _host?.categoryFilterModel ?? null
 
     currentItem: {
-        const host = launcher.commandViewHost;
-        if (!host)
+        const m = _host?.categoryFilterModel;
+        const idx = _host?.currentCategoryFilter;
+        if (!m || idx === undefined)
             return null;
-        return host.categoryFilterModel.itemDataById(host.currentCategoryFilter.toString());
+        return m.itemDataById(idx.toString());
     }
 
     onActivated: item => {
-        if (launcher.commandViewHost)
-            launcher.commandViewHost.setCategoryFilter(parseInt(item.id));
+        if (root._host)
+            root._host.setCategoryFilter(parseInt(item.id));
     }
 }

--- a/src/server/src/qml/qml/ExtensionDropdownAccessory.qml
+++ b/src/server/src/qml/qml/ExtensionDropdownAccessory.qml
@@ -5,9 +5,9 @@ SearchableDropdown {
     compact: true
     minimumWidth: 100
 
-    model: launcher.commandViewHost ? launcher.commandViewHost.dropdownModel : null
-    currentItem: launcher.commandViewHost ? launcher.commandViewHost.dropdownCurrentItem : null
-    placeholder: launcher.commandViewHost ? launcher.commandViewHost.dropdownPlaceholder : ""
+    model: launcher.commandViewHost?.dropdownModel ?? null
+    currentItem: launcher.commandViewHost?.dropdownCurrentItem ?? null
+    placeholder: launcher.commandViewHost?.dropdownPlaceholder ?? ""
 
     onActivated: item => {
         if (launcher.commandViewHost)

--- a/src/server/src/qml/qml/ExtensionDropdownAccessory.qml
+++ b/src/server/src/qml/qml/ExtensionDropdownAccessory.qml
@@ -5,7 +5,7 @@ SearchableDropdown {
     compact: true
     minimumWidth: 100
 
-    items: launcher.commandViewHost ? launcher.commandViewHost.dropdownItems : []
+    model: launcher.commandViewHost ? launcher.commandViewHost.dropdownModel : null
     currentItem: launcher.commandViewHost ? launcher.commandViewHost.dropdownCurrentItem : null
     placeholder: launcher.commandViewHost ? launcher.commandViewHost.dropdownPlaceholder : ""
 

--- a/src/server/src/qml/qml/ExtensionFormView.qml
+++ b/src/server/src/qml/qml/ExtensionFormView.qml
@@ -68,6 +68,8 @@ Item {
                 required property var value
                 required property bool autoFocus
                 required property var fieldData
+                required property var optionsModel
+                required property var currentOption
 
                 readonly property bool isField: type !== "separator" && type !== "description"
 
@@ -233,26 +235,12 @@ Item {
             }
 
             readonly property var _fd: parent.fieldData || ({})
-            readonly property var _items: _fd.items || []
-
-            function _findCurrentItem(items, value) {
-                for (var s = 0; s < items.length; s++) {
-                    var section = items[s];
-                    if (!section || !section.items)
-                        continue;
-                    for (var i = 0; i < section.items.length; i++) {
-                        if (section.items[i].id === value)
-                            return section.items[i];
-                    }
-                }
-                return null;
-            }
 
             SearchableDropdown {
                 id: dropdown
-                items: field._items
+                model: field.parent.optionsModel
                 hasError: field.error !== ""
-                currentItem: field._findCurrentItem(field._items, field.parent.value)
+                currentItem: field.parent.currentOption
                 placeholder: field._fd.placeholder || field.parent.placeholder || ""
                 onActivated: item => {
                     root.formModel.setFieldValue(field.parent.index, item.id);

--- a/src/server/src/qml/qml/ExtensionFormView.qml
+++ b/src/server/src/qml/qml/ExtensionFormView.qml
@@ -68,8 +68,8 @@ Item {
                 required property var value
                 required property bool autoFocus
                 required property var fieldData
-                required property var optionsModel
-                required property var currentOption
+                required property var dropdownModel
+                required property var currentDropdownItem
 
                 readonly property bool isField: type !== "separator" && type !== "description"
 
@@ -238,9 +238,9 @@ Item {
 
             SearchableDropdown {
                 id: dropdown
-                model: field.parent.optionsModel
+                model: field.parent.dropdownModel
                 hasError: field.error !== ""
-                currentItem: field.parent.currentOption
+                currentItem: field.parent.currentDropdownItem
                 placeholder: field._fd.placeholder || field.parent.placeholder || ""
                 onActivated: item => {
                     root.formModel.setFieldValue(field.parent.index, item.id);

--- a/src/server/src/qml/qml/FormAppSelector.qml
+++ b/src/server/src/qml/qml/FormAppSelector.qml
@@ -7,19 +7,15 @@ ColumnLayout {
     spacing: 6
 
     property var model: []
-    property var sections: []
+    property CompletionModel appsModel: null
     property bool filled: false
 
     signal changed(var apps)
 
     function _appInfo(wmClass) {
-        for (let s = 0; s < sections.length; s++) {
-            const items = sections[s].items;
-            for (let i = 0; i < items.length; i++) {
-                if (items[i].id === wmClass)
-                    return items[i];
-            }
-        }
+        const info = appsModel ? appsModel.itemDataById(wmClass) : null;
+        if (info && info.id !== undefined)
+            return info;
         return {
             displayName: wmClass,
             iconSource: ""
@@ -118,7 +114,7 @@ ColumnLayout {
 
     SearchableDropdown {
         placeholder: qsTr("+ Restrict to app…")
-        items: root.sections
+        model: root.appsModel
         currentItem: null
         filled: root.filled
         onActivated: item => root.add(item.id)

--- a/src/server/src/qml/qml/GeneralSettingsPage.qml
+++ b/src/server/src/qml/qml/GeneralSettingsPage.qml
@@ -92,7 +92,7 @@ Flickable {
                 showSeparator: false
                 SearchableDropdown {
                     width: parent.width
-                    items: root.model.languageItems
+                    model: root.model.languageModel
                     currentItem: root.model.currentLanguage
                     onActivated: item => root.model.selectLanguage(item.id)
                 }

--- a/src/server/src/qml/qml/MissingPreferenceView.qml
+++ b/src/server/src/qml/qml/MissingPreferenceView.qml
@@ -59,7 +59,8 @@ Item {
                 required property string description
                 required property string placeholder
                 required property var value
-                required property var options
+                required property var optionsModel
+                required property var currentOption
                 required property bool readOnly
                 required property bool multiple
                 required property bool canChooseFiles
@@ -138,22 +139,9 @@ Item {
             label: parent.label
             info: parent.description
 
-            function _findCurrentItem(items, val) {
-                for (var s = 0; s < items.length; s++) {
-                    var section = items[s];
-                    if (!section || !section.items)
-                        continue;
-                    for (var i = 0; i < section.items.length; i++) {
-                        if (section.items[i].id === val)
-                            return section.items[i];
-                    }
-                }
-                return null;
-            }
-
             SearchableDropdown {
-                items: field.parent.options || []
-                currentItem: field._findCurrentItem(field.parent.options || [], field.parent.value)
+                model: field.parent.optionsModel
+                currentItem: field.parent.currentOption
                 onActivated: item => root.host.prefModel.setFieldValue(field.parent.index, item.id)
             }
         }

--- a/src/server/src/qml/qml/MissingPreferenceView.qml
+++ b/src/server/src/qml/qml/MissingPreferenceView.qml
@@ -59,8 +59,8 @@ Item {
                 required property string description
                 required property string placeholder
                 required property var value
-                required property var optionsModel
-                required property var currentOption
+                required property var dropdownModel
+                required property var currentDropdownItem
                 required property bool readOnly
                 required property bool multiple
                 required property bool canChooseFiles
@@ -140,8 +140,8 @@ Item {
             info: parent.description
 
             SearchableDropdown {
-                model: field.parent.optionsModel
-                currentItem: field.parent.currentOption
+                model: field.parent.dropdownModel
+                currentItem: field.parent.currentDropdownItem
                 onActivated: item => root.host.prefModel.setFieldValue(field.parent.index, item.id)
             }
         }

--- a/src/server/src/qml/qml/OnboardingWindow.qml
+++ b/src/server/src/qml/qml/OnboardingWindow.qml
@@ -224,7 +224,7 @@ Window {
 
                                 SearchableDropdown {
                                     width: parent.width
-                                    items: onboarding.generalModel.themeItems
+                                    model: onboarding.generalModel.themeModel
                                     currentItem: onboarding.generalModel.currentTheme
                                     onActivated: item => onboarding.generalModel.selectTheme(item.id)
                                 }

--- a/src/server/src/qml/qml/PreferenceFormView.qml
+++ b/src/server/src/qml/qml/PreferenceFormView.qml
@@ -26,7 +26,8 @@ Item {
                 required property string description
                 required property string placeholder
                 required property var value
-                required property var options
+                required property var optionsModel
+                required property var currentOption
                 required property bool readOnly
                 required property bool multiple
                 required property bool canChooseFiles
@@ -105,23 +106,10 @@ Item {
             label: parent.label
             info: parent.description
 
-            function _findCurrentItem(items, val) {
-                for (var s = 0; s < items.length; s++) {
-                    var section = items[s];
-                    if (!section || !section.items)
-                        continue;
-                    for (var i = 0; i < section.items.length; i++) {
-                        if (section.items[i].id === val)
-                            return section.items[i];
-                    }
-                }
-                return null;
-            }
-
             SearchableDropdown {
-                items: field.parent.options || []
+                model: field.parent.optionsModel
                 readOnly: field.parent.readOnly
-                currentItem: field._findCurrentItem(field.parent.options || [], field.parent.value)
+                currentItem: field.parent.currentOption
                 onActivated: item => root.prefModel.setFieldValue(field.parent.index, item.id)
             }
         }

--- a/src/server/src/qml/qml/PreferenceFormView.qml
+++ b/src/server/src/qml/qml/PreferenceFormView.qml
@@ -26,8 +26,8 @@ Item {
                 required property string description
                 required property string placeholder
                 required property var value
-                required property var optionsModel
-                required property var currentOption
+                required property var dropdownModel
+                required property var currentDropdownItem
                 required property bool readOnly
                 required property bool multiple
                 required property bool canChooseFiles
@@ -107,9 +107,9 @@ Item {
             info: parent.description
 
             SearchableDropdown {
-                model: field.parent.optionsModel
+                model: field.parent.dropdownModel
                 readOnly: field.parent.readOnly
-                currentItem: field.parent.currentOption
+                currentItem: field.parent.currentDropdownItem
                 onActivated: item => root.prefModel.setFieldValue(field.parent.index, item.id)
             }
         }

--- a/src/server/src/qml/qml/SearchableDropdown.qml
+++ b/src/server/src/qml/qml/SearchableDropdown.qml
@@ -9,6 +9,7 @@ Item {
     activeFocusOnTab: !compact && !readOnly
 
     property var items: []
+    property CompletionModel model: null
     property var currentItem: null
     signal activated(var item)
     signal popupClosed
@@ -117,6 +118,7 @@ Item {
         width: Math.max(compact ? 200 : 250, root.width)
         focus: true
         sections: root.items
+        model: root.model
         showFilter: true
         currentItemId: root.currentItem ? root.currentItem.id : ""
 

--- a/src/server/src/qml/qml/SettingsPreferenceForm.qml
+++ b/src/server/src/qml/qml/SettingsPreferenceForm.qml
@@ -25,8 +25,8 @@ ColumnLayout {
             required property string description
             required property string placeholder
             required property var value
-            required property var optionsModel
-            required property var currentOption
+            required property var dropdownModel
+            required property var currentDropdownItem
             required property bool readOnly
             required property bool multiple
             required property bool canChooseFiles
@@ -144,9 +144,9 @@ ColumnLayout {
 
             SearchableDropdown {
                 width: parent.width
-                model: field.parent.optionsModel
+                model: field.parent.dropdownModel
                 readOnly: field.parent.readOnly
-                currentItem: field.parent.currentOption
+                currentItem: field.parent.currentDropdownItem
                 onActivated: item => root.prefModel.setFieldValue(field.parent.index, item.id)
             }
         }

--- a/src/server/src/qml/qml/SettingsPreferenceForm.qml
+++ b/src/server/src/qml/qml/SettingsPreferenceForm.qml
@@ -25,7 +25,8 @@ ColumnLayout {
             required property string description
             required property string placeholder
             required property var value
-            required property var options
+            required property var optionsModel
+            required property var currentOption
             required property bool readOnly
             required property bool multiple
             required property bool canChooseFiles
@@ -141,24 +142,11 @@ ColumnLayout {
             controlWidth: root.fieldControlWidth
             showSeparator: field.parent.index < settingsRepeater.count - 1
 
-            function _findCurrentItem(items, val) {
-                for (var s = 0; s < items.length; s++) {
-                    var section = items[s];
-                    if (!section || !section.items)
-                        continue;
-                    for (var i = 0; i < section.items.length; i++) {
-                        if (section.items[i].id === val)
-                            return section.items[i];
-                    }
-                }
-                return null;
-            }
-
             SearchableDropdown {
                 width: parent.width
-                items: field.parent.options || []
+                model: field.parent.optionsModel
                 readOnly: field.parent.readOnly
-                currentItem: field._findCurrentItem(field.parent.options || [], field.parent.value)
+                currentItem: field.parent.currentOption
                 onActivated: item => root.prefModel.setFieldValue(field.parent.index, item.id)
             }
         }

--- a/src/server/src/qml/qml/ShortcutFormView.qml
+++ b/src/server/src/qml/qml/ShortcutFormView.qml
@@ -50,7 +50,7 @@ Item {
             error: root.host.appError
 
             SearchableDropdown {
-                items: root.host.appSelectorModel.items
+                model: root.host.appSelectorModel.model
                 currentItem: root.host.selectedApp
                 hasError: appField.error !== ""
                 onActivated: item => root.host.selectApp(item)
@@ -63,7 +63,7 @@ Item {
             error: root.host.iconError
 
             SearchableDropdown {
-                items: root.host.iconItems
+                model: root.host.iconModel
                 currentItem: root.host.selectedIcon
                 hasError: iconField.error !== ""
                 onActivated: item => root.host.selectIcon(item)

--- a/src/server/src/qml/qml/SnippetFormView.qml
+++ b/src/server/src/qml/qml/SnippetFormView.qml
@@ -64,7 +64,7 @@ Item {
 
             FormAppSelector {
                 model: root.host.apps
-                sections: root.host.availableApps
+                appsModel: root.host.availableAppsModel
                 onChanged: apps => root.host.apps = apps
             }
         }

--- a/src/server/src/qml/search-files-view-host.cpp
+++ b/src/server/src/qml/search-files-view-host.cpp
@@ -57,6 +57,7 @@ void SearchFilesViewHost::initialize() {
   model()->addSource(&m_section);
 
   setSearchPlaceholderText(tr("Search for files..."));
+  m_categoryFilterModel.setStringOptions(categoryFilterOptions());
   restoreCategoryFilter();
 
   m_debounce.setSingleShot(true);

--- a/src/server/src/qml/search-files-view-host.hpp
+++ b/src/server/src/qml/search-files-view-host.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "completion-model.hpp"
 #include "list-view-host.hpp"
 #include "search-files-model.hpp"
 #include "services/files-service/abstract-file-indexer.hpp"
@@ -16,7 +17,7 @@ class SearchFilesViewHost : public ListViewHost {
   Q_PROPERTY(QString detailLastModified READ detailLastModified NOTIFY detailChanged)
   Q_PROPERTY(QString detailImageSource READ detailImageSource NOTIFY detailChanged)
   Q_PROPERTY(QString detailTextContent READ detailTextContent NOTIFY detailChanged)
-  Q_PROPERTY(QStringList categoryFilterOptions READ categoryFilterOptions CONSTANT)
+  Q_PROPERTY(CompletionModel *categoryFilterModel READ categoryFilterModel CONSTANT)
   Q_PROPERTY(int currentCategoryFilter READ currentCategoryFilter NOTIFY currentCategoryFilterChanged)
 
 signals:
@@ -38,12 +39,13 @@ public:
   QString detailLastModified() const { return m_detailLastModified; }
   QString detailImageSource() const { return m_detailImageSource; }
   QString detailTextContent() const { return m_detailTextContent; }
-  QStringList categoryFilterOptions() const;
+  CompletionModel *categoryFilterModel() { return &m_categoryFilterModel; }
   int currentCategoryFilter() const { return m_currentCategoryFilter; }
 
   Q_INVOKABLE void setCategoryFilter(int index);
 
 private:
+  QStringList categoryFilterOptions() const;
   void renderRecentFiles();
   void handleDebounce();
   void handleSearchResults();
@@ -70,5 +72,6 @@ private:
   QString m_detailLastModified;
   QString m_detailImageSource;
   QString m_detailTextContent;
+  CompletionModel m_categoryFilterModel{this};
   int m_currentCategoryFilter = 0;
 };

--- a/src/server/src/qml/shortcut-form-view-host.cpp
+++ b/src/server/src/qml/shortcut-form-view-host.cpp
@@ -121,8 +121,7 @@ void ShortcutFormViewHost::buildIconItems() {
 
   for (const auto &[icon, name] : BuiltinIconService::mapping()) {
     auto url = ImageURL::builtinByName(QString::fromLatin1(name));
-    allIcons.append(
-        qml::makeDropdownItem(url.toString(), QString::fromUtf8(name), qml::imageSourceFor(url)));
+    allIcons.append(qml::makeDropdownItem(url.toString(), QString::fromUtf8(name), qml::imageSourceFor(url)));
   }
 
   m_iconModel.setItems(allIcons);

--- a/src/server/src/qml/shortcut-form-view-host.cpp
+++ b/src/server/src/qml/shortcut-form-view-host.cpp
@@ -71,23 +71,11 @@ void ShortcutFormViewHost::initialize() {
       m_selectedApp = m_appSelectorModel->currentItem();
     }
 
-    auto iconStr = m_initialShortcut->icon();
-    bool iconFound = false;
-    for (const auto &sectionVar : m_iconItems) {
-      auto sectionMap = sectionVar.toMap();
-      auto items = sectionMap[QStringLiteral("items")].toList();
-      for (const auto &itemVar : items) {
-        auto item = itemVar.toMap();
-        if (item[QStringLiteral("id")].toString() == iconStr) {
-          m_selectedIcon = item;
-          iconFound = true;
-          break;
-        }
-      }
-      if (iconFound) break;
+    if (auto item = m_iconModel.itemDataById(m_initialShortcut->icon()); !item.isEmpty()) {
+      m_selectedIcon = item;
+    } else {
+      handleLinkBlurred();
     }
-
-    if (!iconFound) { handleLinkBlurred(); }
 
     emit formChanged();
   } else if (!m_prefilledLink.isEmpty() || !m_prefilledName.isEmpty()) {
@@ -103,17 +91,7 @@ void ShortcutFormViewHost::initialize() {
     }
 
     if (!m_prefilledIcon.isEmpty()) {
-      for (const auto &sectionVar : m_iconItems) {
-        auto sectionMap = sectionVar.toMap();
-        auto items = sectionMap[QStringLiteral("items")].toList();
-        for (const auto &itemVar : items) {
-          auto item = itemVar.toMap();
-          if (item[QStringLiteral("id")].toString() == m_prefilledIcon) {
-            m_selectedIcon = item;
-            break;
-          }
-        }
-      }
+      if (auto item = m_iconModel.itemDataById(m_prefilledIcon); !item.isEmpty()) { m_selectedIcon = item; }
     }
 
     if (!m_prefilledLink.isEmpty()) { handleLinkBlurred(); }
@@ -137,26 +115,17 @@ void ShortcutFormViewHost::buildIconItems() {
   QVariantList allIcons;
 
   m_resolvedDefaultIcon = ImageURL::builtin(BuiltinIcon::Link).toString();
-  m_defaultIconEntry = QVariantMap{
-      {QStringLiteral("id"), QStringLiteral("default")},
-      {QStringLiteral("displayName"), tr("Default")},
-      {QStringLiteral("iconSource"), qml::imageSourceFor(ImageURL::builtin(BuiltinIcon::Link))},
-  };
+  m_defaultIconEntry = qml::makeDropdownItem(QStringLiteral("default"), tr("Default"),
+                                             qml::imageSourceFor(ImageURL::builtin(BuiltinIcon::Link)));
   allIcons.append(m_defaultIconEntry);
 
   for (const auto &[icon, name] : BuiltinIconService::mapping()) {
     auto url = ImageURL::builtinByName(QString::fromLatin1(name));
-    allIcons.append(QVariantMap{
-        {QStringLiteral("id"), url.toString()},
-        {QStringLiteral("displayName"), QString::fromUtf8(name)},
-        {QStringLiteral("iconSource"), qml::imageSourceFor(url)},
-    });
+    allIcons.append(
+        qml::makeDropdownItem(url.toString(), QString::fromUtf8(name), qml::imageSourceFor(url)));
   }
 
-  QVariantMap section;
-  section[QStringLiteral("title")] = QString();
-  section[QStringLiteral("items")] = allIcons;
-  m_iconItems.append(section);
+  m_iconModel.setItems(allIcons);
 }
 
 void ShortcutFormViewHost::buildLinkCompletions() {
@@ -186,17 +155,7 @@ void ShortcutFormViewHost::buildLinkCompletions() {
   };
 }
 
-void ShortcutFormViewHost::updateDefaultIconInItems() {
-  if (m_iconItems.isEmpty()) return;
-  auto section = m_iconItems[0].toMap();
-  auto items = section[QStringLiteral("items")].toList();
-  if (!items.isEmpty()) {
-    items[0] = m_defaultIconEntry;
-    section[QStringLiteral("items")] = items;
-    m_iconItems[0] = section;
-    emit iconItemsChanged();
-  }
-}
+void ShortcutFormViewHost::updateDefaultIconInItems() { m_iconModel.updateItem(m_defaultIconEntry); }
 
 void ShortcutFormViewHost::submit() {
   auto toast = context()->services->toastService();
@@ -261,6 +220,9 @@ void ShortcutFormViewHost::submit() {
 }
 
 void ShortcutFormViewHost::handleLinkBlurred() {
+  if (m_link == m_lastDetectedLink) return;
+  m_lastDetectedLink = m_link;
+
   auto appDb = context()->services->appDb();
   QUrl const url(m_link);
 

--- a/src/server/src/qml/shortcut-form-view-host.hpp
+++ b/src/server/src/qml/shortcut-form-view-host.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "app-selector-model.hpp"
 #include "bridge-view.hpp"
+#include "completion-model.hpp"
 #include <QUrl>
 #include <QVariantList>
 #include <QVariantMap>
@@ -25,7 +26,7 @@ public:
   Q_PROPERTY(QString iconError READ iconError NOTIFY errorsChanged)
 
   Q_PROPERTY(AppSelectorModel *appSelectorModel READ appSelectorModel CONSTANT)
-  Q_PROPERTY(QVariantList iconItems READ iconItems NOTIFY iconItemsChanged)
+  Q_PROPERTY(CompletionModel *iconModel READ iconModel CONSTANT)
   Q_PROPERTY(QVariantList linkCompletions READ linkCompletions CONSTANT)
 
   ShortcutFormViewHost();
@@ -45,7 +46,7 @@ public:
   QString iconError() const { return m_iconError; }
 
   AppSelectorModel *appSelectorModel() const { return m_appSelectorModel; }
-  QVariantList iconItems() const { return m_iconItems; }
+  CompletionModel *iconModel() { return &m_iconModel; }
   QVariantList linkCompletions() const { return m_linkCompletions; }
 
   void setName(const QString &v) {
@@ -72,7 +73,6 @@ public:
 signals:
   void formChanged();
   void errorsChanged();
-  void iconItemsChanged();
 
 private:
   void buildIconItems();
@@ -86,6 +86,7 @@ private:
 
   QString m_name;
   QString m_link;
+  QString m_lastDetectedLink;
   QVariantMap m_selectedApp;
   QVariantMap m_selectedIcon;
 
@@ -93,7 +94,7 @@ private:
   QString m_appError;
   QString m_iconError;
 
-  QVariantList m_iconItems;
+  CompletionModel m_iconModel{this};
   QVariantList m_linkCompletions;
   QVariantMap m_defaultIconEntry;
   QString m_resolvedDefaultIcon;

--- a/src/server/src/qml/snippet-form-view-host.cpp
+++ b/src/server/src/qml/snippet-form-view-host.cpp
@@ -32,8 +32,7 @@ void SnippetFormViewHost::initialize() {
   const auto *appDb = context()->services->appDb();
   for (const auto &app : appDb->list({.sortAlphabetically = true})) {
     if (!app->displayable()) continue;
-    allApps.append(
-        qml::makeDropdownItem(app->id(), app->displayName(), qml::imageSourceFor(app->iconUrl())));
+    allApps.append(qml::makeDropdownItem(app->id(), app->displayName(), qml::imageSourceFor(app->iconUrl())));
   }
   m_availableAppsModel.setItems(allApps);
 

--- a/src/server/src/qml/snippet-form-view-host.cpp
+++ b/src/server/src/qml/snippet-form-view-host.cpp
@@ -32,17 +32,10 @@ void SnippetFormViewHost::initialize() {
   const auto *appDb = context()->services->appDb();
   for (const auto &app : appDb->list({.sortAlphabetically = true})) {
     if (!app->displayable()) continue;
-    QVariantMap entry;
-    entry[QStringLiteral("id")] = app->id();
-    entry[QStringLiteral("displayName")] = app->displayName();
-    entry[QStringLiteral("iconSource")] = qml::imageSourceFor(app->iconUrl());
-    allApps.append(entry);
+    allApps.append(
+        qml::makeDropdownItem(app->id(), app->displayName(), qml::imageSourceFor(app->iconUrl())));
   }
-
-  QVariantMap section;
-  section[QStringLiteral("title")] = QString();
-  section[QStringLiteral("items")] = allApps;
-  m_availableApps.append(section);
+  m_availableAppsModel.setItems(allApps);
 
   auto panel = std::make_unique<FormActionPanelState>();
   auto section2 = panel->createSection();

--- a/src/server/src/qml/snippet-form-view-host.hpp
+++ b/src/server/src/qml/snippet-form-view-host.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "bridge-view.hpp"
+#include "completion-model.hpp"
 #include "services/snippet/snippet-db.hpp"
 #include <optional>
 
@@ -13,7 +14,7 @@ class SnippetFormViewHost : public FormViewBase {
   Q_PROPERTY(QString keyword READ keyword WRITE setKeyword NOTIFY formChanged)
   Q_PROPERTY(bool expandAsWord READ expandAsWord WRITE setExpandAsWord NOTIFY formChanged)
   Q_PROPERTY(QStringList apps READ apps WRITE setApps NOTIFY formChanged)
-  Q_PROPERTY(QVariantList availableApps READ availableApps CONSTANT)
+  Q_PROPERTY(CompletionModel *availableAppsModel READ availableAppsModel CONSTANT)
 
   Q_PROPERTY(QVariantList contentCompletions READ contentCompletions CONSTANT)
 
@@ -39,7 +40,7 @@ public:
   QString keyword() const { return m_keyword; }
   bool expandAsWord() const { return m_expandAsWord; }
   QStringList apps() const { return m_apps; }
-  QVariantList availableApps() const { return m_availableApps; }
+  CompletionModel *availableAppsModel() { return &m_availableAppsModel; }
 
   QVariantList contentCompletions() const { return m_contentCompletions; }
 
@@ -101,5 +102,5 @@ private:
   QString m_keywordError;
 
   QVariantList m_contentCompletions;
-  QVariantList m_availableApps;
+  CompletionModel m_availableAppsModel{this};
 };

--- a/src/server/src/qml/view-utils.hpp
+++ b/src/server/src/qml/view-utils.hpp
@@ -29,6 +29,15 @@ QVariantMap accessoryToVariant(const ListAccessory &acc);
 
 inline QString imageSourceFor(const ImageURL &url) { return url.toString(); }
 
+inline QVariantMap makeDropdownItem(const QString &id, const QString &displayName,
+                                    const QString &iconSource = {}) {
+  QVariantMap m;
+  m[QStringLiteral("id")] = id;
+  m[QStringLiteral("displayName")] = displayName;
+  if (!iconSource.isEmpty()) m[QStringLiteral("iconSource")] = iconSource;
+  return m;
+}
+
 inline std::optional<QString> firstDropdownItemValue(const std::vector<DropdownModel::Child> &children) {
   for (const auto &child : children) {
     if (auto *item = std::get_if<DropdownModel::Item>(&child)) {


### PR DESCRIPTION
Much better than serializing everything as `QVariant`s obviously. We got away with it for a long time because most dropdowns only have a few options, but slowdowns could be experienced while using the ones in the "Create Shortcut" form for instance.