### PR TITLE
fix(calculator): map Qt locale names to valid C++ locales for Numen

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -362,6 +362,7 @@ set(SRCS
 	src/services/calculator-service/numen/numen-currency-provider.cpp
 	src/services/calculator-service/numen/numen-calculator-backend.hpp
 	src/services/calculator-service/numen/numen-calculator-backend.cpp
+	src/services/calculator-service/numen/numen-locale.hpp
 
 	src/services/files-service/abstract-file-indexer.hpp
 	src/services/files-service/dummy-file-indexer.hpp
@@ -1292,6 +1293,7 @@ if (BUILD_TESTS AND UNIX AND NOT APPLE)
 	target_sources(${TEST_TARGET} PRIVATE
 		src/services/calculator-service/qalculate/qalculate-backend.cpp
 		tests/calculator/qalculate-backend.cpp
+		tests/calculator/numen-locale.cpp
 	)
 	target_link_libraries(${TEST_TARGET} PRIVATE vicinae::common qalculate Qt6::Concurrent)
 	target_link_libraries(${TEST_TARGET} PRIVATE Catch2::Catch2WithMain Qt6::Core Qt6::Gui)

--- a/src/server/src/services/calculator-service/numen/numen-calculator-backend.cpp
+++ b/src/server/src/services/calculator-service/numen/numen-calculator-backend.cpp
@@ -1,8 +1,11 @@
 #include "services/calculator-service/numen/numen-calculator-backend.hpp"
 #include "numen/numen.hpp"
 #include "services/calculator-service/numen/numen-currency-provider.hpp"
+#include "services/calculator-service/numen/numen-locale.hpp"
 #include "utils/environment.hpp"
+#include <QLocale>
 #include <qfuture.h>
+#include <qlogging.h>
 #include <chrono>
 #include <format>
 
@@ -27,6 +30,13 @@ std::string formatTimezone(const numen::Timezone &tz) {
 }; // namespace
 
 NumenCalculatorBackend::NumenCalculatorBackend() {
+  const auto qtName = QLocale::system().name();
+  m_localeName = calculator::numenLocaleName(qtName.toStdString());
+  if (!m_localeName) {
+    qWarning() << "Numen calculator: system locale" << qtName
+               << "is not a valid C++ locale; falling back to the process locale";
+  }
+
   if (Environment::isAutoRateRefreshDisabled()) return;
 
   m_rateRefreshTimer.setInterval(std::chrono::hours{1});
@@ -47,12 +57,12 @@ NumenCalculatorBackend::ComputeResult NumenCalculatorBackend::compute(const QStr
       .parseOptions =
           {
               .strict = true,
-              .locale = QLocale::system().name().toStdString(),
+              .locale = m_localeName,
           },
   };
 
   return m_numen.compute(question.toStdString(), evalOpts)
-      .transform([&](const numen::ComputedValue &res) -> ComputeResult {
+      .transform([&](const numen::ComputedValue &res) {
         CalculatorResult result{};
 
         if (res.conversion) {
@@ -108,7 +118,8 @@ NumenCalculatorBackend::ComputeResult NumenCalculatorBackend::compute(const QStr
         std::visit(visitor, res.value);
         return result;
       })
-      .value_or(ComputeResult{std::unexpected("Error")});
+      .transform_error(
+          [](const std::string &error) { return CalculatorError(QString::fromStdString(error)); });
 }
 
 QFuture<AbstractCalculatorBackend::RefreshExchangeRatesResult>

--- a/src/server/src/services/calculator-service/numen/numen-calculator-backend.hpp
+++ b/src/server/src/services/calculator-service/numen/numen-calculator-backend.hpp
@@ -2,6 +2,8 @@
 #include "services/calculator-service/abstract-calculator-backend.hpp"
 #include "numen/numen.hpp"
 #include <QTimer>
+#include <optional>
+#include <string>
 
 class NumenCalculatorBackend : public AbstractCalculatorBackend, QObject {
 public:
@@ -19,4 +21,5 @@ public:
 private:
   QTimer m_rateRefreshTimer;
   numen::Numen m_numen{};
+  std::optional<std::string> m_localeName;
 };

--- a/src/server/src/services/calculator-service/numen/numen-locale.hpp
+++ b/src/server/src/services/calculator-service/numen/numen-locale.hpp
@@ -1,0 +1,35 @@
+#pragma once
+#include <array>
+#include <exception>
+#include <locale>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace calculator {
+
+// QLocale::name() returns "en_US". glibc locale names are typically "en_US.UTF-8",
+// so constructing std::locale from the Qt name throws and every compute() fails.
+inline bool isValidStdLocaleName(const std::string &name) {
+  try {
+    std::locale{name};
+    return true;
+  } catch (const std::exception &) { return false; }
+}
+
+inline std::optional<std::string> numenLocaleName(std::string_view qtName) {
+  const std::string name{qtName};
+  const auto candidates = std::to_array<std::string>({
+      name + ".UTF-8",
+      name + ".utf8",
+      name,
+  });
+
+  for (const auto &candidate : candidates) {
+    if (isValidStdLocaleName(candidate)) return candidate;
+  }
+
+  return std::nullopt;
+}
+
+} // namespace calculator

--- a/src/server/tests/calculator/numen-locale.cpp
+++ b/src/server/tests/calculator/numen-locale.cpp
@@ -1,0 +1,27 @@
+#include "services/calculator-service/numen/numen-locale.hpp"
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("does not forward a Qt locale name that std::locale rejects") {
+  constexpr auto qtName = "en_US";
+  if (calculator::isValidStdLocaleName(qtName)) { SKIP("en_US is a valid std::locale name"); }
+
+  const auto resolved = calculator::numenLocaleName(qtName);
+  REQUIRE(resolved != qtName);
+  if (resolved) { REQUIRE(calculator::isValidStdLocaleName(*resolved)); }
+}
+
+TEST_CASE("prefers the UTF-8 variant of a Qt locale name") {
+  if (!calculator::isValidStdLocaleName("en_US.UTF-8")) { SKIP("en_US.UTF-8 is not installed"); }
+
+  REQUIRE(calculator::numenLocaleName("en_US") == "en_US.UTF-8");
+}
+
+TEST_CASE("C locale always resolves") {
+  const auto resolved = calculator::numenLocaleName("C");
+  REQUIRE(resolved);
+  REQUIRE(calculator::isValidStdLocaleName(*resolved));
+}
+
+TEST_CASE("unknown locale names fall back instead of throwing") {
+  REQUIRE_FALSE(calculator::numenLocaleName("definitely_not_a_locale_zz").has_value());
+}


### PR DESCRIPTION
## Summary
- Numen was given `QLocale::name()` (`en_US`), which glibc rejects in favor of `en_US.UTF-8`, so every calculator query threw and was swallowed.
- Resolve a real `std::locale` name at backend start, keep Numen's error instead of a generic `"Error"`, and add a locale regression test.

Fixes https://github.com/vicinaehq/vicinae/issues/1869