### PR TITLE
feat: cross platform text selection service

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -441,6 +441,8 @@ set(SRCS
 	src/services/paste/abstract-paste-service.hpp
 	src/services/paste/dummy-paste-service.hpp
 	src/services/paste/paste-service.cpp
+	src/services/selection/abstract-selection-service.hpp
+	src/services/selection/dummy-selection-service.hpp
 	src/services/browser-extension-service.hpp
 
 	src/internal/program-db/program-db.hpp
@@ -680,6 +682,8 @@ if (APPLE)
 		src/services/tray/macos/tray-service-macos.mm
 		src/services/paste/macos-paste-service.hpp
 		src/services/paste/macos-paste-service.mm
+		src/services/selection/macos-selection-service.hpp
+		src/services/selection/macos-selection-service.mm
 		src/services/power-manager/macos/macos-power-manager.hpp
 		src/services/power-manager/macos/macos-power-manager.mm
 		src/services/audio-control/macos/coreaudio-audio-control.hpp
@@ -712,6 +716,7 @@ if (APPLE)
 		src/services/files-service/macos/spotlight-file-indexer.mm
 		src/services/tray/macos/tray-service-macos.mm
 		src/services/paste/macos-paste-service.mm
+		src/services/selection/macos-selection-service.mm
 		src/services/power-manager/macos/macos-power-manager.mm
 		src/services/window-manager/macos/macos-window.mm
 		src/services/window-manager/macos/macos-window-manager.mm
@@ -739,6 +744,8 @@ elseif (WIN32)
 		src/services/clipboard/windows/windows-clipboard-server.cpp
 		src/services/paste/windows-paste-service.hpp
 		src/services/paste/windows-paste-service.cpp
+		src/services/selection/windows-selection-service.hpp
+		src/services/selection/windows-selection-service.cpp
 		src/services/files-service/windows/win-file-indexer.hpp
 		src/services/files-service/windows/win-file-indexer.cpp
 		src/services/window-manager/windows/windows-window.hpp
@@ -757,7 +764,7 @@ elseif (WIN32)
 		src/services/wallpaper/windows/windows-wallpaper-backend.hpp
 		src/services/wallpaper/windows/windows-wallpaper-backend.cpp
 	)
