### PR TITLE
fix: report accurate text selection on wayland

### DIFF
--- a/src/data-control-server/src/ext/clipman.cpp
+++ b/src/data-control-server/src/ext/clipman.cpp
@@ -24,11 +24,14 @@ void ExtClipman::global(WaylandRegistry &reg, uint32_t name, const char *interfa
   }
 }
 
-void ExtClipman::primarySelection(ExtDataDevice &, ExtDataOffer &offer) {
+void ExtClipman::primarySelection(ExtDataDevice &, ExtDataOffer *offer) {
   if (isatty(STDOUT_FILENO)) {
-    Selection::printPrimarySelectionDebug(offer);
+    if (offer) Selection::printPrimarySelectionDebug(*offer);
     return;
   }
+
+  m_writer(clipboard_proto::Command::PrimarySelectionNotification,
+           offer ? Selection::buildPrimarySelection(*offer) : clipboard_proto::Selection{});
 }
 
 void ExtClipman::selection(ExtDataDevice &, ExtDataOffer &offer) {
@@ -41,7 +44,7 @@ void ExtClipman::selection(ExtDataDevice &, ExtDataOffer &offer) {
   if (std::ranges::find(mimes, Clipboard::CONCEALED_MIME_TYPE) != mimes.end()) return;
 
   auto selection = Selection::buildSelection(Selection::filterMimes(mimes), offer);
-  m_writer(selection);
+  m_writer(clipboard_proto::Command::SelectionNotification, selection);
 }
 
 void ExtClipman::setClipboard(const clipboard_proto::Selection &selection) {

--- a/src/data-control-server/src/ext/clipman.hpp
+++ b/src/data-control-server/src/ext/clipman.hpp
@@ -11,7 +11,7 @@
 #include "wayland/display.hpp"
 #include "common/clipboard-protocol.hpp"
 
-using SelectionWriter = void (*)(const clipboard_proto::Selection &);
+using SelectionWriter = void (*)(clipboard_proto::Command, const clipboard_proto::Selection &);
 
 class ExtClipman : public WaylandDisplay, public WaylandRegistry::Listener, public ExtDataDevice::Listener {
 
@@ -31,5 +31,5 @@ private:
 
   void global(WaylandRegistry &reg, uint32_t name, const char *interface, uint32_t version) override;
   void selection(ExtDataDevice &device, ExtDataOffer &offer) override;
-  void primarySelection(ExtDataDevice &device, ExtDataOffer &offer) override;
+  void primarySelection(ExtDataDevice &device, ExtDataOffer *offer) override;
 };

--- a/src/data-control-server/src/ext/data-device.cpp
+++ b/src/data-control-server/src/ext/data-device.cpp
@@ -37,13 +37,12 @@ void ExtDataDevice::finished(void *data, ext_data_control_device_v1 *) {
   }
 }
 
-void ExtDataDevice::primarySelection(void *data, ext_data_control_device_v1 *, ext_data_control_offer_v1 *) {
+void ExtDataDevice::primarySelection(void *data, ext_data_control_device_v1 *, ext_data_control_offer_v1 *id) {
   auto self = static_cast<ExtDataDevice *>(data);
-
-  if (!self->m_offer) return;
+  ExtDataOffer *offer = (id && self->m_offer && self->m_offer->pointer() == id) ? self->m_offer.get() : nullptr;
 
   for (auto lstn : self->_listeners) {
-    lstn->primarySelection(*self, *self->m_offer);
+    lstn->primarySelection(*self, offer);
   }
 }
 // NOLINTEND(cppcoreguidelines-pro-type-static-cast-downcast)

--- a/src/data-control-server/src/ext/data-device.cpp
+++ b/src/data-control-server/src/ext/data-device.cpp
@@ -37,9 +37,11 @@ void ExtDataDevice::finished(void *data, ext_data_control_device_v1 *) {
   }
 }
 
-void ExtDataDevice::primarySelection(void *data, ext_data_control_device_v1 *, ext_data_control_offer_v1 *id) {
+void ExtDataDevice::primarySelection(void *data, ext_data_control_device_v1 *,
+                                     ext_data_control_offer_v1 *id) {
   auto self = static_cast<ExtDataDevice *>(data);
-  ExtDataOffer *offer = (id && self->m_offer && self->m_offer->pointer() == id) ? self->m_offer.get() : nullptr;
+  ExtDataOffer *offer =
+      (id && self->m_offer && self->m_offer->pointer() == id) ? self->m_offer.get() : nullptr;
 
   for (auto lstn : self->_listeners) {
     lstn->primarySelection(*self, offer);

--- a/src/data-control-server/src/ext/data-device.hpp
+++ b/src/data-control-server/src/ext/data-device.hpp
@@ -10,7 +10,7 @@ public:
     virtual void dataOffer(ExtDataDevice &, ExtDataOffer &) {}
     virtual void selection(ExtDataDevice &, ExtDataOffer &) {}
     virtual void finished(ExtDataDevice &) {}
-    virtual void primarySelection(ExtDataDevice &, ExtDataOffer &) {}
+    virtual void primarySelection(ExtDataDevice &, ExtDataOffer *) {}
   };
 
   void registerListener(Listener *listener) { _listeners.push_back(listener); }

--- a/src/data-control-server/src/main.cpp
+++ b/src/data-control-server/src/main.cpp
@@ -7,14 +7,14 @@
 #include "ext/clipman.hpp"
 #include "common/clipboard-protocol.hpp"
 
-static void writeSelection(const clipboard_proto::Selection &selection) {
+static void writeSelection(clipboard_proto::Command command, const clipboard_proto::Selection &selection) {
   std::string buf;
   if (auto err = glz::write_beve(selection, buf)) {
     std::cerr << "Failed to serialize clipboard selection" << std::endl;
     return;
   }
 
-  uint8_t tag = static_cast<uint8_t>(clipboard_proto::Command::SelectionNotification);
+  uint8_t tag = static_cast<uint8_t>(command);
   uint32_t size = htonl(static_cast<uint32_t>(buf.size() + 1));
   std::cout.write(reinterpret_cast<const char *>(&size), sizeof(size));
   std::cout.write(reinterpret_cast<const char *>(&tag), 1);

--- a/src/data-control-server/src/selection.cpp
+++ b/src/data-control-server/src/selection.cpp
@@ -1,4 +1,5 @@
 #include "selection.hpp"
+#include <algorithm>
 
 namespace Selection {
 
@@ -67,6 +68,25 @@ void printPrimarySelectionDebug(OfferReceiver &offer) {
     std::cout << std::left << std::setw(30) << mime << data << std::endl;
   }
   std::cout << "********** END PRIMARY SELECTION **********" << std::endl;
+}
+
+clipboard_proto::Selection buildPrimarySelection(OfferReceiver &offer) {
+  constexpr size_t maxSize = 1 << 20;
+  const auto &mimes = offer.mimes();
+  clipboard_proto::Selection selection;
+
+  if (std::ranges::find(mimes, Clipboard::CONCEALED_MIME_TYPE) != mimes.end()) return selection;
+
+  for (std::string_view mime : {"text/plain;charset=utf-8", "text/plain"}) {
+    if (std::ranges::find(mimes, mime) == mimes.end()) continue;
+    auto raw = offer.receive(std::string(mime));
+    if (raw.size() > maxSize) return selection;
+    selection.offers.emplace_back(
+        clipboard_proto::Offer{.mime_type = std::string(mime), .data = {raw.begin(), raw.end()}});
+    break;
+  }
+
+  return selection;
 }
 
 }; // namespace Selection

--- a/src/data-control-server/src/selection.hpp
+++ b/src/data-control-server/src/selection.hpp
@@ -26,5 +26,6 @@ std::set<std::string> filterMimes(const std::vector<std::string> &offerMimes);
 clipboard_proto::Selection buildSelection(const std::set<std::string> &filteredMimes, OfferReceiver &offer);
 void printDebug(const std::set<std::string> &filteredMimes, OfferReceiver &offer, const char *label);
 void printPrimarySelectionDebug(OfferReceiver &offer);
+clipboard_proto::Selection buildPrimarySelection(OfferReceiver &offer);
 
 }; // namespace Selection

--- a/src/lib/common/include/common/clipboard-protocol.hpp
+++ b/src/lib/common/include/common/clipboard-protocol.hpp
@@ -8,6 +8,7 @@ namespace clipboard_proto {
 enum class Command : uint8_t {
   SelectionNotification = 0x01,
   SetClipboard = 0x02,
+  PrimarySelectionNotification = 0x03,
 };
 
 struct Offer {

--- a/src/server/src/actions/shortcut/shortcut-actions.hpp
+++ b/src/server/src/actions/shortcut/shortcut-actions.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <QCoreApplication>
 #include <QGuiApplication>
+#include <QEventLoop>
 #include "actions/app/app-actions.hpp"
 #include "builtin_icon.hpp"
 #include "common.hpp"
@@ -19,11 +20,13 @@
 #include <qclipboard.h>
 #include <qlogging.h>
 #include <ranges>
+#include "services/selection/abstract-selection-service.hpp"
 
 namespace {
 QString expandShortcut(const Shortcut &sh, std::span<const QString> args) {
   QString expanded;
   size_t argumentIndex = 0;
+  auto selectionService = ServiceRegistry::instance()->selectionService();
 
   for (const auto &part : sh.parts()) {
     if (auto s = std::get_if<QString>(&part)) {
@@ -31,8 +34,12 @@ QString expandShortcut(const Shortcut &sh, std::span<const QString> args) {
     } else if (auto placeholder = std::get_if<Shortcut::ParsedPlaceholder>(&part)) {
       if (placeholder->id == "clipboard") {
         expanded += QGuiApplication::clipboard()->text();
-      } else if (placeholder->id == "selected") {
-        // TODO: selected text
+      } else if (placeholder->id == "selected" || placeholder->id == "selection") {
+        if (auto selected = selectionService->selectedTextSync()) {
+          expanded += *selected;
+        } else {
+          qWarning() << "Failed to get text selection" << selected.error();
+        }
       } else if (placeholder->id == "uuid") {
         expanded += QUuid::createUuid().toString(QUuid::StringFormat::WithoutBraces);
       } else {

--- a/src/server/src/qml/shortcut-form-view-host.cpp
+++ b/src/server/src/qml/shortcut-form-view-host.cpp
@@ -132,7 +132,7 @@ void ShortcutFormViewHost::buildLinkCompletions() {
       QVariantMap{
           {QStringLiteral("iconSource"), qml::imageSourceFor(ImageURL::builtin(BuiltinIcon::TextCursor))},
           {QStringLiteral("title"), tr("Selected Text")},
-          {QStringLiteral("value"), QStringLiteral("selected")},
+          {QStringLiteral("value"), QStringLiteral("selection")},
       },
       QVariantMap{
           {QStringLiteral("iconSource"), qml::imageSourceFor(ImageURL::builtin(BuiltinIcon::CopyClipboard))},

--- a/src/server/src/server.cpp
+++ b/src/server/src/server.cpp
@@ -274,7 +274,7 @@ int startServer(const ServerLaunchOptions &launchOpts) {
     auto platformPaste =
         std::unique_ptr<AbstractPasteService>(std::make_unique<LinuxPasteService>(*inputServer));
     auto selectionService =
-        std::unique_ptr<AbstractSelectionService>(std::make_unique<LinuxSelectionService>());
+        std::unique_ptr<AbstractSelectionService>(std::make_unique<LinuxSelectionService>(*clipboardManager));
 #elif defined(Q_OS_MACOS)
     auto snippetServer = std::make_unique<MacosSnippetServer>();
     auto platformPaste = std::unique_ptr<AbstractPasteService>(std::make_unique<MacosPasteService>());

--- a/src/server/src/services/clipboard/clipboard-server.hpp
+++ b/src/server/src/services/clipboard/clipboard-server.hpp
@@ -90,6 +90,7 @@ public:
 
 signals:
   void selectionAdded(const ClipboardSelection &selection);
+  void primarySelectionChanged(const QString &text);
 
 protected:
   /**

--- a/src/server/src/services/clipboard/clipboard-service.cpp
+++ b/src/server/src/services/clipboard/clipboard-service.cpp
@@ -773,6 +773,8 @@ ClipboardService::ClipboardService(const std::filesystem::path &path, std::optio
 
   connect(m_clipboardServer.get(), &AbstractClipboardServer::selectionAdded, this,
           &ClipboardService::saveSelection);
+  connect(m_clipboardServer.get(), &AbstractClipboardServer::primarySelectionChanged, this,
+          &ClipboardService::primarySelectionChanged);
   m_historyEvictionTimer.setSingleShot(true);
   m_historyEvictionTimer.setTimerType(Qt::VeryCoarseTimer);
   connect(&m_historyEvictionTimer, &QTimer::timeout, this, &ClipboardService::runEvictionPass);

--- a/src/server/src/services/clipboard/clipboard-service.hpp
+++ b/src/server/src/services/clipboard/clipboard-service.hpp
@@ -38,6 +38,7 @@ signals:
    */
   void selectionUpdated() const;
   void monitoringChanged(bool value) const;
+  void primarySelectionChanged(const QString &text) const;
 
 public:
   enum class OfferDecryptionError {

--- a/src/server/src/services/clipboard/data-control/data-control-clipboard-server.cpp
+++ b/src/server/src/services/clipboard/data-control/data-control-clipboard-server.cpp
@@ -133,6 +133,19 @@ void DataControlClipboardServer::handleRead() {
             emit selectionAdded(cs);
           }
         }
+      } else if (tag == clipboard_proto::Command::PrimarySelectionNotification) {
+        clipboard_proto::Selection selection;
+
+        if (auto err = glz::read_beve(selection, payload)) {
+          qWarning() << "Failed to parse primary selection";
+        } else {
+          QString text;
+          if (!selection.offers.empty()) {
+            const auto &data = selection.offers.front().data;
+            text = QString::fromUtf8(reinterpret_cast<const char *>(data.data()), data.size());
+          }
+          emit primarySelectionChanged(text);
+        }
       } else {
         qWarning() << "Unknown command tag from data-control-server:" << static_cast<int>(tag);
       }

--- a/src/server/src/services/selection/abstract-selection-service.hpp
+++ b/src/server/src/services/selection/abstract-selection-service.hpp
@@ -2,6 +2,7 @@
 #include <QFuture>
 #include <QString>
 #include <expected>
+#include <qeventloop.h>
 
 class AbstractSelectionService {
 public:
@@ -10,4 +11,15 @@ public:
   virtual ~AbstractSelectionService() = default;
 
   virtual QFuture<Result> selectedText() = 0;
+
+  // Spins up a nested event loop to get the selected text synchronously
+  Result selectedTextSync() {
+    QEventLoop loop;
+    auto future = selectedText();
+    future.then(&loop, [&loop](AbstractSelectionService::Result) {
+      QMetaObject::invokeMethod(&loop, &QEventLoop::quit, Qt::QueuedConnection);
+    });
+    loop.exec();
+    return future.result();
+  }
 };

--- a/src/server/src/services/selection/linux-selection-service.cpp
+++ b/src/server/src/services/selection/linux-selection-service.cpp
@@ -1,9 +1,18 @@
 #include "linux-selection-service.hpp"
+#include "services/clipboard/clipboard-service.hpp"
 #include <QClipboard>
 #include <QGuiApplication>
 
+LinuxSelectionService::LinuxSelectionService(ClipboardService &clipboard) {
+  connect(&clipboard, &ClipboardService::primarySelectionChanged, this,
+          [this](const QString &text) { m_primaryText = text; });
+}
+
 QFuture<AbstractSelectionService::Result> LinuxSelectionService::selectedText() {
-  QString text = QGuiApplication::clipboard()->text(QClipboard::Mode::Selection);
+  QString text = m_primaryText;
+
+  // best effort if the compositor doesn't support data control, but that's not accurate.
+  if (text.isEmpty()) text = QGuiApplication::clipboard()->text(QClipboard::Mode::Selection);
 
   if (text.isEmpty()) {
     return QtFuture::makeReadyValueFuture<Result>(

--- a/src/server/src/services/selection/linux-selection-service.hpp
+++ b/src/server/src/services/selection/linux-selection-service.hpp
@@ -1,7 +1,16 @@
 #pragma once
 #include "services/selection/abstract-selection-service.hpp"
+#include <QObject>
 
-class LinuxSelectionService : public AbstractSelectionService {
+class ClipboardService;
+
+class LinuxSelectionService : public QObject, public AbstractSelectionService {
+  Q_OBJECT
+
 public:
+  explicit LinuxSelectionService(ClipboardService &clipboard);
   QFuture<Result> selectedText() override;
+
+private:
+  QString m_primaryText;
 };


### PR DESCRIPTION
QClipboard's `primarySelection` is not an accurate way to get the primary selection on wayland. We need to rely on the data control protocol instead, which most compositors implement.

This makes the text selection API much more reliable, and it allows us to finally implement the `{selection}` shortcut placeholder properly.

Compositors that do not implement it, like Gnome, would need a bespoke solution through the use of the extension. Recommended solution is to not use Gnome.