### PR TITLE
fix: keep List.Item / Grid.Item native id in sync with props.id

### DIFF
--- a/src/typescript/api/src/api/components/grid.tsx
+++ b/src/typescript/api/src/api/components/grid.tsx
@@ -241,9 +241,11 @@ const GridItem: React.FC<Grid.Item.Props> = ({
 	dragContent,
 	content,
 	accessory,
+	id: propsId,
 	...props
 }) => {
-	const id = useRef(props.id ?? randomUUID());
+	const generatedId = useRef(randomUUID());
+	const id = propsId ?? generatedId.current;
 
 	// Remove value wrapper
 	const innerContent =
@@ -289,7 +291,7 @@ const GridItem: React.FC<Grid.Item.Props> = ({
 			}
 			tooltip={tooltip}
 			accessory={serializedAccessory}
-			id={id.current}
+			id={id}
 		>
 			{detail}
 			{actions}

--- a/src/typescript/api/src/api/components/list.tsx
+++ b/src/typescript/api/src/api/components/list.tsx
@@ -355,9 +355,11 @@ const ListItem: React.FC<List.Item.Props> = ({
 	dragContent,
 	icon,
 	accessories,
+	id: propsId,
 	...props
 }) => {
-	const id = useRef(props.id ?? randomUUID());
+	const generatedId = useRef(randomUUID());
+	const id = propsId ?? generatedId.current;
 
 	// Icon
 	let serializedIcon: React.JSX.IntrinsicElements["list-item"]["icon"];
@@ -382,7 +384,7 @@ const ListItem: React.FC<List.Item.Props> = ({
 				dragContent ? Clipboard.serializeContent(dragContent) : undefined
 			}
 			accessories={serializedAccessories}
-			id={id.current}
+			id={id}
 		>
 			{detail}
 			{actions}


### PR DESCRIPTION
## What changed

`List.Item` and `Grid.Item` still generate a stable UUID when `id` is omitted. If `props.id` is set, the native `id` now follows the current prop instead of the value captured on first mount.

## Why

Both components did:

```tsx
const id = useRef(props.id ?? randomUUID());
// ...
id={id.current}
```

`useRef` only runs that initializer once. React can reuse the same component instance when the list updates (same position, no remount). Titles, icons, and actions patch in place, but the native `id` stayed frozen.

That breaks anything keyed off item id: `onSelectionChange`, selection restore, and host actions that look up the selected item. Typical case is a list that first renders without ids (or with placeholder ids) and then fills in the real ones after a fetch.

This is not the reconciler `insertBefore` bug from [#1856](https://github.com/vicinaehq/vicinae/pull/1856). That one moved keyed siblings that already had stable ids. This one is a reused instance whose `props.id` never reached native.

Fallback ids are unchanged. `useRef(randomUUID())` still holds a stable id for items that never pass `id`.