### PR TITLE
fix: numen calculator backend not working for some locales

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787736819,
-        "narHash": "sha256-cV5xEJJK3BvhU8rEd4mC9UsmDi5qscv/kzGPhBRC5WA=",
+        "lastModified": 1787900134,
+        "narHash": "sha256-VYXO0XZlgj06dxJZRhrD3WoSsvq/c7+/Akyoa22pefw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9fbb54b33e91ee4ca368e35a78e0613c720600b3",
+        "rev": "83199d0d373dd3ac2b9a1996b1d0263f76ab7a4c",
         "type": "github"
       },
       "original": {
@@ -39,16 +39,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1787953571,
-        "narHash": "sha256-cUly+bzaPwj9fiUmC+Gh7gwKAZjINCKZKGf/gPMhJJg=",
+        "lastModified": 1788091454,
+        "narHash": "sha256-yfM9Y+fPy43+0SckUr+4WugTJ9JVmfg4lyoYtRwjEFM=",
         "owner": "vicinaehq",
         "repo": "numen",
-        "rev": "7cfed1e8322ac6ebd0db9cbf0db31e27385965bc",
+        "rev": "7b4d9099589ef8df1ff56effadcf3c0e8f1fbf58",
         "type": "github"
       },
       "original": {
         "owner": "vicinaehq",
-        "ref": "v0.5.1",
+        "ref": "v0.6.0",
         "repo": "numen",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     numen = {
-      url = "github:vicinaehq/numen/v0.5.1";
+      url = "github:vicinaehq/numen/v0.6.0";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -16,7 +16,7 @@ else()
 
 	FetchContent_Declare(numen
 	  GIT_REPOSITORY https://github.com/vicinaehq/numen
-	  GIT_TAG        v0.5.1
+	  GIT_TAG        v0.6.0
 	)
 
 	FetchContent_MakeAvailable(numen)

--- a/src/server/src/services/calculator-service/numen/numen-calculator-backend.cpp
+++ b/src/server/src/services/calculator-service/numen/numen-calculator-backend.cpp
@@ -5,6 +5,7 @@
 #include <qfuture.h>
 #include <chrono>
 #include <format>
+#include <variant>
 
 namespace {
 std::string formatTimezone(const numen::Timezone &tz) {
@@ -44,16 +45,16 @@ NumenCalculatorBackend::ComputeResult NumenCalculatorBackend::compute(const QStr
                                                                       const ComputeOptions &opts) {
 
   numen::EvalOptions evalOpts{
-      .parseOptions =
-          {
-              .strict = true,
-              .locale = QLocale::system().name().toStdString(),
-          },
+      .parseOptions = {.strict = true},
   };
 
   return m_numen.compute(question.toStdString(), evalOpts)
       .transform([&](const numen::ComputedValue &res) -> ComputeResult {
         CalculatorResult result{};
+
+        if (std::holds_alternative<std::string>(res.value) && !res.conversion) {
+          return std::unexpected(CalculatorError{"Cannot display string without explicit conversion"});
+        }
 
         if (res.conversion) {
           result.type = CalculatorAnswerType::CONVERSION;
@@ -103,7 +104,8 @@ NumenCalculatorBackend::ComputeResult NumenCalculatorBackend::compute(const QStr
               }
             },
             [&](const numen::Boolean &b) { result.answer.text = b.value ? "true" : "false"; },
-            [&](const numen::Duration &b) { result.answer.text = QString::fromStdString(b.toString()); }};
+            [&](const numen::Duration &b) { result.answer.text = QString::fromStdString(b.toString()); },
+            [&](const std::string &str) { result.answer.text = QString::fromStdString(str); }};
 
         std::visit(visitor, res.value);
         return result;


### PR DESCRIPTION
The `numen` calculator backend wasn't working for some users because in some circumstances their locale could not be parsed. Instead of explicitly passing the locale from `QLocale::name()` (which may not directly map to what numen expects) we rely on the `numen` library inferring the right system locale all by itself (fixed in v0.6.0).

fixes #1869 