### PR TITLE
feat(extensions): implement launchCommand API

### DIFF
--- a/extra/extension-boilerplate/package.json
+++ b/extra/extension-boilerplate/package.json
@@ -128,6 +128,18 @@
 			"mode": "view"
 		},
 		{
+			"name": "launch-command",
+			"title": "Launch Command",
+			"description": "Test the launch command stuff",
+			"mode": "view"
+		},
+		{
+			"name": "context-echo",
+			"title": "Context Echo",
+			"description": "Echo the command launch context",
+			"mode": "view"
+		},
+		{
 			"name": "desktop-notif-interval",
 			"title": "Desktop Notification Interval",
 			"description": "Desktop Notification Interval",

--- a/extra/extension-boilerplate/src/context-echo.tsx
+++ b/extra/extension-boilerplate/src/context-echo.tsx
@@ -1,9 +1,9 @@
 import { Detail, type LaunchProps } from "@vicinae/api";
 
-export default function ContextEcho({ launchContext = {} }: LaunchProps) {
+export default function ContextEcho(props: LaunchProps) {
 	return (
 		<Detail
-			markdown={`\`\`\`json\n${JSON.stringify(launchContext, null, 2)}\n\`\`\``}
+			markdown={`\`\`\`json\n${JSON.stringify(props, null, 2)}\n\`\`\``}
 		/>
 	);
 }

--- a/extra/extension-boilerplate/src/context-echo.tsx
+++ b/extra/extension-boilerplate/src/context-echo.tsx
@@ -1,0 +1,9 @@
+import { Detail, type LaunchProps } from "@vicinae/api";
+
+export default function ContextEcho({ launchContext = {} }: LaunchProps) {
+	return (
+		<Detail
+			markdown={`\`\`\`json\n${JSON.stringify(launchContext, null, 2)}\n\`\`\``}
+		/>
+	);
+}

--- a/extra/extension-boilerplate/src/launch-command.tsx
+++ b/extra/extension-boilerplate/src/launch-command.tsx
@@ -1,0 +1,84 @@
+import {
+	Action,
+	ActionPanel,
+	launchCommand,
+	LaunchType,
+	List,
+} from "@vicinae/api";
+
+const intraCommands: any[] = [
+	{ name: "window-switcher", context: {}, arguments: {} },
+	{
+		name: "context-echo",
+		context: {
+			myString: "SomeString",
+			myNumber: 3,
+			someArray: [1, 2, true, { key: 1, arr: [1, 2, 42] }],
+		},
+		arguments: { key: "value" },
+	},
+];
+const interCommands = [
+	{
+		extensionName: "wallhaven",
+		name: "downloaded-wallpapers",
+		author: "aurelleb",
+		context: {},
+		arguments: {},
+	},
+];
+
+export default function LaunchIntra() {
+	return (
+		<List>
+			<List.Section title="Intra launch">
+				{intraCommands.map((cmd) => (
+					<List.Item
+						key={cmd.name}
+						title={cmd.name}
+						actions={
+							<ActionPanel>
+								<Action
+									title="Launch command"
+									onAction={() => {
+										launchCommand({
+											name: cmd.name,
+											type: LaunchType.UserInitiated as any,
+											context: cmd.context ?? {},
+											arguments: cmd.arguments ?? {},
+										});
+									}}
+								/>
+							</ActionPanel>
+						}
+					/>
+				))}
+			</List.Section>
+			<List.Section title="Inter launch">
+				{interCommands.map((cmd) => (
+					<List.Item
+						key={cmd.name}
+						title={cmd.name}
+						actions={
+							<ActionPanel>
+								<Action
+									title="Launch command"
+									onAction={() => {
+										launchCommand({
+											name: cmd.name,
+											extensionName: cmd.extensionName,
+											ownerOrAuthorName: cmd.author,
+											type: LaunchType.UserInitiated as any,
+											context: cmd.context ?? {},
+											arguments: cmd.arguments ?? {},
+										});
+									}}
+								/>
+							</ActionPanel>
+						}
+					/>
+				))}
+			</List.Section>
+		</List>
+	);
+}

--- a/figura/tsapi.fig
+++ b/figura/tsapi.fig
@@ -250,7 +250,24 @@ struct UpdateCommandMetadataPayload {
   subtitle?: string;
 };
 
+enum LaunchType {
+  User,
+  Background,
+  CommandLine
+};
+
+struct LaunchCommandOptions {
+  extensionName: string;
+  name: string;
+  ownerOrAuthorName: string;
+  type: LaunchType;
+  arguments?: any;
+  context?: any;
+  fallbackText?: string;
+};
+
 service Command {
+  fn launchCommand(options: LaunchCommandOptions) => void;
   fn updateCommandMetadata(payload: UpdateCommandMetadataPayload) => void;
   fn openExtensionPreferences() => void;
   fn openCommandPreferences() => void;

--- a/src/server/src/common.hpp
+++ b/src/server/src/common.hpp
@@ -1,12 +1,12 @@
 #pragma once
 #include <QString>
 #include <cstdint>
-#include <optional>
+#include <glaze/glaze.hpp>
 #include <qjsonobject.h>
 
 class CommandContext;
 
-using LaunchContext = QJsonObject;
+using LaunchContext = glz::generic;
 
 struct LaunchProps {
   QString query;

--- a/src/server/src/extension/extension-command-runtime.cpp
+++ b/src/server/src/extension/extension-command-runtime.cpp
@@ -19,6 +19,8 @@
 #include "services/asset-resolver/asset-resolver.hpp"
 #include <QString>
 #include <glaze/json/generic.hpp>
+#include <glaze/json/prettify.hpp>
+#include <glaze/json/write.hpp>
 #include <qfuturewatcher.h>
 #include <qlogging.h>
 #include <ranges>
@@ -101,8 +103,7 @@ void ExtensionCommandRuntime::load(const LaunchProps &props) {
   opts.owner_or_author_name = m_command->author().toStdString();
   opts.is_raycast = m_command->isRaycast();
   opts.preferences = qJsonObjectToGlazeGeneric(preferenceValues);
-  opts.launch_context =
-      props.launchContext ? qJsonObjectToGlazeGeneric(*props.launchContext) : glz::generic{};
+  opts.launch_context = props.launchContext;
   opts.arguments = props.arguments |
                    std::views::transform([](auto &&pair) -> std::pair<std::string, std::string> {
                      return {pair.first.toStdString(), pair.second.toStdString()};

--- a/src/server/src/extension/extension-command-runtime.cpp
+++ b/src/server/src/extension/extension-command-runtime.cpp
@@ -53,7 +53,8 @@ void ExtensionCommandRuntime::initialize() {
   auto *clipboard = new ExtClipboardService(*m_transport, *services->clipman(), *services->pasteService());
   auto *storage = new ExtStorageService(*m_transport, *services->localStorage(), storageNamespace);
   auto *fileSearch = new ExtFileSearchService(*m_transport, *services->fileService());
-  auto *command = new ExtCommandService(*m_transport, m_command, services->rootItemManager(), *ctx.settings);
+  auto *command = new ExtCommandService(*m_transport, m_command, services->rootItemManager(), *ctx.settings,
+                                        *ctx.navigation);
   auto *oauth = new ExtOAuthService(*m_transport, m_command->extensionId(), ctx);
   auto wallpaper = new ExtWallpaperService(*m_transport, *services->wallpaperManager());
   auto browserExtension = new ExtBrowserExtensionService(*m_transport, *services->browserExtension());

--- a/src/server/src/extension/services/command-service.hpp
+++ b/src/server/src/extension/services/command-service.hpp
@@ -13,6 +13,8 @@ namespace {
 LaunchProps transformApiLaunchProps(const tsapi::LaunchCommandOptions &options) {
   LaunchProps props;
 
+  props.launchContext = options.context;
+
   if (auto t = options.fallbackText) props.fallbackText = QString::fromStdString(t.value());
   if (auto args = options.arguments; args && args->is_object()) {
     for (const auto &[k, v] : args->get_object()) {
@@ -36,8 +38,6 @@ public:
         m_settings(settings) {}
 
   tsapi::Result<void>::Future launchCommand(tsapi::LaunchCommandOptions options) override {
-    qDebug() << "extension launching another command with name" << options.name;
-
     for (auto item : m_rootManager->extensions()) {
       auto &repo = item->repository();
 
@@ -46,6 +46,7 @@ public:
         for (const auto &cmd : repo->commands()) {
           if (cmd->commandId() == options.name) {
             m_nav.activateEntrypoint(cmd->uniqueId(), {.props = transformApiLaunchProps(options)});
+            return Void::ok();
           }
         }
       }

--- a/src/server/src/extension/services/command-service.hpp
+++ b/src/server/src/extension/services/command-service.hpp
@@ -1,16 +1,58 @@
 #pragma once
+#include "common.hpp"
 #include "extension/extension-command.hpp"
 #include "generated/tsapi.hpp"
+#include "navigation-controller.hpp"
 #include "services/root-item-manager/root-item-manager.hpp"
 #include "settings-controller/settings-controller.hpp"
+#include "root-search/extensions/extension-root-provider.hpp"
+#include "command.hpp"
+#include <qlogging.h>
+
+namespace {
+LaunchProps transformApiLaunchProps(const tsapi::LaunchCommandOptions &options) {
+  LaunchProps props;
+
+  if (auto t = options.fallbackText) props.fallbackText = QString::fromStdString(t.value());
+  if (auto args = options.arguments; args && args->is_object()) {
+    for (const auto &[k, v] : args->get_object()) {
+      if (v.is_string()) {
+        props.arguments.push_back({QString::fromStdString(k), QString::fromStdString(v.get_string())});
+      }
+    }
+  }
+
+  return props;
+}
+}; // namespace
 
 class ExtCommandService : public tsapi::AbstractCommand {
   using Void = tsapi::Result<void>;
 
 public:
   ExtCommandService(tsapi::RpcTransport &transport, const std::shared_ptr<ExtensionCommand> &command,
-                    RootItemManager *rootManager, SettingsController &settings)
-      : AbstractCommand(transport), m_command(command), m_rootManager(rootManager), m_settings(settings) {}
+                    RootItemManager *rootManager, SettingsController &settings, NavigationController &nav)
+      : AbstractCommand(transport), m_command(command), m_rootManager(rootManager), m_nav(nav),
+        m_settings(settings) {}
+
+  tsapi::Result<void>::Future launchCommand(tsapi::LaunchCommandOptions options) override {
+    qDebug() << "extension launching another command with name" << options.name;
+
+    for (auto item : m_rootManager->extensions()) {
+      auto &repo = item->repository();
+
+      if (options.extensionName == repo->name() &&
+          options.ownerOrAuthorName == item->repository()->author()) {
+        for (const auto &cmd : repo->commands()) {
+          if (cmd->commandId() == options.name) {
+            m_nav.activateEntrypoint(cmd->uniqueId(), {.props = transformApiLaunchProps(options)});
+          }
+        }
+      }
+    }
+
+    return Void::fail("No such command");
+  }
 
   tsapi::Result<void>::Future openExtensionPreferences() override {
     // for now both behave the same, we may want to scroll to preferences section in the future for this one
@@ -37,5 +79,6 @@ public:
 private:
   std::shared_ptr<ExtensionCommand> m_command;
   RootItemManager *m_rootManager;
+  NavigationController &m_nav;
   SettingsController &m_settings;
 };

--- a/src/server/src/internal/glaze-qt.hpp
+++ b/src/server/src/internal/glaze-qt.hpp
@@ -2,6 +2,7 @@
 #include <QDateTime>
 #include <QString>
 #include <glaze/json/generic.hpp>
+#include <glaze/json/prettify.hpp>
 #include <glaze/json/read.hpp>
 #include <glaze/json/write.hpp>
 #include <qjsonobject.h>
@@ -60,3 +61,9 @@ QJsonValue glazeToQJsonValue(const glz::generic &v);
 QJsonObject glazeToQJsonObject(const glz::generic::object_t &v);
 glz::generic::object_t qJsonObjectToGlazeGeneric(const QJsonObject &v);
 glz::generic qJsonValueToGlazeGeneric(const QJsonValue &v);
+
+std::string glazeStringify(const auto &data) {
+  std::string buf{};
+  glz::write_json(data, buf);
+  return glz::prettify_json(buf);
+}

--- a/src/typescript/api/src/api/command.ts
+++ b/src/typescript/api/src/api/command.ts
@@ -1,6 +1,6 @@
 import { getClient } from "./client";
-import { environment } from "./environment";
-import type { LaunchType } from "./proto/api";
+import { environment, LaunchType } from "./environment";
+import type * as api from "./proto/api";
 
 /**
  * Update the values of properties declared in the manifest of the current command.
@@ -16,22 +16,19 @@ export async function updateCommandMetadata(metadata: {
 	});
 }
 
-export type IntraExtensionLaunchOptions = {
+type LaunchOptionsBase = {
 	name: string;
 	type: LaunchType;
-	arguments?: Record<string, string>;
 	context?: Record<string, string>;
+	arguments?: Record<string, string>;
 	fallbackText?: string;
 };
 
-export type InterExtensionLaunchOptions = {
+export type IntraExtensionLaunchOptions = LaunchOptionsBase;
+
+export type InterExtensionLaunchOptions = LaunchOptionsBase & {
 	extensionName: string;
-	name: string;
 	ownerOrAuthorName: string;
-	type: LaunchType;
-	arguments?: Record<string, string>;
-	context?: Record<string, string>;
-	fallbackText?: string;
 };
 
 export type LaunchOptions =
@@ -62,12 +59,18 @@ export async function launchCommand(options: LaunchOptions) {
 		? options.ownerOrAuthorName
 		: environment.ownerOrAuthorName;
 
+	const transformLaunchType = (type: LaunchType): api.LaunchType => {
+		if (type === LaunchType.UserInitiated) return "User";
+		if (type === LaunchType.Background) return "Background";
+		return "CommandLine";
+	};
+
 	await getClient().Command.launchCommand({
 		extensionName: extensionName,
 		ownerOrAuthorName: ownerOrAuthorName,
 		name: options.name,
 		arguments: options.arguments,
 		context: options.context,
-		type: options.type,
+		type: transformLaunchType(options.type),
 	});
 }

--- a/src/typescript/api/src/api/command.ts
+++ b/src/typescript/api/src/api/command.ts
@@ -1,4 +1,6 @@
 import { getClient } from "./client";
+import { environment } from "./environment";
+import type { LaunchType } from "./proto/api";
 
 /**
  * Update the values of properties declared in the manifest of the current command.
@@ -11,5 +13,48 @@ export async function updateCommandMetadata(metadata: {
 }): Promise<void> {
 	await getClient().Command.updateCommandMetadata({
 		subtitle: metadata.subtitle ?? undefined,
+	});
+}
+
+export type IntraExtensionLaunchOptions = {
+	name: string;
+	type: LaunchType;
+	arguments?: Record<string, string>;
+	context?: Record<string, string>;
+	fallbackText?: string;
+};
+
+export type InterExtensionLaunchOptions = {
+	extensionName: string;
+	name: string;
+	ownerOrAuthorName: string;
+	type: LaunchType;
+	arguments?: Record<string, string>;
+	context?: Record<string, string>;
+	fallbackText?: string;
+};
+
+export type LaunchOptions =
+	| InterExtensionLaunchOptions
+	| IntraExtensionLaunchOptions;
+
+export async function launchCommand(options: LaunchOptions) {
+	const isInter = (t: LaunchOptions): t is InterExtensionLaunchOptions => {
+		return Object.hasOwn(t, "extensionName");
+	};
+	const extensionName = isInter(options)
+		? options.extensionName
+		: environment.extensionName;
+	const ownerOrAuthorName = isInter(options)
+		? options.ownerOrAuthorName
+		: environment.ownerOrAuthorName;
+
+	await getClient().Command.launchCommand({
+		extensionName: extensionName,
+		ownerOrAuthorName: ownerOrAuthorName,
+		name: options.name,
+		arguments: options.arguments,
+		type: options.type,
+		context: options.context,
 	});
 }

--- a/src/typescript/api/src/api/command.ts
+++ b/src/typescript/api/src/api/command.ts
@@ -38,6 +38,19 @@ export type LaunchOptions =
 	| InterExtensionLaunchOptions
 	| IntraExtensionLaunchOptions;
 
+/**
+ * Launch another command from the current extension or a different one.
+ *
+ * The `context` object can be used to pass arbitrary JSON stringifiable data
+ * to the other command. Note that buffer or date objects NEED to be encoded/stringified before
+ * passing them.
+ *
+ * @returns Returns when the other command has been successfully launched. Note that control is fully transferred
+ * to the other command and that the current command from which `launchCommand` has been called is effectively unloaded
+ * if the call succeeds.
+ *
+ * @throws If the command doesn't exist or couldn't be started, for any reason.
+ */
 export async function launchCommand(options: LaunchOptions) {
 	const isInter = (t: LaunchOptions): t is InterExtensionLaunchOptions => {
 		return Object.hasOwn(t, "extensionName");
@@ -54,7 +67,7 @@ export async function launchCommand(options: LaunchOptions) {
 		ownerOrAuthorName: ownerOrAuthorName,
 		name: options.name,
 		arguments: options.arguments,
-		type: options.type,
 		context: options.context,
+		type: options.type,
 	});
 }

--- a/src/typescript/api/src/api/proto/api.ts
+++ b/src/typescript/api/src/api/proto/api.ts
@@ -90,6 +90,8 @@ export type NotificationUrgency = 'Low' | 'Normal' | 'High';
 
 export type FileSearchCategory = 'Other' | 'Directory' | 'Image' | 'Video' | 'Audio' | 'Document' | 'Archive' | 'Application';
 
+export type LaunchType = 'User' | 'Background' | 'CommandLine';
+
 export type WallpaperFit = 'Cover' | 'Contain' | 'Stretch' | 'Center' | 'Tile';
 
 export type Application = {
@@ -224,6 +226,16 @@ export type FileSearchOptions = {
 
 export type UpdateCommandMetadataPayload = {
 	subtitle?: string;
+}
+
+export type LaunchCommandOptions = {
+	extensionName: string;
+	name: string;
+	ownerOrAuthorName: string;
+	type: LaunchType;
+	arguments?: any;
+	context?: any;
+	fallbackText?: string;
 }
 
 export type PKCEClientOptions = {
@@ -455,6 +467,10 @@ class FileSearchService {
 
 class CommandService {
 	constructor(private readonly transport: RpcTransport) {}
+
+	launchCommand(options: LaunchCommandOptions): Promise<void> {
+		return this.transport.request("Command/launchCommand", { options});	
+	}
 
 	updateCommandMetadata(payload: UpdateCommandMetadataPayload): Promise<void> {
 		return this.transport.request("Command/updateCommandMetadata", { payload});	

--- a/src/typescript/extension-manager/src/loaders/load-no-view-command.ts
+++ b/src/typescript/extension-manager/src/loaders/load-no-view-command.ts
@@ -15,7 +15,7 @@ export default async (data: LaunchEventData) => {
 	await entrypoint({
 		launchType: environment.launchType,
 		arguments: data.argumentValues,
-		launchContext: data.launch_context ?? {},
+		launchContext: data.launch_context || undefined,
 		cwd: data.cwd,
 		fallbackText: data.fallbackText,
 	} as LaunchProps);

--- a/src/typescript/extension-manager/src/loaders/load-no-view-command.ts
+++ b/src/typescript/extension-manager/src/loaders/load-no-view-command.ts
@@ -15,7 +15,7 @@ export default async (data: LaunchEventData) => {
 	await entrypoint({
 		launchType: environment.launchType,
 		arguments: data.argumentValues,
-		launchContext: data.launch_context,
+		launchContext: data.launch_context ?? {},
 		cwd: data.cwd,
 		fallbackText: data.fallbackText,
 	} as LaunchProps);

--- a/src/typescript/extension-manager/src/loaders/load-view-command.tsx
+++ b/src/typescript/extension-manager/src/loaders/load-view-command.tsx
@@ -46,7 +46,7 @@ const App: React.FC<{ component: ComponentType; launchProps: LaunchProps }> = ({
 	);
 };
 
-export default async function(data: extensionServer.LaunchEventData) {
+export default async function (data: extensionServer.LaunchEventData) {
 	const module = await import(pathToFileURL(data.entrypoint).href);
 	const Component = module.default.default;
 	const sendRender = (views: ViewData[]) => {

--- a/src/typescript/extension-manager/src/loaders/load-view-command.tsx
+++ b/src/typescript/extension-manager/src/loaders/load-view-command.tsx
@@ -46,7 +46,7 @@ const App: React.FC<{ component: ComponentType; launchProps: LaunchProps }> = ({
 	);
 };
 
-export default async function (data: extensionServer.LaunchEventData) {
+export default async function(data: extensionServer.LaunchEventData) {
 	const module = await import(pathToFileURL(data.entrypoint).href);
 	const Component = module.default.default;
 	const sendRender = (views: ViewData[]) => {
@@ -63,7 +63,7 @@ export default async function (data: extensionServer.LaunchEventData) {
 			launchProps={{
 				launchType: environment.launchType,
 				arguments: data.argumentValues,
-				launchContext: data.launch_context,
+				launchContext: data.launch_context || undefined,
 				fallbackText: data.fallbackText,
 				cwd: data.cwd,
 			}}

--- a/src/typescript/extension-manager/src/worker.tsx
+++ b/src/typescript/extension-manager/src/worker.tsx
@@ -21,6 +21,8 @@ class Lifecycle extends extensionServer.LifecycleService {
 	async launch(data: extensionServer.LaunchEventData): Promise<boolean> {
 		const { environment } = workerData as { environment: EnvironmentType };
 
+		console.error({ data });
+
 		// raycast compat captures preference values at load time: keep before patchRequire
 		loadEnviron(environment, data);
 		patchRequire(environment);

--- a/src/typescript/extension-manager/src/worker.tsx
+++ b/src/typescript/extension-manager/src/worker.tsx
@@ -21,8 +21,6 @@ class Lifecycle extends extensionServer.LifecycleService {
 	async launch(data: extensionServer.LaunchEventData): Promise<boolean> {
 		const { environment } = workerData as { environment: EnvironmentType };
 
-		console.error({ data });
-
 		// raycast compat captures preference values at load time: keep before patchRequire
 		loadEnviron(environment, data);
 		patchRequire(environment);

--- a/src/typescript/raycast-api-compat/src/index.ts
+++ b/src/typescript/raycast-api-compat/src/index.ts
@@ -43,6 +43,7 @@ export {
 	trash,
 	updateCommandMetadata,
 	useNavigation,
+	launchCommand
 } from "@vicinae/api";
 export { Clipboard } from "./clipboard.js";
 export { BrowserExtension } from "./browser.js";
@@ -57,7 +58,6 @@ export {
 	showInFinder,
 } from "./system.js";
 export {
-	launchCommand,
 	MenuBarExtra,
 	unsupported,
 } from "./unsupported.js";

--- a/src/typescript/raycast-api-compat/src/index.ts
+++ b/src/typescript/raycast-api-compat/src/index.ts
@@ -43,7 +43,7 @@ export {
 	trash,
 	updateCommandMetadata,
 	useNavigation,
-	launchCommand
+	launchCommand,
 } from "@vicinae/api";
 export { Clipboard } from "./clipboard.js";
 export { BrowserExtension } from "./browser.js";


### PR DESCRIPTION
Implement the [launchCommand](https://developers.raycast.com/api-reference/command) API, allowing extension commands to transfer execution control to another command.