### PR TITLE
feat: add built-in notes scratchpad

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -140,6 +140,8 @@ set(SRCS
 	src/root-search/extensions/extension-root-provider.cpp
 	src/root-search/shortcuts/shortcut-root-provider.hpp
 	src/root-search/shortcuts/shortcut-root-provider.cpp
+	src/root-search/notes/note-root-provider.hpp
+	src/root-search/notes/note-root-provider.cpp
 	src/root-search/apps/app-root-provider.hpp
 	src/root-search/apps/app-root-provider.cpp
 
@@ -296,6 +298,8 @@ set(SRCS
 	src/extensions/clipboard/clipboard-extension.cpp
 
 	src/extensions/snippet/snippet-extension.cpp
+
+	src/extensions/note/note-extension.hpp
 
 	src/extensions/vicinae/refresh-apps-command.hpp
 	src/extensions/vicinae/refresh-apps-command.cpp
@@ -491,6 +495,11 @@ set(SRCS
 	src/services/snippet/null-snippet-server.hpp
 	src/services/snippet/snippet-db.cpp
 
+	src/services/note/note-service.hpp
+	src/services/note/note-db.hpp
+	src/services/note/note-db.cpp
+	src/actions/note/note-actions.hpp
+
 	# QML frontend
 	src/qml/keybind-bridge.hpp
 	src/qml/launcher-window.hpp
@@ -599,6 +608,12 @@ set(SRCS
 	src/qml/manage-snippets-model.cpp
 	src/qml/manage-snippets-view-host.hpp
 	src/qml/manage-snippets-view-host.cpp
+	src/qml/manage-notes-model.hpp
+	src/qml/manage-notes-model.cpp
+	src/qml/manage-notes-view-host.hpp
+	src/qml/manage-notes-view-host.cpp
+	src/qml/note-form-view-host.hpp
+	src/qml/note-form-view-host.cpp
 	src/qml/raycast-store-model.hpp
 	src/qml/raycast-store-model.cpp
 	src/qml/raycast-store-view-host.hpp
@@ -1059,6 +1074,7 @@ set(VICINAE_QML_FILES
 	src/qml/qml/FormCheckbox.qml
 	src/qml/qml/FormSeparator.qml
 	src/qml/qml/SnippetFormView.qml
+	src/qml/qml/NoteFormView.qml
 	src/qml/qml/AliasFormView.qml
 	src/qml/qml/ShortcutFormView.qml
 	src/qml/qml/FormCompletedInput.qml
@@ -1292,8 +1308,13 @@ if (BUILD_TESTS AND UNIX AND NOT APPLE)
 	target_sources(${TEST_TARGET} PRIVATE
 		src/services/calculator-service/qalculate/qalculate-backend.cpp
 		tests/calculator/qalculate-backend.cpp
+
+		./database/vicinae/migrations.qrc
+		src/utils/migration-manager/migration-manager.cpp
+		src/services/note/note-db.cpp
+		tests/note/note-db.cpp
 	)
-	target_link_libraries(${TEST_TARGET} PRIVATE vicinae::common qalculate Qt6::Concurrent)
+	target_link_libraries(${TEST_TARGET} PRIVATE vicinae::common vicinae::fuzzy qalculate sqlcipher Qt6::Concurrent)
 	target_link_libraries(${TEST_TARGET} PRIVATE Catch2::Catch2WithMain Qt6::Core Qt6::Gui)
 	target_compile_features(${TEST_TARGET} PUBLIC cxx_std_23)
 endif()

--- a/src/server/database/vicinae/migrations.qrc
+++ b/src/server/database/vicinae/migrations.qrc
@@ -3,5 +3,6 @@
         <file>migrations/001_init.sql</file>
         <file>migrations/002_add_recent_files.sql</file>
         <file>migrations/003_add_oauth_token_store.sql</file>
+        <file>migrations/004_add_notes.sql</file>
     </qresource>
 </RCC>

--- a/src/server/database/vicinae/migrations/004_add_notes.sql
+++ b/src/server/database/vicinae/migrations/004_add_notes.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS note (
+	id TEXT PRIMARY KEY,
+	title TEXT NOT NULL,
+	body TEXT NOT NULL DEFAULT '',
+	pinned_at INTEGER, -- if NULL, not pinned
+	created_at INTEGER NOT NULL,
+	updated_at INTEGER NOT NULL,
+	last_used_at INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_note_pinned_updated
+ON note(
+	pinned_at DESC,
+	updated_at DESC
+);

--- a/src/server/src/actions/note/note-actions.hpp
+++ b/src/server/src/actions/note/note-actions.hpp
@@ -1,0 +1,127 @@
+#pragma once
+#include <QCoreApplication>
+#include "builtin_icon.hpp"
+#include "keyboard/keybind.hpp"
+#include "navigation-controller.hpp"
+#include "qml/note-form-view-host.hpp"
+#include "service-registry.hpp"
+#include "services/clipboard/clipboard-service.hpp"
+#include "services/note/note-db.hpp"
+#include "services/note/note-service.hpp"
+#include "services/paste/paste-service.hpp"
+#include "services/toast/toast-service.hpp"
+#include "ui/action-pannel/action.hpp"
+#include "ui/image/url.hpp"
+
+/**
+ * Actions shared by the "Manage Notes" list and the notes root search provider.
+ */
+namespace note_actions {
+
+class CopyNoteAction : public AbstractAction {
+  Q_DECLARE_TR_FUNCTIONS(CopyNoteAction)
+
+  note::Note m_note;
+
+public:
+  void execute(ApplicationContext *ctx) override {
+    if (!ctx->services->clipman()->copyText(QString::fromStdString(m_note.body), {.transient = true})) {
+      ctx->services->toastService()->failure(tr("Failed to copy note"));
+      return;
+    }
+
+    ctx->services->noteService()->registerUse(m_note.id);
+    ctx->navigation->showHud(tr("Copied to clipboard"), ImageURL::builtin(BuiltinIcon::CopyClipboard));
+  }
+
+  explicit CopyNoteAction(note::Note note)
+      : AbstractAction(tr("Copy note"), ImageURL::builtin(BuiltinIcon::CopyClipboard)),
+        m_note(std::move(note)) {
+    setShortcut(Keybind::CopyAction);
+  }
+};
+
+class PasteNoteAction : public AbstractAction {
+  Q_DECLARE_TR_FUNCTIONS(PasteNoteAction)
+
+  note::Note m_note;
+
+public:
+  void execute(ApplicationContext *ctx) override {
+    ctx->services->pasteService()->pasteContent(Clipboard::Text{QString::fromStdString(m_note.body)},
+                                                {.transient = true});
+    ctx->services->noteService()->registerUse(m_note.id);
+    ctx->navigation->closeWindow();
+  }
+
+  explicit PasteNoteAction(note::Note note)
+      : AbstractAction(tr("Paste to active window"), ImageURL::builtin(BuiltinIcon::CopyClipboard)),
+        m_note(std::move(note)) {
+    setShortcut(Keybind::PasteAction);
+  }
+};
+
+class EditNoteAction : public AbstractAction {
+  Q_DECLARE_TR_FUNCTIONS(EditNoteAction)
+
+  note::Note m_note;
+
+public:
+  void execute(ApplicationContext *ctx) override {
+    ctx->navigation->pushView(new NoteFormViewHost(m_note, NoteFormViewHost::Mode::Edit));
+  }
+
+  explicit EditNoteAction(note::Note note)
+      : AbstractAction(tr("Edit note"), ImageURL::builtin(BuiltinIcon::Pencil)), m_note(std::move(note)) {
+    setShortcut(Keybind::EditAction);
+  }
+};
+
+class TogglePinNoteAction : public AbstractAction {
+  Q_DECLARE_TR_FUNCTIONS(TogglePinNoteAction)
+
+  note::Note m_note;
+
+public:
+  void execute(ApplicationContext *ctx) override {
+    const bool pin = !m_note.pinned();
+
+    if (const auto res = ctx->services->noteService()->setPinned(m_note.id, pin); !res) {
+      ctx->services->toastService()->failure(res.error().c_str());
+      return;
+    }
+
+    ctx->navigation->showHud(pin ? tr("Pinned note") : tr("Unpinned note"));
+  }
+
+  explicit TogglePinNoteAction(note::Note note)
+      : AbstractAction(note.pinned() ? tr("Unpin note") : tr("Pin note"),
+                       ImageURL::builtin(note.pinned() ? BuiltinIcon::PinDisabled : BuiltinIcon::Pin)),
+        m_note(std::move(note)) {
+    setShortcut(Keybind::PinAction);
+  }
+};
+
+class RemoveNoteAction : public AbstractAction {
+  Q_DECLARE_TR_FUNCTIONS(RemoveNoteAction)
+
+  note::Note m_note;
+
+public:
+  void execute(ApplicationContext *ctx) override {
+    if (const auto res = ctx->services->noteService()->removeNote(m_note.id); !res) {
+      ctx->services->toastService()->failure(res.error().c_str());
+      return;
+    }
+
+    ctx->navigation->showHud(tr("Removed note"));
+  }
+
+  explicit RemoveNoteAction(note::Note note)
+      : AbstractAction(tr("Remove note"), ImageURL::builtin(BuiltinIcon::Trash)), m_note(std::move(note)) {
+    setStyle(AbstractAction::Style::Danger);
+    setShortcut(Keybind::DangerousRemoveAction);
+  }
+};
+
+} // namespace note_actions

--- a/src/server/src/actions/note/note-actions.hpp
+++ b/src/server/src/actions/note/note-actions.hpp
@@ -86,12 +86,14 @@ public:
   void execute(ApplicationContext *ctx) override {
     const bool pin = !m_note.pinned();
 
+    auto *toast = ctx->services->toastService();
+
     if (const auto res = ctx->services->noteService()->setPinned(m_note.id, pin); !res) {
-      ctx->services->toastService()->failure(res.error().c_str());
+      toast->failure(res.error().c_str());
       return;
     }
 
-    ctx->navigation->showHud(pin ? tr("Pinned note") : tr("Unpinned note"));
+    toast->setToast(pin ? tr("Pinned note") : tr("Unpinned note"));
   }
 
   explicit TogglePinNoteAction(note::Note note)
@@ -109,12 +111,14 @@ class RemoveNoteAction : public AbstractAction {
 
 public:
   void execute(ApplicationContext *ctx) override {
+    auto *toast = ctx->services->toastService();
+
     if (const auto res = ctx->services->noteService()->removeNote(m_note.id); !res) {
-      ctx->services->toastService()->failure(res.error().c_str());
+      toast->failure(res.error().c_str());
       return;
     }
 
-    ctx->navigation->showHud(tr("Removed note"));
+    toast->setToast(tr("Removed note"));
   }
 
   explicit RemoveNoteAction(note::Note note)

--- a/src/server/src/command-database.cpp
+++ b/src/server/src/command-database.cpp
@@ -7,6 +7,7 @@
 #include "extensions/power-management/power-management-extension.hpp"
 #include "extensions/shortcut/shortcut-extension.hpp"
 #include "extensions/font/font-extension.hpp"
+#include "extensions/note/note-extension.hpp"
 #include "extensions/snippet/snippet-extension.hpp"
 #include "extensions/theme/theme-extension.hpp"
 #include "extensions/developer/developer-extension.hpp"
@@ -49,6 +50,7 @@ CommandDatabase::CommandDatabase(const ServiceRegistry &services) {
   registerRepository<DeveloperExtension>();
 
   registerRepository<SnippetExtension>();
+  registerRepository<NoteExtension>();
 
 #ifdef QT_DEBUG
   registerRepository<InternalExtension>();

--- a/src/server/src/extensions/note/note-extension.hpp
+++ b/src/server/src/extensions/note/note-extension.hpp
@@ -1,0 +1,45 @@
+#pragma once
+#include <QCoreApplication>
+#include "command-database.hpp"
+#include "qml/manage-notes-view-host.hpp"
+#include "qml/note-form-view-host.hpp"
+#include "single-view-command-context.hpp"
+#include "ui/image/url.hpp"
+
+namespace {
+class CreateNoteCommand : public BuiltinViewCommand<NoteFormViewHost> {
+  QString id() const override { return "create"; }
+  QString name() const override { return QCoreApplication::translate("CreateNoteCommand", "Create Note"); }
+  ImageURL iconUrl() const override {
+    return ImageURL::builtin(BuiltinIcon::NewDocument).setBackgroundTint(SemanticColor::Yellow);
+  }
+};
+
+class ManageNotesCommand : public BuiltinViewCommand<ManageNotesViewHost> {
+  QString id() const override { return "manage"; }
+  QString name() const override { return QCoreApplication::translate("ManageNotesCommand", "Manage Notes"); }
+  ImageURL iconUrl() const override {
+    return ImageURL::builtin(BuiltinIcon::BlankDocument).setBackgroundTint(SemanticColor::Yellow);
+  }
+};
+} // namespace
+
+// The `notes` provider id belongs to NoteRootProvider, which surfaces the notes themselves.
+class NoteExtension : public BuiltinCommandRepository {
+  QString id() const override { return "manage-notes"; }
+  QString displayName() const override {
+    return QCoreApplication::translate("NoteExtension", "Manage Notes");
+  }
+  QString description() const override {
+    return QCoreApplication::translate("NoteExtension", "Local notes you can search, pin and paste");
+  }
+  ImageURL iconUrl() const override {
+    return ImageURL::builtin(BuiltinIcon::BlankDocument).setBackgroundTint(SemanticColor::Yellow);
+  }
+
+public:
+  NoteExtension() {
+    registerCommand<CreateNoteCommand>();
+    registerCommand<ManageNotesCommand>();
+  }
+};

--- a/src/server/src/qml/manage-notes-model.cpp
+++ b/src/server/src/qml/manage-notes-model.cpp
@@ -1,0 +1,41 @@
+#include "manage-notes-model.hpp"
+#include "actions/note/note-actions.hpp"
+#include "builtin_icon.hpp"
+#include "service-registry.hpp"
+#include "services/paste/paste-service.hpp"
+#include "theme/colors.hpp"
+
+QString ManageNotesSection::displayTitle(const note::Note &item) const {
+  return QString::fromStdString(item.title);
+}
+
+std::optional<ImageURL> ManageNotesSection::displayIcon(const note::Note &) const {
+  return ImageURL(BuiltinIcon::BlankDocument);
+}
+
+AccessoryList ManageNotesSection::displayAccessories(const note::Note &item) const {
+  if (!item.pinned()) return {};
+
+  return {{.tooltip = tr("Pinned"),
+           .icon = ImageURL::builtin(BuiltinIcon::Pin).setFill(SemanticColor::TextMuted)}};
+}
+
+std::unique_ptr<ActionPanelState> ManageNotesSection::buildActionPanel(const note::Note &item) const {
+  auto panel = std::make_unique<ListActionPanelState>();
+  auto *main = panel->createSection();
+  auto *manage = panel->createSection();
+  auto *danger = panel->createSection();
+
+  if (scope().services()->pasteService()->supportsPaste()) {
+    main->addAction(new note_actions::PasteNoteAction(item));
+  }
+
+  main->addAction(new note_actions::CopyNoteAction(item));
+
+  manage->addAction(new note_actions::EditNoteAction(item));
+  manage->addAction(new note_actions::TogglePinNoteAction(item));
+
+  danger->addAction(new note_actions::RemoveNoteAction(item));
+
+  return panel;
+}

--- a/src/server/src/qml/manage-notes-model.hpp
+++ b/src/server/src/qml/manage-notes-model.hpp
@@ -1,0 +1,26 @@
+#pragma once
+#include <QCoreApplication>
+#include "fuzzy-section.hpp"
+#include "services/note/note-db.hpp"
+
+class ManageNotesSection : public FuzzySection<note::Note> {
+  Q_DECLARE_TR_FUNCTIONS(ManageNotesSection)
+
+public:
+  QString sectionName() const override { return tr("Notes ({count})"); }
+
+  void setOnNoteSelected(std::function<void(const note::Note &)> cb) { m_onNoteSelected = std::move(cb); }
+
+  void onSelected(int i) override {
+    if (m_onNoteSelected) m_onNoteSelected(at(i));
+  }
+
+protected:
+  QString displayTitle(const note::Note &item) const override;
+  std::optional<ImageURL> displayIcon(const note::Note &item) const override;
+  AccessoryList displayAccessories(const note::Note &item) const override;
+  std::unique_ptr<ActionPanelState> buildActionPanel(const note::Note &item) const override;
+
+private:
+  std::function<void(const note::Note &)> m_onNoteSelected;
+};

--- a/src/server/src/qml/manage-notes-view-host.cpp
+++ b/src/server/src/qml/manage-notes-view-host.cpp
@@ -1,0 +1,89 @@
+#include <QDateTime>
+#include "manage-notes-view-host.hpp"
+#include "note-form-view-host.hpp"
+#include "service-registry.hpp"
+#include "services/note/note-service.hpp"
+
+QUrl ManageNotesViewHost::qmlComponentUrl() const {
+  return QUrl(QStringLiteral("qrc:/Vicinae/DetailListView.qml"));
+}
+
+QVariantMap ManageNotesViewHost::qmlProperties() {
+  return {{QStringLiteral("host"), QVariant::fromValue(this)}};
+}
+
+void ManageNotesViewHost::initialize() {
+  BaseView::initialize();
+  initModel();
+
+  m_noteService = context()->services->noteService();
+
+  m_section.setOnNoteSelected([this](const note::Note &note) { loadDetail(note); });
+  model()->addSource(&m_section);
+
+  setSearchPlaceholderText(tr("Search for notes..."));
+
+  connect(m_noteService, &NoteService::notesChanged, this, &ManageNotesViewHost::reload);
+
+  connect(model(), &QAbstractItemModel::modelReset, this, [this]() {
+    if (model()->rowCount() == 0) clearDetail();
+  });
+}
+
+void ManageNotesViewHost::loadInitialData() { reload(); }
+
+void ManageNotesViewHost::beforePop() {
+  clearDetail();
+  ListViewHost::beforePop();
+}
+
+void ManageNotesViewHost::loadDetail(const note::Note &note) {
+  QVariantList meta;
+
+  const auto addRow = [&meta](const QString &label, const QString &value) {
+    meta.append(QVariantMap{
+        {QStringLiteral("label"), label},
+        {QStringLiteral("value"), value},
+    });
+  };
+
+  addRow(tr("Created at"), QDateTime::fromSecsSinceEpoch(note.createdAt).toString());
+  addRow(tr("Updated at"), QDateTime::fromSecsSinceEpoch(note.updatedAt).toString());
+
+  if (note.lastUsedAt) {
+    addRow(tr("Last used"), QDateTime::fromSecsSinceEpoch(*note.lastUsedAt).toString());
+  }
+
+  if (note.pinnedAt) { addRow(tr("Pinned at"), QDateTime::fromSecsSinceEpoch(*note.pinnedAt).toString()); }
+
+  m_detailMetadata = meta;
+  m_detailMarkdown = QString::fromStdString(note.body);
+  m_hasDetail = true;
+
+  emit detailChanged();
+}
+
+void ManageNotesViewHost::clearDetail() {
+  if (!m_hasDetail) return;
+
+  m_hasDetail = false;
+  m_detailMarkdown.clear();
+  m_detailMetadata.clear();
+
+  emit detailChanged();
+}
+
+std::unique_ptr<ActionPanelState> ManageNotesViewHost::emptyActionPanel() {
+  auto panel = std::make_unique<ListActionPanelState>();
+  auto *section = panel->createSection();
+  auto *create = new StaticAction(tr("Create note"), BuiltinIcon::Plus, [this](ApplicationContext *ctx) {
+    ctx->navigation->pushView(new NoteFormViewHost());
+  });
+
+  create->setPrimary(true);
+  section->addAction(create);
+
+  return panel;
+}
+
+void ManageNotesViewHost::reload() { m_section.setItems(m_noteService->database()->notes()); }

--- a/src/server/src/qml/manage-notes-view-host.hpp
+++ b/src/server/src/qml/manage-notes-view-host.hpp
@@ -1,0 +1,50 @@
+#pragma once
+#include <QVariantList>
+#include "builtin_icon.hpp"
+#include "list-view-host.hpp"
+#include "manage-notes-model.hpp"
+
+class NoteService;
+
+class ManageNotesViewHost : public ListViewHost {
+  Q_OBJECT
+
+  Q_PROPERTY(bool hasDetail READ hasDetail NOTIFY detailChanged)
+  Q_PROPERTY(QString detailMarkdown READ detailMarkdown NOTIFY detailChanged)
+  Q_PROPERTY(QVariantList detailMetadata READ detailMetadata NOTIFY detailChanged)
+  Q_PROPERTY(QString emptyTitle MEMBER m_emptyTitle CONSTANT)
+  Q_PROPERTY(QString emptyDescription MEMBER m_emptyDescription CONSTANT)
+  Q_PROPERTY(ImageUrl emptyIcon MEMBER m_emptyIcon CONSTANT)
+
+signals:
+  void detailChanged();
+
+public:
+  QUrl qmlComponentUrl() const override;
+  QVariantMap qmlProperties() override;
+  void initialize() override;
+  void loadInitialData() override;
+  void beforePop() override;
+
+  bool hasDetail() const { return m_hasDetail; }
+  QString detailMarkdown() const { return m_detailMarkdown; }
+  QVariantList detailMetadata() const { return m_detailMetadata; }
+
+protected:
+  std::unique_ptr<ActionPanelState> emptyActionPanel() override;
+
+private:
+  void loadDetail(const note::Note &note);
+  void clearDetail();
+  void reload();
+
+  ManageNotesSection m_section;
+  NoteService *m_noteService = nullptr;
+
+  bool m_hasDetail = false;
+  QString m_detailMarkdown;
+  QVariantList m_detailMetadata;
+  QString m_emptyTitle = tr("No notes");
+  QString m_emptyDescription = tr("Create a note to get started");
+  ImageUrl m_emptyIcon = ImageUrl(ImageURL(BuiltinIcon::BlankDocument));
+};

--- a/src/server/src/qml/note-form-view-host.cpp
+++ b/src/server/src/qml/note-form-view-host.cpp
@@ -1,0 +1,76 @@
+#include <QUrl>
+#include "note-form-view-host.hpp"
+#include "service-registry.hpp"
+#include "services/note/note-service.hpp"
+#include "services/toast/toast-service.hpp"
+#include "ui/action-pannel/action-panel-state.hpp"
+#include "ui/action-pannel/action.hpp"
+
+NoteFormViewHost::NoteFormViewHost(note::Note note, Mode mode)
+    : m_mode(mode), m_initialNote(std::move(note)) {}
+
+QUrl NoteFormViewHost::qmlComponentUrl() const {
+  return QUrl(QStringLiteral("qrc:/Vicinae/NoteFormView.qml"));
+}
+
+QVariantMap NoteFormViewHost::qmlProperties() {
+  return {{QStringLiteral("host"), QVariant::fromValue(this)}};
+}
+
+void NoteFormViewHost::initialize() {
+  BaseView::initialize();
+
+  m_service = context()->services->noteService();
+
+  auto panel = std::make_unique<FormActionPanelState>();
+  auto *section = panel->createSection();
+  auto *submitAction =
+      new StaticAction(tr("Submit"), ImageURL::builtin(BuiltinIcon::EnterKey), [this]() { submit(); });
+
+  section->addAction(submitAction);
+  setActions(std::move(panel));
+
+  if (m_initialNote) {
+    m_title = QString::fromStdString(m_initialNote->title);
+    m_body = QString::fromStdString(m_initialNote->body);
+    emit formChanged();
+
+    if (m_mode == Mode::Edit) { setNavigationTitle(tr("Edit \"%1\"").arg(m_title)); }
+  }
+}
+
+void NoteFormViewHost::submit() {
+  const auto toast = context()->services->toastService();
+
+  const note::NotePayload payload{
+      .title = m_title.trimmed().toStdString(),
+      .body = m_body.toStdString(),
+  };
+
+  m_titleError.clear();
+
+  if (payload.title.empty()) {
+    m_titleError = tr("Title should not be empty");
+    emit errorsChanged();
+    toast->failure(tr("Validation failed"));
+    return;
+  }
+
+  emit errorsChanged();
+
+  if (m_mode == Mode::Edit && m_initialNote) {
+    if (const auto result = m_service->updateNote(m_initialNote->id, payload); !result) {
+      toast->failure(result.error().c_str());
+      return;
+    }
+    toast->success(tr("Note updated"));
+  } else {
+    if (const auto result = m_service->createNote(payload); !result) {
+      toast->failure(result.error().c_str());
+      return;
+    }
+    toast->success(tr("Note created"));
+  }
+
+  popSelf();
+}

--- a/src/server/src/qml/note-form-view-host.hpp
+++ b/src/server/src/qml/note-form-view-host.hpp
@@ -1,0 +1,57 @@
+#pragma once
+#include <optional>
+#include "bridge-view.hpp"
+#include "services/note/note-db.hpp"
+
+class NoteService;
+
+class NoteFormViewHost : public FormViewBase {
+  Q_OBJECT
+
+  Q_PROPERTY(QString title READ title WRITE setTitle NOTIFY formChanged)
+  Q_PROPERTY(QString body READ body WRITE setBody NOTIFY formChanged)
+  Q_PROPERTY(QString titleError READ titleError NOTIFY errorsChanged)
+
+signals:
+  void formChanged();
+  void errorsChanged();
+
+public:
+  enum class Mode { Create, Edit };
+
+  NoteFormViewHost() = default;
+  NoteFormViewHost(note::Note note, Mode mode);
+
+  QUrl qmlComponentUrl() const override;
+  QVariantMap qmlProperties() override;
+  void initialize() override;
+
+  Q_INVOKABLE void submit();
+
+  QString title() const { return m_title; }
+  QString body() const { return m_body; }
+  QString titleError() const { return m_titleError; }
+
+  void setTitle(const QString &v) {
+    if (m_title != v) {
+      m_title = v;
+      emit formChanged();
+    }
+  }
+
+  void setBody(const QString &v) {
+    if (m_body != v) {
+      m_body = v;
+      emit formChanged();
+    }
+  }
+
+private:
+  Mode m_mode = Mode::Create;
+  std::optional<note::Note> m_initialNote;
+  NoteService *m_service = nullptr;
+
+  QString m_title;
+  QString m_body;
+  QString m_titleError;
+};

--- a/src/server/src/qml/qml/DetailListView.qml
+++ b/src/server/src/qml/qml/DetailListView.qml
@@ -76,6 +76,9 @@ Item {
 
     readonly property bool _hasCustomDetail: root.host.detailContentUrl !== undefined && root.host.detailContentUrl.toString() !== ""
 
+    // Hosts exposing `detailMarkdown` get their detail rendered as markdown instead of plain text.
+    readonly property bool _hasMarkdownDetail: root.host.detailMarkdown !== undefined
+
     Component {
         id: detailPanel
 
@@ -84,7 +87,7 @@ Item {
 
             Loader {
                 anchors.fill: parent
-                sourceComponent: root._hasCustomDetail ? null : defaultTextContent
+                sourceComponent: root._hasCustomDetail ? null : (root._hasMarkdownDetail ? markdownContent : defaultTextContent)
                 source: root._hasCustomDetail ? root.host.detailContentUrl : ""
             }
         }
@@ -94,6 +97,14 @@ Item {
         id: defaultTextContent
         TextViewer {
             text: root.host.detailContent
+        }
+    }
+
+    Component {
+        id: markdownContent
+        MarkdownText {
+            markdown: root.host.detailMarkdown
+            topPadding: 6
         }
     }
 }

--- a/src/server/src/qml/qml/NoteFormView.qml
+++ b/src/server/src/qml/qml/NoteFormView.qml
@@ -1,0 +1,38 @@
+import QtQuick
+
+Item {
+    id: root
+    required property var host
+
+    FormView {
+        id: formView
+        anchors.fill: parent
+        Component.onCompleted: Qt.callLater(formView.focusFirst)
+
+        FormField {
+            id: titleField
+            label: qsTr("Title")
+            error: root.host.titleError
+
+            FormTextInput {
+                text: root.host.title
+                placeholder: qsTr("Meeting notes")
+                hasError: titleField.error !== ""
+                onTextEdited: root.host.title = text
+            }
+        }
+
+        FormField {
+            label: qsTr("Body")
+            info: qsTr("Markdown is rendered when previewing the note.")
+            topAlignLabel: true
+
+            FormTextArea {
+                text: root.host.body
+                placeholder: qsTr("## Agenda")
+                minRows: 8
+                onTextEdited: root.host.body = text
+            }
+        }
+    }
+}

--- a/src/server/src/root-search/notes/note-root-provider.cpp
+++ b/src/server/src/root-search/notes/note-root-provider.cpp
@@ -1,0 +1,97 @@
+#include "root-search/notes/note-root-provider.hpp"
+#include "actions/note/note-actions.hpp"
+#include "actions/root-search/root-search-actions.hpp"
+#include "builtin_icon.hpp"
+#include "service-registry.hpp"
+#include "services/paste/paste-service.hpp"
+#include "theme/colors.hpp"
+#include "ui/image/url.hpp"
+
+RootNoteItem::RootNoteItem(note::Note note) : m_note(std::move(note)) {}
+
+QString RootNoteItem::title() const { return QString::fromStdString(m_note.title); }
+
+double RootNoteItem::baseScoreWeight() const { return 1.4; }
+
+AccessoryList RootNoteItem::accessories() const {
+  AccessoryList accessories;
+
+  accessories.reserve(2);
+
+  if (m_note.pinned()) {
+    accessories.emplace_back(ListAccessory{
+        .tooltip = tr("Pinned"),
+        .icon = ImageURL::builtin(BuiltinIcon::Pin).setFill(SemanticColor::TextMuted),
+    });
+  }
+
+  accessories.emplace_back(ListAccessory{.text = tr("Note"), .color = SemanticColor::TextMuted});
+
+  return accessories;
+}
+
+ImageURL RootNoteItem::iconUrl() const {
+  return ImageURL(BuiltinIcon::BlankDocument).setBackgroundTint(SemanticColor::Yellow);
+}
+
+EntrypointId RootNoteItem::uniqueId() const { return EntrypointId{"notes", m_note.id}; }
+
+QString RootNoteItem::typeDisplayName() const { return tr("Note"); }
+
+std::unique_ptr<ActionPanelState> RootNoteItem::newActionPanel(ApplicationContext *ctx,
+                                                               const RootItemMetadata &metadata) const {
+  auto panel = std::make_unique<ListActionPanelState>();
+  auto *main = panel->createSection();
+  auto *manage = panel->createSection();
+  auto *itemSection = panel->createSection();
+  auto *danger = panel->createSection();
+
+  panel->setTitle(title());
+
+  if (ctx->services->pasteService()->supportsPaste()) {
+    main->addAction(new note_actions::PasteNoteAction(m_note));
+  }
+
+  main->addAction(new note_actions::CopyNoteAction(m_note));
+
+  manage->addAction(new note_actions::EditNoteAction(m_note));
+  manage->addAction(new note_actions::TogglePinNoteAction(m_note));
+
+  for (const auto action :
+       RootSearchActionGenerator::generateActions(*this, *ctx->services->rootItemManager())) {
+    itemSection->addAction(action);
+  }
+
+  danger->addAction(new note_actions::RemoveNoteAction(m_note));
+
+  return panel;
+}
+
+std::vector<std::shared_ptr<RootItem>> NoteRootProvider::loadItems() const {
+  const auto &notes = m_service.database()->notes();
+  std::vector<std::shared_ptr<RootItem>> items;
+
+  items.reserve(notes.size());
+
+  for (const auto &note : notes) {
+    items.emplace_back(std::make_shared<RootNoteItem>(note));
+  }
+
+  return items;
+}
+
+QString NoteRootProvider::displayName() const {
+  return QCoreApplication::translate("NoteRootProvider", "Notes");
+}
+
+QString NoteRootProvider::uniqueId() const { return "notes"; }
+
+ImageURL NoteRootProvider::icon() const {
+  return ImageURL::builtin(BuiltinIcon::BlankDocument).setBackgroundTint(SemanticColor::Yellow);
+}
+
+RootProvider::Type NoteRootProvider::type() const { return RootProvider::Type::GroupProvider; }
+
+NoteRootProvider::NoteRootProvider(NoteService &service) : m_service(service) {
+  connect(&service, &NoteService::notesChanged, this, [this]() { emit itemsChanged(); });
+}

--- a/src/server/src/root-search/notes/note-root-provider.hpp
+++ b/src/server/src/root-search/notes/note-root-provider.hpp
@@ -1,0 +1,37 @@
+#pragma once
+#include <QCoreApplication>
+#include "common.hpp"
+#include "services/note/note-db.hpp"
+#include "services/note/note-service.hpp"
+#include "services/root-item-manager/root-item-manager.hpp"
+
+class RootNoteItem : public RootItem {
+  Q_DECLARE_TR_FUNCTIONS(RootNoteItem)
+
+  note::Note m_note;
+
+  QString title() const override;
+  double baseScoreWeight() const override;
+  AccessoryList accessories() const override;
+  ImageURL iconUrl() const override;
+  EntrypointId uniqueId() const override;
+  QString typeDisplayName() const override;
+  std::unique_ptr<ActionPanelState> newActionPanel(ApplicationContext *ctx,
+                                                   const RootItemMetadata &metadata) const override;
+
+public:
+  explicit RootNoteItem(note::Note note);
+};
+
+class NoteRootProvider : public RootProvider {
+  NoteService &m_service;
+
+public:
+  QString displayName() const override;
+  QString uniqueId() const override;
+  ImageURL icon() const override;
+  Type type() const override;
+  std::vector<std::shared_ptr<RootItem>> loadItems() const override;
+
+  explicit NoteRootProvider(NoteService &service);
+};

--- a/src/server/src/server.cpp
+++ b/src/server/src/server.cpp
@@ -19,6 +19,7 @@
 #include "extensions/root/root-command.hpp"
 #include "root-search/apps/app-root-provider.hpp"
 #include "root-search/extensions/extension-root-provider.hpp"
+#include "root-search/notes/note-root-provider.hpp"
 #include "root-search/shortcuts/shortcut-root-provider.hpp"
 #ifdef Q_OS_MACOS
 #include "root-search/macos-settings/macos-settings-root-provider.hpp"
@@ -65,6 +66,7 @@
 #include "services/window-manager/window-manager.hpp"
 #include "services/wallpaper/wallpaper-manager.hpp"
 #include "services/app-runtime/app-runtime.hpp"
+#include "services/note/note-service.hpp"
 #include "services/snippet/snippet-service.hpp"
 #include "services/global-shortcuts/global-shortcut-service.hpp"
 #include "services/global-shortcuts/global-shortcut-backend-factory.hpp"
@@ -303,6 +305,7 @@ int startServer(const ServerLaunchOptions &launchOpts) {
     auto glyphService =
         std::make_unique<GlyphService>(Omnicast::dataDir() / "emojis" / "emojis.json", omniDb.get());
     auto calculatorService = std::make_unique<CalculatorService>(*omniDb.get());
+    auto noteService = std::make_unique<NoteService>(*omniDb.get());
     auto fileService = std::make_unique<FileService>(*omniDb);
     auto oauthService = std::make_unique<OAuthService>(*omniDb);
     auto extensionRegistry = std::make_unique<ExtensionRegistry>(*localStorage);
@@ -340,6 +343,7 @@ int startServer(const ServerLaunchOptions &launchOpts) {
 #endif
     registry->setSnippetServerBackend(std::move(snippetServer));
     registry->setSnippetService(std::move(snippetService));
+    registry->setNoteService(std::move(noteService));
     registry->setWindowManager(std::move(windowManager));
     registry->setAppRuntime(std::move(appRuntime));
     registry->setFontService(std::move(fontService));
@@ -417,6 +421,7 @@ int startServer(const ServerLaunchOptions &launchOpts) {
 
     root->loadProvider(std::make_unique<AppRootProvider>(*registry->appDb()));
     root->loadProvider(std::make_unique<ShortcutRootProvider>(*registry->shortcuts()));
+    root->loadProvider(std::make_unique<NoteRootProvider>(*registry->noteService()));
     root->loadProvider(std::make_unique<ScriptRootProvider>(*registry->scriptDb()));
     root->loadProvider(std::make_unique<BrowserTabProvider>(*registry->browserExtension()));
 #ifdef Q_OS_MACOS

--- a/src/server/src/service-registry.cpp
+++ b/src/server/src/service-registry.cpp
@@ -32,6 +32,7 @@
 #include "services/app-runtime/app-runtime.hpp"
 #include "services/global-shortcuts/global-shortcut-service.hpp"
 #include "services/snippet/snippet-service.hpp"
+#include "services/note/note-service.hpp"
 #include "services/paste/paste-service.hpp"
 #include "services/file-chooser/file-chooser-service.hpp"
 #include "services/news/news-service.hpp"
@@ -70,6 +71,8 @@ LinuxInputServer *ServiceRegistry::inputServer() const { return m_inputServer.ge
 #endif
 
 SnippetService *ServiceRegistry::snippetService() const { return m_snippetService.get(); }
+
+NoteService *ServiceRegistry::noteService() const { return m_noteService.get(); }
 
 PasteService *ServiceRegistry::pasteService() const { return m_pasteService.get(); }
 AbstractSelectionService *ServiceRegistry::selectionService() const { return m_selectionService.get(); }
@@ -172,6 +175,10 @@ void ServiceRegistry::setSnippetServerBackend(std::unique_ptr<AbstractSnippetSer
 
 void ServiceRegistry::setSnippetService(std::unique_ptr<SnippetService> service) {
   m_snippetService = std::move(service);
+}
+
+void ServiceRegistry::setNoteService(std::unique_ptr<NoteService> service) {
+  m_noteService = std::move(service);
 }
 
 void ServiceRegistry::setPasteService(std::unique_ptr<PasteService> service) {

--- a/src/server/src/service-registry.hpp
+++ b/src/server/src/service-registry.hpp
@@ -29,6 +29,7 @@ class AbstractSnippetServer;
 class LinuxInputServer;
 #endif
 class SnippetService;
+class NoteService;
 class BrowserExtensionService;
 class WindowMaterialManager;
 class ShortcutInhibitManager;
@@ -77,6 +78,7 @@ public:
   LinuxInputServer *inputServer() const;
 #endif
   SnippetService *snippetService() const;
+  NoteService *noteService() const;
   PasteService *pasteService() const;
   AbstractSelectionService *selectionService() const;
   FileChooserService *fileChooserService() const;
@@ -117,6 +119,7 @@ public:
 #endif
   void setSnippetServerBackend(std::unique_ptr<AbstractSnippetServer> backend);
   void setSnippetService(std::unique_ptr<SnippetService> service);
+  void setNoteService(std::unique_ptr<NoteService> service);
   void setPasteService(std::unique_ptr<PasteService> service);
   void setSelectionService(std::unique_ptr<AbstractSelectionService> service);
   void setFileChooserService(std::unique_ptr<FileChooserService> service);
@@ -157,6 +160,7 @@ private:
 #endif
   std::unique_ptr<AbstractSnippetServer> m_snippetServerBackend;
   std::unique_ptr<SnippetService> m_snippetService;
+  std::unique_ptr<NoteService> m_noteService;
   std::unique_ptr<PasteService> m_pasteService;
   std::unique_ptr<AbstractSelectionService> m_selectionService;
   std::unique_ptr<FileChooserService> m_fileChooserService;

--- a/src/server/src/services/note/note-db.cpp
+++ b/src/server/src/services/note/note-db.cpp
@@ -1,0 +1,167 @@
+#include <QDateTime>
+#include <QUuid>
+#include <algorithm>
+#include "omni-database.hpp"
+#include "services/note/note-db.hpp"
+
+using namespace note;
+
+namespace {
+std::uint64_t now() { return static_cast<std::uint64_t>(QDateTime::currentSecsSinceEpoch()); }
+} // namespace
+
+NoteDatabase::NoteDatabase(OmniDatabase &db) : m_db(db) { reload(); }
+
+void NoteDatabase::reload() {
+  auto stmt = m_db.db().prepare(R"(
+    SELECT id, title, body, pinned_at, created_at, updated_at, last_used_at FROM note
+    ORDER BY pinned_at DESC, updated_at DESC, rowid DESC
+  )");
+
+  m_notes.clear();
+
+  while (stmt.step()) {
+    Note note;
+
+    note.id = stmt.columnText(0);
+    note.title = stmt.columnText(1);
+    note.body = stmt.columnText(2);
+    if (!stmt.isNull(3)) note.pinnedAt = stmt.columnUInt64(3);
+    note.createdAt = stmt.columnUInt64(4);
+    note.updatedAt = stmt.columnUInt64(5);
+    if (!stmt.isNull(6)) note.lastUsedAt = stmt.columnUInt64(6);
+
+    m_notes.emplace_back(std::move(note));
+  }
+}
+
+const Note *NoteDatabase::findById(std::string_view id) const {
+  auto it = std::ranges::find_if(m_notes, [&](auto &&note) { return note.id == id; });
+
+  return it == m_notes.end() ? nullptr : &*it;
+}
+
+std::optional<std::string> NoteDatabase::validate(const NotePayload &payload) {
+  if (payload.title.empty()) return tr("Title cannot be empty").toStdString();
+  if (payload.title.size() > MAX_TITLE_LENGTH) {
+    return tr("Title exceeds maximum length of %1").arg(MAX_TITLE_LENGTH).toStdString();
+  }
+
+  return std::nullopt;
+}
+
+std::expected<Note, std::string> NoteDatabase::createNote(const NotePayload &payload) {
+  if (m_notes.size() >= MAX_NOTES) {
+    return std::unexpected(tr("Note limit reached (%1)").arg(MAX_NOTES).toStdString());
+  }
+
+  if (const auto error = validate(payload)) { return std::unexpected(*error); }
+
+  const auto id = QUuid::createUuid().toString(QUuid::WithoutBraces).toStdString();
+  const auto timestamp = now();
+
+  auto stmt = m_db.db().prepare(R"(
+    INSERT INTO note (id, title, body, created_at, updated_at)
+    VALUES (:id, :title, :body, :created_at, :updated_at)
+  )");
+
+  stmt.bind(":id", id);
+  stmt.bind(":title", payload.title);
+  stmt.bind(":body", payload.body);
+  stmt.bind(":created_at", timestamp);
+  stmt.bind(":updated_at", timestamp);
+
+  if (!stmt.exec()) { return std::unexpected(m_db.db().lastError()); }
+
+  reload();
+
+  return Note{
+      .id = id,
+      .title = payload.title,
+      .body = payload.body,
+      .createdAt = timestamp,
+      .updatedAt = timestamp,
+  };
+}
+
+std::expected<Note, std::string> NoteDatabase::updateNote(std::string_view id, const NotePayload &payload) {
+  if (const auto error = validate(payload)) { return std::unexpected(*error); }
+
+  const auto *existing = findById(id);
+
+  if (!existing) { return std::unexpected(tr("No note with that ID").toStdString()); }
+
+  Note updated = *existing;
+
+  updated.title = payload.title;
+  updated.body = payload.body;
+  updated.updatedAt = now();
+
+  auto stmt = m_db.db().prepare(R"(
+    UPDATE note SET title = :title, body = :body, updated_at = :updated_at WHERE id = :id
+  )");
+
+  stmt.bind(":title", updated.title);
+  stmt.bind(":body", updated.body);
+  stmt.bind(":updated_at", updated.updatedAt);
+  stmt.bind(":id", id);
+
+  if (!stmt.exec()) { return std::unexpected(m_db.db().lastError()); }
+
+  reload();
+
+  return updated;
+}
+
+std::expected<Note, std::string> NoteDatabase::removeNote(std::string_view id) {
+  const auto *existing = findById(id);
+
+  if (!existing) { return std::unexpected(tr("No note with that ID").toStdString()); }
+
+  Note removed = *existing;
+  auto stmt = m_db.db().prepare("DELETE FROM note WHERE id = :id");
+
+  stmt.bind(":id", id);
+
+  if (!stmt.exec()) { return std::unexpected(m_db.db().lastError()); }
+
+  reload();
+
+  return removed;
+}
+
+std::expected<Note, std::string> NoteDatabase::setPinned(std::string_view id, bool pinned) {
+  const auto *existing = findById(id);
+
+  if (!existing) { return std::unexpected(tr("No note with that ID").toStdString()); }
+
+  Note updated = *existing;
+
+  updated.pinnedAt = pinned ? std::optional{now()} : std::nullopt;
+
+  auto stmt = m_db.db().prepare("UPDATE note SET pinned_at = :pinned_at WHERE id = :id");
+
+  stmt.bind(":pinned_at", updated.pinnedAt);
+  stmt.bind(":id", id);
+
+  if (!stmt.exec()) { return std::unexpected(m_db.db().lastError()); }
+
+  reload();
+
+  return updated;
+}
+
+std::expected<void, std::string> NoteDatabase::registerUse(std::string_view id) {
+  if (!findById(id)) { return std::unexpected(tr("No note with that ID").toStdString()); }
+
+  auto stmt = m_db.db().prepare("UPDATE note SET last_used_at = :last_used_at WHERE id = :id");
+
+  stmt.bind(":last_used_at", now());
+  stmt.bind(":id", id);
+
+  if (!stmt.exec()) { return std::unexpected(m_db.db().lastError()); }
+
+  reload();
+
+  return {};
+}

--- a/src/server/src/services/note/note-db.hpp
+++ b/src/server/src/services/note/note-db.hpp
@@ -1,0 +1,70 @@
+#pragma once
+#include <QCoreApplication>
+#include <cstdint>
+#include <expected>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+#include "fuzzy/fuzzy-searchable.hpp"
+
+class OmniDatabase;
+
+namespace note {
+
+struct Note {
+  std::string id;
+  std::string title;
+  std::string body;
+  std::optional<std::uint64_t> pinnedAt;
+  std::uint64_t createdAt = 0;
+  std::uint64_t updatedAt = 0;
+  std::optional<std::uint64_t> lastUsedAt;
+
+  bool pinned() const { return pinnedAt.has_value(); }
+};
+
+struct NotePayload {
+  std::string title;
+  std::string body;
+};
+
+} // namespace note
+
+template <> struct fuzzy::FuzzySearchable<note::Note> {
+  static fuzzy::Match score(const note::Note &item, const fuzzy::Query &query) {
+    return fuzzy::scoreWeighted({{item.title, 1.0}, {item.body, 0.4}}, query);
+  }
+};
+
+/**
+ * CRUD over the `note` table. Notes are few and small, so the whole table is cached in memory and
+ * refreshed from SQL after each mutation, which keeps a single source of truth for the ordering
+ * (pinned first, then most recently updated, insertion order breaking same-second ties).
+ */
+class NoteDatabase {
+  Q_DECLARE_TR_FUNCTIONS(NoteDatabase)
+
+public:
+  static constexpr std::size_t MAX_NOTES = 10000;
+  static constexpr std::size_t MAX_TITLE_LENGTH = 200;
+
+  explicit NoteDatabase(OmniDatabase &db);
+
+  std::expected<note::Note, std::string> createNote(const note::NotePayload &payload);
+  std::expected<note::Note, std::string> updateNote(std::string_view id, const note::NotePayload &payload);
+  std::expected<note::Note, std::string> removeNote(std::string_view id);
+  std::expected<note::Note, std::string> setPinned(std::string_view id, bool pinned);
+  std::expected<void, std::string> registerUse(std::string_view id);
+
+  const std::vector<note::Note> &notes() const { return m_notes; }
+  const note::Note *findById(std::string_view id) const;
+
+private:
+  static std::optional<std::string> validate(const note::NotePayload &payload);
+
+  void reload();
+
+  OmniDatabase &m_db;
+  std::vector<note::Note> m_notes;
+};

--- a/src/server/src/services/note/note-service.hpp
+++ b/src/server/src/services/note/note-service.hpp
@@ -1,0 +1,47 @@
+#pragma once
+#include <qobject.h>
+#include <qtmetamacros.h>
+#include "services/note/note-db.hpp"
+
+class OmniDatabase;
+
+class NoteService : public QObject {
+  Q_OBJECT
+
+signals:
+  void notesChanged();
+
+public:
+  explicit NoteService(OmniDatabase &db) : m_db(db) {}
+
+  auto createNote(const note::NotePayload &payload) {
+    auto res = m_db.createNote(payload);
+    if (res) emit notesChanged();
+    return res;
+  }
+
+  auto updateNote(std::string_view id, const note::NotePayload &payload) {
+    auto res = m_db.updateNote(id, payload);
+    if (res) emit notesChanged();
+    return res;
+  }
+
+  auto removeNote(std::string_view id) {
+    auto res = m_db.removeNote(id);
+    if (res) emit notesChanged();
+    return res;
+  }
+
+  auto setPinned(std::string_view id, bool pinned) {
+    auto res = m_db.setPinned(id, pinned);
+    if (res) emit notesChanged();
+    return res;
+  }
+
+  auto registerUse(std::string_view id) { return m_db.registerUse(id); }
+
+  NoteDatabase *database() { return &m_db; }
+
+private:
+  NoteDatabase m_db;
+};

--- a/src/server/tests/.clang-tidy
+++ b/src/server/tests/.clang-tidy
@@ -1,0 +1,5 @@
+# Catch2 decomposes REQUIRE(a == b) into `Decomposer <= a == b`, which the chained
+# comparison check flags on every assertion.
+InheritParentConfig: true
+Checks: >
+  -bugprone-chained-comparison

--- a/src/server/tests/note/note-db.cpp
+++ b/src/server/tests/note/note-db.cpp
@@ -1,0 +1,180 @@
+#include <catch2/catch_test_macros.hpp>
+#include <QTemporaryDir>
+#include <span>
+#include "omni-database.hpp"
+#include "services/note/note-db.hpp"
+
+namespace {
+
+/// Every fixture gets its own on-disk database so migrations run for real.
+class NoteFixture {
+public:
+  NoteFixture() {
+    REQUIRE(m_dir.isValid());
+    m_omniDb = std::make_unique<OmniDatabase>(m_dir.filePath("vicinae.db").toStdString());
+    m_db = std::make_unique<NoteDatabase>(*m_omniDb);
+  }
+
+  NoteDatabase &db() { return *m_db; }
+
+  note::Note insert(const std::string &title, const std::string &body = {}) {
+    auto res = m_db->createNote({.title = title, .body = body});
+    REQUIRE(res);
+    return *res;
+  }
+
+private:
+  QTemporaryDir m_dir;
+  std::unique_ptr<OmniDatabase> m_omniDb;
+  std::unique_ptr<NoteDatabase> m_db;
+};
+
+std::vector<std::string> titlesMatching(const NoteDatabase &db, std::string_view query) {
+  std::vector<Scored<int>> filtered;
+  const auto &notes = db.notes();
+
+  fuzzy::fuzzyFilter<note::Note>(std::span<const note::Note>(notes), query, filtered);
+
+  std::vector<std::string> titles;
+
+  titles.reserve(filtered.size());
+
+  for (const auto &scored : filtered) {
+    titles.emplace_back(notes[scored.data].title);
+  }
+
+  return titles;
+}
+
+} // namespace
+
+TEST_CASE("the migration creates an empty note table") {
+  NoteFixture fixture;
+
+  REQUIRE(fixture.db().notes().empty());
+}
+
+TEST_CASE("inserted notes are persisted and readable") {
+  NoteFixture fixture;
+
+  auto note = fixture.insert("Grocery list", "- milk\n- eggs");
+
+  REQUIRE_FALSE(note.id.empty());
+  REQUIRE(note.createdAt > 0);
+  REQUIRE(note.updatedAt == note.createdAt);
+  REQUIRE_FALSE(note.pinned());
+
+  REQUIRE(fixture.db().notes().size() == 1);
+
+  const auto *stored = fixture.db().findById(note.id);
+
+  REQUIRE(stored);
+  REQUIRE(stored->title == "Grocery list");
+  REQUIRE(stored->body == "- milk\n- eggs");
+}
+
+TEST_CASE("notes without a title are rejected") {
+  NoteFixture fixture;
+
+  REQUIRE_FALSE(fixture.db().createNote({.title = "", .body = "orphan"}));
+  REQUIRE_FALSE(fixture.db().createNote({.title = std::string(NoteDatabase::MAX_TITLE_LENGTH + 1, 'a')}));
+  REQUIRE(fixture.db().notes().empty());
+}
+
+TEST_CASE("updating a note rewrites its title and body") {
+  NoteFixture fixture;
+
+  auto note = fixture.insert("Draft", "wip");
+  auto updated = fixture.db().updateNote(note.id, {.title = "Final", .body = "done"});
+
+  REQUIRE(updated);
+  REQUIRE(updated->id == note.id);
+  REQUIRE(updated->createdAt == note.createdAt);
+  REQUIRE(updated->updatedAt >= note.updatedAt);
+
+  const auto *stored = fixture.db().findById(note.id);
+
+  REQUIRE(stored);
+  REQUIRE(stored->title == "Final");
+  REQUIRE(stored->body == "done");
+}
+
+TEST_CASE("updating an unknown note fails") {
+  NoteFixture fixture;
+
+  REQUIRE_FALSE(fixture.db().updateNote("nope", {.title = "Final"}));
+  REQUIRE_FALSE(fixture.db().removeNote("nope"));
+  REQUIRE_FALSE(fixture.db().setPinned("nope", true));
+  REQUIRE_FALSE(fixture.db().registerUse("nope"));
+}
+
+TEST_CASE("pinned notes are listed first") {
+  NoteFixture fixture;
+
+  fixture.insert("First");
+  fixture.insert("Second");
+  auto third = fixture.insert("Third");
+
+  REQUIRE(fixture.db().notes().front().title == "Third");
+
+  auto pinned = fixture.db().setPinned(third.id, true);
+
+  REQUIRE(pinned);
+  REQUIRE(pinned->pinned());
+
+  auto stillPinned = fixture.db().setPinned(fixture.db().notes().at(1).id, true);
+
+  REQUIRE(stillPinned);
+
+  const auto &notes = fixture.db().notes();
+
+  REQUIRE(notes.size() == 3);
+  REQUIRE(notes[0].pinned());
+  REQUIRE(notes[1].pinned());
+  REQUIRE_FALSE(notes[2].pinned());
+
+  REQUIRE(fixture.db().setPinned(third.id, false));
+  REQUIRE_FALSE(fixture.db().findById(third.id)->pinned());
+}
+
+TEST_CASE("using a note records the last use timestamp") {
+  NoteFixture fixture;
+
+  auto note = fixture.insert("Snippet-ish");
+
+  REQUIRE_FALSE(note.lastUsedAt);
+  REQUIRE(fixture.db().registerUse(note.id));
+  REQUIRE(fixture.db().findById(note.id)->lastUsedAt);
+}
+
+TEST_CASE("fuzzy search matches titles and bodies") {
+  NoteFixture fixture;
+
+  fixture.insert("Grocery list", "milk and eggs");
+  fixture.insert("Release checklist", "bump the version");
+  fixture.insert("Postgres commands", "vacuum analyze");
+
+  REQUIRE(titlesMatching(fixture.db(), "grocery") == std::vector<std::string>{"Grocery list"});
+  REQUIRE(titlesMatching(fixture.db(), "vacuum") == std::vector<std::string>{"Postgres commands"});
+  REQUIRE(titlesMatching(fixture.db(), "chcklst") == std::vector<std::string>{"Release checklist"});
+  REQUIRE(titlesMatching(fixture.db(), "nothing-here").empty());
+  REQUIRE(titlesMatching(fixture.db(), "").size() == 3);
+}
+
+TEST_CASE("removed notes are gone") {
+  NoteFixture fixture;
+
+  auto keep = fixture.insert("Keep");
+  auto drop = fixture.insert("Drop");
+
+  auto removed = fixture.db().removeNote(drop.id);
+
+  REQUIRE(removed);
+  REQUIRE(removed->title == "Drop");
+  REQUIRE_FALSE(fixture.db().findById(drop.id));
+
+  const auto &notes = fixture.db().notes();
+
+  REQUIRE(notes.size() == 1);
+  REQUIRE(notes.front().id == keep.id);
+}


### PR DESCRIPTION
## Walkthrough

HyperFrames walkthrough of this PR.

![Walkthrough](https://raw.githubusercontent.com/mvanhorn/vicinae/109f1a15005b17a986d050db35792f25a127c772/evidence/vicinae-1863-notes.gif)

[mp4](https://raw.githubusercontent.com/mvanhorn/vicinae/evidence/evidence/vicinae-1863-notes.mp4)

## What

A built-in `Notes` feature: local notes you can search, edit, pin, copy and paste. Two commands (**Create Note**, **Manage Notes**) plus a root search provider so individual notes show up in the root list, like shortcuts and scripts.

Snippets are keyword expansion. This is the "jot it down, get it back later" case, which has no home today. Shaped to mirror snippets so there's nothing new to learn. Storage is `OmniDatabase` rather than a JSON file because notes are pinnable and time-ordered, which `calculator_history` already models. No sync, no AI, no floating window.

<img alt="Manage Notes list with rendered markdown detail pane" src="https://raw.githubusercontent.com/mvanhorn/vicinae/c5e943b103b76aa6f75c196a115f2989b6e8f950/docs/notes-manage.png" />
<img alt="Root search showing a note result with a Note accessory" src="https://raw.githubusercontent.com/mvanhorn/vicinae/c5e943b103b76aa6f75c196a115f2989b6e8f950/docs/notes-root-search.png" />
<img alt="Create Note form with title and markdown body" src="https://raw.githubusercontent.com/mvanhorn/vicinae/c5e943b103b76aa6f75c196a115f2989b6e8f950/docs/notes-create-form.png" />

## Two decisions worth a look

- `NoteExtension::id()` is `manage-notes`, not `notes`, because `NoteRootProvider::uniqueId()` takes `notes`. `RootItemManager::loadProvider` replaces a provider on id collision, so sharing the id would silently drop both commands from root search. Same split as `ShortcutExtension` / `ShortcutRootProvider`.
- `DetailListView.qml` gets a 6-line additive branch: a host exposing `detailMarkdown` renders markdown instead of plain text. Existing hosts don't define it, so they're untouched. The alternative was duplicating the whole list/detail component for one pane.

## Files

New:

```
src/server/database/vicinae/migrations/004_add_notes.sql
src/server/src/services/note/note-db.{hpp,cpp}
src/server/src/services/note/note-service.hpp
src/server/src/actions/note/note-actions.hpp
src/server/src/extensions/note/note-extension.hpp
src/server/src/qml/note-form-view-host.{hpp,cpp}
src/server/src/qml/manage-notes-model.{hpp,cpp}
src/server/src/qml/manage-notes-view-host.{hpp,cpp}
src/server/src/qml/qml/NoteFormView.qml
src/server/src/root-search/notes/note-root-provider.{hpp,cpp}
src/server/tests/note/note-db.cpp
src/server/tests/.clang-tidy
```

Modified:

```
src/server/CMakeLists.txt
src/server/database/vicinae/migrations.qrc
src/server/src/command-database.cpp
src/server/src/server.cpp
src/server/src/service-registry.{hpp,cpp}
src/server/src/qml/qml/DetailListView.qml
```

The new `tests/.clang-tidy` turns off `bugprone-chained-comparison` for the tests tree: Catch2 decomposes `REQUIRE(a == b)` into `Decomposer <= a == b`, which trips it on every assertion (the existing calculator test hits it 8 times).

## Tests

9 Catch2 cases in the existing `vicinae-server-tests` target: insert, validation, update, pin ordering, `last_used_at`, fuzzy search over title and body, delete. Each opens a real `OmniDatabase` in a `QTemporaryDir`, so migration `004` runs for real.

```
cmake -S . -B build -G Ninja -DBUILD_TESTS=ON -DUSE_SYSTEM_CMARK_GFM=OFF
cmake --build build --parallel $(nproc)
make test
```

`vicinae-server-tests`: 170 assertions in 18 cases, passing. `clang-format` clean; `clang-tidy` clean on the new files. Also driven by hand in the running launcher (GCC 14 / Qt 6.9.1): create, list, markdown detail, search by title and by body, pin reordering, edit, copy, remove, root search.

## AI disclosure

Generated with Claude Opus 5, held to the same bar as hand-written code per CONTRIBUTING: patterns copied from the existing snippet, shortcut and calculator code, formatted, linted, tested, manually exercised.

Opening directly rather than starting on Discord was an explicit request. Happy to move it there, or to drop the root search provider if that scope isn't wanted.

