### PR TITLE
ci(nix): pass --no-update-lock-file to nix build to enforce lockfile sync

### DIFF
--- a/.github/workflows/cachix.yaml
+++ b/.github/workflows/cachix.yaml
@@ -32,9 +32,9 @@ jobs:
         authToken: ${{ github.ref == 'refs/heads/main' && secrets.CACHIX_AUTH_TOKEN || '' }}
         pushFilter: "(swift-bin|swift-.*-RELEASE.*\\.tar\\.gz)"
     - name: Build Flake
-      run: nix build -L
+      run: nix build -L --no-update-lock-file
     - name: Build Soulver backend
       if: matrix.os == 'depot-ubuntu-24.04-16'
-      run: nix build -L .#with-soulver
+      run: nix build -L --no-update-lock-file .#with-soulver
     - name: Run Test Shell
       run: nix develop --command echo OK

--- a/.github/workflows/nix-support.yml
+++ b/.github/workflows/nix-support.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: cachix/install-nix-action@v31
       - name: Check nix hashes
         run: |
-          nix run .#nix-update-script --extra-experimental-features nix-command flakes --accept-flake-config
+          nix run --no-update-lock-file .#nix-update-script --extra-experimental-features nix-command flakes --accept-flake-config


### PR DESCRIPTION
Hi!

So yesterday i tried to `--update` my nixos, which resulted into compiling vicinae from scratch, fetching all the deps, even after having cache configured.
upon further investigation, I found out the flake.lock was not updated when flake.nix was updated, which caused mismatch.
the commit: https://github.com/vicinaehq/vicinae/tree/59f5eabb0e91ae2ae3b3954f02e7592f1b13b300

I tried to fix that in the CI.
I was thinking to have workflow like how noctalia-shell has https://github.com/noctalia-dev/noctalia/blob/0f61b0ae07607739189d07a0a7617ef0d8f3796c/.github/workflows/update-flake.yml
which auto-updates the flake.lock but I think no-bot-commits are preferred here, so I propose simply adding the --locked flag to the Nix CI commands instead, so CI could fail properly.

P.S
I also found that https://github.com/vicinaehq/vicinae/pull/1826 fixes this as it updates the flake.nix and flake.lock.

Thanks for building Vicinae, really enjoying using it!