### PR TITLE
feat: get rid of refresh rates preference

### DIFF
--- a/src/server/src/extensions/calculator/calculator-extension.hpp
+++ b/src/server/src/extensions/calculator/calculator-extension.hpp
@@ -97,22 +97,7 @@ public:
     backendPref.setTitle(tr("Calculator Backend"));
     backendPref.setDescription(tr("Which backend to use to perform calculations"));
 
-    auto refreshOnStartup = Preference::makeCheckbox("refreshRatesOnStartup");
-
-    refreshOnStartup.setDefaultValue(true);
-    refreshOnStartup.setTitle(tr("Refresh rates on startup"));
-    refreshOnStartup.setDescription(
-        tr("Whether exchange rates should be refreshed every time the vicinae server is started. If the "
-           "current backend does not support it, this is ignored."));
-
-    return {backendPref, refreshOnStartup};
-  }
-
-  void initialized(const QJsonObject &value) const override {
-    auto calc = ServiceRegistry::instance()->calculatorService();
-    bool refreshOnStartup = value.value("refreshRatesOnStartup").toBool();
-
-    if (refreshOnStartup) { calc->backend()->refreshExchangeRates(); }
+    return {backendPref};
   }
 
   void preferenceValuesChanged(const QJsonObject &value) const override {

--- a/src/server/src/services/calculator-service/calculator-service.cpp
+++ b/src/server/src/services/calculator-service/calculator-service.cpp
@@ -5,6 +5,7 @@
 #include "services/calculator-service/abstract-calculator-backend.hpp"
 #include "services/calculator-service/calculator-service.hpp"
 #include "services/calculator-service/numen/numen-calculator-backend.hpp"
+#include "utils/environment.hpp"
 #include <ranges>
 #include <qdatetime.h>
 #include <qlogging.h>
@@ -32,6 +33,10 @@ bool CalculatorService::setBackend(AbstractCalculatorBackend *newBackend) {
   }
 
   qInfo() << "Started" << newBackend->displayName() << "calculator backend";
+
+  if (newBackend->supportsRefreshExchangeRates() && !Environment::isAutoRateRefreshDisabled()) {
+    newBackend->refreshExchangeRates();
+  }
 
   if (m_backend) { m_backend->stop(); }
 

--- a/src/server/src/services/calculator-service/numen/numen-calculator-backend.cpp
+++ b/src/server/src/services/calculator-service/numen/numen-calculator-backend.cpp
@@ -1,6 +1,7 @@
 #include "services/calculator-service/numen/numen-calculator-backend.hpp"
 #include "numen/numen.hpp"
 #include "services/calculator-service/numen/numen-currency-provider.hpp"
+#include "utils/environment.hpp"
 #include <qfuture.h>
 #include <chrono>
 #include <format>
@@ -26,6 +27,8 @@ std::string formatTimezone(const numen::Timezone &tz) {
 }; // namespace
 
 NumenCalculatorBackend::NumenCalculatorBackend() {
+  if (Environment::isAutoRateRefreshDisabled()) return;
+
   m_rateRefreshTimer.setInterval(std::chrono::hours{1});
   m_rateRefreshTimer.start();
   connect(&m_rateRefreshTimer, &QTimer::timeout, this, [this]() { m_numen.updateRates(); });

--- a/src/server/src/utils/environment.hpp
+++ b/src/server/src/utils/environment.hpp
@@ -140,6 +140,12 @@ inline std::optional<std::string> updateVersionOverride() {
 }
 
 /**
+ * Disables automatic exchange rate refreshes (on backend start and periodic).
+ * Rates can still be refreshed manually from the calculator extension.
+ */
+inline bool isAutoRateRefreshDisabled() { return getenv("VICINAE_DISABLE_AUTO_RATE_REFRESH"); }
+
+/**
  * Gets human-readable environment description
  */
 inline QString getEnvironmentDescription() {


### PR DESCRIPTION
Every calculator backend has a different way to refresh their currency exchange rates, and might be able to automatically update them at specific interval. The "refresh on startup" preference is too general and fights the multi backend system too much.

From now on we just refresh the rates when the backend starts, which also handles backend switching better.

if `VICINAE_DISABLE_AUTO_RATE_REFRESH` is set backends won't try to refresh their rates (except the SoulverCore one). Generally this is not recommended at all, but it's still there if users really need an explicit opt out for whatever reason.