### PR TITLE
feat: implement arg completer fast track support

### DIFF
--- a/src/server/src/navigation-controller.cpp
+++ b/src/server/src/navigation-controller.cpp
@@ -20,6 +20,8 @@
 
 NavigationController::NavigationController(ApplicationContext &ctx) : m_ctx(ctx) {}
 
+void NavigationController::requestCompleterFocus() { emit completerFocusedRequested(); }
+
 void NavigationController::setNavigationTitle(const QString &navigationTitle, const BaseView *caller) {
   if (auto state = findViewState(VALUE_OR(caller, topView()))) {
     state->navigation.title = navigationTitle;

--- a/src/server/src/navigation-controller.hpp
+++ b/src/server/src/navigation-controller.hpp
@@ -118,6 +118,7 @@ signals:
 
   void completionCreated(const CompleterState &completer) const;
   void completionDestroyed() const;
+  void completerFocusedRequested() const;
 
   void headerVisiblityChanged(bool value);
   void searchVisibilityChanged(bool value);
@@ -173,6 +174,8 @@ public:
 
   void setDialog(DialogContentWidget *dialog);
   void confirmAlert(const QString &title, const QString &description, const std::function<void()> &onConfirm);
+
+  void requestCompleterFocus();
 
   void createCompletion(const ArgumentList &args, const ImageURL &icon);
   void destroyCurrentCompletion();

--- a/src/server/src/qml/launcher-window.cpp
+++ b/src/server/src/qml/launcher-window.cpp
@@ -240,6 +240,8 @@ LauncherWindow::LauncherWindow(ApplicationContext &ctx, QObject *parent)
             emit navigationStatusChanged();
           });
 
