### PR TITLE
feat: proper default semantics for shortcuts

### DIFF
--- a/src/server/src/actions/shortcut/shortcut-actions.hpp
+++ b/src/server/src/actions/shortcut/shortcut-actions.hpp
@@ -60,14 +60,16 @@ public:
     auto shortcut = ctx->services->shortcuts();
     const auto expanded = expandShortcut(*m_shortcut, m_arguments);
 
-    if (m_app) {
-      appDb->launch(*m_app, {expanded});
-    } else if (auto app = appDb->findById(m_shortcut->app())) {
-      appDb->launch(*app, {expanded});
-    } else {
-      toast->setToast(tr("No app with id %1").arg(m_shortcut->app()), ToastStyle::Danger);
+    auto app = m_app ? m_app : ShortcutService::resolveApp(*appDb, m_shortcut->app(), expanded);
+
+    if (!app) {
+      auto message = m_shortcut->isDefaultApp() ? tr("No default app to open %1").arg(expanded)
+                                                : tr("No app with id %1").arg(m_shortcut->app());
+      toast->setToast(message, ToastStyle::Danger);
       return;
     }
+
+    appDb->launch(*app, {expanded});
 
     shortcut->registerVisit(m_shortcut->id());
     ctx->navigation->closeWindow();

--- a/src/server/src/qml/manage-shortcuts-view-host.cpp
+++ b/src/server/src/qml/manage-shortcuts-view-host.cpp
@@ -57,10 +57,11 @@ void ManageShortcutsViewHost::loadDetail(const std::shared_ptr<Shortcut> &shortc
       {QStringLiteral("value"), shortcut->name()},
   });
 
-  if (auto app = appDb->findById(shortcut->app())) {
+  if (auto app = ShortcutService::resolveApp(*appDb, shortcut->app(), shortcut->url())) {
     meta.append(QVariantMap{
         {QStringLiteral("label"), tr("Application")},
-        {QStringLiteral("value"), app->displayName()},
+        {QStringLiteral("value"),
+         shortcut->isDefaultApp() ? tr("%1 (Default)").arg(app->displayName()) : app->displayName()},
         {QStringLiteral("icon"), qml::imageSourceFor(app->iconUrl())},
     });
   }

--- a/src/server/src/qml/shortcut-form-view-host.cpp
+++ b/src/server/src/qml/shortcut-form-view-host.cpp
@@ -66,16 +66,16 @@ void ShortcutFormViewHost::initialize() {
     m_link = m_initialShortcut->url();
 
     auto appId = m_initialShortcut->app();
-    if (appDb->findById(appId)) {
+    if (!m_initialShortcut->isDefaultApp() && appDb->findById(appId)) {
       m_appSelectorModel->selectById(appId);
       m_selectedApp = m_appSelectorModel->currentItem();
     }
 
     if (auto item = m_iconModel.itemDataById(m_initialShortcut->icon()); !item.isEmpty()) {
       m_selectedIcon = item;
-    } else {
-      handleLinkBlurred();
     }
+
+    handleLinkBlurred();
 
     emit formChanged();
   } else if (!m_prefilledLink.isEmpty() || !m_prefilledName.isEmpty()) {
@@ -190,13 +190,6 @@ void ShortcutFormViewHost::submit() {
   auto appId = m_selectedApp[QStringLiteral("id")].toString();
   auto iconId = m_selectedIcon[QStringLiteral("id")].toString();
 
-  if (appId == QStringLiteral("default")) {
-    auto appDb = context()->services->appDb();
-    auto opener = appDb->findDefaultOpener(m_link);
-    if (!opener) { opener = appDb->webBrowser(); }
-    if (opener) { appId = opener->id(); }
-  }
-
   if (iconId == QStringLiteral("default")) { iconId = m_resolvedDefaultIcon; }
 
   if (m_mode == Mode::Edit) {
@@ -267,15 +260,8 @@ void ShortcutFormViewHost::selectApp(const QVariantMap &item) {
   m_selectedApp = item;
 
   if (!m_link.isEmpty()) {
-    auto appId = item[QStringLiteral("id")].toString();
-    auto appDb = context()->services->appDb();
-    std::shared_ptr<AbstractApplication> resolvedApp;
-    if (appId == QStringLiteral("default")) {
-      resolvedApp = appDb->findDefaultOpener(m_link);
-      if (!resolvedApp) resolvedApp = appDb->webBrowser();
-    } else {
-      resolvedApp = appDb->findById(appId);
-    }
+    auto resolvedApp = ShortcutService::resolveApp(*context()->services->appDb(),
+                                                   item[QStringLiteral("id")].toString(), m_link);
 
     if (resolvedApp) m_resolvedDefaultIcon = resolvedApp->iconUrl().toString();
 

--- a/src/server/src/services/shortcut/shortcut-service.cpp
+++ b/src/server/src/services/shortcut/shortcut-service.cpp
@@ -1,5 +1,6 @@
 #include "services/shortcut/shortcut-service.hpp"
 #include "omni-database.hpp"
+#include "services/app-service/app-service.hpp"
 #include <qlogging.h>
 
 std::shared_ptr<Shortcut> ShortcutService::fromSerialized(const shortcut::SerializedShortcut &s) {
@@ -145,4 +146,11 @@ bool ShortcutService::createShortcut(const QString &name, const QString &icon, c
 ShortcutService::ShortcutService(const std::filesystem::path &path, OmniDatabase *db) : m_db(path) {
   if (db && m_db.shortcuts().empty()) { migrateFromDatabase(*db); }
   loadAll();
+}
+
+std::shared_ptr<AbstractApplication>
+ShortcutService::resolveApp(const AppService &appDb, const QString &appId, const QString &target) {
+  if (appId != Shortcut::defaultAppId()) return appDb.findById(appId);
+  if (auto app = appDb.findDefaultOpener(target)) return app;
+  return appDb.webBrowser();
 }

--- a/src/server/src/services/shortcut/shortcut-service.hpp
+++ b/src/server/src/services/shortcut/shortcut-service.hpp
@@ -8,6 +8,8 @@
 #include <vector>
 
 class OmniDatabase;
+class AppService;
+class AbstractApplication;
 
 class ShortcutService : public QObject {
   Q_OBJECT
@@ -28,6 +30,9 @@ public:
                       const QString &app);
   Shortcut *findById(const QString &id);
   bool registerVisit(const QString &id);
+
+  static std::shared_ptr<AbstractApplication> resolveApp(const AppService &appDb, const QString &appId,
+                                                         const QString &target);
 
   ShortcutService(const std::filesystem::path &path, OmniDatabase *db = nullptr);
 

--- a/src/server/src/services/shortcut/shortcut.hpp
+++ b/src/server/src/services/shortcut/shortcut.hpp
@@ -55,6 +55,8 @@ public:
    * The ID of the application that is configured to open this url.
    */
   QString app() const;
+  bool isDefaultApp() const { return m_app == defaultAppId(); }
+  static QString defaultAppId() { return QStringLiteral("default"); }
   QString name() const;
   QString icon() const;
   int openCount() const;


### PR DESCRIPTION
Saving a shortcut with the default app as an opener saves "default" as the opener instead of saving the current default app. This means the shortcut will always open in the default app for the given URI, even if it is changed.

Typical example: an https URL will open in the currently configured default browser even if the shortcut was configured at a time where the default browser was a different one. Before this, the shortcut was stuck on the initial browser.