### PR TITLE
fix: use helper function to do QT platform checks

### DIFF
--- a/src/server/src/internal/wayland/layer-shell.cpp
+++ b/src/server/src/internal/wayland/layer-shell.cpp
@@ -1,5 +1,5 @@
 #include "layer-shell.hpp"
-#include <QGuiApplication>
+#include "environment.hpp"
 #include <QtWaylandClient/QWaylandClientExtension>
 #include "qwayland-wlr-layer-shell-unstable-v1.h"
 
@@ -14,7 +14,7 @@ public:
 namespace Wayland {
 
 bool hasLayerShell() {
-  if (QGuiApplication::platformName() != "wayland") { return false; }
+  if (!Environment::isWaylandSession()) { return false; }
 
   static LayerShellV1 layerShell;
   return layerShell.isActive();

--- a/src/server/src/internal/wayland/xdg-activation.cpp
+++ b/src/server/src/internal/wayland/xdg-activation.cpp
@@ -1,5 +1,5 @@
 #include "xdg-activation.hpp"
-#include <QGuiApplication>
+#include "environment.hpp"
 #include <QtWaylandClient/QWaylandClientExtension>
 #include <qlogging.h>
 #include <qwindow.h>
@@ -28,7 +28,7 @@ protected:
 };
 
 XdgActivationV1 *activation() {
-  if (QGuiApplication::platformName() != "wayland") return nullptr;
+  if (!Environment::isWaylandSession()) return nullptr;
 
   static XdgActivationV1 instance;
   return instance.isActive() ? &instance : nullptr;

--- a/src/server/src/services/clipboard/data-control/data-control-clipboard-server.cpp
+++ b/src/server/src/services/clipboard/data-control/data-control-clipboard-server.cpp
@@ -1,3 +1,4 @@
+#include "environment.hpp"
 #include "log/message-handler.hpp"
 #include "pid-file/pid-file.hpp"
 #include "services/clipboard/clipboard-server.hpp"
@@ -40,7 +41,7 @@ public:
 } // namespace
 
 bool DataControlClipboardServer::isActivatable() const {
-  if (QGuiApplication::platformName() != "wayland") { return false; }
+  if (!Environment::isWaylandSession()) return false;
 
   static DataControlManagerV1 manager;
   return manager.isActive();

--- a/src/server/src/services/clipboard/x11/x11-clipboard-server.hpp
+++ b/src/server/src/services/clipboard/x11/x11-clipboard-server.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include "../qt/qt-clipboard-server.hpp"
-#include <QGuiApplication>
+#include "environment.hpp"
 #include <qbuffer.h>
 #include <qclipboard.h>
 #include <QUrl>
@@ -9,5 +9,5 @@
 class X11ClipboardServer : public AbstractQtClipboardServer {
 public:
   QString id() const override { return "x11"; }
-  bool isActivatable() const override { return QGuiApplication::platformName() == "xcb"; }
+  bool isActivatable() const override { return Environment::isX11(); }
 };

--- a/src/server/src/services/global-shortcuts/global-shortcut-backend-factory.cpp
+++ b/src/server/src/services/global-shortcuts/global-shortcut-backend-factory.cpp
@@ -10,7 +10,6 @@
 #elifdef Q_OS_LINUX
 #include "services/global-shortcuts/vicinae-hotkey-global-shortcut-backend.hpp"
 #include "services/global-shortcuts/x11-global-shortcut-backend.hpp"
-#include <QGuiApplication>
 #endif
 
 std::unique_ptr<AbstractGlobalShortcutBackend> createGlobalShortcutBackend() {
@@ -20,7 +19,7 @@ std::unique_ptr<AbstractGlobalShortcutBackend> createGlobalShortcutBackend() {
   return std::make_unique<WindowsGlobalShortcutBackend>();
 #elifdef Q_OS_LINUX
   if (Environment::isX11()) { return std::make_unique<X11GlobalShortcutBackend>(); }
-  if (QGuiApplication::platformName() == "wayland") {
+  if (Environment::isWaylandSession()) {
     auto backend = std::make_unique<VicinaeHotkeyGlobalShortcutBackend>();
     if (backend->isSupported()) { return backend; }
   }

--- a/src/server/src/services/shortcut-inhibit/shortcut-inhibit-manager.hpp
+++ b/src/server/src/services/shortcut-inhibit/shortcut-inhibit-manager.hpp
@@ -4,7 +4,7 @@
 #include "common/types.hpp"
 #include "services/shortcut-inhibit/abstract-shortcut-inhibit-manager.hpp"
 #ifdef Q_OS_LINUX
-#include <QGuiApplication>
+#include "environment.hpp"
 #include "services/shortcut-inhibit/wayland-shortcut-inhibit-manager.hpp"
 #endif
 
@@ -19,9 +19,7 @@ public:
 private:
   static std::unique_ptr<AbstractShortcutInhibitManager> createManager() {
 #ifdef Q_OS_LINUX
-    if (QGuiApplication::platformName() == "wayland") {
-      return std::make_unique<WaylandShortcutInhibitManager>();
-    }
+    if (Environment::isWaylandSession()) { return std::make_unique<WaylandShortcutInhibitManager>(); }
 #endif
     return std::make_unique<DummyShortcutInhibitManager>();
   }

--- a/src/server/src/services/window-manager/wayland/wayland.cpp
+++ b/src/server/src/services/window-manager/wayland/wayland.cpp
@@ -88,7 +88,7 @@ bool WaylandWindowManager::closeWindow(const AbstractWindow &window) const {
 
 // cosmic needs its own top level management protocol integration
 bool WaylandWindowManager::isActivatable() const {
-  return QGuiApplication::platformName() == "wayland" && !Environment::isCosmicDesktop();
+  return Environment::isWaylandSession() && !Environment::isCosmicDesktop();
 }
 
 bool WaylandWindowManager::ping() const {

--- a/src/server/src/services/window-manager/x11/x11-window-manager.cpp
+++ b/src/server/src/services/window-manager/x11/x11-window-manager.cpp
@@ -1,4 +1,5 @@
 #include "x11-window-manager.hpp"
+#include "environment.hpp"
 #include "x11-event-listener.hpp"
 #include "x11-window.hpp"
 #include <QCoreApplication>
@@ -21,10 +22,7 @@ X11WindowManager::~X11WindowManager() {
   m_screen = nullptr;
 }
 
-bool X11WindowManager::isActivatable() const {
-  // Check if we're running on X11 (xcb platform)
-  return QGuiApplication::platformName() == "xcb";
-}
+bool X11WindowManager::isActivatable() const { return Environment::isX11(); }
 
 void X11WindowManager::start() {
   // Initialize connection

--- a/src/server/src/services/window-material/window-material-manager.hpp
+++ b/src/server/src/services/window-material/window-material-manager.hpp
@@ -4,7 +4,7 @@
 #include "services/window-material/null-window-material-backend.hpp"
 #include "services/window-material/window-material-backend.hpp"
 #ifdef Q_OS_LINUX
-#include <QGuiApplication>
+#include "environment.hpp"
 #include "services/window-material/ext-background-effect-v1-manager.hpp"
 #endif
 
@@ -26,9 +26,7 @@ public:
 private:
   static std::unique_ptr<WindowMaterialBackend> createBackend() {
 #ifdef Q_OS_LINUX
-    if (QGuiApplication::platformName() == "wayland") {
-      return std::make_unique<ExtBackgroundEffectV1Manager>();
-    }
+    if (Environment::isWaylandSession()) { return std::make_unique<ExtBackgroundEffectV1Manager>(); }
 #endif
     return std::make_unique<NullWindowMaterialBackend>();
   }

--- a/src/server/src/utils/environment.hpp
+++ b/src/server/src/utils/environment.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <QtGlobal>
+#include <qguiapplication.h>
 #ifndef Q_OS_WIN
 #include "xdgpp/env/env.hpp"
 #endif
@@ -34,7 +35,10 @@ inline bool isGnomeEnvironment() {
   return desktop.contains("GNOME", Qt::CaseInsensitive) || session.contains("gnome", Qt::CaseInsensitive);
 }
 
-inline bool isWaylandSession() { return QGuiApplication::platformName() == "wayland"; }
+inline bool isWaylandSession() {
+  const auto platform = QGuiApplication::platformName();
+  return platform == "wayland" || platform == "wayland-egl";
+}
 
 inline bool isX11() { return QGuiApplication::platformName() == "xcb"; }
 

--- a/src/server/src/utils/qt-wayland-utils.hpp
+++ b/src/server/src/utils/qt-wayland-utils.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <QGuiApplication>
+#include "environment.hpp"
 #include <qwindow.h>
 #include <wayland-client-protocol.h>
 #include <qpa/qplatformnativeinterface.h>
@@ -17,7 +18,7 @@ struct ScopedRegion {
 };
 
 inline wl_surface *getWindowSurface(QWindow *win) {
-  if (QGuiApplication::platformName() != "wayland") return nullptr;
+  if (!Environment::isWaylandSession()) return nullptr;
   auto iface = qApp->platformNativeInterface();
   return static_cast<wl_surface *>(iface->nativeResourceForWindow("surface", win));
 }


### PR DESCRIPTION
Fix the case where the QT platform is `wayland-egl` instead of `wayland`. Although the former is considered legacy, it's still Wayland as a platform.

fixes #1831