### PR TITLE
a11y: annotate important QML components

### DIFF
--- a/src/server/src/qml/qml/ActionItemDelegate.qml
+++ b/src/server/src/qml/qml/ActionItemDelegate.qml
@@ -16,6 +16,12 @@ Item {
 
     signal clicked
 
+    Accessible.role: Accessible.MenuItem
+    Accessible.name: root.title
+    Accessible.selectable: true
+    Accessible.selected: root.selected
+    Accessible.onPressAction: root.clicked()
+
     readonly property var _win: root.Window.window
     // Qt.Tool contains the Qt.Popup bit, so mask the full window type or the
     // launcher window itself matches for in-scene popups

--- a/src/server/src/qml/qml/CalculatorResultDelegate.qml
+++ b/src/server/src/qml/qml/CalculatorResultDelegate.qml
@@ -10,6 +10,12 @@ SelectableDelegate {
     required property string calcAnswer
     required property string calcAnswerUnit
 
+    Accessible.role: Accessible.ListItem
+    Accessible.name: root.calcQuestion
+    Accessible.description: root.calcAnswerUnit !== "" ? `${root.calcAnswer} ${root.calcAnswerUnit}` : root.calcAnswer
+    Accessible.selectable: true
+    Accessible.selected: root.selected
+
     // quite naive, but good enough.
     // if we find we need this to be actually accurate, we probably need a per backend
     // way to figure out what token carries operator significance.

--- a/src/server/src/qml/qml/CompletionPopup.qml
+++ b/src/server/src/qml/qml/CompletionPopup.qml
@@ -223,6 +223,11 @@ Popup {
                 readonly property bool _isHighlighted: index === root._highlightedIndex
                 readonly property bool _isSelected: itemType === "item" && root.currentItemId !== "" && itemData && itemData.id === root.currentItemId
 
+                Accessible.role: del.itemType === "item" ? Accessible.ListItem : Accessible.Heading
+                Accessible.name: del.title
+                Accessible.selectable: del.itemType === "item"
+                Accessible.selected: del._isSelected || del._isHighlighted
+
                 RowLayout {
                     id: sectionRow
                     visible: del.itemType === "section"

--- a/src/server/src/qml/qml/FooterButton.qml
+++ b/src/server/src/qml/qml/FooterButton.qml
@@ -10,6 +10,10 @@ Item {
 
     signal clicked
 
+    Accessible.role: Accessible.Button
+    Accessible.name: root.label
+    Accessible.onPressAction: root.clicked()
+
     readonly property bool hovered: mouseArea.containsMouse
     readonly property int horizontalPadding: 8
     readonly property int buttonHeight: 28

--- a/src/server/src/qml/qml/FormCheckbox.qml
+++ b/src/server/src/qml/qml/FormCheckbox.qml
@@ -15,6 +15,12 @@ Item {
 
     signal toggled
 
+    Accessible.role: Accessible.CheckBox
+    Accessible.name: root.label
+    Accessible.checkable: true
+    Accessible.checked: root.checked
+    Accessible.onToggleAction: root.toggle()
+
     function toggle() {
         if (root.readOnly)
             return;

--- a/src/server/src/qml/qml/FormField.qml
+++ b/src/server/src/qml/qml/FormField.qml
@@ -46,6 +46,10 @@ ColumnLayout {
                         children[i].filled = Qt.binding(function () {
                             return root.filled;
                         });
+                    if (children[i].accessibleLabel !== undefined)
+                        children[i].accessibleLabel = Qt.binding(function () {
+                            return root.label;
+                        });
                 }
             }
         }

--- a/src/server/src/qml/qml/FormFilePicker.qml
+++ b/src/server/src/qml/qml/FormFilePicker.qml
@@ -22,6 +22,10 @@ FocusScope {
     readonly property bool _directoriesOnly: canChooseDirectories && !canChooseFiles
     property bool _waitingForPortal: false
 
+    Accessible.role: Accessible.Button
+    Accessible.name: root.selectedPaths && root.selectedPaths.length > 0 ? root.selectedPaths.join(", ") : (root._directoriesOnly ? qsTr("No directory selected") : qsTr("No file selected"))
+    Accessible.onPressAction: root._openDialog()
+
     function forceActiveFocus() {
         focusItem.forceActiveFocus();
     }

--- a/src/server/src/qml/qml/FormTextInput.qml
+++ b/src/server/src/qml/qml/FormTextInput.qml
@@ -17,6 +17,7 @@ FocusScope {
     // we usually want that on in settings window but not in form commands
     property bool releaseFocusOnAccept: false
     property alias echoMode: input.echoMode
+    property string accessibleLabel: ""
     readonly property bool editing: input.activeFocus
 
     signal textEdited
@@ -52,6 +53,8 @@ FocusScope {
 
     TextInput {
         id: input
+        Accessible.name: root.accessibleLabel !== "" ? root.accessibleLabel : root.placeholder
+        Accessible.readOnly: root.readOnly
         anchors.fill: parent
         anchors.leftMargin: 10
         anchors.rightMargin: 10

--- a/src/server/src/qml/qml/GenericGridView.qml
+++ b/src/server/src/qml/qml/GenericGridView.qml
@@ -287,6 +287,12 @@ Item {
                                 readonly property bool cellSelected: root.cmdModel && root.cmdModel.selectedSection === cellSection && root.cmdModel.selectedItem === cellItem
                                 readonly property bool cellHovered: cellMouseArea.containsMouse && HoverActivation.active
 
+                                Accessible.role: Accessible.Cell
+                                Accessible.name: root.cmdModel ? root.cmdModel.cellTitle(cellSection, cellItem) : ""
+                                Accessible.description: root.cmdModel ? root.cmdModel.cellSubtitle(cellSection, cellItem) : ""
+                                Accessible.selectable: true
+                                Accessible.selected: cellWrapper.cellSelected
+
                                 width: rowItem.cellWidth
                                 height: rowItem.cellHeight + rowItem.cellTextHeight
 

--- a/src/server/src/qml/qml/ListItemDelegate.qml
+++ b/src/server/src/qml/qml/ListItemDelegate.qml
@@ -5,6 +5,12 @@ SelectableDelegate {
     id: root
     height: 38
 
+    Accessible.role: Accessible.ListItem
+    Accessible.name: itemTitle
+    Accessible.description: itemSubtitle
+    Accessible.selectable: true
+    Accessible.selected: root.selected
+
     required property string itemTitle
     required property string itemSubtitle
     required property string itemIconSource

--- a/src/server/src/qml/qml/SearchBar.qml
+++ b/src/server/src/qml/qml/SearchBar.qml
@@ -49,6 +49,8 @@ Item {
 
             TextInput {
                 id: searchInput
+                Accessible.name: "search-input"
+                Accessible.description: launcher.searchPlaceholder
                 anchors.fill: parent
                 verticalAlignment: TextInput.AlignVCenter
                 font.family: Theme.fontFamily

--- a/src/server/src/qml/qml/SearchableDropdown.qml
+++ b/src/server/src/qml/qml/SearchableDropdown.qml
@@ -26,6 +26,10 @@ Item {
 
     property real _closedTime: 0
 
+    Accessible.role: Accessible.ComboBox
+    Accessible.name: root.currentItem?.displayName ?? root.placeholder ?? ""
+    Accessible.onPressAction: root.open()
+
     function open() {
         if (root.readOnly || completionPopup.visible)
             return;

--- a/src/server/src/qml/qml/SettingsRow.qml
+++ b/src/server/src/qml/qml/SettingsRow.qml
@@ -57,6 +57,14 @@ ColumnLayout {
             Layout.preferredWidth: root.controlWidth
             Layout.alignment: Qt.AlignVCenter
             implicitHeight: children.length > 0 ? children[0].implicitHeight : 0
+            onChildrenChanged: {
+                for (var i = 0; i < children.length; i++) {
+                    if (children[i].accessibleLabel !== undefined)
+                        children[i].accessibleLabel = Qt.binding(function () {
+                            return root.label;
+                        });
+                }
+            }
         }
     }
 

--- a/src/server/src/qml/qml/SettingsSidebar.qml
+++ b/src/server/src/qml/qml/SettingsSidebar.qml
@@ -179,6 +179,12 @@ Item {
                 readonly property bool _selected: root._activeKey === navItem._key
                 readonly property bool _enabled: navItem.model.enabled !== false
 
+                Accessible.ignored: navItem.model.kind === "divider"
+                Accessible.role: Accessible.ListItem
+                Accessible.name: navItem.model.label ?? ""
+                Accessible.selectable: true
+                Accessible.selected: navItem._selected
+
                 ViciDivider {
                     visible: navItem.model.kind === "divider"
                     anchors.left: parent.left

--- a/src/server/src/qml/qml/SettingsToggle.qml
+++ b/src/server/src/qml/qml/SettingsToggle.qml
@@ -8,7 +8,14 @@ Item {
     activeFocusOnTab: true
 
     property bool checked: false
+    property string accessibleLabel: ""
     signal toggled(bool checked)
+
+    Accessible.role: Accessible.CheckBox
+    Accessible.name: root.accessibleLabel
+    Accessible.checkable: true
+    Accessible.checked: root.checked
+    Accessible.onToggleAction: root.toggled(!root.checked)
 
     function _shifted(c, dh, ds, dl) {
         const h = (c.hslHue < 0 ? 0 : c.hslHue) + dh;

--- a/src/server/src/qml/qml/ViciButton.qml
+++ b/src/server/src/qml/qml/ViciButton.qml
@@ -15,6 +15,10 @@ Rectangle {
 
     signal clicked
 
+    Accessible.role: Accessible.Button
+    Accessible.name: root.text !== "" ? root.text : root.icon
+    Accessible.onPressAction: root.clicked()
+
     readonly property bool hovered: mouseArea.containsMouse
     readonly property bool _hasIcon: root.icon !== "" || root.iconSource !== undefined
     readonly property bool _hasText: root.text !== ""


### PR DESCRIPTION
Annotate important Vicinae QML components so that they export proper accessibility information, e.g for at-spi on Linux.

Will help with screen readers, and most importantly, testing.