### PR TITLE
feat: add file action to run as an executable

### DIFF
--- a/src/server/src/utils/file-list-item.hpp
+++ b/src/server/src/utils/file-list-item.hpp
@@ -2,6 +2,7 @@
 #include <QCoreApplication>
 #include "actions/app/app-actions.hpp"
 #include "actions/files/file-actions.hpp"
+#include "builtin_icon.hpp"
 #include "clipboard-actions.hpp"
 #include "common/context.hpp"
 #include "keyboard/keybind.hpp"
@@ -12,9 +13,12 @@
 #include "internal/keyboard/keyboard.hpp"
 #include "services/toast/toast-service.hpp"
 #include "services/wallpaper/wallpaper-manager.hpp"
+#include "ui/action-pannel/action.hpp"
+#include <algorithm>
 #include <qmimedatabase.h>
 #include <filesystem>
 #include <memory>
+#include <system_error>
 
 namespace FileActions {
 
@@ -76,8 +80,53 @@ private:
   std::filesystem::path m_path;
 };
 
+class RunExecutableAction : public AbstractAction {
+  Q_DECLARE_TR_FUNCTIONS(RunExecutableAction)
+
+public:
+  struct Options {
+    bool mkExec = false;
+  };
+
+  RunExecutableAction(std::filesystem::path path, const Options &opts)
+      : m_path(std::move(path)), m_opts(opts) {}
+
+  QString title() const override { return tr("Run executable"); }
+
+  std::optional<ImageURL> icon() const override { return BuiltinIcon::Terminal; }
+
+  void execute(ApplicationContext *ctx) override {
+    namespace fs = std::filesystem;
+
+    if (m_opts.mkExec) {
+      std::error_code ec{};
+      fs::permissions(m_path, fs::perms::owner_exec, fs::perm_options::add, ec);
+      if (ec) {
+        ctx->services->toastService()->failure(tr("Failed to give executable permission"));
+        return;
+      }
+    }
+
+    if (ctx->services->appDb()->launchRaw({QString::fromStdString(m_path.string())})) {
+      ctx->navigation->closeWindow();
+    } else {
+      ctx->services->toastService()->failure(tr("Failed to start executable"));
+    }
+  }
+
+private:
+  std::filesystem::path m_path;
+  Options m_opts;
+};
+
 inline std::unique_ptr<ActionPanelState> actionPanel(const std::filesystem::path &path,
                                                      const ApplicationContext *ctx) {
+  // extensions for which we allow granting executable permission on the fly
+  // most of the time we want to avoid doing that, but for e.g AppImages that's
+  // what a lot of users would expect.
+  const auto AUTO_EXECUTABLE_EXTENSIONS = {".AppImage"};
+
+  namespace fs = std::filesystem;
   QMimeDatabase mimeDb;
   auto panel = std::make_unique<ListActionPanelState>();
   auto section = panel->createSection();
@@ -90,6 +139,26 @@ inline std::unique_ptr<ActionPanelState> actionPanel(const std::filesystem::path
   if (!openers.empty()) {
     auto open = new OpenFileAction(path, openers.front());
     section->addAction(open);
+  }
+
+  {
+    std::error_code ec{};
+    const auto pm = fs::status(path, ec).permissions();
+    const bool isExec =
+        (pm & (fs::perms::owner_exec | fs::perms::group_exec | fs::perms::others_exec)) != fs::perms::none;
+    AbstractAction *action = nullptr;
+
+    if (isExec) {
+      action = new RunExecutableAction(path, {.mkExec = false});
+    } else if (std::ranges::any_of(AUTO_EXECUTABLE_EXTENSIONS,
+                                   [&](auto &&ext) { return path.extension() == ext; })) {
+      action = new RunExecutableAction(path, {.mkExec = true});
+    }
+
+    if (action) {
+      if (openers.empty()) action->setPrimary(true);
+      section->addAction(action);
+    }
   }
 
   if (fileBrowser) { section->addAction(new RevealFileInFolderAction(path)); }

--- a/src/server/src/utils/file-list-item.hpp
+++ b/src/server/src/utils/file-list-item.hpp
@@ -97,6 +97,7 @@ public:
 
   void execute(ApplicationContext *ctx) override {
     namespace fs = std::filesystem;
+    auto const files = ctx->services->fileService();
 
     if (m_opts.mkExec) {
       std::error_code ec{};
@@ -109,6 +110,7 @@ public:
 
     if (ctx->services->appDb()->launchRaw({QString::fromStdString(m_path.string())})) {
       ctx->navigation->closeWindow();
+      files->saveAccess(m_path);
     } else {
       ctx->services->toastService()->failure(tr("Failed to start executable"));
     }


### PR DESCRIPTION
For files that are granted executable permission or are meant to be
executed (e.g AppImage), add a new action to run it directly.

fixes #1843

<img width="1171" height="735" alt="image" src="https://github.com/user-attachments/assets/843d475c-53f9-4d48-ae02-4eb3610c314e" />

