### PR TITLE
fix: show all root items in suggestions

### DIFF
--- a/src/server/src/services/root-item-manager/root-item-manager.cpp
+++ b/src/server/src/services/root-item-manager/root-item-manager.cpp
@@ -138,7 +138,7 @@ double RootItemManager::SearchableRootItem::frecency() const {
 }
 
 double RootItemManager::SearchableRootItem::fuzzyScore(const fuzzy::Query &query) const {
-  if (query.empty()) return 100.0 * frecency();
+  if (query.empty()) return 100.0 - fuzzy::FRECENCY_WEIGHT + fuzzy::FRECENCY_WEIGHT * frecency();
 
   using WS = fzf::WeightedString;
   std::string alias = meta->alias.value_or("");


### PR DESCRIPTION
When no query is set we should still see items with zero visits. Frecency should only decide ranking and not filtering in this scenario.

Regression introduced by #1802 