### PR TITLE
fix: allow SNI tray host to be replaced

### DIFF
--- a/src/server/src/services/tray-host/sni/sni-tray-host.cpp
+++ b/src/server/src/services/tray-host/sni/sni-tray-host.cpp
@@ -115,19 +115,14 @@ TrayMenuItem toMenuItem(const DBusMenuLayout &layout) {
 SniTrayHost::SniTrayHost() : m_watcher(WATCHER_SERVICE, QDBusConnection::sessionBus()) {
   registerSniMetaTypes();
 
-  connect(&m_watcher, &QDBusServiceWatcher::serviceRegistered, this,
-          [this](const QString &) { watcherAppeared(); });
-  connect(&m_watcher, &QDBusServiceWatcher::serviceUnregistered, this, [this](const QString &) {
-    watcherVanished();
-    m_ownWatcher.tryClaim();
-  });
+  connect(&m_watcher, &QDBusServiceWatcher::serviceOwnerChanged, this,
+          [this](const QString &, const QString &, const QString &newOwner) {
+            if (m_available) watcherVanished();
+            if (!newOwner.isEmpty()) watcherAppeared();
+          });
 
   auto *iface = QDBusConnection::sessionBus().interface();
-  if (iface && iface->isServiceRegistered(WATCHER_SERVICE)) {
-    watcherAppeared();
-  } else {
-    m_ownWatcher.tryClaim();
-  }
+  if (iface && iface->isServiceRegistered(WATCHER_SERVICE)) watcherAppeared();
 }
 
 SniTrayHost::~SniTrayHost() {

--- a/src/server/src/services/tray-host/sni/sni-watcher.cpp
+++ b/src/server/src/services/tray-host/sni/sni-watcher.cpp
@@ -1,47 +1,117 @@
 #include "sni-watcher.hpp"
 #include <QDBusConnection>
+#include <QDBusConnectionInterface>
 #include <QDBusMessage>
+#include <QDBusPendingCallWatcher>
+#include <QDBusPendingReply>
+#include <QDebug>
 
 static constexpr const char *WATCHER_SERVICE = "org.kde.StatusNotifierWatcher";
 static constexpr const char *WATCHER_PATH = "/StatusNotifierWatcher";
 
-SniWatcher::SniWatcher(QObject *parent) : QObject(parent) {
+SniWatcher::SniWatcher(QObject *parent)
+    : QObject(parent), m_nameWatcher(WATCHER_SERVICE, QDBusConnection::sessionBus()) {
+  connect(&m_nameWatcher, &QDBusServiceWatcher::serviceOwnerChanged, this, &SniWatcher::onNameOwnerChanged);
+
   m_serviceWatcher.setConnection(QDBusConnection::sessionBus());
   m_serviceWatcher.setWatchMode(QDBusServiceWatcher::WatchForUnregistration);
   connect(&m_serviceWatcher, &QDBusServiceWatcher::serviceUnregistered, this, &SniWatcher::serviceGone);
+
+  m_claimTimer.setSingleShot(true);
+  m_claimTimer.setInterval(CLAIM_DELAY_MS);
+  connect(&m_claimTimer, &QTimer::timeout, this, &SniWatcher::tryClaim);
+
+  m_queuePoll.setInterval(QUEUE_POLL_MS);
+  connect(&m_queuePoll, &QTimer::timeout, this, &SniWatcher::pollQueuedOwners);
+
+  auto *iface = QDBusConnection::sessionBus().interface();
+  if (!iface || !iface->isServiceRegistered(WATCHER_SERVICE)) m_claimTimer.start();
 }
 
 SniWatcher::~SniWatcher() { release(); }
 
-bool SniWatcher::tryClaim() {
-  if (m_owned) return true;
+void SniWatcher::onNameOwnerChanged(const QString &, const QString &, const QString &newOwner) {
+  const bool ours = newOwner == QDBusConnection::sessionBus().baseService();
+
+  if (newOwner.isEmpty()) {
+    if (m_owned) {
+      qInfo() << "Lost StatusNotifierWatcher name";
+      dropped();
+    }
+    m_claimTimer.start();
+    return;
+  }
+
+  m_claimTimer.stop();
+  if (m_owned && !ours) {
+    qInfo() << "StatusNotifierWatcher taken over by" << newOwner;
+    dropped();
+  }
+}
+
+void SniWatcher::tryClaim() {
+  if (m_owned) return;
 
   auto bus = QDBusConnection::sessionBus();
+  auto *iface = bus.interface();
+  if (!iface || iface->isServiceRegistered(WATCHER_SERVICE)) return;
+
   if (!bus.registerObject(WATCHER_PATH, this,
                           QDBusConnection::ExportAllSlots | QDBusConnection::ExportAllProperties |
                               QDBusConnection::ExportAllSignals)) {
-    return false;
-  }
-  if (!bus.registerService(WATCHER_SERVICE)) {
-    bus.unregisterObject(WATCHER_PATH);
-    return false;
+    return;
   }
 
+  auto reply = iface->registerService(WATCHER_SERVICE, QDBusConnectionInterface::DontQueueService,
+                                      QDBusConnectionInterface::AllowReplacement);
+  if (!reply.isValid() || reply.value() != QDBusConnectionInterface::ServiceRegistered) {
+    bus.unregisterObject(WATCHER_PATH);
+    return;
+  }
+
+  qInfo() << "No StatusNotifierWatcher on the session bus, acting as tray host";
   m_owned = true;
-  return true;
+  m_queuePoll.start();
 }
 
 void SniWatcher::release() {
   if (!m_owned) return;
-  auto bus = QDBusConnection::sessionBus();
-  bus.unregisterService(WATCHER_SERVICE);
-  bus.unregisterObject(WATCHER_PATH);
+  QDBusConnection::sessionBus().unregisterService(WATCHER_SERVICE);
+  dropped();
+}
+
+void SniWatcher::dropped() {
   m_owned = false;
+  m_queuePoll.stop();
+  QDBusConnection::sessionBus().unregisterObject(WATCHER_PATH);
   m_items.clear();
   m_hosts.clear();
   for (const auto &name : m_serviceWatcher.watchedServices()) {
     m_serviceWatcher.removeWatchedService(name);
   }
+}
+
+void SniWatcher::pollQueuedOwners() {
+  auto bus = QDBusConnection::sessionBus();
+  auto msg = QDBusMessage::createMethodCall("org.freedesktop.DBus", "/org/freedesktop/DBus",
+                                            "org.freedesktop.DBus", "ListQueuedOwners");
+  msg << QString(WATCHER_SERVICE);
+
+  auto *watcher = new QDBusPendingCallWatcher(bus.asyncCall(msg), this);
+  connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher *w) {
+    w->deleteLater();
+    QDBusPendingReply<QStringList> reply = *w;
+    if (reply.isError() || !m_owned) return;
+
+    const auto self = QDBusConnection::sessionBus().baseService();
+    for (const auto &owner : reply.value()) {
+      if (owner != self) {
+        qInfo() << "Releasing StatusNotifierWatcher to queued owner" << owner;
+        release();
+        return;
+      }
+    }
+  });
 }
 
 void SniWatcher::RegisterStatusNotifierItem(const QString &service) {

--- a/src/server/src/services/tray-host/sni/sni-watcher.hpp
+++ b/src/server/src/services/tray-host/sni/sni-watcher.hpp
@@ -3,10 +3,15 @@
 #include <QDBusServiceWatcher>
 #include <QObject>
 #include <QStringList>
+#include <QTimer>
 
 /**
  * Minimal org.kde.StatusNotifierWatcher implementation, used only when no other
  * watcher (bar, DE shell) owns the name on the session bus.
+ *
+ * The name is claimed after a grace period so that a desktop host that briefly drops it
+ * (GNOME toggles extensions on lock/unlock) can take it back first, and it is released
+ * as soon as another connection is queued for it so the real host wins on its own.
  */
 class SniWatcher : public QObject, protected QDBusContext {
   Q_OBJECT
@@ -19,8 +24,6 @@ public:
   explicit SniWatcher(QObject *parent = nullptr);
   ~SniWatcher() override;
 
-  bool tryClaim();
-  void release();
   bool owned() const { return m_owned; }
 
   QStringList registeredItems() const { return m_items; }
@@ -38,9 +41,20 @@ signals:
   void StatusNotifierHostUnregistered();
 
 private:
+  static constexpr int CLAIM_DELAY_MS = 3000;
+  static constexpr int QUEUE_POLL_MS = 5000;
+
+  void onNameOwnerChanged(const QString &name, const QString &oldOwner, const QString &newOwner);
+  void tryClaim();
+  void release();
+  void dropped();
+  void pollQueuedOwners();
   void serviceGone(const QString &name);
 
+  QDBusServiceWatcher m_nameWatcher;
   QDBusServiceWatcher m_serviceWatcher;
+  QTimer m_claimTimer;
+  QTimer m_queuePoll;
   QStringList m_items;
   QStringList m_hosts;
   bool m_owned = false;


### PR DESCRIPTION
Vicinae now waits a few seconds before reserving the SNI tray host if none is available. It also allows other clients to replace it if needed.

This aims to fix race conditions such as the one described in #1893 

fixes #1893