### PR TITLE
fix(appimage): bundle libstdc++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,14 @@ if (NOT USE_SYSTEM_KF6 AND NOT WIN32)
 	import_kf6()
 endif()
 
+# The appimage bundles its own libraries (including the GCC runtime) in usr/lib.
+# linuxdeploy only patches a RUNPATH into the usr/bin copies it deploys, so install
+# every binary with a self-relative RUNPATH so the libexec helpers resolve the
+# bundled libraries too (#1841).
+if (VICINAE_PROVENANCE STREQUAL "appimage")
+	set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib" "$ORIGIN/../../lib")
+endif()
+
 set(VENDOR_DIR ${CMAKE_SOURCE_DIR}/vendor)
 
 include_directories(

--- a/scripts/mkappimage.sh
+++ b/scripts/mkappimage.sh
@@ -21,6 +21,18 @@ cp extra/vicinae.png ${APPDIR}
 # https://github.com/linuxdeploy/linuxdeploy-plugin-qt/issues/57
 cp /usr/lib/$(uname -m)-linux-gnu/libssl.so* ${APPDIR}/usr/lib/
 
+# Our GCC toolchain is newer than the libstdc++ shipped by LTS distros, so the
+# binaries can reference GLIBCXX versions the host doesn't have. linuxdeploy
+# excludelists the GCC runtime, so bundle it ourselves; RUNPATH ($ORIGIN/../lib)
+# makes our binaries prefer it over the host copy (#1841).
+for lib in libstdc++.so.6 libgcc_s.so.1; do
+	src=$(${CXX:-g++} -print-file-name=$lib)
+	case "$src" in
+		/*) cp -L "$src" ${APPDIR}/usr/lib/ ;;
+		*) die "$lib not found in toolchain" ;;
+	esac
+done
+
 # qtkeychain dlopens libsecret instead of linking it, so linuxdeploy can't see it in the
 # dependency tree and the host copy can't be loaded next to our bundled glib/openssl.
 # Without it qtkeychain silently falls back to kwallet or errors out (#1632).


### PR DESCRIPTION
This way we don't depend on the system libstdc++ which might be too out of date to be viable.