### PR TITLE
fix: normalized transliteration scoring

### DIFF
--- a/src/lib/fuzzy/include/fuzzy/fzf.hpp
+++ b/src/lib/fuzzy/include/fuzzy/fzf.hpp
@@ -646,8 +646,8 @@ inline Query::Query(std::string_view text, const Matcher &matcher) : text(text) 
       for (const auto scheme : {TranslitScheme::Primary, TranslitScheme::Alternate}) {
         auto translit = transliterate(word.text, scheme);
         if (!translit) continue;
-        auto const exists = std::ranges::any_of(
-            word.variants, [&](const Word::Variant &v) { return v.text == *translit; });
+        auto const exists =
+            std::ranges::any_of(word.variants, [&](const Word::Variant &v) { return v.text == *translit; });
         if (exists) continue;
         int const self = matcher.match_folded(*translit, *translit).score;
         word.variants.push_back({.text = std::move(*translit), .self = self});

--- a/src/lib/fuzzy/include/fuzzy/fzf.hpp
+++ b/src/lib/fuzzy/include/fuzzy/fzf.hpp
@@ -66,13 +66,20 @@ enum class Scheme { Default, Path, History };
 class Matcher;
 inline const Matcher &threadLocalMatcher();
 
-// A query prepared for scoring many items: split into words, each with the best score it can
-// reach (`self`, the word matched against itself), so per-item scoring never recomputes it.
+// A query prepared for scoring many items: split into words, each expanded into its matchable
+// variants (the word itself, then its transliterations), each with the best score it can reach
+// (`self`, the variant matched against itself — transliterations are byte-shorter than their
+// source script, so each needs its own ceiling, #1859).
 // Ceilings depend on the matcher scheme; the default matcher is used unless one is given.
 struct Query {
   struct Word {
+    struct Variant {
+      std::string text;
+      int self = 0;
+    };
+
     std::string text;
-    int self = 0;
+    std::vector<Variant> variants;
   };
 
   std::string text;
@@ -146,23 +153,40 @@ public:
     int minQuality = 100;
 
     for (const auto &word : query.words) {
-      int maxWeighted = 0;
-      int maxRaw = 0;
-      auto score = [&](const WeightedString &str) {
-        auto const r = match(str.str, word.text);
-        if (r.coherent) { maxRaw = std::max(maxRaw, r.score); }
-        maxWeighted = std::max(maxWeighted, static_cast<int>(r.score * str.weight));
-      };
-      for (const auto &s : range1)
-        score(s);
-      for (const auto &s : range2)
-        score(s);
+      int bestWeighted = 0;
+      int bestWeightedRatio = 0;
+      int bestSelf = 0;
+      int quality = 0;
 
-      if (!maxWeighted) return {};
+      for (const auto &variant : word.variants) {
+        if (variant.self <= 0) continue;
 
-      minQuality = std::min(minQuality, word.self > 0 ? maxRaw * 100 / word.self : 0);
-      weightedSum += maxWeighted;
-      selfSum += word.self;
+        int maxWeighted = 0;
+        int maxRaw = 0;
+        auto score = [&](const WeightedString &str) {
+          auto const r = match_folded(str.str, variant.text);
+          if (r.coherent) { maxRaw = std::max(maxRaw, r.score); }
+          maxWeighted = std::max(maxWeighted, static_cast<int>(r.score * str.weight));
+        };
+        for (const auto &s : range1)
+          score(s);
+        for (const auto &s : range2)
+          score(s);
+
+        int const weightedRatio = maxWeighted * 100 / variant.self;
+        if (maxWeighted && (bestWeighted == 0 || weightedRatio > bestWeightedRatio)) {
+          bestWeighted = maxWeighted;
+          bestWeightedRatio = weightedRatio;
+          bestSelf = variant.self;
+        }
+        quality = std::max(quality, maxRaw * 100 / variant.self);
+      }
+
+      if (!bestWeighted) return {};
+
+      minQuality = std::min(minQuality, quality);
+      weightedSum += bestWeighted;
+      selfSum += bestSelf;
     }
 
     if (query.words.empty() || selfSum == 0) return {};
@@ -183,37 +207,35 @@ public:
   }
 
   Result match(std::string_view text, std::string_view pattern, bool with_pos = false) const {
-    const auto match = [&](std::string_view candidate) {
-      if (!has_non_ascii(text) && !has_non_ascii(candidate)) {
-        return match_ascii(text, candidate, with_pos);
-      }
-
-      fold_text(text);
-      const std::string_view ftext{m_fold_text.data(), m_fold_text.size()};
-      const std::string_view fpat = fold_pattern(candidate);
-
-      Result result = match_ascii(ftext, fpat, with_pos);
-      if (result.matched()) {
-        result.start = m_fold_off[result.start];
-        result.end = m_fold_off[result.end];
-        for (int &position : result.positions) {
-          position = m_fold_off[position];
-        }
-      }
-      return result;
-    };
-
-    Result best = match(pattern);
+    Result best = match_folded(text, pattern, with_pos);
     if (!has_non_ascii(pattern) || !needsTransliteration(pattern)) { return best; }
 
     for (const auto scheme : {TranslitScheme::Primary, TranslitScheme::Alternate}) {
       if (!transliterate(pattern, m_translit_pattern, scheme) || m_translit_pattern == pattern) { continue; }
 
-      Result candidate = match(m_translit_pattern);
+      Result candidate = match_folded(text, m_translit_pattern, with_pos);
       if (candidate.score > best.score) { best = std::move(candidate); }
     }
 
     return best;
+  }
+
+  Result match_folded(std::string_view text, std::string_view pattern, bool with_pos = false) const {
+    if (!has_non_ascii(text) && !has_non_ascii(pattern)) { return match_ascii(text, pattern, with_pos); }
+
+    fold_text(text);
+    const std::string_view ftext{m_fold_text.data(), m_fold_text.size()};
+    const std::string_view fpat = fold_pattern(pattern);
+
+    Result result = match_ascii(ftext, fpat, with_pos);
+    if (result.matched()) {
+      result.start = m_fold_off[result.start];
+      result.end = m_fold_off[result.end];
+      for (int &position : result.positions) {
+        position = m_fold_off[position];
+      }
+    }
+    return result;
   }
 
   Result match_ascii(std::string_view text, std::string_view pattern, bool with_pos = false) const {
@@ -614,9 +636,25 @@ inline const Matcher &threadLocalMatcher() {
 
 inline Query::Query(std::string_view text, const Matcher &matcher) : text(text) {
   for (auto &&part : std::views::split(std::string_view{this->text}, std::string_view{" "})) {
-    std::string_view const word{part};
-    if (word.empty()) continue;
-    words.push_back({.text = std::string(word), .self = matcher.match(word, word).score});
+    std::string_view const wordText{part};
+    if (wordText.empty()) continue;
+
+    Word word{.text = std::string(wordText)};
+    word.variants.push_back({.text = word.text, .self = matcher.match_folded(word.text, word.text).score});
+
+    if (needsTransliteration(word.text)) {
+      for (const auto scheme : {TranslitScheme::Primary, TranslitScheme::Alternate}) {
+        auto translit = transliterate(word.text, scheme);
+        if (!translit) continue;
+        auto const exists = std::ranges::any_of(
+            word.variants, [&](const Word::Variant &v) { return v.text == *translit; });
+        if (exists) continue;
+        int const self = matcher.match_folded(*translit, *translit).score;
+        word.variants.push_back({.text = std::move(*translit), .self = self});
+      }
+    }
+
+    words.push_back(std::move(word));
   }
 }
 

--- a/src/lib/fuzzy/tests/main.cpp
+++ b/src/lib/fuzzy/tests/main.cpp
@@ -177,8 +177,7 @@ TEST_CASE("transliteration: each variant is normalized against its own ceiling")
   REQUIRE(mixed.score == 100);
   REQUIRE(mixed.quality == 100);
 
-  auto const both =
-      fuzzy::scoreWeighted({{"Telegram", 1.0}, {"Телеграм", 1.0}}, fuzzy::Query{"телеграм"});
+  auto const both = fuzzy::scoreWeighted({{"Telegram", 1.0}, {"Телеграм", 1.0}}, fuzzy::Query{"телеграм"});
   REQUIRE(both.score == 100);
   REQUIRE(both.quality == 100);
 

--- a/src/lib/fuzzy/tests/main.cpp
+++ b/src/lib/fuzzy/tests/main.cpp
@@ -142,6 +142,62 @@ TEST_CASE("transliteration: matching across scripts") {
           matcher.match_ascii("Telegram", "teleg").score);
 }
 
+TEST_CASE("transliteration: normalized score and quality survive the gate (#1859)") {
+  const auto &m = fzf::threadLocalMatcher();
+
+  auto const tg = m.score_query("Telegram", fzf::Query{"телеграм"});
+  REQUIRE(tg.score == 100);
+  REQUIRE(tg.quality == 100);
+
+  for (std::string_view q : {"те", "тел", "теле", "телег", "телегр", "телегра", "телеграм"}) {
+    REQUIRE(fuzzy::scoreWeighted({{"Telegram", 1.0}}, fuzzy::Query{q}).accepted());
+  }
+
+  REQUIRE(fuzzy::scoreWeighted({{"Terminal", 1.0}}, fuzzy::Query{"τερμιναλ"}).accepted());
+  REQUIRE(fuzzy::scoreWeighted({{"Открыть Discord", 1.0}}, fuzzy::Query{"открыть дискорд"}).accepted());
+
+  auto const cyr = m.score_query("Телеграм", fzf::Query{"телеграм"});
+  REQUIRE(cyr.score == 100);
+  REQUIRE(cyr.quality == 100);
+
+  REQUIRE_FALSE(fuzzy::scoreWeighted({{"Telegram", 1.0}}, fuzzy::Query{"музыка"}).accepted());
+}
+
+TEST_CASE("transliteration: each variant is normalized against its own ceiling") {
+  const auto &m = fzf::threadLocalMatcher();
+
+  // "diskord" (primary) cannot match "Discord"; only the alternate scheme (к -> c) can
+  auto const alt = m.score_query("Discord", fzf::Query{"дискорд"});
+  REQUIRE(alt.score == 100);
+  REQUIRE(alt.quality == 100);
+
+  REQUIRE(fuzzy::scoreWeighted({{"Telegram", 1.0}}, fuzzy::Query{"телеgram"}).accepted());
+
+  auto const mixed = m.score_query("Открыть Discord", fzf::Query{"открыть дискорд"});
+  REQUIRE(mixed.score == 100);
+  REQUIRE(mixed.quality == 100);
+
+  auto const both =
+      fuzzy::scoreWeighted({{"Telegram", 1.0}, {"Телеграм", 1.0}}, fuzzy::Query{"телеграм"});
+  REQUIRE(both.score == 100);
+  REQUIRE(both.quality == 100);
+
+  REQUIRE_FALSE(fuzzy::scoreWeighted({{"Telegram", 1.0}}, fuzzy::Query{"ьъ"}).accepted());
+}
+
+TEST_CASE("transliteration: direct match() still resolves cross-script patterns") {
+  const auto &m = fzf::threadLocalMatcher();
+
+  auto const r = m.match("Telegram", "телеграм", true);
+  REQUIRE(r.matched());
+  REQUIRE(r.start == 0);
+  REQUIRE(r.end == 8);
+  REQUIRE(r.positions == std::vector<int>{0, 1, 2, 3, 4, 5, 6, 7});
+
+  REQUIRE(m.match("Discord", "дискорд").matched());
+  REQUIRE_FALSE(m.match("Telegram", "музыка").matched());
+}
+
 TEST_CASE("query score: quality is the worst per-word match, weighted respects field weights") {
   const auto &m = fzf::threadLocalMatcher();
   using WS = fzf::WeightedString;


### PR DESCRIPTION
The maximum score for a transliteratable query should be based on its latin transliteration, not on its original form. Otherwise it gets an heavy scoring penalty.

Also added tests to watch for regressions on this front.

This bug was introduced by #1802

fixes #1859