-	list(APPEND LIBS shell32 ole32 shlwapi user32 gdi32 advapi32 version windowsapp dwmapi comctl32 uuid)
+	list(APPEND LIBS shell32 ole32 shlwapi user32 gdi32 advapi32 version windowsapp dwmapi comctl32 uuid uiautomationcore)
 else()
 	list(APPEND SRCS
 		src/services/app-runtime/linux/linux-app-runtime.hpp
@@ -828,6 +835,7 @@ if (UNIX AND NOT APPLE)
 		src/services/desktop-notification/freedesktop/freedesktop-notification-client.cpp
 
 		src/services/paste/linux-paste-service.cpp
+		src/services/selection/linux-selection-service.cpp
 
 		src/services/input-server/linux-input-server.hpp
 		src/services/input-server/linux-input-server.cpp

--- a/src/server/src/extension/extension-command-runtime.cpp
+++ b/src/server/src/extension/extension-command-runtime.cpp
@@ -47,7 +47,7 @@ void ExtensionCommandRuntime::initialize() {
   auto *eventCore = new ExtEventCoreService(*m_transport);
   auto *app = new ExtApplicationService(*m_transport, *services->appDb());
   auto *ui = new ExtUIService(*m_transport, context()->navigation.get(), m_command, eventCore,
-                              *services->toastService());
+                              *services->toastService(), *services->selectionService());
   auto *wm = new ExtWindowManagementService(*m_transport, *services->windowManager(), *services->appDb(),
                                             *services->appRuntime(), *ctx.navigation);
   auto *clipboard = new ExtClipboardService(*m_transport, *services->clipman(), *services->pasteService());

--- a/src/server/src/extension/services/ui-service.hpp
+++ b/src/server/src/extension/services/ui-service.hpp
@@ -7,6 +7,7 @@
 #include "navigation-controller.hpp"
 #include "qml/extension-view-host.hpp"
 #include "services/desktop-notification/desktop-notification-client.hpp"
+#include "services/selection/abstract-selection-service.hpp"
 #include "services/toast/toast-service.hpp"
 #include "ui/alert/alert.hpp"
 #include "ui/image/image-renderer.hpp"
@@ -31,9 +32,9 @@ class ExtUIService : public tsapi::AbstractUI {
 public:
   ExtUIService(tsapi::RpcTransport &transport, NavigationController *navigation,
                const std::shared_ptr<ExtensionCommand> &command, tsapi::AbstractEventCore *eventCore,
-               ToastService &toast, QObject *parent = nullptr)
+               ToastService &toast, AbstractSelectionService &selection, QObject *parent = nullptr)
       : AbstractUI(transport), m_navigation(navigation), m_command(command), m_eventCore(eventCore),
-        m_toast(toast) {
+        m_toast(toast), m_selection(selection) {
     connect(&m_modelWatcher, &QFutureWatcher<ParsedRenderData>::finished, this, &ExtUIService::modelCreated);
     connect(navigation, &NavigationController::viewPoped, this, &ExtUIService::handleViewPoped);
   }
@@ -134,8 +135,12 @@ public:
   }
 
   tsapi::Result<std::string>::Future getSelectedText() override {
-    auto text = QGuiApplication::clipboard()->text(QClipboard::Mode::Selection);
-    return tsapi::Result<std::string>::ok(text.toStdString());
+    using Result = tsapi::Result<std::string>;
+
+    return m_selection.selectedText().then(this, [](AbstractSelectionService::Result result) -> Result::Type {
+      if (!result) return std::unexpected(result.error().toStdString());
+      return result->toStdString();
+    });
   }
 
   tsapi::Result<void>::Future sendDesktopNotification(tsapi::DesktopNotificationPayload data) override {
@@ -267,5 +272,6 @@ private:
   std::shared_ptr<ExtensionCommand> m_command;
   tsapi::AbstractEventCore *m_eventCore;
   ToastService &m_toast;
+  AbstractSelectionService &m_selection;
   DesktopNotificationClient m_notificationClient;
 };

--- a/src/server/src/server.cpp
+++ b/src/server/src/server.cpp
@@ -76,14 +76,18 @@
 #include "services/audio-control/audio-control-service.hpp"
 #include "services/paste/paste-service.hpp"
 #include "services/paste/dummy-paste-service.hpp"
+#include "services/selection/dummy-selection-service.hpp"
 #ifdef Q_OS_LINUX
 #include "services/paste/linux-paste-service.hpp"
+#include "services/selection/linux-selection-service.hpp"
 #endif
 #ifdef Q_OS_MACOS
 #include "services/paste/macos-paste-service.hpp"
+#include "services/selection/macos-selection-service.hpp"
 #endif
 #ifdef Q_OS_WIN
 #include "services/paste/windows-paste-service.hpp"
+#include "services/selection/windows-selection-service.hpp"
 #endif
 #include "settings-controller/settings-controller.hpp"
 #include "services/tray/tray-service.hpp"
@@ -263,15 +267,23 @@ int startServer(const ServerLaunchOptions &launchOpts) {
     auto snippetServer = std::make_unique<LinuxSnippetServer>(*inputServer);
     auto platformPaste =
         std::unique_ptr<AbstractPasteService>(std::make_unique<LinuxPasteService>(*inputServer));
+    auto selectionService =
+        std::unique_ptr<AbstractSelectionService>(std::make_unique<LinuxSelectionService>());
 #elif defined(Q_OS_MACOS)
     auto snippetServer = std::make_unique<MacosSnippetServer>();
     auto platformPaste = std::unique_ptr<AbstractPasteService>(std::make_unique<MacosPasteService>());
+    auto selectionService =
+        std::unique_ptr<AbstractSelectionService>(std::make_unique<MacosSelectionService>());
 #elif defined(Q_OS_WIN)
     auto snippetServer = std::make_unique<NullSnippetServer>();
     auto platformPaste = std::unique_ptr<AbstractPasteService>(std::make_unique<WindowsPasteService>());
+    auto selectionService =
+        std::unique_ptr<AbstractSelectionService>(std::make_unique<WindowsSelectionService>());
 #else
     auto snippetServer = std::make_unique<NullSnippetServer>();
     auto platformPaste = std::unique_ptr<AbstractPasteService>(std::make_unique<DummyPasteService>());
+    auto selectionService =
+        std::unique_ptr<AbstractSelectionService>(std::make_unique<DummySelectionService>());
 #endif
     auto snippetService =
         std::make_unique<SnippetService>(Omnicast::dataDir() / "snippets" / "snippets.json", *snippetServer,
@@ -319,6 +331,7 @@ int startServer(const ServerLaunchOptions &launchOpts) {
     registry->setExtensionManager(std::move(extensionManager));
     registry->setClipman(std::move(clipboardManager));
     registry->setPasteService(std::move(pasteService));
+    registry->setSelectionService(std::move(selectionService));
 #ifdef Q_OS_LINUX
     registry->setInputServer(std::move(inputServer));
 #endif

--- a/src/server/src/service-registry.cpp
+++ b/src/server/src/service-registry.cpp
@@ -15,6 +15,7 @@
 #include "services/shortcut/shortcut-service.hpp"
 #include "services/calculator-service/calculator-service.hpp"
 #include "services/clipboard/clipboard-service.hpp"
+#include "services/selection/abstract-selection-service.hpp"
 #include "services/glyph-service/glyph-service.hpp"
 #include "services/extension-registry/extension-registry.hpp"
 #include "services/files-service/file-service.hpp"
@@ -71,6 +72,7 @@ LinuxInputServer *ServiceRegistry::inputServer() const { return m_inputServer.ge
 SnippetService *ServiceRegistry::snippetService() const { return m_snippetService.get(); }
 
 PasteService *ServiceRegistry::pasteService() const { return m_pasteService.get(); }
+AbstractSelectionService *ServiceRegistry::selectionService() const { return m_selectionService.get(); }
 
 FileChooserService *ServiceRegistry::fileChooserService() const { return m_fileChooserService.get(); }
 
@@ -174,6 +176,10 @@ void ServiceRegistry::setSnippetService(std::unique_ptr<SnippetService> service)
 
 void ServiceRegistry::setPasteService(std::unique_ptr<PasteService> service) {
   m_pasteService = std::move(service);
+}
+
+void ServiceRegistry::setSelectionService(std::unique_ptr<AbstractSelectionService> service) {
+  m_selectionService = std::move(service);
 }
 
 void ServiceRegistry::setFileChooserService(std::unique_ptr<FileChooserService> service) {

--- a/src/server/src/service-registry.hpp
+++ b/src/server/src/service-registry.hpp
@@ -35,6 +35,7 @@ class ShortcutInhibitManager;
 class FileChooserService;
 class NewsService;
 class PasteService;
+class AbstractSelectionService;
 class TelemetryService;
 class UpdateService;
 class AudioControlService;
@@ -77,6 +78,7 @@ public:
 #endif
   SnippetService *snippetService() const;
   PasteService *pasteService() const;
+  AbstractSelectionService *selectionService() const;
   FileChooserService *fileChooserService() const;
   NewsService *newsService() const;
   WindowMaterialManager *windowMaterialManager() const;
@@ -116,6 +118,7 @@ public:
   void setSnippetServerBackend(std::unique_ptr<AbstractSnippetServer> backend);
   void setSnippetService(std::unique_ptr<SnippetService> service);
   void setPasteService(std::unique_ptr<PasteService> service);
+  void setSelectionService(std::unique_ptr<AbstractSelectionService> service);
   void setFileChooserService(std::unique_ptr<FileChooserService> service);
   void setNewsService(std::unique_ptr<NewsService> service);
   void setWindowMaterialManager(std::unique_ptr<WindowMaterialManager> manager);
@@ -155,6 +158,7 @@ private:
   std::unique_ptr<AbstractSnippetServer> m_snippetServerBackend;
   std::unique_ptr<SnippetService> m_snippetService;
   std::unique_ptr<PasteService> m_pasteService;
+  std::unique_ptr<AbstractSelectionService> m_selectionService;
   std::unique_ptr<FileChooserService> m_fileChooserService;
   std::unique_ptr<NewsService> m_newsService;
   std::unique_ptr<WindowMaterialManager> m_windowMaterialManager;

--- a/src/server/src/services/selection/abstract-selection-service.hpp
+++ b/src/server/src/services/selection/abstract-selection-service.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include <QFuture>
+#include <QString>
+#include <expected>
+
+class AbstractSelectionService {
+public:
+  using Result = std::expected<QString, QString>;
+
+  virtual ~AbstractSelectionService() = default;
+
+  virtual QFuture<Result> selectedText() = 0;
+};

--- a/src/server/src/services/selection/dummy-selection-service.hpp
+++ b/src/server/src/services/selection/dummy-selection-service.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#include "services/selection/abstract-selection-service.hpp"
+
+class DummySelectionService : public AbstractSelectionService {
+public:
+  QFuture<Result> selectedText() override {
+    return QtFuture::makeReadyValueFuture<Result>(
+        std::unexpected(QStringLiteral("Selected text is not supported on this platform")));
+  }
+};

--- a/src/server/src/services/selection/linux-selection-service.cpp
+++ b/src/server/src/services/selection/linux-selection-service.cpp
@@ -1,0 +1,14 @@
+#include "linux-selection-service.hpp"
+#include <QClipboard>
+#include <QGuiApplication>
+
+QFuture<AbstractSelectionService::Result> LinuxSelectionService::selectedText() {
+  QString text = QGuiApplication::clipboard()->text(QClipboard::Mode::Selection);
+
+  if (text.isEmpty()) {
+    return QtFuture::makeReadyValueFuture<Result>(
+        std::unexpected(QStringLiteral("Unable to get selected text")));
+  }
+
+  return QtFuture::makeReadyValueFuture<Result>(std::move(text));
+}

--- a/src/server/src/services/selection/linux-selection-service.hpp
+++ b/src/server/src/services/selection/linux-selection-service.hpp
@@ -1,0 +1,7 @@
+#pragma once
+#include "services/selection/abstract-selection-service.hpp"
+
+class LinuxSelectionService : public AbstractSelectionService {
+public:
+  QFuture<Result> selectedText() override;
+};

--- a/src/server/src/services/selection/macos-selection-service.hpp
+++ b/src/server/src/services/selection/macos-selection-service.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include "services/selection/abstract-selection-service.hpp"
+#include <QObject>
+
+class MacosSelectionService : public QObject, public AbstractSelectionService {
+  Q_OBJECT
+
+public:
+  QFuture<Result> selectedText() override;
+
+private:
+  QFuture<Result> copyFromFrontmostApp(int pid);
+};

--- a/src/server/src/services/selection/macos-selection-service.mm
+++ b/src/server/src/services/selection/macos-selection-service.mm
@@ -1,0 +1,147 @@
+#include "macos-selection-service.hpp"
+#import <AppKit/AppKit.h>
+#include <ApplicationServices/ApplicationServices.h>
+#include <QPromise>
+#include <QTimer>
+#include <QtLogging>
+#include <unistd.h>
+
+namespace {
+
+using Result = AbstractSelectionService::Result;
+
+constexpr CGKeyCode VK_ANSI_C = 0x08;
+constexpr int COPY_POLL_INTERVAL_MS = 10;
+constexpr int COPY_TIMEOUT_MS = 400;
+NSString *const TRANSIENT_UTI = @"org.nspasteboard.TransientType";
+
+QFuture<Result> ready(Result result) { return QtFuture::makeReadyValueFuture<Result>(std::move(result)); }
+
+QFuture<Result> fail(const QString &error) { return ready(std::unexpected(error)); }
+
+std::optional<pid_t> frontmostPid() {
+  NSRunningApplication *front = [[NSWorkspace sharedWorkspace] frontmostApplication];
+  if (!front) return std::nullopt;
+
+  pid_t pid = front.processIdentifier;
+  if (pid <= 0 || pid == getpid()) return std::nullopt;
+
+  return pid;
+}
+
+QString accessibilitySelectedText(pid_t pid) {
+  QString result;
+  AXUIElementRef app = AXUIElementCreateApplication(pid);
+  CFTypeRef focused = nullptr;
+
+  if (AXUIElementCopyAttributeValue(app, kAXFocusedUIElementAttribute, &focused) == kAXErrorSuccess &&
+      focused) {
+    CFTypeRef value = nullptr;
+    if (AXUIElementCopyAttributeValue(static_cast<AXUIElementRef>(focused), kAXSelectedTextAttribute,
+                                      &value) == kAXErrorSuccess &&
+        value) {
+      if (CFGetTypeID(value) == CFStringGetTypeID()) {
+        result = QString::fromCFString(static_cast<CFStringRef>(value));
+      }
+      CFRelease(value);
+    }
+    CFRelease(focused);
+  }
+
+  CFRelease(app);
+  return result;
+}
+
+void postKeyToPid(pid_t pid, CGKeyCode key, bool down, CGEventFlags flags) {
+  CGEventRef event = CGEventCreateKeyboardEvent(nullptr, key, down);
+  if (!event) return;
+  CGEventSetFlags(event, flags);
+  CGEventPostToPid(pid, event);
+  CFRelease(event);
+}
+
+NSArray<NSPasteboardItem *> *snapshotPasteboard(NSPasteboard *pb) {
+  NSMutableArray<NSPasteboardItem *> *copies = [NSMutableArray array];
+
+  for (NSPasteboardItem *item in pb.pasteboardItems) {
+    NSPasteboardItem *copy = [[NSPasteboardItem alloc] init];
+    for (NSPasteboardType type in item.types) {
+      if (NSData *data = [item dataForType:type]) { [copy setData:data forType:type]; }
+    }
+    if (copy.types.count > 0) { [copies addObject:copy]; }
+  }
+
+  return copies;
+}
+
+// The restore is flagged transient so the clipboard monitor doesn't re-index what was already there.
+void restorePasteboard(NSPasteboard *pb, NSArray<NSPasteboardItem *> *items) {
+  [pb clearContents];
+  if (items.count == 0) return;
+  [items.firstObject setString:@"" forType:TRANSIENT_UTI];
+  [pb writeObjects:items];
+}
+
+} // namespace
+
+QFuture<Result> MacosSelectionService::selectedText() {
+  if (!AXIsProcessTrusted()) {
+    return fail(QStringLiteral("Accessibility permission is required to read the selected text"));
+  }
+
+  @autoreleasepool {
+    auto pid = frontmostPid();
+    if (!pid) return fail(QStringLiteral("Unable to get selected text"));
+
+    if (QString text = accessibilitySelectedText(*pid); !text.isEmpty()) { return ready(std::move(text)); }
+
+    return copyFromFrontmostApp(*pid);
+  }
+}
+
+QFuture<Result> MacosSelectionService::copyFromFrontmostApp(int pid) {
+  NSPasteboard *pb = [NSPasteboard generalPasteboard];
+  NSInteger const before = pb.changeCount;
+  NSArray<NSPasteboardItem *> *snapshot = snapshotPasteboard(pb);
+
+  postKeyToPid(pid, VK_ANSI_C, true, kCGEventFlagMaskCommand);
+  postKeyToPid(pid, VK_ANSI_C, false, kCGEventFlagMaskCommand);
+
+  auto promise = std::make_shared<QPromise<Result>>();
+  promise->start();
+
+  auto *timer = new QTimer(this);
+  auto elapsed = std::make_shared<int>(0);
+
+  timer->setInterval(COPY_POLL_INTERVAL_MS);
+  connect(timer, &QTimer::timeout, this, [timer, promise, elapsed, before, snapshot]() {
+    *elapsed += COPY_POLL_INTERVAL_MS;
+
+    @autoreleasepool {
+      NSPasteboard *pb = [NSPasteboard generalPasteboard];
+
+      if (pb.changeCount == before) {
+        if (*elapsed < COPY_TIMEOUT_MS) return;
+        timer->deleteLater();
+        promise->addResult(std::unexpected(QStringLiteral("Unable to get selected text")));
+        promise->finish();
+        return;
+      }
+
+      timer->deleteLater();
+      NSString *str = [pb stringForType:NSPasteboardTypeString];
+      QString text = str ? QString::fromNSString(str) : QString();
+      restorePasteboard(pb, snapshot);
+
+      if (text.isEmpty()) {
+        promise->addResult(std::unexpected(QStringLiteral("Unable to get selected text")));
+      } else {
+        promise->addResult(std::move(text));
+      }
+      promise->finish();
+    }
+  });
+  timer->start();
+
+  return promise->future();
+}

--- a/src/server/src/services/selection/windows-selection-service.cpp
+++ b/src/server/src/services/selection/windows-selection-service.cpp
@@ -1,7 +1,12 @@
 #include "windows-selection-service.hpp"
-#include <memory>
 #include <windows.h>
+#include <objbase.h>
+#include <oleauto.h>
 #include <uiautomation.h>
+#include <wrl/client.h>
+#include "utils/scoped-com.hpp"
+
+using Microsoft::WRL::ComPtr;
 
 namespace {
 
@@ -16,26 +21,17 @@ void CALLBACK foregroundChanged(HWINEVENTHOOK, DWORD, HWND hwnd, LONG, LONG, DWO
   if (pid && pid != GetCurrentProcessId()) g_lastForeground = hwnd;
 }
 
-template <typename T> struct ComRelease {
-  void operator()(T *p) const {
-    if (p) p->Release();
-  }
-};
-template <typename T> using ComPtr = std::unique_ptr<T, ComRelease<T>>;
-
 QString textFromPattern(IUIAutomationTextPattern *pattern) {
-  IUIAutomationTextRangeArray *rawRanges = nullptr;
-  if (FAILED(pattern->GetSelection(&rawRanges)) || !rawRanges) return {};
-  ComPtr<IUIAutomationTextRangeArray> ranges(rawRanges);
+  ComPtr<IUIAutomationTextRangeArray> ranges;
+  if (FAILED(pattern->GetSelection(&ranges)) || !ranges) return {};
 
   int count = 0;
   ranges->get_Length(&count);
 
   QString text;
   for (int i = 0; i < count; ++i) {
-    IUIAutomationTextRange *rawRange = nullptr;
-    if (FAILED(ranges->GetElement(i, &rawRange)) || !rawRange) continue;
-    ComPtr<IUIAutomationTextRange> range(rawRange);
+    ComPtr<IUIAutomationTextRange> range;
+    if (FAILED(ranges->GetElement(i, &range)) || !range) continue;
 
     BSTR bstr = nullptr;
     if (SUCCEEDED(range->GetText(-1, &bstr)) && bstr) {
@@ -48,25 +44,23 @@ QString textFromPattern(IUIAutomationTextPattern *pattern) {
 }
 
 QString textFromElement(IUIAutomationElement *element) {
-  IUnknown *rawPattern = nullptr;
-  if (FAILED(element->GetCurrentPattern(UIA_TextPatternId, &rawPattern)) || !rawPattern) return {};
-  ComPtr<IUnknown> unknown(rawPattern);
+  ComPtr<IUnknown> unknown;
+  if (FAILED(element->GetCurrentPattern(UIA_TextPatternId, &unknown)) || !unknown) return {};
 
-  IUIAutomationTextPattern *rawText = nullptr;
-  if (FAILED(unknown->QueryInterface(IID_PPV_ARGS(&rawText))) || !rawText) return {};
-  ComPtr<IUIAutomationTextPattern> pattern(rawText);
+  ComPtr<IUIAutomationTextPattern> pattern;
+  if (FAILED(unknown.As(&pattern)) || !pattern) return {};
 
-  return textFromPattern(pattern.get());
+  return textFromPattern(pattern.Get());
 }
 
 QString selectedTextFromWindow(HWND foreground) {
-  IUIAutomation *rawAutomation = nullptr;
-  if (FAILED(CoCreateInstance(CLSID_CUIAutomation, nullptr, CLSCTX_INPROC_SERVER,
-                              IID_PPV_ARGS(&rawAutomation))) ||
-      !rawAutomation) {
+  ScopedCom com;
+  ComPtr<IUIAutomation> automation;
+  if (FAILED(
+          CoCreateInstance(CLSID_CUIAutomation, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&automation))) ||
+      !automation) {
     return {};
   }
-  ComPtr<IUIAutomation> automation(rawAutomation);
 
   // GetFocusedElement would resolve to the launcher; ask the target thread for its focused control
   GUITHREADINFO info{};
@@ -74,29 +68,25 @@ QString selectedTextFromWindow(HWND foreground) {
   DWORD thread = GetWindowThreadProcessId(foreground, nullptr);
   HWND focus = (thread && GetGUIThreadInfo(thread, &info) && info.hwndFocus) ? info.hwndFocus : foreground;
 
-  IUIAutomationElement *rawElement = nullptr;
-  if (FAILED(automation->ElementFromHandle(focus, &rawElement)) || !rawElement) return {};
-  ComPtr<IUIAutomationElement> element(rawElement);
+  ComPtr<IUIAutomationElement> element;
+  if (FAILED(automation->ElementFromHandle(focus, &element)) || !element) return {};
 
-  if (QString text = textFromElement(element.get()); !text.isEmpty()) return text;
+  if (QString text = textFromElement(element.Get()); !text.isEmpty()) return text;
 
   VARIANT focusedValue;
   focusedValue.vt = VT_BOOL;
   focusedValue.boolVal = VARIANT_TRUE;
 
-  IUIAutomationCondition *rawCondition = nullptr;
-  if (FAILED(
-          automation->CreatePropertyCondition(UIA_HasKeyboardFocusPropertyId, focusedValue, &rawCondition)) ||
-      !rawCondition) {
+  ComPtr<IUIAutomationCondition> condition;
+  if (FAILED(automation->CreatePropertyCondition(UIA_HasKeyboardFocusPropertyId, focusedValue, &condition)) ||
+      !condition) {
     return {};
   }
-  ComPtr<IUIAutomationCondition> condition(rawCondition);
 
-  IUIAutomationElement *rawFocused = nullptr;
-  if (FAILED(element->FindFirst(TreeScope_Subtree, condition.get(), &rawFocused)) || !rawFocused) return {};
-  ComPtr<IUIAutomationElement> focused(rawFocused);
+  ComPtr<IUIAutomationElement> focused;
+  if (FAILED(element->FindFirst(TreeScope_Subtree, condition.Get(), &focused)) || !focused) return {};
 
-  return textFromElement(focused.get());
+  return textFromElement(focused.Get());
 }
 
 } // namespace

--- a/src/server/src/services/selection/windows-selection-service.cpp
+++ b/src/server/src/services/selection/windows-selection-service.cpp
@@ -1,0 +1,130 @@
+#include "windows-selection-service.hpp"
+#include <memory>
+#include <windows.h>
+#include <uiautomation.h>
+
+namespace {
+
+using Result = AbstractSelectionService::Result;
+
+HWND g_lastForeground = nullptr;
+
+void CALLBACK foregroundChanged(HWINEVENTHOOK, DWORD, HWND hwnd, LONG, LONG, DWORD, DWORD) {
+  if (!hwnd) return;
+  DWORD pid = 0;
+  GetWindowThreadProcessId(hwnd, &pid);
+  if (pid && pid != GetCurrentProcessId()) g_lastForeground = hwnd;
+}
+
+template <typename T> struct ComRelease {
+  void operator()(T *p) const {
+    if (p) p->Release();
+  }
+};
+template <typename T> using ComPtr = std::unique_ptr<T, ComRelease<T>>;
+
+QString textFromPattern(IUIAutomationTextPattern *pattern) {
+  IUIAutomationTextRangeArray *rawRanges = nullptr;
+  if (FAILED(pattern->GetSelection(&rawRanges)) || !rawRanges) return {};
+  ComPtr<IUIAutomationTextRangeArray> ranges(rawRanges);
+
+  int count = 0;
+  ranges->get_Length(&count);
+
+  QString text;
+  for (int i = 0; i < count; ++i) {
+    IUIAutomationTextRange *rawRange = nullptr;
+    if (FAILED(ranges->GetElement(i, &rawRange)) || !rawRange) continue;
+    ComPtr<IUIAutomationTextRange> range(rawRange);
+
+    BSTR bstr = nullptr;
+    if (SUCCEEDED(range->GetText(-1, &bstr)) && bstr) {
+      text += QString::fromWCharArray(bstr, static_cast<int>(SysStringLen(bstr)));
+      SysFreeString(bstr);
+    }
+  }
+
+  return text;
+}
+
+QString textFromElement(IUIAutomationElement *element) {
+  IUnknown *rawPattern = nullptr;
+  if (FAILED(element->GetCurrentPattern(UIA_TextPatternId, &rawPattern)) || !rawPattern) return {};
+  ComPtr<IUnknown> unknown(rawPattern);
+
+  IUIAutomationTextPattern *rawText = nullptr;
+  if (FAILED(unknown->QueryInterface(IID_PPV_ARGS(&rawText))) || !rawText) return {};
+  ComPtr<IUIAutomationTextPattern> pattern(rawText);
+
+  return textFromPattern(pattern.get());
+}
+
+QString selectedTextFromWindow(HWND foreground) {
+  IUIAutomation *rawAutomation = nullptr;
+  if (FAILED(CoCreateInstance(CLSID_CUIAutomation, nullptr, CLSCTX_INPROC_SERVER,
+                              IID_PPV_ARGS(&rawAutomation))) ||
+      !rawAutomation) {
+    return {};
+  }
+  ComPtr<IUIAutomation> automation(rawAutomation);
+
+  // GetFocusedElement would resolve to the launcher; ask the target thread for its focused control
+  GUITHREADINFO info{};
+  info.cbSize = sizeof(GUITHREADINFO);
+  DWORD thread = GetWindowThreadProcessId(foreground, nullptr);
+  HWND focus = (thread && GetGUIThreadInfo(thread, &info) && info.hwndFocus) ? info.hwndFocus : foreground;
+
+  IUIAutomationElement *rawElement = nullptr;
+  if (FAILED(automation->ElementFromHandle(focus, &rawElement)) || !rawElement) return {};
+  ComPtr<IUIAutomationElement> element(rawElement);
+
+  if (QString text = textFromElement(element.get()); !text.isEmpty()) return text;
+
+  VARIANT focusedValue;
+  focusedValue.vt = VT_BOOL;
+  focusedValue.boolVal = VARIANT_TRUE;
+
+  IUIAutomationCondition *rawCondition = nullptr;
+  if (FAILED(
+          automation->CreatePropertyCondition(UIA_HasKeyboardFocusPropertyId, focusedValue, &rawCondition)) ||
+      !rawCondition) {
+    return {};
+  }
+  ComPtr<IUIAutomationCondition> condition(rawCondition);
+
+  IUIAutomationElement *rawFocused = nullptr;
+  if (FAILED(element->FindFirst(TreeScope_Subtree, condition.get(), &rawFocused)) || !rawFocused) return {};
+  ComPtr<IUIAutomationElement> focused(rawFocused);
+
+  return textFromElement(focused.get());
+}
+
+} // namespace
+
+WindowsSelectionService::WindowsSelectionService() {
+  g_lastForeground = GetForegroundWindow();
+  m_hook = SetWinEventHook(EVENT_SYSTEM_FOREGROUND, EVENT_SYSTEM_FOREGROUND, nullptr, foregroundChanged, 0, 0,
+                           WINEVENT_OUTOFCONTEXT | WINEVENT_SKIPOWNPROCESS);
+}
+
+WindowsSelectionService::~WindowsSelectionService() {
+  if (m_hook) UnhookWinEvent(static_cast<HWINEVENTHOOK>(m_hook));
+}
+
+QFuture<Result> WindowsSelectionService::selectedText() {
+  HWND target = g_lastForeground;
+
+  if (!target || !IsWindow(target)) {
+    return QtFuture::makeReadyValueFuture<Result>(
+        std::unexpected(QStringLiteral("Unable to get selected text")));
+  }
+
+  QString text = selectedTextFromWindow(target);
+
+  if (text.isEmpty()) {
+    return QtFuture::makeReadyValueFuture<Result>(
+        std::unexpected(QStringLiteral("Unable to get selected text")));
+  }
+
+  return QtFuture::makeReadyValueFuture<Result>(std::move(text));
+}

--- a/src/server/src/services/selection/windows-selection-service.hpp
+++ b/src/server/src/services/selection/windows-selection-service.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include "services/selection/abstract-selection-service.hpp"
+
+class WindowsSelectionService : public AbstractSelectionService {
+public:
+  WindowsSelectionService();
+  ~WindowsSelectionService() override;
+
+  QFuture<Result> selectedText() override;
+
+private:
+  void *m_hook = nullptr;
+};


### PR DESCRIPTION
The currently implementation of `getSelectedText` doesn't actually work on macOS and Windows because they have no concept of primary selection.

This fixes it by providing a platform specific implementation. On macOS, the accessibility permission needs to be granted in order for that to work.

fixes #1816 