### PR TITLE
fix(macos): stop app watcher from rescanning in a loop

### DIFF
--- a/src/server/src/services/app-service/app-service.cpp
+++ b/src/server/src/services/app-service/app-service.cpp
@@ -135,15 +135,30 @@ AppService::findCuratedOpeners(const QString &target) const {
 }
 
 bool AppService::reinstallWatches(const std::vector<fs::path> &paths) {
-  for (const auto &path : m_watcher->directories()) {
-    m_watcher->removePath(path);
-  }
-
   auto isDir = [](auto &&path) { return fs::is_directory(path); };
 
+  QStringList desired;
+
   for (const auto &path : paths | std::views::filter(isDir)) {
-    m_watcher->addPath(QString::fromStdWString(path.wstring()));
+    desired.append(QString::fromStdWString(path.wstring()));
   }
+
+  desired.sort();
+  desired.removeDuplicates();
+
+  QStringList current = m_watcher->directories();
+
+  current.sort();
+
+  // Rebuilding an identical watch set re-triggers directoryChanged, which
+  // schedules another rescan, which lands back here: the loop never settles.
+  if (current == desired) return true;
+
+  // Qt's macOS backend rebuilds the whole FSEventStream on every
+  // add/removePath and blocks in FSEventStreamFlushSync until fseventsd
+  // answers, so batch instead of paying that once per path.
+  if (!current.isEmpty()) m_watcher->removePaths(current);
+  if (!desired.isEmpty()) m_watcher->addPaths(desired);
 
   return true;
 }

--- a/src/server/src/services/app-service/app-service.cpp
+++ b/src/server/src/services/app-service/app-service.cpp
@@ -135,28 +135,22 @@ AppService::findCuratedOpeners(const QString &target) const {
 }
 
 bool AppService::reinstallWatches(const std::vector<fs::path> &paths) {
-  auto isDir = [](auto &&path) { return fs::is_directory(path); };
-
+  QStringList current = m_watcher->directories();
   QStringList desired;
+  std::error_code ec{};
 
-  for (const auto &path : paths | std::views::filter(isDir)) {
-    desired.append(QString::fromStdWString(path.wstring()));
+  for (const auto &path : paths) {
+    if (fs::is_directory(path, ec)) { desired.append(QString::fromStdString(path.string())); }
   }
 
   desired.sort();
   desired.removeDuplicates();
-
-  QStringList current = m_watcher->directories();
-
   current.sort();
 
-  // Rebuilding an identical watch set re-triggers directoryChanged, which
-  // schedules another rescan, which lands back here: the loop never settles.
+  // It's important that we don't reinstall the watches if the directories haven't changed.
+  // On some systems it's a no-op, on others like macOS it can trigger a new flood
+  // of events, which can create some performance problems.
   if (current == desired) return true;
-
-  // Qt's macOS backend rebuilds the whole FSEventStream on every
-  // add/removePath and blocks in FSEventStreamFlushSync until fseventsd
-  // answers, so batch instead of paying that once per path.
   if (!current.isEmpty()) m_watcher->removePaths(current);
   if (!desired.isEmpty()) m_watcher->addPaths(desired);
 


### PR DESCRIPTION
Fixes the macOS slowdown in #1790.

`reinstallWatches()` tore the watch set down and rebuilt it one path at a time on every rescan. On macOS each `add`/`removePath` rebuilds the whole `FSEventStream` and blocks the calling thread in `FSEventStreamFlushSync`, and restarting the stream re-fires `directoryChanged`, which schedules another rescan via `m_rescanDebounce` and lands straight back in `reinstallWatches()`. Nothing else feeds that debounce except a preferences change, so once it started it never settled — the UI thread stayed blocked and the launcher took ~1s to open with visible per-keystroke lag.

Two changes: return early when the watch set is unchanged (this is what breaks the cycle), and use the batched `addPaths`/`removePaths` overloads so a genuine change costs one stream rebuild per side instead of one per path.

Measured with `sample` and `fs_usage`, idle with the window closed, on a machine with ~250 application bundles (M4 Max, macOS 26.6.2):

| | v0.26.3 | this branch |
|---|---|---|
| filesystem syscalls / 15s | ~13,500 | 0 |
| main thread in `FSEventStreamFlushSync` | 57% | 0% |
| main thread in `QFileSystemWatcher::addPath` | 49% | 0% |
| CPU | ~1-2% | 0.0% |

The patched main thread profiles as 8840/8841 samples parked in `__CFRunLoopServiceMachPort`. Detection is unchanged: a new `.app` under `~/Applications` is picked up in 1-2s and a removal within 3s, still through the existing 500ms debounce.

Tested locally on macOS via `make release` + `make mac-bundle`. Untested on Linux and Windows, though the change is platform-agnostic — the pathological cost is macOS-specific but the redundant reinstall was happening everywhere.

Happy to take this further up instead if you'd prefer — e.g. have `scanSync()` not call `reinstallWatches()` at all and only reinstall when `searchPaths()` actually changes.
