### PR TITLE
feat: add time-based clipboard eviction threshold

### DIFF
--- a/src/server/src/extensions/clipboard/clipboard-extension.cpp
+++ b/src/server/src/extensions/clipboard/clipboard-extension.cpp
@@ -2,7 +2,6 @@
 #include <QCoreApplication>
 #include <chrono>
 #include "builtin_icon.hpp"
-#include "numen/numen.hpp"
 #include "single-view-command-context.hpp"
 #include "services/clipboard/clipboard-service.hpp"
 #include "services/toast/toast-service.hpp"
@@ -71,10 +70,10 @@ void ClipboardExtension::initialized(const QJsonObject &preferences) const {
 
 void ClipboardExtension::preferenceValuesChanged(const QJsonObject &value) const {
   auto parseEvictionThreshold = [](const QString &text) -> std::optional<std::chrono::seconds> {
-    if (text == "never") return std::nullopt;
-    auto parsed = numen::Numen{}.parse<std::chrono::seconds>(text.toStdString());
-    if (!parsed) return std::nullopt;
-    return *parsed;
+    bool ok = false;
+    auto secs = text.toLongLong(&ok);
+    if (!ok || secs <= 0) return std::nullopt;
+    return std::chrono::seconds(secs);
   };
 
   auto clipman = ServiceRegistry::instance()->clipman();
@@ -91,10 +90,13 @@ void ClipboardExtension::preferenceValuesChanged(const QJsonObject &value) const
 }
 
 std::vector<Preference> ClipboardExtension::preferences() const {
+  using namespace std::chrono_literals;
+  auto secs = [](std::chrono::seconds s) { return QString::number(s.count()); };
+
   std::vector<Preference::DropdownData::Option> evictionThresholdPresets = {
-      {tr("Never"), "never"},   {tr("15 minutes"), "15 minutes"}, {tr("1 hour"), "1 hour"},
-      {tr("1 day"), "1 day"},   {tr("1 week"), "1 week"},         {tr("1 month"), "1 month"},
-      {tr("1 year"), "1 year"},
+      {tr("Never"), "never"},          {tr("15 minutes"), secs(15min)}, {tr("1 hour"), secs(1h)},
+      {tr("1 day"), secs(24h)},        {tr("1 week"), secs(24h * 7)},   {tr("1 month"), secs(24h * 30)},
+      {tr("1 year"), secs(24h * 365)},
   };
 
   auto monitoring = Preference::makeCheckbox("monitoring");
@@ -102,13 +104,13 @@ std::vector<Preference> ClipboardExtension::preferences() const {
   auto preserveTaggedSelections = Preference::makeCheckbox("preserveTagged");
   auto eraseOnStartup = Preference::makeCheckbox("eraseOnStartup");
 
-  evictionThreshold.setTitle("Eviction threshold");
-  evictionThreshold.setDescription("Automatically delete selections older than this threshold");
+  evictionThreshold.setTitle(tr("Eviction threshold"));
+  evictionThreshold.setDescription(tr("Automatically delete selections older than this threshold"));
   evictionThreshold.setDefaultValue("never");
 
-  preserveTaggedSelections.setTitle("Preserve tagged");
+  preserveTaggedSelections.setTitle(tr("Preserve tagged"));
   preserveTaggedSelections.setDescription(
-      "Never evict or mass delete selections that have been explicitly tagged (pinned, custom keyword).");
+      tr("Never evict or mass delete selections that have been explicitly tagged (pinned, custom keyword)"));
   preserveTaggedSelections.setDefaultValue(true);
 
   eraseOnStartup.setTitle(tr("Erase on startup"));
@@ -116,8 +118,7 @@ std::vector<Preference> ClipboardExtension::preferences() const {
   eraseOnStartup.setDefaultValue(false);
 
   monitoring.setTitle(tr("Clipboard monitoring"));
-  monitoring.setDescription(tr("Whether clipboard activity is recorded in the history. Every clipboard "
-                               "action performed while this is turned off will not be recorded."));
+  monitoring.setDescription(tr("Whether new clipboard selections are appended to the history"));
   monitoring.setDefaultValue(true);
 
 #ifdef Q_OS_MACOS
@@ -127,7 +128,7 @@ std::vector<Preference> ClipboardExtension::preferences() const {
   ignorePasswords.setDefaultValue(true);
   ignorePasswords.setTitle(tr("Ignore Passwords"));
   ignorePasswords.setDescription(
-      tr("Ignore selections that can be identified as a password. This may not work with all apps."));
+      tr("Ignore selections that can be identified as a password. May not work with all apps."));
 
   return {monitoring, ignorePasswords, preserveTaggedSelections, evictionThreshold, eraseOnStartup};
 #endif

--- a/src/server/src/extensions/clipboard/clipboard-extension.cpp
+++ b/src/server/src/extensions/clipboard/clipboard-extension.cpp
@@ -1,6 +1,8 @@
 #include "extensions/clipboard/clipboard-extension.hpp"
 #include <QCoreApplication>
+#include <chrono>
 #include "builtin_icon.hpp"
+#include "numen/numen.hpp"
 #include "single-view-command-context.hpp"
 #include "services/clipboard/clipboard-service.hpp"
 #include "services/toast/toast-service.hpp"
@@ -68,17 +70,46 @@ void ClipboardExtension::initialized(const QJsonObject &preferences) const {
 }
 
 void ClipboardExtension::preferenceValuesChanged(const QJsonObject &value) const {
+  auto parseEvictionThreshold = [](const QString &text) -> std::optional<std::chrono::seconds> {
+    if (text == "never") return std::nullopt;
+    auto parsed = numen::Numen{}.parse<std::chrono::seconds>(text.toStdString());
+    if (!parsed) return std::nullopt;
+    return *parsed;
+  };
+
   auto clipman = ServiceRegistry::instance()->clipman();
+  auto evictionThreshold = parseEvictionThreshold(value.value("evictionThreshold").toString());
+  auto preservedTaggedSelections = value.value("preserveTagged").toBool();
+
   clipman->setRecordAllOffers(value.value("store-all-offerings").toBool());
   clipman->setMonitoring(value.value("monitoring").toBool());
+  clipman->setHistoryEvictionThreshold(evictionThreshold, preservedTaggedSelections);
+
 #ifndef Q_OS_MACOS
   clipman->setIgnorePasswords(value.value("ignorePasswords").toBool());
 #endif
 }
 
 std::vector<Preference> ClipboardExtension::preferences() const {
+  std::vector<Preference::DropdownData::Option> evictionThresholdPresets = {
+      {tr("Never"), "never"},   {tr("15 minutes"), "15 minutes"}, {tr("1 hour"), "1 hour"},
+      {tr("1 day"), "1 day"},   {tr("1 week"), "1 week"},         {tr("1 month"), "1 month"},
+      {tr("1 year"), "1 year"},
+  };
+
   auto monitoring = Preference::makeCheckbox("monitoring");
+  auto evictionThreshold = Preference::makeDropdown("evictionThreshold", evictionThresholdPresets);
+  auto preserveTaggedSelections = Preference::makeCheckbox("preserveTagged");
   auto eraseOnStartup = Preference::makeCheckbox("eraseOnStartup");
+
+  evictionThreshold.setTitle("Eviction threshold");
+  evictionThreshold.setDescription("Automatically delete selections older than this threshold");
+  evictionThreshold.setDefaultValue("never");
+
+  preserveTaggedSelections.setTitle("Preserve tagged");
+  preserveTaggedSelections.setDescription(
+      "Never evict or mass delete selections that have been explicitly tagged (pinned, custom keyword).");
+  preserveTaggedSelections.setDefaultValue(true);
 
   eraseOnStartup.setTitle(tr("Erase on startup"));
   eraseOnStartup.setDescription(tr("Erase clipboard history every time the vicinae server is started"));
@@ -90,16 +121,14 @@ std::vector<Preference> ClipboardExtension::preferences() const {
   monitoring.setDefaultValue(true);
 
 #ifdef Q_OS_MACOS
-  return {monitoring, eraseOnStartup};
+  return {monitoring, preserveTaggedSelections, evictionThreshold, eraseOnStartup};
 #else
   auto ignorePasswords = Preference::makeCheckbox("ignorePasswords");
   ignorePasswords.setDefaultValue(true);
   ignorePasswords.setTitle(tr("Ignore Passwords"));
   ignorePasswords.setDescription(
-      tr("Ignore selections that can be identified as a password. This relies on the application providing "
-         "an explicit hint that the selection is a password. While most password managers and private "
-         "browser windows do, some might not implement this properly."));
+      tr("Ignore selections that can be identified as a password. This may not work with all apps."));
 
-  return {monitoring, ignorePasswords, eraseOnStartup};
+  return {monitoring, ignorePasswords, preserveTaggedSelections, evictionThreshold, eraseOnStartup};
 #endif
 }

--- a/src/server/src/extensions/clipboard/history/clipboard-history-controller.cpp
+++ b/src/server/src/extensions/clipboard/history/clipboard-history-controller.cpp
@@ -6,6 +6,8 @@ ClipboardHistoryController::ClipboardHistoryController(ClipboardService *clipboa
   connect(&m_watcher, &QueryWatcher::finished, this, &ClipboardHistoryController::handleResults);
   connect(clipboard, &ClipboardService::selectionPinStatusChanged, this,
           &ClipboardHistoryController::handleClipboardChanged);
+  connect(clipboard, &ClipboardService::selectionKeywordsChanged, this,
+          &ClipboardHistoryController::handleClipboardChanged);
   connect(clipboard, &ClipboardService::selectionRemoved, this,
           &ClipboardHistoryController::handleClipboardChanged);
   connect(clipboard, &ClipboardService::allSelectionsRemoved, this,

--- a/src/server/src/qml/clipboard-history-model.hpp
+++ b/src/server/src/qml/clipboard-history-model.hpp
@@ -6,7 +6,7 @@
 
 class ClipboardHistorySection : public SectionSource {
 public:
-  enum ExtraRole { IsPinned = 100 };
+  enum ExtraRole { IsPinned = 100, IsTagged };
   enum class DefaultAction { Copy, Paste };
 
   void setEntries(const PaginatedResponse<ClipboardHistoryEntry> &page);
@@ -29,10 +29,13 @@ public:
 
   QVariant customData(int i, int role) const override {
     if (role == IsPinned) return m_entries[i].pinnedAt != 0;
+    if (role == IsTagged) return !m_entries[i].keywords.isEmpty();
     return {};
   }
 
-  QHash<int, QByteArray> customRoleNames() const override { return {{IsPinned, "isPinned"}}; }
+  QHash<int, QByteArray> customRoleNames() const override {
+    return {{IsPinned, "isPinned"}, {IsTagged, "isTagged"}};
+  }
 
 protected:
   QString itemId(int i) const override;

--- a/src/server/src/qml/clipboard-history-view-host.cpp
+++ b/src/server/src/qml/clipboard-history-view-host.cpp
@@ -72,6 +72,10 @@ ClipboardHistoryViewHost::ClipboardHistoryViewHost() : ViewHostBase() {
   m_kindFilterModel.setStringOptions({tr("All"), tr("Text"), tr("Images"), tr("Links"), tr("Files")});
 }
 
+ClipboardHistoryViewHost::~ClipboardHistoryViewHost() {
+  if (m_clipman) m_clipman->resumeEviction();
+}
+
 QUrl ClipboardHistoryViewHost::qmlComponentUrl() const {
   return QUrl(QStringLiteral("qrc:/Vicinae/ClipboardHistoryView.qml"));
 }
@@ -88,6 +92,7 @@ void ClipboardHistoryViewHost::initialize() {
   BaseView::initialize();
 
   m_clipman = context()->services->clipman();
+  m_clipman->pauseEviction();
   m_model.setScope(ViewScope(context(), this));
 
   m_section.setOnEntrySelected([this](const ClipboardHistoryEntry &e) { loadDetail(e); });

--- a/src/server/src/qml/clipboard-history-view-host.hpp
+++ b/src/server/src/qml/clipboard-history-view-host.hpp
@@ -33,6 +33,7 @@ class ClipboardHistoryViewHost : public ViewHostBase {
 
 public:
   explicit ClipboardHistoryViewHost();
+  ~ClipboardHistoryViewHost() override;
 
   QUrl qmlComponentUrl() const override;
   QUrl qmlSearchAccessoryUrl() const override;

--- a/src/server/src/qml/qml/ClipboardHistoryView.qml
+++ b/src/server/src/qml/qml/ClipboardHistoryView.qml
@@ -102,6 +102,7 @@ Item {
                 required property string iconSource
                 required property var itemAccessory
                 required property bool isPinned
+                required property bool isTagged
                 required property bool isDraggable
 
                 sourceComponent: isSection ? sectionComponent : itemComponent
@@ -162,6 +163,14 @@ Item {
                                     ViciImage {
                                         visible: delegateLoader.isPinned
                                         source: Img.builtin("pin").withFillColor(Theme.danger)
+                                        sourceSize.width: 14
+                                        sourceSize.height: 14
+                                        Layout.preferredWidth: 14
+                                        Layout.preferredHeight: 14
+                                    }
+                                    ViciImage {
+                                        visible: delegateLoader.isTagged && !delegateLoader.isPinned
+                                        source: Img.builtin("tag").withFillColor(Theme.accent)
                                         sourceSize.width: 14
                                         sourceSize.height: 14
                                         Layout.preferredWidth: 14

--- a/src/server/src/services/clipboard/clipboard-db.cpp
+++ b/src/server/src/services/clipboard/clipboard-db.cpp
@@ -379,6 +379,18 @@ std::vector<QString> ClipboardDatabase::evictOlderThan(std::chrono::seconds secs
   return evicted;
 }
 
+std::optional<int64_t> ClipboardDatabase::oldestEvictableTimestamp(bool preserveTagged) {
+  std::string query = "SELECT MIN(updated_at) FROM selection";
+
+  if (preserveTagged) { query += " WHERE pinned_at IS NULL AND keywords == ''"; }
+
+  auto stmt = m_db.prepare(query);
+
+  if (!stmt.step() || stmt.isNull(0)) return std::nullopt;
+
+  return stmt.columnInt64(0);
+}
+
 bool ClipboardDatabase::insertOffer(const InsertClipboardOfferPayload &payload) {
   auto stmt = m_db.prepare(R"(
     INSERT INTO data_offer (id, selection_id, mime_type, text_preview, content_hash_md5, encryption_type, size, kind, url_host)

--- a/src/server/src/services/clipboard/clipboard-db.cpp
+++ b/src/server/src/services/clipboard/clipboard-db.cpp
@@ -90,9 +90,10 @@ PaginatedResponse<ClipboardHistoryEntry> ClipboardDatabase::query(int limit, int
         s.kind,
         o.url_host,
         o.encryption_type,
-        s.total_count
+        s.total_count,
+        s.keywords
       FROM (
-        SELECT id, pinned_at, updated_at, kind, preferred_mime_type,
+        SELECT id, pinned_at, updated_at, kind, preferred_mime_type, keywords,
                COUNT(*) OVER() as total_count
         FROM selection
         ORDER BY pinned_at DESC, updated_at DESC
@@ -117,7 +118,8 @@ PaginatedResponse<ClipboardHistoryEntry> ClipboardDatabase::query(int limit, int
         selection.kind,
         o.url_host,
         o.encryption_type,
-        COUNT(*) OVER() as count
+        COUNT(*) OVER() as count,
+        selection.keywords
       FROM selection
       JOIN data_offer o
         ON o.selection_id = selection.id
@@ -154,6 +156,7 @@ PaginatedResponse<ClipboardHistoryEntry> ClipboardDatabase::query(int limit, int
                               .mimeType = stmt.columnQString(1),
                               .textPreview = stmt.columnQString(2),
                               .pinnedAt = stmt.columnUInt64(3),
+                              .keywords = stmt.columnQString(11),
                               .md5sum = stmt.columnQString(4),
                               .updatedAt = stmt.columnUInt64(5),
                               .size = stmt.columnUInt64(6),
@@ -200,9 +203,38 @@ bool ClipboardDatabase::setKeywords(const QString &id, const QString &keywords) 
   });
 }
 
-bool ClipboardDatabase::removeAll() {
-  return m_db.exec("DELETE FROM selection_fts") && m_db.exec("DELETE FROM data_offer") &&
-         m_db.exec("DELETE FROM selection");
+std::optional<std::vector<QString>> ClipboardDatabase::removeAll(bool preserveTagged) {
+  auto tx = m_db.transaction();
+
+  if (!preserveTagged) {
+    const bool ok = m_db.exec("DELETE FROM selection_fts") && m_db.exec("DELETE FROM data_offer") &&
+                    m_db.exec("DELETE FROM selection");
+
+    if (!ok) return std::nullopt;
+
+    tx.commit();
+
+    return std::vector<QString>{};
+  }
+
+  std::vector<QString> removed;
+
+  auto stmt = m_db.prepare(R"(
+    SELECT o.id
+    FROM data_offer o
+    JOIN selection s ON s.id = o.selection_id
+    WHERE s.pinned_at IS NULL AND s.keywords == ''
+  )");
+
+  while (stmt.step()) {
+    removed.emplace_back(stmt.columnQString(0));
+  }
+
+  if (!m_db.exec("DELETE FROM selection WHERE pinned_at IS NULL AND keywords == ''")) return std::nullopt;
+
+  tx.commit();
+
+  return removed;
 }
 
 std::vector<QString> ClipboardDatabase::removeSelection(const QString &selectionId) {
@@ -337,6 +369,8 @@ std::vector<QString> ClipboardDatabase::evictOlderThan(std::chrono::seconds secs
 
   evicted.reserve(0xF);
 
+  auto tx = m_db.transaction();
+
   {
     std::ostringstream oss{};
     oss << R"(
@@ -375,6 +409,8 @@ std::vector<QString> ClipboardDatabase::evictOlderThan(std::chrono::seconds secs
       return {};
     }
   }
+
+  tx.commit();
 
   return evicted;
 }

--- a/src/server/src/services/clipboard/clipboard-db.cpp
+++ b/src/server/src/services/clipboard/clipboard-db.cpp
@@ -1,7 +1,10 @@
 #include "clipboard-db.hpp"
 #include "utils/migration-manager/migration-manager.hpp"
 #include "vicinae.hpp"
+#include <chrono>
+#include <filesystem>
 #include <qlogging.h>
+#include <sstream>
 
 extern "C" int vicinaeFuzzyTrigramInit(sqlite3 *, char **, const void *);
 
@@ -326,6 +329,54 @@ void ClipboardDatabase::runMigrations() {
   MigrationManager manager(m_db, "clipboard");
 
   manager.runMigrations();
+}
+
+std::vector<QString> ClipboardDatabase::evictOlderThan(std::chrono::seconds secs, bool preserveTagged) {
+  constexpr auto PRESERVE_TAGGED_WHERE = " AND pinned_at IS NULL AND keywords == ''";
+  std::vector<QString> evicted{};
+
+  evicted.reserve(0xF);
+
+  {
+    std::ostringstream oss{};
+    oss << R"(
+  	SELECT o.id 
+	FROM data_offer o
+	JOIN selection s ON s.id = o.selection_id
+	WHERE unixepoch() - s.updated_at > :threshold
+  )";
+
+    if (preserveTagged) { oss << PRESERVE_TAGGED_WHERE; }
+
+    auto stmt = m_db.prepare(oss.str());
+
+    stmt.bind(":threshold", secs.count());
+
+    while (stmt.step()) {
+      evicted.emplace_back(stmt.columnQString(0));
+    }
+  }
+
+  if (evicted.empty()) return evicted;
+
+  {
+    std::ostringstream oss{};
+
+    oss << "DELETE FROM selection WHERE unixepoch() - updated_at > :threshold";
+
+    if (preserveTagged) { oss << PRESERVE_TAGGED_WHERE; }
+
+    auto stmt = m_db.prepare(oss.str());
+
+    stmt.bind(":threshold", secs.count());
+
+    if (!stmt.exec()) {
+      qCritical() << "Failed to evict older selections" << stmt.lastError().c_str();
+      return {};
+    }
+  }
+
+  return evicted;
 }
 
 bool ClipboardDatabase::insertOffer(const InsertClipboardOfferPayload &payload) {

--- a/src/server/src/services/clipboard/clipboard-db.hpp
+++ b/src/server/src/services/clipboard/clipboard-db.hpp
@@ -2,7 +2,6 @@
 #include <cstdint>
 #include <QString>
 #include <QStringList>
-#include <numbers>
 #include <optional>
 #include <functional>
 #include <vector>
@@ -113,7 +112,9 @@ public:
   std::optional<PreferredClipboardOfferRecord> findPreferredOffer(const QString &selectionId);
 
   // return the IDs of the offers that were removed, so that the clipboard service can remove them from disk
-  std::vector<QString> evictOlderThan(std::chrono::seconds secs, bool preservedTagged = true);
+  std::vector<QString> evictOlderThan(std::chrono::seconds secs, bool preserveTagged = true);
+
+  std::optional<int64_t> oldestEvictableTimestamp(bool preserveTagged = true);
 
   void runMigrations();
 

--- a/src/server/src/services/clipboard/clipboard-db.hpp
+++ b/src/server/src/services/clipboard/clipboard-db.hpp
@@ -59,6 +59,7 @@ struct ClipboardHistoryEntry {
   QString mimeType;
   QString textPreview;
   uint64_t pinnedAt;
+  QString keywords;
   QString md5sum;
   uint64_t updatedAt;
   uint64_t size;
@@ -97,7 +98,7 @@ public:
 
   static QStringList searchTerms(const QString &query);
 
-  bool removeAll();
+  std::optional<std::vector<QString>> removeAll(bool preserveTagged = false);
 
   bool setKeywords(const QString &id, const QString &keywords);
   std::optional<QString> retrieveKeywords(const QString &id);

--- a/src/server/src/services/clipboard/clipboard-db.hpp
+++ b/src/server/src/services/clipboard/clipboard-db.hpp
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include <QString>
 #include <QStringList>
+#include <numbers>
 #include <optional>
 #include <functional>
 #include <vector>
@@ -108,7 +109,11 @@ public:
   bool insertOffer(const InsertClipboardOfferPayload &payload);
   bool indexSelectionContent(const QString &selectionId, const QString &content);
   std::vector<QString> removeSelection(const QString &selectionId);
+
   std::optional<PreferredClipboardOfferRecord> findPreferredOffer(const QString &selectionId);
+
+  // return the IDs of the offers that were removed, so that the clipboard service can remove them from disk
+  std::vector<QString> evictOlderThan(std::chrono::seconds secs, bool preservedTagged = true);
 
   void runMigrations();
 

--- a/src/server/src/services/clipboard/clipboard-service.cpp
+++ b/src/server/src/services/clipboard/clipboard-service.cpp
@@ -111,40 +111,56 @@ void ClipboardService::setIgnorePasswords(bool value) { m_ignorePasswords = valu
 
 void ClipboardService::setHistoryEvictionThreshold(std::optional<std::chrono::seconds> threshold,
                                                    bool preserveTaggedSelections) {
-  if (threshold == m_evictionThreshold) return;
+  if (threshold == m_evictionThreshold && preserveTaggedSelections == m_preserveTaggedSelections) return;
 
   m_evictionThreshold = threshold;
   m_preserveTaggedSelections = preserveTaggedSelections;
+  constexpr auto MISCONFIGURATION_GRACE_DELAY = std::chrono::seconds(60);
+
   m_historyEvictionTimer.stop();
-  m_historyEvictionTimer.setInterval(60000);
-  m_historyEvictionTimer.start();
-  scheduleEviction();
+
+  if (m_evictionThreshold) m_historyEvictionTimer.start(MISCONFIGURATION_GRACE_DELAY);
 }
 
-void ClipboardService::scheduleEviction() {
-  if (m_evictionThreshold) {
-    qDebug() << "scheduling clipboard eviction...";
+void ClipboardService::armEvictionTimer(std::optional<int64_t> oldestTimestamp) {
+  using namespace std::chrono;
+  using namespace std::chrono_literals;
 
-    // this can be expensive, so we run it in a separate thread
-    QThreadPool::globalInstance()->start(
-        [this, t = *m_evictionThreshold, preserve = m_preserveTaggedSelections]() {
-          const auto evictedIds = openDatabase().evictOlderThan(t, preserve);
-          std::error_code ec{};
-          std::size_t evictedCount = 0;
+  constexpr auto maxDelay = duration_cast<seconds>(6h);
 
-          for (const auto &evicted : evictedIds) {
-            fs::path path = m_dataDir / evicted.toStdString();
-            if (fs::remove(path, ec)) {
-              qDebug() << "removed" << path << "from disk";
-              ++evictedCount;
-            } else {
-              qWarning() << "failed to remove clipboard offer at" << path;
-            }
+  if (!m_evictionThreshold || !oldestTimestamp) return;
+
+  const auto now = duration_cast<seconds>(system_clock::now().time_since_epoch());
+  const auto delay = std::clamp(seconds(*oldestTimestamp) + *m_evictionThreshold - now + 1s, 1s, maxDelay);
+
+  m_historyEvictionTimer.start(duration_cast<milliseconds>(delay));
+}
+
+void ClipboardService::runEvictionPass() {
+  if (!m_evictionThreshold) return;
+
+  // this can be expensive, so we run it in a separate thread
+  QThreadPool::globalInstance()->start(
+      [this, t = *m_evictionThreshold, preserve = m_preserveTaggedSelections]() {
+        auto db = openDatabase();
+        const auto evictedIds = db.evictOlderThan(t, preserve);
+        const auto oldest = db.oldestEvictableTimestamp(preserve);
+        std::error_code ec{};
+        std::size_t evictedCount = 0;
+
+        for (const auto &evicted : evictedIds) {
+          fs::path path = m_dataDir / evicted.toStdString();
+          if (fs::remove(path, ec)) {
+            ++evictedCount;
+          } else {
+            qWarning() << "failed to remove clipboard offer at" << path;
           }
+        }
 
-          qInfo() << "evicted" << evictedCount << "clipboard offers";
-        });
-  }
+        if (evictedCount > 0) qInfo() << "evicted" << evictedCount << "clipboard offers";
+
+        QMetaObject::invokeMethod(this, [this, oldest]() { armEvictionTimer(oldest); });
+      });
 }
 
 void ClipboardService::setMonitoring(bool value) {
@@ -732,9 +748,17 @@ ClipboardService::ClipboardService(const std::filesystem::path &path, std::optio
 
   connect(m_clipboardServer.get(), &AbstractClipboardServer::selectionAdded, this,
           &ClipboardService::saveSelection);
-  connect(&m_historyEvictionTimer, &QTimer::timeout, this, &ClipboardService::scheduleEviction);
+  m_historyEvictionTimer.setSingleShot(true);
+  m_historyEvictionTimer.setTimerType(Qt::VeryCoarseTimer);
+  connect(&m_historyEvictionTimer, &QTimer::timeout, this, &ClipboardService::runEvictionPass);
   connect(&m_indexingSelection, &decltype(m_indexingSelection)::finished, this, [this]() {
     if (m_indexingSelection.isCanceled()) return;
     if (auto result = m_indexingSelection.result()) { emit itemInserted(*result); }
+
+    if (m_evictionThreshold && !m_historyEvictionTimer.isActive()) {
+      const auto now = std::chrono::duration_cast<std::chrono::seconds>(
+          std::chrono::system_clock::now().time_since_epoch());
+      armEvictionTimer(now.count());
+    }
   });
 }

--- a/src/server/src/services/clipboard/clipboard-service.cpp
+++ b/src/server/src/services/clipboard/clipboard-service.cpp
@@ -136,8 +136,20 @@ void ClipboardService::armEvictionTimer(std::optional<int64_t> oldestTimestamp) 
   m_historyEvictionTimer.start(duration_cast<milliseconds>(delay));
 }
 
+void ClipboardService::pauseEviction() { m_evictionPaused = true; }
+
+void ClipboardService::resumeEviction() {
+  m_evictionPaused = false;
+  if (std::exchange(m_evictionDeferred, false)) runEvictionPass();
+}
+
 void ClipboardService::runEvictionPass() {
   if (!m_evictionThreshold) return;
+
+  if (m_evictionPaused) {
+    m_evictionDeferred = true;
+    return;
+  }
 
   // this can be expensive, so we run it in a separate thread
   QThreadPool::globalInstance()->start(
@@ -406,7 +418,11 @@ std::optional<QString> ClipboardService::retrieveKeywords(const QString &id) {
 }
 
 bool ClipboardService::setKeywords(const QString &id, const QString &keywords) {
-  return openDatabase().setKeywords(id, keywords);
+  if (!openDatabase().setKeywords(id, keywords)) return false;
+
+  emit selectionKeywordsChanged(id, keywords);
+
+  return true;
 }
 
 ClipboardSelection &ClipboardService::sanitizeSelection(ClipboardSelection &selection) {
@@ -704,14 +720,23 @@ Clipboard::ReadContent ClipboardService::readContent() {
 
 bool ClipboardService::removeAllSelections() {
   auto db = openDatabase();
+  const auto removedIds = db.removeAll(m_preserveTaggedSelections);
 
-  if (!db.removeAll()) {
+  if (!removedIds) {
     qWarning() << "Failed to remove all clipboard selections";
     return false;
   }
 
-  fs::remove_all(m_dataDir);
-  fs::create_directories(m_dataDir);
+  if (m_preserveTaggedSelections) {
+    std::error_code ec{};
+
+    for (const auto &id : *removedIds) {
+      fs::remove(m_dataDir / id.toStdString(), ec);
+    }
+  } else {
+    fs::remove_all(m_dataDir);
+    fs::create_directories(m_dataDir);
+  }
 
   emit allSelectionsRemoved();
 

--- a/src/server/src/services/clipboard/clipboard-service.cpp
+++ b/src/server/src/services/clipboard/clipboard-service.cpp
@@ -1,12 +1,14 @@
 #include <QClipboard>
 #include "clipboard-service.hpp"
 #include <algorithm>
+#include <cstddef>
 #include <filesystem>
 #include <numeric>
 #include <QGuiApplication>
 #include <qfuturewatcher.h>
 #include <qstandardpaths.h>
 #include <qtconcurrentrun.h>
+#include <qthreadpool.h>
 #include "common/clipboard-formats.hpp"
 #include "common/types.hpp"
 #ifdef Q_OS_LINUX
@@ -106,6 +108,44 @@ void ClipboardService::setEncryptionKey(std::optional<db::EncryptionKey> key) {
 bool ClipboardService::isEncryptionReady() const { return m_encrypter.get(); }
 
 void ClipboardService::setIgnorePasswords(bool value) { m_ignorePasswords = value; }
+
+void ClipboardService::setHistoryEvictionThreshold(std::optional<std::chrono::seconds> threshold,
+                                                   bool preserveTaggedSelections) {
+  if (threshold == m_evictionThreshold) return;
+
+  m_evictionThreshold = threshold;
+  m_preserveTaggedSelections = preserveTaggedSelections;
+  m_historyEvictionTimer.stop();
+  m_historyEvictionTimer.setInterval(60000);
+  m_historyEvictionTimer.start();
+  scheduleEviction();
+}
+
+void ClipboardService::scheduleEviction() {
+  if (m_evictionThreshold) {
+    qDebug() << "scheduling clipboard eviction...";
+
+    // this can be expensive, so we run it in a separate thread
+    QThreadPool::globalInstance()->start(
+        [this, t = *m_evictionThreshold, preserve = m_preserveTaggedSelections]() {
+          const auto evictedIds = openDatabase().evictOlderThan(t, preserve);
+          std::error_code ec{};
+          std::size_t evictedCount = 0;
+
+          for (const auto &evicted : evictedIds) {
+            fs::path path = m_dataDir / evicted.toStdString();
+            if (fs::remove(path, ec)) {
+              qDebug() << "removed" << path << "from disk";
+              ++evictedCount;
+            } else {
+              qWarning() << "failed to remove clipboard offer at" << path;
+            }
+          }
+
+          qInfo() << "evicted" << evictedCount << "clipboard offers";
+        });
+  }
+}
 
 void ClipboardService::setMonitoring(bool value) {
   if (m_monitoring == value) return;
@@ -692,6 +732,7 @@ ClipboardService::ClipboardService(const std::filesystem::path &path, std::optio
 
   connect(m_clipboardServer.get(), &AbstractClipboardServer::selectionAdded, this,
           &ClipboardService::saveSelection);
+  connect(&m_historyEvictionTimer, &QTimer::timeout, this, &ClipboardService::scheduleEviction);
   connect(&m_indexingSelection, &decltype(m_indexingSelection)::finished, this, [this]() {
     if (m_indexingSelection.isCanceled()) return;
     if (auto result = m_indexingSelection.result()) { emit itemInserted(*result); }

--- a/src/server/src/services/clipboard/clipboard-service.hpp
+++ b/src/server/src/services/clipboard/clipboard-service.hpp
@@ -6,6 +6,7 @@
 #include "services/clipboard/clipboard-encrypter.hpp"
 #include "services/clipboard/clipboard-server.hpp"
 #include <QString>
+#include <chrono>
 #include <expected>
 #include <filesystem>
 #include <QJsonObject>
@@ -92,6 +93,12 @@ public:
   void setIgnorePasswords(bool value);
   bool isEncryptionReady() const;
 
+  /**
+   * std::nullopt to disable eviction
+   */
+  void setHistoryEvictionThreshold(std::optional<std::chrono::seconds> threshold,
+                                   bool preserveTaggedSelections = true);
+
 private:
   ClipboardDatabase openDatabase() const { return ClipboardDatabase(m_dbKey); }
 
@@ -124,6 +131,8 @@ private:
 
   static ClipboardOfferKind getKind(const ClipboardDataOffer &offer);
 
+  void scheduleEviction();
+
   void restoreClipboard();
 
   bool m_recordAllOffers = true;
@@ -132,4 +141,7 @@ private:
   std::optional<ClipboardSelection> m_lastSelection;
   QTimer m_restoreTimer;
   QFutureWatcher<std::expected<ClipboardHistoryEntry, QString>> m_indexingSelection;
+  std::optional<std::chrono::seconds> m_evictionThreshold;
+  bool m_preserveTaggedSelections = true;
+  QTimer m_historyEvictionTimer;
 };

--- a/src/server/src/services/clipboard/clipboard-service.hpp
+++ b/src/server/src/services/clipboard/clipboard-service.hpp
@@ -131,7 +131,8 @@ private:
 
   static ClipboardOfferKind getKind(const ClipboardDataOffer &offer);
 
-  void scheduleEviction();
+  void runEvictionPass();
+  void armEvictionTimer(std::optional<int64_t> oldestTimestamp);
 
   void restoreClipboard();
 

--- a/src/server/src/services/clipboard/clipboard-service.hpp
+++ b/src/server/src/services/clipboard/clipboard-service.hpp
@@ -30,6 +30,7 @@ signals:
   void itemCopied(const InsertClipboardHistoryLine &item) const;
   void itemInserted(const ClipboardHistoryEntry &entry) const;
   void selectionPinStatusChanged(const QString &id, bool pinned) const;
+  void selectionKeywordsChanged(const QString &id, const QString &keywords) const;
   void selectionRemoved(const QString &id) const;
   /**
    * When a selection is copied, its update time is modified which makes it appear on top
@@ -99,6 +100,9 @@ public:
   void setHistoryEvictionThreshold(std::optional<std::chrono::seconds> threshold,
                                    bool preserveTaggedSelections = true);
 
+  void pauseEviction();
+  void resumeEviction();
+
 private:
   ClipboardDatabase openDatabase() const { return ClipboardDatabase(m_dbKey); }
 
@@ -144,5 +148,7 @@ private:
   QFutureWatcher<std::expected<ClipboardHistoryEntry, QString>> m_indexingSelection;
   std::optional<std::chrono::seconds> m_evictionThreshold;
   bool m_preserveTaggedSelections = true;
+  bool m_evictionPaused = false;
+  bool m_evictionDeferred = false;
   QTimer m_historyEvictionTimer;
 };


### PR DESCRIPTION
Allow users to define a clipboard eviction threshold so that entries older than the given threshold get automatically removed from history.

The default threshold is `never`, to remain compatible with the current state.

We also add a toggle (on by default) to exclude tagged selections from eviction.

fixes #1315 

 
<img width="1098" height="1014" alt="image" src="https://github.com/user-attachments/assets/f73d6ccf-b802-4bb2-ba25-cfe3f4d8fa41" />
