### PR TITLE
feat: add kde settings entries in root search

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -829,6 +829,8 @@ if (UNIX AND NOT APPLE)
 		src/services/app-service/xdg/xdg-app-database.hpp
 		src/services/app-service/xdg/xdg-app-database.cpp
 		src/services/app-service/xdg/xdg-app.cpp
+		src/root-search/kde-settings/kde-settings-root-provider.hpp
+		src/root-search/kde-settings/kde-settings-root-provider.cpp
 		src/services/file-chooser/xdp-file-chooser/xdp-file-chooser.hpp
 		src/services/file-chooser/xdp-file-chooser/xdp-file-chooser.cpp
 		src/services/power-manager/systemd/systemd-power-manager.cpp

--- a/src/server/src/root-search/kde-settings/kde-settings-root-provider.cpp
+++ b/src/server/src/root-search/kde-settings/kde-settings-root-provider.cpp
@@ -1,0 +1,93 @@
+#include "root-search/kde-settings/kde-settings-root-provider.hpp"
+#include "actions/app/app-actions.hpp"
+#include "actions/root-search/root-search-actions.hpp"
+#include "clipboard-actions.hpp"
+#include "service-registry.hpp"
+#include "ui/action-pannel/action-panel-state.hpp"
+#include "ui/image/url.hpp"
+
+static const QString KCM_ID_PREFIX = QStringLiteral("kcm_");
+
+QString KdeSettingsRootItem::title() const { return m_app->displayName(); }
+
+QString KdeSettingsRootItem::typeDisplayName() const { return tr("KDE Settings"); }
+
+ImageURL KdeSettingsRootItem::iconUrl() const { return m_app->iconUrl(); }
+
+EntrypointId KdeSettingsRootItem::uniqueId() const {
+  return EntrypointId("kde-settings", m_app->id().remove(".desktop").toStdString());
+}
+
+AccessoryList KdeSettingsRootItem::accessories() const {
+  return {{.text = tr("KDE Settings"), .color = SemanticColor::TextMuted}};
+}
+
+std::vector<QString> KdeSettingsRootItem::keywords() const {
+  auto keywords = m_app->keywords();
+
+  if (auto name = m_app->unlocalizedName()) { keywords.emplace_back(name.value()); }
+
+  return keywords;
+}
+
+std::vector<std::pair<QString, QString>> KdeSettingsRootItem::settingsMetadata() const {
+  return {{QStringLiteral("ID"), m_app->id()},
+          {tr("Name"), m_app->displayName()},
+          {tr("Where"), QString::fromStdString(m_app->path().string())}};
+}
+
+std::unique_ptr<ActionPanelState>
+KdeSettingsRootItem::newActionPanel(ApplicationContext *ctx, const RootItemMetadata &metadata) const {
+  auto panel = std::make_unique<ListActionPanelState>();
+  auto mainSection = panel->createSection();
+  auto utils = panel->createSection();
+  auto itemSection = panel->createSection();
+
+  auto open = new OpenAppAction(m_app, tr("Open in System Settings"), {});
+  open->setClearSearch(true);
+  mainSection->addAction(open);
+
+  utils->addAction(new CopyToClipboardAction(Clipboard::Text(m_app->id()), tr("Copy Module ID")));
+
+  for (const auto &action :
+       RootSearchActionGenerator::generateActions(*this, *ctx->services->rootItemManager())) {
+    itemSection->addAction(action);
+  }
+
+  panel->setTitle(m_app->displayName());
+  return panel;
+}
+
+KdeSettingsRootProvider::KdeSettingsRootProvider(AppService &appService) : m_appService(appService) {
+  connect(&m_appService, &AppService::appsChanged, this, &KdeSettingsRootProvider::itemsChanged);
+}
+
+QString KdeSettingsRootProvider::uniqueId() const { return "kde-settings"; }
+
+QString KdeSettingsRootProvider::displayName() const { return tr("KDE Settings"); }
+
+QString KdeSettingsRootProvider::description() const {
+  return tr("Modules of the KDE System Settings application.");
+}
+
+ImageURL KdeSettingsRootProvider::icon() const {
+  return ImageURL::system("preferences-system").withFallback(ImageURL::builtin(BuiltinIcon::Cog));
+}
+
+RootProvider::Type KdeSettingsRootProvider::type() const { return RootProvider::Type::GroupProvider; }
+
+std::vector<std::shared_ptr<RootItem>> KdeSettingsRootProvider::loadItems() const {
+  // kcm modules are just desktop files with NoDisplay=true
+  const auto apps = m_appService.list();
+  std::vector<std::shared_ptr<RootItem>> items;
+
+  items.reserve(apps.size());
+
+  for (const auto &app : apps) {
+    if (app->id().startsWith(KCM_ID_PREFIX)) {
+      items.emplace_back(std::make_shared<KdeSettingsRootItem>(app));
+    }
+  }
+
+  return items;
+}

