### PR TITLE
feat(macOS): draggable window and snap guides

### DIFF
--- a/src/server/src/qml/launcher-window-platform.hpp
+++ b/src/server/src/qml/launcher-window-platform.hpp
@@ -2,9 +2,17 @@
 #include <QtGlobal>
 
 class QQuickWindow;
+class QWindow;
 
 // Native windowing quirks the launcher window needs handled per platform.
 namespace LauncherWindowPlatform {
+
+#ifdef Q_OS_MACOS
+// Raises the drag snap overlay above the menu bar and Dock.
+void prepareOverlayWindow(QWindow *window);
+#else
+inline void prepareOverlayWindow(QWindow *) {}
+#endif
 
 #ifdef Q_OS_WIN
 // The system only grants foreground to the process that last received input;

--- a/src/server/src/qml/launcher-window.cpp
+++ b/src/server/src/qml/launcher-window.cpp
@@ -1,5 +1,8 @@
 #include "launcher-window.hpp"
 #include "launcher-window-platform.hpp"
+#ifdef Q_OS_MACOS
+#include "macos-chrome-attached.hpp"
+#endif
 #ifdef Q_OS_LINUX
 #include "internal/wayland/xdg-activation.hpp"
 #endif
@@ -44,11 +47,29 @@
 #include <QKeyEvent>
 #include <qcoreevent.h>
 #include <qlogging.h>
+#include <algorithm>
+#include <filesystem>
 #include <memory>
+#include <glaze/glaze.hpp>
 
 #ifdef __GLIBC__
 #include <malloc.h>
 #endif
+
+struct SavedWindowPosition {
+  std::string screen;
+  int x = 0;
+  int y = 0;
+};
+
+namespace {
+
+constexpr int DRAG_SNAP_DISTANCE = 32;
+constexpr int MIN_VISIBLE_ON_RESTORE = 40;
+
+std::filesystem::path windowPositionPath() { return Omnicast::stateDir() / "launcher-window.json"; }
+
+} // namespace
 
 LauncherWindow::LauncherWindow(ApplicationContext &ctx, QObject *parent)
     : QObject(parent), m_ctx(ctx), m_actionPanel(new ActionPanelController(ctx, this)),
@@ -410,6 +431,7 @@ void LauncherWindow::handleVisibilityChanged(bool visible) {
 #endif
   } else {
     LauncherWindowPlatform::suppressHeldKeyReleases();
+    if (m_dragOverlayVisible) endWindowDrag();
     m_window->hide();
     updateWindowTitle();
     m_cacheEvictionTimer.start();
@@ -622,9 +644,157 @@ bool LauncherWindow::canPositionWindow() { return Environment::supportsArbitrary
 
 void LauncherWindow::positionOnCursorScreen() {
   if (!m_window || !canPositionWindow()) return;
-  const QRect g = cursorScreenGeometry();
-  m_window->setX(g.x() + (g.width() - m_window->width()) / 2);
-  m_window->setY(g.y() + (g.height() - m_window->height()) / 3);
+  auto *screen = QGuiApplication::screenAt(QCursor::pos());
+  if (!screen) screen = QGuiApplication::primaryScreen();
+  if (!screen) return;
+
+  // place as if fully expanded so compact mode keeps the same top edge
+  const QRect avail = screen->availableGeometry();
+  const int refHeight =
+      m_overrideHeight ? m_overrideHeight : m_ctx.services->config()->value().launcherWindow.size.height;
+  m_window->setPosition(avail.left() + (avail.width() - m_window->width()) / 2,
+                        avail.top() + (avail.height() - refHeight) / 3);
+}
+
+bool LauncherWindow::restoreWindowPosition() {
+  if (!m_window || !canPositionWindow()) return false;
+
+  SavedWindowPosition saved;
+  std::string buf;
+  if (glz::read_file_json(saved, windowPositionPath().string(), buf)) return false;
+
+  const auto screens = QGuiApplication::screens();
+  auto it = std::ranges::find(screens, QString::fromStdString(saved.screen), &QScreen::name);
+  if (it == screens.end()) return false;
+
+  // exact restore, deliberately unclamped: partial-offscreen placements are legitimate
+  const QPoint pos = (*it)->geometry().topLeft() + QPoint(saved.x, saved.y);
+  const QRect winRect(pos, m_window->size());
+  const QRect visible = winRect & (*it)->virtualGeometry();
+  if (visible.width() < MIN_VISIBLE_ON_RESTORE || visible.height() < MIN_VISIBLE_ON_RESTORE) return false;
+
+  m_window->setPosition(pos);
+  return true;
+}
+
+void LauncherWindow::applyShowPlacement() {
+  if (!restoreWindowPosition()) positionOnCursorScreen();
+}
+
+// AppKit shifts this panel ~40px upward after orderFront (source unidentified, immune to
+// animationBehavior=None), hence: show at opacity 0, re-assert placement next tick, reveal.
+void LauncherWindow::prepareShow() {
+  if (!m_window) return;
+  m_window->setOpacity(0.0);
+  applyShowPlacement();
+}
+
+void LauncherWindow::finalizeShow() {
+  QTimer::singleShot(0, this, [this]() {
+    if (!m_window) return;
+    applyShowPlacement();
+    m_window->setOpacity(1.0);
+  });
+}
+
+void LauncherWindow::beginWindowDrag() {
+  if (!m_window || !canPositionWindow() || m_dragOverlayVisible) return;
+
+  m_dragOffset = QCursor::pos() - m_window->position();
+  auto *screen = QGuiApplication::screenAt(QCursor::pos());
+  if (!screen) screen = m_window->screen();
+  computeDragAnchors(screen);
+  updateActiveDragAnchor(m_window->position());
+  m_dragOverlayVisible = true;
+  emit dragOverlayChanged();
+#ifdef Q_OS_MACOS
+  if (m_dragOverlayWindow) macosPrepareOverlayWindow(m_dragOverlayWindow);
+#endif
+}
+
+void LauncherWindow::registerDragOverlay(QQuickWindow *window) { m_dragOverlayWindow = window; }
+
+void LauncherWindow::updateWindowDrag() {
+  if (!m_window || !m_dragOverlayVisible) return;
+
+  const QPoint cursor = QCursor::pos();
+  const QPoint pos = cursor - m_dragOffset;
+  auto *screen = QGuiApplication::screenAt(cursor);
+  if (screen && screen != m_dragScreen) computeDragAnchors(screen);
+  m_window->setPosition(pos);
+  updateActiveDragAnchor(pos);
+}
+
+void LauncherWindow::endWindowDrag() {
+  if (!m_dragOverlayVisible) return;
+
+  if (m_dragActiveAnchor >= 0) m_window->setPosition(m_dragAnchorTargets[m_dragActiveAnchor]);
+  saveWindowPosition();
+  m_dragOverlayVisible = false;
+  emit dragOverlayChanged();
+  if (m_dragActiveAnchor != -1) {
+    m_dragActiveAnchor = -1;
+    emit dragActiveAnchorChanged();
+  }
+}
+
+void LauncherWindow::computeDragAnchors(QScreen *screen) {
+  m_dragScreen = screen;
+  m_dragAnchorTargets.clear();
+  m_dragAnchors.clear();
+  m_dragGuideXs.clear();
+  m_dragGuideYs.clear();
+  if (!screen || !m_window) return;
+
+  const QRect avail = screen->availableGeometry();
+  const int w = m_window->width();
+  const int h = m_window->height();
+  const int xs[] = {avail.left(), avail.left() + (avail.width() - w) / 2, avail.left() + avail.width() - w};
+  const int ys[] = {avail.top(), avail.top() + (avail.height() - h) / 2, avail.top() + avail.height() - h};
+
+  for (int y : ys) {
+    for (int x : xs) {
+      m_dragAnchorTargets.push_back(QPoint(x, y));
+      const QPoint center = QPoint(x, y) - screen->geometry().topLeft() + QPoint(w / 2, h / 2);
+      m_dragAnchors.push_back(
+          QVariantMap{{QStringLiteral("x"), center.x()}, {QStringLiteral("y"), center.y()}});
+      if (!m_dragGuideXs.contains(center.x())) m_dragGuideXs.push_back(center.x());
+      if (!m_dragGuideYs.contains(center.y())) m_dragGuideYs.push_back(center.y());
+    }
+  }
+
+  m_dragOverlayGeometry = screen->geometry();
+  emit dragOverlayChanged();
+}
+
+void LauncherWindow::updateActiveDragAnchor(QPoint windowPos) {
+  int best = -1;
+  int bestDist = DRAG_SNAP_DISTANCE * DRAG_SNAP_DISTANCE;
+  for (int i = 0; i < m_dragAnchorTargets.size(); ++i) {
+    const QPoint d = windowPos - m_dragAnchorTargets[i];
+    const int dist = d.x() * d.x() + d.y() * d.y();
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = i;
+    }
+  }
+  if (m_dragActiveAnchor != best) {
+    m_dragActiveAnchor = best;
+    emit dragActiveAnchorChanged();
+  }
+}
+
+void LauncherWindow::saveWindowPosition() {
+  if (!m_window) return;
+  QScreen *screen = m_window->screen();
+  if (!screen) return;
+
+  const QPoint rel = m_window->position() - screen->geometry().topLeft();
+  const SavedWindowPosition saved{.screen = screen->name().toStdString(), .x = rel.x(), .y = rel.y()};
+  std::string buf;
+  if (auto const error = glz::write_file_json(saved, windowPositionPath().string(), buf)) {
+    qWarning() << "Failed to write launcher window position" << windowPositionPath().string();
+  }
 }
 
 void LauncherWindow::openFooterMenu() { m_footerPanel->toggle(true); }

--- a/src/server/src/qml/launcher-window.cpp
+++ b/src/server/src/qml/launcher-window.cpp
@@ -1,8 +1,5 @@
 #include "launcher-window.hpp"
 #include "launcher-window-platform.hpp"
-#ifdef Q_OS_MACOS
-#include "macos-chrome-attached.hpp"
-#endif
 #ifdef Q_OS_LINUX
 #include "internal/wayland/xdg-activation.hpp"
 #endif
@@ -707,9 +704,7 @@ void LauncherWindow::beginWindowDrag() {
   updateActiveDragAnchor(m_window->position());
   m_dragOverlayVisible = true;
   emit dragOverlayChanged();
-#ifdef Q_OS_MACOS
-  if (m_dragOverlayWindow) macosPrepareOverlayWindow(m_dragOverlayWindow);
-#endif
+  LauncherWindowPlatform::prepareOverlayWindow(m_dragOverlayWindow);
 }
 
 void LauncherWindow::registerDragOverlay(QQuickWindow *window) { m_dragOverlayWindow = window; }

--- a/src/server/src/qml/launcher-window.hpp
+++ b/src/server/src/qml/launcher-window.hpp
@@ -4,7 +4,9 @@
 #include <QObject>
 #include <QQmlApplicationEngine>
 #include <QTimer>
+#include <QPoint>
 #include <QRect>
+#include <QVariantList>
 #include <qtmetamacros.h>
 
 class ActionPanelController;
@@ -19,6 +21,7 @@ class PlatformBridge;
 class ThemeBridge;
 class ViewHostBase;
 class QQuickWindow;
+class QScreen;
 class BaseView;
 class DialogContentWidget;
 
@@ -54,6 +57,12 @@ class LauncherWindow : public QObject {
   Q_PROPERTY(int lsLayer READ lsLayer NOTIFY lsChanged)
   Q_PROPERTY(int lsKeyboardInteractivity READ lsKeyboardInteractivity NOTIFY lsChanged)
   Q_PROPERTY(bool canPositionWindow READ canPositionWindow CONSTANT)
+  Q_PROPERTY(bool dragOverlayVisible READ dragOverlayVisible NOTIFY dragOverlayChanged)
+  Q_PROPERTY(QRect dragOverlayGeometry READ dragOverlayGeometry NOTIFY dragOverlayChanged)
+  Q_PROPERTY(QVariantList dragAnchors READ dragAnchors NOTIFY dragOverlayChanged)
+  Q_PROPERTY(QVariantList dragGuideXs READ dragGuideXs NOTIFY dragOverlayChanged)
+  Q_PROPERTY(QVariantList dragGuideYs READ dragGuideYs NOTIFY dragOverlayChanged)
+  Q_PROPERTY(int dragActiveAnchor READ dragActiveAnchor NOTIFY dragActiveAnchorChanged)
 
 public:
   explicit LauncherWindow(ApplicationContext &ctx, QObject *parent = nullptr);
@@ -99,6 +108,20 @@ public:
   Q_INVOKABLE void setCompleterValue(int index, const QString &value);
   Q_INVOKABLE QRect cursorScreenGeometry() const;
   Q_INVOKABLE void positionOnCursorScreen();
+  Q_INVOKABLE bool restoreWindowPosition();
+  Q_INVOKABLE void prepareShow();
+  Q_INVOKABLE void finalizeShow();
+  Q_INVOKABLE void beginWindowDrag();
+  Q_INVOKABLE void updateWindowDrag();
+  Q_INVOKABLE void endWindowDrag();
+  Q_INVOKABLE void registerDragOverlay(QQuickWindow *window);
+
+  bool dragOverlayVisible() const { return m_dragOverlayVisible; }
+  QRect dragOverlayGeometry() const { return m_dragOverlayGeometry; }
+  QVariantList dragAnchors() const { return m_dragAnchors; }
+  QVariantList dragGuideXs() const { return m_dragGuideXs; }
+  QVariantList dragGuideYs() const { return m_dragGuideYs; }
+  int dragActiveAnchor() const { return m_dragActiveAnchor; }
   Q_INVOKABLE void openFooterMenu();
 
 signals:
@@ -126,6 +149,8 @@ signals:
   void windowSizeOverrideChanged();
   void overlayChanged();
   void lsChanged();
+  void dragOverlayChanged();
+  void dragActiveAnchorChanged();
 
 private:
   bool eventFilter(QObject *obj, QEvent *event) override;
@@ -137,6 +162,10 @@ private:
   void setCompacted(bool value);
   void tryCompaction();
   void applyWindowConfig();
+  void applyShowPlacement();
+  void saveWindowPosition();
+  void computeDragAnchors(QScreen *screen);
+  void updateActiveDragAnchor(QPoint windowPos);
   bool isLayerShellActive() const;
   void setExclusiveFocus(bool exclusive);
   void updateLayerShellProps();
@@ -167,6 +196,17 @@ private:
   bool m_statusBarVisible = true;
   bool m_viewWasPopped = false;
   bool m_viewWasReplaced = false;
+
+  QPoint m_dragOffset;
+  QQuickWindow *m_dragOverlayWindow = nullptr;
+  QScreen *m_dragScreen = nullptr;
+  QList<QPoint> m_dragAnchorTargets;
+  QVariantList m_dragAnchors;
+  QVariantList m_dragGuideXs;
+  QVariantList m_dragGuideYs;
+  QRect m_dragOverlayGeometry;
+  int m_dragActiveAnchor = -1;
+  bool m_dragOverlayVisible = false;
   bool m_pendingLauncherFileChoice = false;
   QString m_searchPlaceholder;
   QUrl m_searchAccessoryUrl;

--- a/src/server/src/qml/macos-chrome-attached.hpp
+++ b/src/server/src/qml/macos-chrome-attached.hpp
@@ -152,10 +152,6 @@ public:
   int windowLevel() const { return m_windowLevel; }
   void setWindowLevel(int value);
 
-  // Show the launcher panel placed on the cursor's screen without AppKit's reveal-time slide:
-  // beginShow() hides and positions it before it is shown, finishShow() reveals it once settled.
-  Q_INVOKABLE void beginShow(qreal yFraction, qreal referenceHeight = 0);
-  Q_INVOKABLE void finishShow(qreal yFraction, qreal referenceHeight = 0);
   Q_INVOKABLE void placeBottomCenter(qreal bottomMargin);
 
 private:
@@ -206,6 +202,8 @@ public:
 
 void macosSetAccessoryActivationPolicy();
 void macosActivateApp();
+
+void macosPrepareOverlayWindow(QWindow *window);
 void macosReleaseMenuShortcuts();
 
 // True when NSGlassEffectView is available (macOS 26 Tahoe and later).

--- a/src/server/src/qml/macos-chrome-attached.hpp
+++ b/src/server/src/qml/macos-chrome-attached.hpp
@@ -202,8 +202,6 @@ public:
 
 void macosSetAccessoryActivationPolicy();
 void macosActivateApp();
-
-void macosPrepareOverlayWindow(QWindow *window);
 void macosReleaseMenuShortcuts();
 
 // True when NSGlassEffectView is available (macOS 26 Tahoe and later).

--- a/src/server/src/qml/macos-chrome-attached.mm
+++ b/src/server/src/qml/macos-chrome-attached.mm
@@ -5,7 +5,6 @@
 #include <QPointer>
 #include <QQuickItem>
 #include <QQuickWindow>
-#include <QTimer>
 
 #import <AppKit/AppKit.h>
 #import <QuartzCore/QuartzCore.h>
@@ -152,25 +151,6 @@ NSScreen *cursorScreen() {
     if (NSPointInRect(mouse, candidate.frame)) return candidate;
   }
   return [NSScreen mainScreen];
-}
-
-void placeWindowOnCursorScreen(QWindow *window, qreal yFraction, qreal referenceHeight) {
-  if (!window) return;
-  NSView *view = nsViewFromWinId(window->winId());
-  if (!view) return;
-  NSWindow *nswin = view.window;
-  if (!nswin) return;
-
-  NSScreen *screen = cursorScreen();
-  if (!screen) return;
-
-  NSRect const vf = screen.visibleFrame;
-  NSSize const size = nswin.frame.size;
-  CGFloat const refHeight = referenceHeight > 0 ? referenceHeight : size.height;
-  CGFloat const x = vf.origin.x + (vf.size.width - size.width) / 2.0;
-  CGFloat const visibleTop = vf.origin.y + vf.size.height;
-  CGFloat const windowTop = visibleTop - (vf.size.height - refHeight) * yFraction;
-  [nswin setFrameOrigin:NSMakePoint(x, windowTop - size.height)];
 }
 
 } // namespace
@@ -640,6 +620,19 @@ void macosSetAccessoryActivationPolicy() {
 
 void macosActivateApp() { [NSApp activateIgnoringOtherApps:YES]; }
 
+void macosPrepareOverlayWindow(QWindow *window) {
+  if (!window || !window->handle()) return;
+  NSView *view = nsViewFromWinId(window->winId());
+  if (!view) return;
+  NSWindow *nswin = view.window;
+  if (!nswin) return;
+
+  nswin.level = NSStatusWindowLevel;
+  nswin.collectionBehavior |=
+      NSWindowCollectionBehaviorCanJoinAllSpaces | NSWindowCollectionBehaviorFullScreenAuxiliary;
+  nswin.ignoresMouseEvents = YES;
+}
+
 static void macosClearMenuShortcuts(NSMenu *menu) {
   if (!menu) return;
   NSMenu *servicesMenu = [NSApp servicesMenu];
@@ -657,22 +650,6 @@ static void macosClearMenuShortcuts(NSMenu *menu) {
 void macosReleaseMenuShortcuts() {
   macosClearMenuShortcuts([NSApp mainMenu]);
   dispatch_async(dispatch_get_main_queue(), ^{ macosClearMenuShortcuts([NSApp mainMenu]); });
-}
-
-void MacOSPanelAttached::beginShow(qreal yFraction, qreal referenceHeight) {
-  if (!m_window) return;
-  m_window->setOpacity(0.0);
-  placeWindowOnCursorScreen(m_window, yFraction, referenceHeight);
-}
-
-void MacOSPanelAttached::finishShow(qreal yFraction, qreal referenceHeight) {
-  if (!m_window) return;
-  QPointer<MacOSPanelAttached> self(this);
-  QTimer::singleShot(0, this, [self, yFraction, referenceHeight]() {
-    if (!self || !self->m_window) return;
-    placeWindowOnCursorScreen(self->m_window, yFraction, referenceHeight);
-    self->m_window->setOpacity(1.0);
-  });
 }
 
 void MacOSPanelAttached::placeBottomCenter(qreal bottomMargin) {

--- a/src/server/src/qml/macos-chrome-attached.mm
+++ b/src/server/src/qml/macos-chrome-attached.mm
@@ -1,4 +1,5 @@
 #include "macos-chrome-attached.hpp"
+#include "launcher-window-platform.hpp"
 
 #include <qevent.h>
 #include <qlogging.h>
@@ -620,7 +621,7 @@ void macosSetAccessoryActivationPolicy() {
 
 void macosActivateApp() { [NSApp activateIgnoringOtherApps:YES]; }
 
-void macosPrepareOverlayWindow(QWindow *window) {
+void LauncherWindowPlatform::prepareOverlayWindow(QWindow *window) {
   if (!window || !window->handle()) return;
   NSView *view = nsViewFromWinId(window->winId());
   if (!view) return;

--- a/src/server/src/qml/qml/LauncherWindow.qml
+++ b/src/server/src/qml/qml/LauncherWindow.qml
@@ -3,6 +3,7 @@ import QtQuick.Window
 import QtQuick.Layouts
 import QtQuick.Controls
 import QtQuick.Effects
+import QtQuick.Shapes
 
 Window {
     id: root
@@ -308,6 +309,79 @@ Window {
         AlertDialog {
             id: alertDialog
         }
+
+        MouseArea {
+            anchors.fill: parent
+            z: 300
+            enabled: launcher.canPositionWindow
+            acceptedButtons: Qt.LeftButton
+            onPressed: mouse => {
+                if (mouse.modifiers & Qt.ControlModifier) {
+                    launcher.beginWindowDrag();
+                } else {
+                    mouse.accepted = false;
+                }
+            }
+            onPositionChanged: launcher.updateWindowDrag()
+            onReleased: launcher.endWindowDrag()
+            onCanceled: launcher.endWindowDrag()
+        }
+    }
+
+    Window {
+        id: anchorOverlay
+        visible: launcher.dragOverlayVisible
+        x: launcher.dragOverlayGeometry.x
+        y: launcher.dragOverlayGeometry.y
+        width: launcher.dragOverlayGeometry.width
+        height: launcher.dragOverlayGeometry.height
+        flags: Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint | Qt.WindowTransparentForInput | Qt.WindowDoesNotAcceptFocus
+        color: "transparent"
+
+        Component.onCompleted: launcher.registerDragOverlay(anchorOverlay)
+
+        readonly property var activeAnchor: launcher.dragActiveAnchor >= 0 ? launcher.dragAnchors[launcher.dragActiveAnchor] : null
+
+        component GuideLine: Shape {
+            property bool active: false
+            property bool vertical: false
+
+            ShapePath {
+                strokeStyle: ShapePath.DashLine
+                dashPattern: [3, 3]
+                strokeWidth: 2
+                strokeColor: active ? Theme.accent : Config.withAlpha(Theme.foreground, 0.45)
+                fillColor: "transparent"
+                startX: 0
+                startY: 0
+
+                PathLine {
+                    x: vertical ? 0 : anchorOverlay.width
+                    y: vertical ? anchorOverlay.height : 0
+                }
+            }
+        }
+
+        Repeater {
+            model: launcher.dragGuideXs
+
+            GuideLine {
+                required property var modelData
+                x: modelData
+                vertical: true
+                active: anchorOverlay.activeAnchor !== null && anchorOverlay.activeAnchor.x === modelData
+            }
+        }
+
+        Repeater {
+            model: launcher.dragGuideYs
+
+            GuideLine {
+                required property var modelData
+                y: modelData
+                active: anchorOverlay.activeAnchor !== null && anchorOverlay.activeAnchor.y === modelData
+            }
+        }
     }
 
     Connections {
@@ -352,7 +426,7 @@ Window {
         function onWindowVisiblityChanged(visible) {
             if (visible) {
                 root.aboutToShow();
-                if (root.autoPlaceOnShow)
+                if (root.autoPlaceOnShow && !launcher.restoreWindowPosition())
                     launcher.positionOnCursorScreen();
                 root.visible = true;
                 root.raise();

--- a/src/server/src/qml/qml/LauncherWindowMacOS.qml
+++ b/src/server/src/qml/qml/LauncherWindowMacOS.qml
@@ -1,6 +1,4 @@
 LauncherWindow {
-    readonly property real placementFraction: 1 / 3
-
     nativeChrome: true
     color: "transparent"
     shadowPadding: 0
@@ -11,8 +9,8 @@ LauncherWindow {
     minimumHeight: _contentH
     maximumHeight: _contentH
 
-    onAboutToShow: MacOSPanel.beginShow(placementFraction, _h)
-    onShown: MacOSPanel.finishShow(placementFraction, _h)
+    onAboutToShow: launcher.prepareShow()
+    onShown: launcher.finalizeShow()
 
     MacOSWindow.enabled: true
     MacOSWindow.cornerRadius: cornerRadius


### PR DESCRIPTION
Allow the launcher window to be freely moved on macOS, with snap guides to help placement.


https://github.com/user-attachments/assets/52502248-357a-4213-8396-f28927131534


