### PR TITLE
fix(ext): support React createElement factory

### DIFF
--- a/src/typescript/extension-manager/src/patch-require.ts
+++ b/src/typescript/extension-manager/src/patch-require.ts
@@ -3,12 +3,22 @@ import type { EnvironmentType } from "./types";
 
 const injectJsxGlobals = () => {
 	const { jsx, jsxs, Fragment } = require("react/jsx-runtime");
+	const { createElement } = require("react");
 
-	// react/jsx-runtime always expect non-null props
+	const isKey = (v: unknown) =>
+		v === undefined || typeof v === "string" || typeof v === "number";
+
 	const safeJsx =
 		(original: typeof jsx) =>
-		(type: React.ElementType, props: unknown, key: React.Key) =>
-			original(type, props ?? {}, key);
+		(type: React.ElementType, props: any, ...rest: unknown[]) => {
+			props ??= {};
+			const classic =
+				rest.length > 1 ||
+				(rest.length === 1 && !isKey(rest[0])) ||
+				"key" in props;
+			if (classic) return createElement(type, props, ...rest);
+			return original(type, props, rest[0] as React.Key);
+		};
 
 	(globalThis as any)._jsx = safeJsx(jsx);
 	(globalThis as any)._jsxs = safeJsx(jsxs);


### PR DESCRIPTION
It looks like Raycast extensions compiled with a recent version of the `ray` toolchain now use the `createElement` factory, causing problems when executed by the Vicinae extension runtime.

This PR just adds support for it.

This issue was first discovered trying to run the recently published [wojack picker](https://www.raycast.com/itsmeonli/wojak-picker) extension, which wouldn't run if executed in its pre-bundled form (fine if compiled with the Vicinae toolchain).