+  connect(nav, &NavigationController::completerFocusedRequested, this,
+          &LauncherWindow::completerFocusRequested);
   connect(nav, &NavigationController::completionCreated, this, [this](const CompleterState &state) {
     m_hasCompleter = true;
     m_completerArgs.clear();

--- a/src/server/src/qml/launcher-window.hpp
+++ b/src/server/src/qml/launcher-window.hpp
@@ -123,6 +123,7 @@ signals:
   void completerChanged();
   void completerValuesChanged();
   void completerValidationFailed();
+  void completerFocusRequested();
   void windowSizeOverrideChanged();
   void overlayChanged();
   void lsChanged();

--- a/src/server/src/qml/qml/ArgCompleter.qml
+++ b/src/server/src/qml/qml/ArgCompleter.qml
@@ -16,15 +16,7 @@ RowLayout {
     spacing: 4
 
     function focusFirst() {
-        const item = argRepeater.itemAt(0)?.item;
-
-        if (!item) {
-            console.warn("Cannot focus first, may not be an input field");
-            return false;
-        }
-
-        item.forceActiveFocus();
-        return true;
+        argRepeater.itemAt(0)?.item?.forceActiveFocus();
     }
 
     function validate() {

--- a/src/server/src/qml/qml/ArgCompleter.qml
+++ b/src/server/src/qml/qml/ArgCompleter.qml
@@ -15,6 +15,18 @@ RowLayout {
 
     spacing: 4
 
+    function focusFirst() {
+        const item = argRepeater.itemAt(0)?.item;
+
+        if (!item) {
+            console.warn("Cannot focus first, may not be an input field");
+            return false;
+        }
+
+        item.forceActiveFocus();
+        return true;
+    }
+
     function validate() {
         var firstRequired = -1;
         for (var i = 0; i < argRepeater.count; i++) {

--- a/src/server/src/qml/qml/CalculatorResultDelegate.qml
+++ b/src/server/src/qml/qml/CalculatorResultDelegate.qml
@@ -10,13 +10,13 @@ SelectableDelegate {
     required property string calcAnswer
     required property string calcAnswerUnit
 
-	// quite naive, but good enough.
-	// if we find we need this to be actually accurate, we probably need a per backend
-	// way to figure out what token carries operator significance.
+    // quite naive, but good enough.
+    // if we find we need this to be actually accurate, we probably need a per backend
+    // way to figure out what token carries operator significance.
     function highlight(expr) {
-        const escaped = expr.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
-        const tokens = /(\b(?:to|in|as|of|mod|and|or|xor)\b|[+\-*\/^%()=,])/gi
-        return escaped.replace(tokens, m => `<font color="${Theme.textMuted}">${m}</font>`)
+        const escaped = expr.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+        const tokens = /(\b(?:to|in|as|of|mod|and|or|xor)\b|[+\-*\/^%()=,])/gi;
+        return escaped.replace(tokens, m => `<font color="${Theme.textMuted}">${m}</font>`);
     }
 
     Item {

--- a/src/server/src/qml/qml/SearchBar.qml
+++ b/src/server/src/qml/qml/SearchBar.qml
@@ -358,6 +358,10 @@ Item {
                 searchInput.forceActiveFocus();
             }
         }
+        function onCompleterFocusRequested() {
+            if (launcher.hasCompleter)
+                argCompleter.focusFirst();
+        }
         function onCompleterValidationFailed() {
             argCompleter.validate();
         }

--- a/src/server/src/qml/root-view-host.cpp
+++ b/src/server/src/qml/root-view-host.cpp
@@ -5,6 +5,7 @@
 #include "service-registry.hpp"
 #include "services/keybinding/keybinding-service.hpp"
 #include "view-scope.hpp"
+#include <algorithm>
 #include <qevent.h>
 
 void RootViewHost::initialize() {
@@ -86,8 +87,16 @@ bool RootViewHost::tryAliasFastTrack() {
 
   // if the command has a completer, we focus the first input instead of activating
   if (nav->hasCompleter()) {
-    nav->requestCompleterFocus();
-    return true;
+    // FIXME: we need to make sure we are not eating space if we are in the completer,
+    // since completer input is routed through the same path as launcher input.
+    // We should probably architecture this in a better way
+    const auto isEmpty =
+        std::ranges::all_of(nav->completionValues(), [](auto &&pair) { return pair.second.isEmpty(); });
+    if (isEmpty) {
+      nav->requestCompleterFocus();
+      return true;
+    }
+    return false;
   }
 
   // no-view command cannot use fast track

--- a/src/server/src/qml/root-view-host.cpp
+++ b/src/server/src/qml/root-view-host.cpp
@@ -1,4 +1,5 @@
 #include "root-view-host.hpp"
+#include "lib/figura/src/utils.hpp"
 #include "root-search-model.hpp"
 #include "section-source.hpp"
 #include "service-registry.hpp"
@@ -74,16 +75,28 @@ void RootViewHost::beforeActionExecuted(const AbstractAction *action) {
 bool RootViewHost::tryAliasFastTrack() {
   const auto manager = context()->services->rootItemManager();
   const auto item = m_model->selectedRootItem();
+  auto &nav = context()->navigation;
 
-  if (!item || !item->supportsAliasSpaceShortcut()) return false;
+  if (!item) return false;
 
   const auto query = context()->navigation->searchText(this).toStdString();
   const auto meta = manager->itemMetadata(item->uniqueId());
 
-  if (!meta.alias || !meta.alias->starts_with(query)) return false;
+  if (!meta.alias || meta.alias != toLower(query)) return false;
 
-  m_model->activateSelected();
-  return true;
+  // if the command has a completer, we focus the first input instead of activating
+  if (nav->hasCompleter()) {
+    nav->requestCompleterFocus();
+    return true;
+  }
+
+  // no-view command cannot use fast track
+  if (item->supportsAliasSpaceShortcut()) {
+    m_model->activateSelected();
+    return true;
+  }
+
+  return false;
 }
 
 bool RootViewHost::inputFilter(QKeyEvent *event) {


### PR DESCRIPTION
Aliased root search command that creates a completer now has its first input focused when `<space>` is pressed AND the alias fully matches the query.

This also changes the behavior of aliased fast track so that it only happens if the exact alias is pressed. This means aliases can no longer be fast tracked from their prefix, it needs to be an exact match.

fixes #1094 