### PR TITLE
fix: copy extension directories atomically

### DIFF
--- a/src/server/src/services/extension-registry/extension-registry.cpp
+++ b/src/server/src/services/extension-registry/extension-registry.cpp
@@ -35,8 +35,10 @@ ExtensionRegistry::ExtensionRegistry(LocalStorageService &storage) : m_storage(s
 
 QFuture<bool> ExtensionRegistry::installFromZip(const QString &id, const std::string &data,
                                                 const std::function<void(bool)> &cb) {
-  fs::path const extractDir = localExtensionDirectory() / id.toStdString();
-  auto future = QtConcurrent::run([id, data, extractDir]() {
+  fs::path const extensionsDir = localExtensionDirectory();
+  fs::path const extractDir = extensionsDir / id.toStdString();
+  fs::path const stagingDir = extensionsDir / (".staging-" + id.toStdString());
+  auto future = QtConcurrent::run([id, data, extractDir, stagingDir]() {
     Unzipper unzip = std::string_view(data);
 
     if (!unzip) {
@@ -44,7 +46,26 @@ QFuture<bool> ExtensionRegistry::installFromZip(const QString &id, const std::st
       return false;
     }
 
-    unzip.extract(extractDir, {.stripComponents = 1});
+    std::error_code ec;
+
+    fs::remove_all(stagingDir, ec);
+    unzip.extract(stagingDir, {.stripComponents = 1});
+
+    if (!fs::is_regular_file(stagingDir / "package.json", ec)) {
+      qCritical() << "Extracted bundle for" << id << "has no package.json, discarding";
+      fs::remove_all(stagingDir, ec);
+      return false;
+    }
+
+    fs::remove_all(extractDir, ec);
+    fs::rename(stagingDir, extractDir, ec);
+
+    if (ec) {
+      qCritical() << "Failed to move extension bundle into" << extractDir.c_str() << ec.message();
+      fs::remove_all(stagingDir, ec);
+      return false;
+    }
+
     return true;
   });
 

--- a/src/typescript/api/src/commands/build/index.ts
+++ b/src/typescript/api/src/commands/build/index.ts
@@ -1,6 +1,14 @@
 import * as esbuild from "esbuild";
-import { cpSync, existsSync, mkdirSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import {
+	cpSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
 import type { CommandDef } from "../../cli.js";
 import ManifestSchema from "../../schemas/manifest.js";
 import { updateExtensionTypes } from "../../utils/extension-types.js";
@@ -125,8 +133,23 @@ const build: CommandDef = {
 			process.exit(1);
 		}
 
-		mkdirSync(outDir, { recursive: true });
-		await doBuild(outDir);
+		mkdirSync(dirname(outDir), { recursive: true });
+		const stagingDir = mkdtempSync(join(dirname(outDir), ".build-"));
+
+		try {
+			await doBuild(stagingDir);
+			rmSync(outDir, {
+				recursive: true,
+				force: true,
+				maxRetries: 5,
+				retryDelay: 100,
+			});
+			renameSync(stagingDir, outDir);
+		} catch (error) {
+			rmSync(stagingDir, { recursive: true, force: true });
+			throw error;
+		}
+
 		logger.logReady(`built extension successfully - output at ${outDir}`);
 	},
 };


### PR DESCRIPTION
Make it so that extensions are built/extracted in a temporary staging directory and then moved to their definitive, scannable location. That way, we don't send a burst of file watcher events and we make sure the full extension is scanned.