### PR TITLE
fix: reorder extension List items when siblings move

### DIFF
--- a/src/typescript/extension-manager/src/reconciler.ts
+++ b/src/typescript/extension-manager/src/reconciler.ts
@@ -193,18 +193,18 @@ const createHostConfig = (hostCtx: HostContext, callback: () => void) => {
 
 		insertBefore(parent, child, beforeChild) {
 			if (!parent.children) parent.children = [];
-			const beforeIndex = parent.children.indexOf(beforeChild);
 
 			const selfIdx = parent.children.indexOf(child);
 			if (selfIdx !== -1) parent.children.splice(selfIdx, 1);
 
-			if (beforeIndex !== -1) {
-				parent.children.splice(beforeIndex, 0, child);
-				child._parent = parent;
-				emitDirty(parent);
-			} else {
+			const beforeIndex = parent.children.indexOf(beforeChild);
+			if (beforeIndex === -1) {
 				throw new Error("Unreachable");
 			}
+
+			parent.children.splice(beforeIndex, 0, child);
+			child._parent = parent;
+			emitDirty(parent);
 		},
 
 		insertInContainerBefore(container, child, beforeChild) {


### PR DESCRIPTION
## What changed

- `insertBefore` in the extension reconciler now looks up `beforeChild` **after** removing the moving node, so a forward move (Move Down) splices at the live index instead of appending the item.

## Why

React reorders keyed `<List.Item>` children with `insertBefore`. We captured `beforeChild`'s index, then spliced the moving child out first. That shifted the reference node, so the item landed at the end of the section. Titles/actions patched in place; visual order stayed wrong until the command remounted.

Found this while testing pin/favorite reorder on the Workspace extension ([vicinaehq/extensions#354](https://github.com/vicinaehq/extensions/pull/354)). That flow has been broken in the Raycast port: pins use stable `id`s and splice on move, but the live list never applied the sibling reorder.

The host list already applies the child array it receives and restores selection by item id. This only fixes the tree order sent to the host.

**What was happening** 

https://github.com/user-attachments/assets/b090dca7-881f-4892-8c02-751d99228895

**Expected Behavior**

https://github.com/user-attachments/assets/236e753d-bac3-4f78-81b4-066f795d4675