--- a/src/server/src/root-search/kde-settings/kde-settings-root-provider.hpp
+++ b/src/server/src/root-search/kde-settings/kde-settings-root-provider.hpp
@@ -1,0 +1,39 @@
+#pragma once
+#include "services/app-service/app-service.hpp"
+#include "services/root-item-manager/root-item-manager.hpp"
+#include <QCoreApplication>
+
+class KdeSettingsRootItem : public RootItem {
+  Q_DECLARE_TR_FUNCTIONS(KdeSettingsRootItem)
+
+  std::shared_ptr<AbstractApplication> m_app;
+
+  QString title() const override;
+  QString typeDisplayName() const override;
+  ImageURL iconUrl() const override;
+  EntrypointId uniqueId() const override;
+  AccessoryList accessories() const override;
+  std::vector<QString> keywords() const override;
+  std::unique_ptr<ActionPanelState> newActionPanel(ApplicationContext *ctx,
+                                                   const RootItemMetadata &metadata) const override;
+  std::vector<std::pair<QString, QString>> settingsMetadata() const override;
+
+public:
+  explicit KdeSettingsRootItem(std::shared_ptr<AbstractApplication> app) : m_app(std::move(app)) {}
+};
+
+class KdeSettingsRootProvider : public RootProvider {
+  Q_DECLARE_TR_FUNCTIONS(KdeSettingsRootProvider)
+
+  AppService &m_appService;
+
+public:
+  QString uniqueId() const override;
+  QString displayName() const override;
+  QString description() const override;
+  ImageURL icon() const override;
+  Type type() const override;
+  std::vector<std::shared_ptr<RootItem>> loadItems() const override;
+
+  explicit KdeSettingsRootProvider(AppService &appService);
+};

--- a/src/server/src/server.cpp
+++ b/src/server/src/server.cpp
@@ -23,6 +23,9 @@
 #ifdef Q_OS_MACOS
 #include "root-search/macos-settings/macos-settings-root-provider.hpp"
 #endif
+#ifdef Q_OS_LINUX
+#include "root-search/kde-settings/kde-settings-root-provider.hpp"
+#endif
 #ifdef Q_OS_WIN
 #include "root-search/control-panel/control-panel-root-provider.hpp"
 #include "root-search/windows-settings/windows-settings-root-provider.hpp"
@@ -418,6 +421,11 @@ int startServer(const ServerLaunchOptions &launchOpts) {
     root->loadProvider(std::make_unique<BrowserTabProvider>(*registry->browserExtension()));
 #ifdef Q_OS_MACOS
     root->loadProvider(std::make_unique<MacSettingsRootProvider>());
+#endif
+#ifdef Q_OS_LINUX
+    if (Environment::isPlasmaDesktop()) {
+      root->loadProvider(std::make_unique<KdeSettingsRootProvider>(*registry->appDb()));
+    }
 #endif
 #ifdef Q_OS_WIN
     root->loadProvider(std::make_unique<WinSettingsRootProvider>());


### PR DESCRIPTION
Show Plasma 6 KCM modules in root search for direct access to KDE settings.

<img width="1167" height="733" alt="image" src="https://github.com/user-attachments/assets/67d6708d-ae39-4b08-9378-d812ce08399d" />
