### PR TITLE
feat: smoother root file search

### DIFF
--- a/src/server/src/qml/qml/HorizontalLoadingBar.qml
+++ b/src/server/src/qml/qml/HorizontalLoadingBar.qml
@@ -31,9 +31,11 @@ Item {
         running: root._active
     }
 
+    property int showDelay: 250
+    property int hideDelay: 100
+
     Timer {
         id: debounce
-        interval: 100
         onTriggered: {
             if (root.loading) {
                 bar.x = -bar.width;
@@ -44,5 +46,8 @@ Item {
         }
     }
 
-    onLoadingChanged: debounce.restart()
+    onLoadingChanged: {
+        debounce.interval = loading ? root.showDelay : root.hideDelay;
+        debounce.restart();
+    }
 }

--- a/src/server/src/qml/qml/RootSearchList.qml
+++ b/src/server/src/qml/qml/RootSearchList.qml
@@ -8,6 +8,7 @@ GenericListView {
     listModel: cmdModel
     autoWireModel: true
     selectFirstOnReset: cmdModel.selectFirstOnReset
+    suppressEmpty: launcher.isLoading
 
     delegate: Loader {
         id: delegateLoader

--- a/src/server/src/qml/root-search-model.cpp
+++ b/src/server/src/qml/root-search-model.cpp
@@ -75,7 +75,6 @@ void RootSearchModel::setFilter(const QString &text) {
   if (!fileSearchApplicable()) {
     m_filesSource->setFiles({});
     m_hasFileResults = false;
-    scope().setLoading(false);
   }
   m_fileSearchDebounce.stop();
 
@@ -104,6 +103,7 @@ bool RootSearchModel::rerunSearch() {
       m_newsSource->setItems({});
       m_favoritesSource->setItems({});
       m_fallbackSource->setItems({});
+      scope().setLoading(false);
       rebuild();
       return true;
     }
@@ -118,6 +118,7 @@ bool RootSearchModel::rerunSearch() {
         m_resultsSource->setQueryEmpty(false);
         m_newsSource->setItems({});
         m_favoritesSource->setItems({});
+        scope().setLoading(false);
         rebuild();
         return true;
       }
@@ -158,6 +159,7 @@ bool RootSearchModel::rerunSearch() {
   m_resultsSource->setItems(std::move(results));
 
   refreshCalculator();
+  scope().setLoading(fileSearchApplicable());
   if (!text.isEmpty()) m_fileSearchDebounce.start();
 
   rebuild();
@@ -239,7 +241,6 @@ void RootSearchModel::startFileSearch() {
   if (!fileSearchApplicable()) return;
   if (m_fileWatcher.isRunning()) { m_fileWatcher.cancel(); }
   m_fileSearchQuery = m_query;
-  scope().setLoading(true);
   m_fileWatcher.setFuture(m_fileService->queryAsync(m_query));
 }
 

--- a/src/server/src/qml/root-search-model.cpp
+++ b/src/server/src/qml/root-search-model.cpp
@@ -23,7 +23,7 @@ RootSearchModel::RootSearchModel(const ViewScope &scope, QObject *parent)
 
   using namespace std::chrono_literals;
 
-  m_fileSearchDebounce.setInterval(200ms);
+  m_fileSearchDebounce.setInterval(50ms);
   m_fileSearchDebounce.setSingleShot(true);
 
   connect(&m_fileSearchDebounce, &QTimer::timeout, this, &RootSearchModel::startFileSearch);
@@ -72,7 +72,11 @@ void RootSearchModel::setFilter(const QString &text) {
   scope().clearActions();
 
   m_calcSource->setResult({});
-  m_filesSource->setFiles({});
+  if (!fileSearchApplicable()) {
+    m_filesSource->setFiles({});
+    m_hasFileResults = false;
+    scope().setLoading(false);
+  }
   m_fileSearchDebounce.stop();
 
   bool const directMatch = rerunSearch();
@@ -136,7 +140,10 @@ bool RootSearchModel::rerunSearch() {
     m_updateSource->setUpdate({});
     m_newsSource->setItems({});
     m_favoritesSource->setItems({});
-    m_fallbackSource->setItems(m_manager->fallbackItems());
+
+    bool const awaitingFiles = fileSearchApplicable() && !m_hasFileResults;
+    m_fallbackSource->setItems(awaitingFiles ? std::vector<std::shared_ptr<RootItem>>{}
+                                             : m_manager->fallbackItems());
   }
 
   std::vector<OwnedResult> results;
@@ -148,25 +155,32 @@ bool RootSearchModel::rerunSearch() {
     });
   }
 
-  bool inhibitCalculator = !results.empty();
-
   m_resultsSource->setItems(std::move(results));
 
-  if (!text.isEmpty()) {
-    if (text.startsWith("=")) {
-      if (auto res = m_calculator->backend()->compute(QString::fromStdString(m_query.substr(1)), {})) {
-        m_calcSource->setResult(res.value());
-      }
-    } else if (!inhibitCalculator && m_query.size() >= CALCULATOR_MIN_CHARS) {
-      if (auto res = m_calculator->backend()->compute(QString::fromStdString(m_query), {})) {
-        m_calcSource->setResult(res.value());
-      }
-    }
-    m_fileSearchDebounce.start();
-  }
+  refreshCalculator();
+  if (!text.isEmpty()) m_fileSearchDebounce.start();
 
   rebuild();
   return false;
+}
+
+void RootSearchModel::refreshCalculator() {
+  m_calcSource->setResult({});
+
+  if (m_query.empty()) return;
+
+  if (m_query.starts_with('=')) {
+    if (auto res = m_calculator->backend()->compute(QString::fromStdString(m_query.substr(1)), {})) {
+      m_calcSource->setResult(res.value());
+    }
+    return;
+  }
+
+  if (m_resultsSource->count() > 0 || m_query.size() < CALCULATOR_MIN_CHARS) return;
+
+  if (auto res = m_calculator->backend()->compute(QString::fromStdString(m_query), {})) {
+    m_calcSource->setResult(res.value());
+  }
 }
 
 void RootSearchModel::setSelectedIndex(int index) {
@@ -217,21 +231,36 @@ const RootItem *RootSearchModel::selectedRootItem() const {
   return section ? section->rootItem(itemIdx) : nullptr;
 }
 
+bool RootSearchModel::fileSearchApplicable() const {
+  return m_fileSearchEnabled && m_query.size() >= MIN_FS_TEXT_LENGTH;
+}
+
 void RootSearchModel::startFileSearch() {
-  if (!m_fileSearchEnabled || m_query.size() < MIN_FS_TEXT_LENGTH) return;
+  if (!fileSearchApplicable()) return;
   if (m_fileWatcher.isRunning()) { m_fileWatcher.cancel(); }
   m_fileSearchQuery = m_query;
+  scope().setLoading(true);
   m_fileWatcher.setFuture(m_fileService->queryAsync(m_query));
 }
 
 void RootSearchModel::handleFileSearchFinished() {
   if (!m_fileWatcher.isFinished() || m_fileSearchQuery != m_query) return;
+  scope().setLoading(false);
   m_filesSource->setFiles(m_fileWatcher.result());
   m_fileSearchQuery.clear();
+  m_hasFileResults = true;
+  m_fallbackSource->setItems(m_manager->fallbackItems());
+
+  bool const atDefault = selectedIndex() < 0 || selectedIndex() == nextSelectableIndex(-1, 1);
 
   auto saved = selectFirstOnReset();
   setSelectFirstOnReset(false);
   rebuild();
   setSelectFirstOnReset(saved);
-  refreshActionPanel();
+
+  if (atDefault) {
+    setSelectedIndex(nextSelectableIndex(-1, 1));
+  } else {
+    refreshActionPanel();
+  }
 }

--- a/src/server/src/qml/root-search-model.hpp
+++ b/src/server/src/qml/root-search-model.hpp
@@ -36,6 +36,8 @@ private:
   void startCalculator();
   void startFileSearch();
   void handleFileSearchFinished();
+  bool fileSearchApplicable() const;
+  void refreshCalculator();
 
   static constexpr int MIN_FS_TEXT_LENGTH = 3;
 
@@ -64,4 +66,5 @@ private:
   std::string m_calculatorSearchQuery;
   std::string m_fileSearchQuery;
   bool m_fileSearchEnabled = false;
+  bool m_hasFileResults = false;
 };

--- a/src/server/src/qml/view-scope.hpp
+++ b/src/server/src/qml/view-scope.hpp
@@ -13,6 +13,7 @@ public:
   }
   void clearActions() const { nav()->clearActions(m_owner); }
   void setNavigationTitle(const QString &title) const { nav()->setNavigationTitle(title, m_owner); }
+  void setLoading(bool value) const { nav()->setLoading(value, m_owner); }
 
   bool executePrimaryAction() const { return nav()->executePrimaryAction(); }
   void closeWindow(const CloseWindowOptions &opts = {}) const { nav()->closeWindow(opts); }


### PR DESCRIPTION
fixes a bug introduced by #1806 where the first fallback item would grab the current selection permanently and keep it even after file search results were made available.

This also generally improve the feel of searching files from the root search, reducing the amount of "blinking states" while searching files continuously.

Fallback items are now shown once the file search query has been answered, and never before that.