### PR TITLE
feat: Windows media control

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -792,6 +792,8 @@ elseif (WIN32)
 		src/services/wallpaper/windows/windows-wallpaper-backend.cpp
 		src/services/audio-control/windows/wasapi-audio-control.hpp
 		src/services/audio-control/windows/wasapi-audio-control.cpp
+		src/services/media-control/windows/windows-media-control.hpp
+		src/services/media-control/windows/windows-media-control.cpp
 	)
 	list(APPEND LIBS shell32 ole32 shlwapi user32 gdi32 advapi32 version windowsapp dwmapi comctl32 uuid uiautomationcore)
 else()

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -790,6 +790,8 @@ elseif (WIN32)
 		src/services/url-scheme/win-url-scheme-registrar.cpp
 		src/services/wallpaper/windows/windows-wallpaper-backend.hpp
 		src/services/wallpaper/windows/windows-wallpaper-backend.cpp
+		src/services/audio-control/windows/wasapi-audio-control.hpp
+		src/services/audio-control/windows/wasapi-audio-control.cpp
 	)
 	list(APPEND LIBS shell32 ole32 shlwapi user32 gdi32 advapi32 version windowsapp dwmapi comctl32 uuid uiautomationcore)
 else()

--- a/src/server/src/command-database.cpp
+++ b/src/server/src/command-database.cpp
@@ -55,8 +55,9 @@ CommandDatabase::CommandDatabase(const ServiceRegistry &services) {
   registerRepository<InternalExtension>();
 #endif
 
+  registerRepository<MediaExtension>();
+
 #ifdef Q_OS_UNIX
   registerRepository<SystemExtension>();
-  registerRepository<MediaExtension>();
 #endif
 }

--- a/src/server/src/extensions/media/media-extension.hpp
+++ b/src/server/src/extensions/media/media-extension.hpp
@@ -7,7 +7,7 @@
 #include "single-view-command-context.hpp"
 #include "theme/colors.hpp"
 
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) || defined(Q_OS_WIN)
 #include "qml/now-playing-view-host.hpp"
 #include "services/media-control/media-control-service.hpp"
 #endif
@@ -16,7 +16,7 @@ namespace {
 
 const QColor MEDIA_COMMAND_TINT = QColor(128, 132, 138);
 
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) || defined(Q_OS_WIN)
 
 QString playerQuery(const CommandController &controller) {
   const auto &args = controller.launchProps().arguments;
@@ -327,7 +327,7 @@ class MediaExtension : public BuiltinCommandRepository {
 public:
   MediaExtension() {
     // only MPRIS is implemented for now, other platforms get the dummy backend
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) || defined(Q_OS_WIN)
     registerCommand<NowPlayingCommand>();
     registerCommand<PlayPauseCommand>();
     registerCommand<NextTrackCommand>();

--- a/src/server/src/extensions/media/media-extension.hpp
+++ b/src/server/src/extensions/media/media-extension.hpp
@@ -8,6 +8,7 @@
 #include "theme/colors.hpp"
 
 #if defined(Q_OS_LINUX) || defined(Q_OS_WIN)
+#include "extensions/media/player-app.hpp"
 #include "qml/now-playing-view-host.hpp"
 #include "services/media-control/media-control-service.hpp"
 #endif
@@ -31,10 +32,18 @@ QString trackLabel(const MediaPlayer &player) {
   return QCoreApplication::translate("media-extension", "%1 — %2").arg(player.title, player.artist);
 }
 
-std::optional<MediaPlayer> findPlayer(const AbstractMediaControl *media, const QString &query) {
-  if (query.isEmpty()) return media->defaultPlayer();
+std::optional<MediaPlayer> findPlayer(const ApplicationContext *ctx, const QString &query) {
+  auto media = ctx->services->mediaControl()->provider();
+
+  if (query.isEmpty()) {
+    auto player = media->defaultPlayer();
+    if (player) resolvePlayerIdentity(ctx, *player);
+    return player;
+  }
 
   auto all = media->players();
+  resolvePlayerIdentities(ctx, all);
+
   const auto text = query.toStdString();
   std::vector<Scored<int>> filtered;
 
@@ -49,7 +58,7 @@ std::optional<MediaPlayer> findPlayer(const AbstractMediaControl *media, const Q
  * Player the command should act on, notifying the user when there is none.
  */
 std::optional<MediaPlayer> resolvePlayer(const ApplicationContext *ctx, const QString &query) {
-  auto player = findPlayer(ctx->services->mediaControl()->provider(), query);
+  auto player = findPlayer(ctx, query);
 
   if (player) return player;
 

--- a/src/server/src/extensions/media/player-app.hpp
+++ b/src/server/src/extensions/media/player-app.hpp
@@ -5,7 +5,8 @@
 #include "services/app-service/app-service.hpp"
 #include "services/media-control/abstract-media-control.hpp"
 
-inline std::shared_ptr<AbstractApplication> playerApp(const ApplicationContext *ctx, const MediaPlayer &player) {
+inline std::shared_ptr<AbstractApplication> playerApp(const ApplicationContext *ctx,
+                                                      const MediaPlayer &player) {
   if (player.appId.isEmpty()) return nullptr;
   return ctx->services->appDb()->find(player.appId);
 }

--- a/src/server/src/extensions/media/player-app.hpp
+++ b/src/server/src/extensions/media/player-app.hpp
@@ -11,9 +11,6 @@ inline std::shared_ptr<AbstractApplication> playerApp(const ApplicationContext *
   return ctx->services->appDb()->find(player.appId);
 }
 
-/**
- * Replaces the backend's best-effort identity with the installed app's name when it can be resolved.
- */
 inline void resolvePlayerIdentity(const ApplicationContext *ctx, MediaPlayer &player) {
   if (auto app = playerApp(ctx, player)) player.identity = app->displayName();
 }

--- a/src/server/src/extensions/media/player-app.hpp
+++ b/src/server/src/extensions/media/player-app.hpp
@@ -1,0 +1,24 @@
+#pragma once
+#include <memory>
+#include <vector>
+#include "common/context.hpp"
+#include "services/app-service/app-service.hpp"
+#include "services/media-control/abstract-media-control.hpp"
+
+inline std::shared_ptr<AbstractApplication> playerApp(const ApplicationContext *ctx, const MediaPlayer &player) {
+  if (player.appId.isEmpty()) return nullptr;
+  return ctx->services->appDb()->find(player.appId);
+}
+
+/**
+ * Replaces the backend's best-effort identity with the installed app's name when it can be resolved.
+ */
+inline void resolvePlayerIdentity(const ApplicationContext *ctx, MediaPlayer &player) {
+  if (auto app = playerApp(ctx, player)) player.identity = app->displayName();
+}
+
+inline void resolvePlayerIdentities(const ApplicationContext *ctx, std::vector<MediaPlayer> &players) {
+  for (auto &player : players) {
+    resolvePlayerIdentity(ctx, player);
+  }
+}

--- a/src/server/src/qml/now-playing-view-host.hpp
+++ b/src/server/src/qml/now-playing-view-host.hpp
@@ -2,6 +2,7 @@
 #include <QCoreApplication>
 #include "builtin_icon.hpp"
 #include "common/context.hpp"
+#include "extensions/media/player-app.hpp"
 #include "fuzzy/fuzzy-searchable.hpp"
 #include "mono-list-view-host.hpp"
 #include "services/media-control/media-control-service.hpp"
@@ -40,17 +41,23 @@ public:
   QString displaySubtitle(const ItemType &e) const override { return e.artist; }
 
   std::optional<ImageURL> displayIcon(const ItemType &e) const override {
-    if (e.status == PlaybackStatus::Playing) {
-      return ImageURL::builtin(BuiltinIcon::PauseFilled).setFill(SemanticColor::Green);
-    }
+    if (auto app = playerApp(context(), e)) return app->iconUrl();
 
-    return ImageURL::builtin(BuiltinIcon::PlayFilled);
+    return ImageURL::builtin(BuiltinIcon::Music);
   }
 
   AccessoryList displayAccessories(const ItemType &e) const override {
-    if (e.title.isEmpty()) return {};
+    if (e.status == PlaybackStatus::Playing) {
+      return {{.text = tr("Playing"),
+               .color = SemanticColor::Green,
+               .icon = ImageURL::builtin(BuiltinIcon::PlayFilled).setFill(SemanticColor::Green)}};
+    }
 
-    return {ListAccessory{.text = e.identity}};
+    if (e.status == PlaybackStatus::Paused) {
+      return {{.text = tr("Paused"), .icon = ImageURL::builtin(BuiltinIcon::PauseFilled)}};
+    }
+
+    return {};
   }
 
   std::unique_ptr<ActionPanelState> buildActionPanel(const ItemType &e) const override {
@@ -79,5 +86,9 @@ public:
   }
 
 private:
-  void reload() { setItems(context()->services->mediaControl()->provider()->players()); }
+  void reload() {
+    auto players = context()->services->mediaControl()->provider()->players();
+    resolvePlayerIdentities(context(), players);
+    setItems(std::move(players));
+  }
 };

--- a/src/server/src/services/app-service/windows/win-app-database.cpp
+++ b/src/server/src/services/app-service/windows/win-app-database.cpp
@@ -27,6 +27,7 @@
 #include "utils/scoped-com.hpp"
 
 #include <QDebug>
+#include <QFileInfo>
 #include <QJsonArray>
 #include <array>
 #include <chrono>
@@ -602,8 +603,13 @@ void WindowsAppDatabase::indexAliases(const std::shared_ptr<WindowsApplication> 
       [&](const Win32ShortcutApp &s) {
         add(s.aumid);
         add(s.program);
+        add(QFileInfo(s.program).fileName());
       },
-      [&](const Win32ExeApp &e) { add(toQString(e.exe)); }, [&](const PackagedApp &p) { add(p.aumid); },
+      [&](const Win32ExeApp &e) {
+        add(toQString(e.exe));
+        add(toQString(e.exe.filename()));
+      },
+      [&](const PackagedApp &p) { add(p.aumid); },
       [](const auto &) {});
 }
 

--- a/src/server/src/services/app-service/windows/win-app-database.cpp
+++ b/src/server/src/services/app-service/windows/win-app-database.cpp
@@ -609,8 +609,7 @@ void WindowsAppDatabase::indexAliases(const std::shared_ptr<WindowsApplication> 
         add(toQString(e.exe));
         add(toQString(e.exe.filename()));
       },
-      [&](const PackagedApp &p) { add(p.aumid); },
-      [](const auto &) {});
+      [&](const PackagedApp &p) { add(p.aumid); }, [](const auto &) {});
 }
 
 void WindowsAppDatabase::addShortcut(const fs::path &file) {

--- a/src/server/src/services/audio-control/abstract-audio-control.hpp
+++ b/src/server/src/services/audio-control/abstract-audio-control.hpp
@@ -1,16 +1,6 @@
 #pragma once
 #include <optional>
-#include <vector>
 #include <QString>
-
-struct AudioSink {
-  QString name;
-  QString description;
-  std::optional<QString> activePort;
-  float volume = 0.0f;
-  bool muted = false;
-  bool isDefault = false;
-};
 
 class AbstractAudioControl {
 public:
@@ -24,7 +14,4 @@ public:
   virtual bool isMuted() const = 0;
   virtual bool setMuted(bool muted) = 0;
   virtual bool toggleMute() = 0;
-
-  virtual std::vector<AudioSink> listSinks() const = 0;
-  virtual bool setDefaultSink(const QString &sinkName) = 0;
 };

--- a/src/server/src/services/audio-control/audio-control-service.hpp
+++ b/src/server/src/services/audio-control/audio-control-service.hpp
@@ -5,6 +5,8 @@
 #include "services/audio-control/pactl/pactl-audio-control.hpp"
 #elif defined(Q_OS_MACOS)
 #include "services/audio-control/macos/coreaudio-audio-control.hpp"
+#elif defined(Q_OS_WIN)
+#include "services/audio-control/windows/wasapi-audio-control.hpp"
 #else
 #include "services/audio-control/dummy-audio-control.hpp"
 #endif
@@ -17,6 +19,8 @@ public:
     m_backend = std::make_unique<PactlAudioControl>();
 #elif defined(Q_OS_MACOS)
     m_backend = std::make_unique<CoreAudioControl>();
+#elif defined(Q_OS_WIN)
+    m_backend = std::make_unique<WasapiAudioControl>();
 #else
     m_backend = std::make_unique<DummyAudioControl>();
 #endif

--- a/src/server/src/services/audio-control/dummy-audio-control.hpp
+++ b/src/server/src/services/audio-control/dummy-audio-control.hpp
@@ -12,7 +12,4 @@ public:
   bool isMuted() const override { return false; }
   bool setMuted(bool) override { return false; }
   bool toggleMute() override { return false; }
-
-  std::vector<AudioSink> listSinks() const override { return {}; }
-  bool setDefaultSink(const QString &) override { return false; }
 };

--- a/src/server/src/services/audio-control/macos/coreaudio-audio-control.cpp
+++ b/src/server/src/services/audio-control/macos/coreaudio-audio-control.cpp
@@ -149,27 +149,6 @@ bool writeMute(AudioDeviceID device, bool muted) {
   return count > 0 && ok;
 }
 
-std::optional<QString> stringProperty(AudioObjectID object, AudioObjectPropertySelector selector) {
-  AudioObjectPropertyAddress addr{selector, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMain};
-  CFStringRef ref = nullptr;
-  UInt32 size = sizeof(ref);
-
-  if (AudioObjectGetPropertyData(object, &addr, 0, nullptr, &size, &ref) != noErr || !ref) {
-    return std::nullopt;
-  }
-
-  QString value = QString::fromCFString(ref);
-  CFRelease(ref);
-  return value;
-}
-
-bool hasOutputStreams(AudioDeviceID device) {
-  AudioObjectPropertyAddress addr{kAudioDevicePropertyStreams, kAudioObjectPropertyScopeOutput,
-                                  kAudioObjectPropertyElementMain};
-  UInt32 size = 0;
-  return AudioObjectGetPropertyDataSize(device, &addr, 0, nullptr, &size) == noErr && size > 0;
-}
-
 } // namespace
 
 QString CoreAudioControl::id() const { return "coreaudio"; }
@@ -203,56 +182,3 @@ bool CoreAudioControl::setMuted(bool muted) {
 }
 
 bool CoreAudioControl::toggleMute() { return setMuted(!isMuted()); }
-
-std::vector<AudioSink> CoreAudioControl::listSinks() const {
-  AudioObjectPropertyAddress addr{kAudioHardwarePropertyDevices, kAudioObjectPropertyScopeGlobal,
-                                  kAudioObjectPropertyElementMain};
-  UInt32 size = 0;
-  if (AudioObjectGetPropertyDataSize(kAudioObjectSystemObject, &addr, 0, nullptr, &size) != noErr) return {};
-
-  std::vector<AudioDeviceID> devices(size / sizeof(AudioDeviceID));
-  if (AudioObjectGetPropertyData(kAudioObjectSystemObject, &addr, 0, nullptr, &size, devices.data()) !=
-      noErr) {
-    return {};
-  }
-
-  auto defaultDevice = defaultOutputDevice();
-
-  std::vector<AudioSink> sinks;
-  sinks.reserve(devices.size());
-
-  for (auto device : devices) {
-    if (!hasOutputStreams(device)) continue;
-
-    auto uid = stringProperty(device, kAudioDevicePropertyDeviceUID);
-    if (!uid) continue;
-
-    AudioSink sink;
-    sink.name = *uid;
-    sink.description = stringProperty(device, kAudioObjectPropertyName).value_or(*uid);
-    sink.volume = readVolume(device).value_or(0.0f);
-    sink.muted = readMute(device).value_or(false);
-    sink.isDefault = defaultDevice && *defaultDevice == device;
-    sinks.emplace_back(std::move(sink));
-  }
-
-  return sinks;
-}
-
-bool CoreAudioControl::setDefaultSink(const QString &sinkName) {
-  CFStringRef uid = sinkName.toCFString();
-  AudioObjectPropertyAddress translate{kAudioHardwarePropertyTranslateUIDToDevice,
-                                       kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMain};
-  AudioDeviceID device = kAudioObjectUnknown;
-  UInt32 size = sizeof(device);
-
-  OSStatus status =
-      AudioObjectGetPropertyData(kAudioObjectSystemObject, &translate, sizeof(uid), &uid, &size, &device);
-  CFRelease(uid);
-  if (status != noErr || device == kAudioObjectUnknown) return false;
-
-  AudioObjectPropertyAddress addr{kAudioHardwarePropertyDefaultOutputDevice, kAudioObjectPropertyScopeGlobal,
-                                  kAudioObjectPropertyElementMain};
-  return AudioObjectSetPropertyData(kAudioObjectSystemObject, &addr, 0, nullptr, sizeof(device), &device) ==
-         noErr;
-}

--- a/src/server/src/services/audio-control/pactl/pactl-audio-control.hpp
+++ b/src/server/src/services/audio-control/pactl/pactl-audio-control.hpp
@@ -3,7 +3,17 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <vector>
 #include "../abstract-audio-control.hpp"
+
+struct AudioSink {
+  QString name;
+  QString description;
+  std::optional<QString> activePort;
+  float volume = 0.0f;
+  bool muted = false;
+  bool isDefault = false;
+};
 
 class PactlAudioControl : public AbstractAudioControl {
 public:
@@ -19,10 +29,9 @@ public:
   bool setMuted(bool muted) override;
   bool toggleMute() override;
 
-  std::vector<AudioSink> listSinks() const override;
-  bool setDefaultSink(const QString &sinkName) override;
-
 private:
+  std::vector<AudioSink> listSinks() const;
+  bool setDefaultSink(const QString &sinkName);
   std::optional<AudioSink> getDefaultSink() const;
   std::optional<std::string> run(std::initializer_list<std::string_view> args) const;
 

--- a/src/server/src/services/audio-control/windows/wasapi-audio-control.cpp
+++ b/src/server/src/services/audio-control/windows/wasapi-audio-control.cpp
@@ -14,7 +14,8 @@ ComPtr<IAudioEndpointVolume> defaultEndpointVolume() {
   ComPtr<IMMDevice> device;
   ComPtr<IAudioEndpointVolume> volume;
 
-  if (FAILED(CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL, IID_PPV_ARGS(&enumerator))) ||
+  if (FAILED(
+          CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL, IID_PPV_ARGS(&enumerator))) ||
       FAILED(enumerator->GetDefaultAudioEndpoint(eRender, eConsole, &device))) {
     return nullptr;
   }

--- a/src/server/src/services/audio-control/windows/wasapi-audio-control.cpp
+++ b/src/server/src/services/audio-control/windows/wasapi-audio-control.cpp
@@ -1,0 +1,66 @@
+#include "wasapi-audio-control.hpp"
+#include "utils/scoped-com.hpp"
+#include <algorithm>
+#include <endpointvolume.h>
+#include <mmdeviceapi.h>
+#include <wrl/client.h>
+
+using Microsoft::WRL::ComPtr;
+
+namespace {
+
+ComPtr<IAudioEndpointVolume> defaultEndpointVolume() {
+  ComPtr<IMMDeviceEnumerator> enumerator;
+  ComPtr<IMMDevice> device;
+  ComPtr<IAudioEndpointVolume> volume;
+
+  if (FAILED(CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL, IID_PPV_ARGS(&enumerator))) ||
+      FAILED(enumerator->GetDefaultAudioEndpoint(eRender, eConsole, &device))) {
+    return nullptr;
+  }
+
+  device->Activate(__uuidof(IAudioEndpointVolume), CLSCTX_ALL, nullptr, &volume);
+  return volume;
+}
+
+std::optional<float> readVolume(IAudioEndpointVolume *volume) {
+  float level = 0.0f;
+  if (!volume || FAILED(volume->GetMasterVolumeLevelScalar(&level))) return std::nullopt;
+  return level;
+}
+
+} // namespace
+
+QString WasapiAudioControl::id() const { return "wasapi"; }
+
+float WasapiAudioControl::getVolume() const {
+  ScopedCom com;
+  return readVolume(defaultEndpointVolume().Get()).value_or(0.0f);
+}
+
+std::optional<float> WasapiAudioControl::setVolume(float level) {
+  ScopedCom com;
+  auto volume = defaultEndpointVolume();
+  if (!volume) return std::nullopt;
+
+  level = std::clamp(level, 0.0f, 1.0f);
+  if (FAILED(volume->SetMasterVolumeLevelScalar(level, nullptr))) return std::nullopt;
+  return readVolume(volume.Get()).value_or(level);
+}
+
+std::optional<float> WasapiAudioControl::adjustVolume(float delta) { return setVolume(getVolume() + delta); }
+
+bool WasapiAudioControl::isMuted() const {
+  ScopedCom com;
+  auto volume = defaultEndpointVolume();
+  BOOL muted = FALSE;
+  return volume && SUCCEEDED(volume->GetMute(&muted)) && muted;
+}
+
+bool WasapiAudioControl::setMuted(bool muted) {
+  ScopedCom com;
+  auto volume = defaultEndpointVolume();
+  return volume && SUCCEEDED(volume->SetMute(muted ? TRUE : FALSE, nullptr));
+}
+
+bool WasapiAudioControl::toggleMute() { return setMuted(!isMuted()); }

--- a/src/server/src/services/audio-control/windows/wasapi-audio-control.hpp
+++ b/src/server/src/services/audio-control/windows/wasapi-audio-control.hpp
@@ -1,9 +1,6 @@
 #pragma once
 #include "services/audio-control/abstract-audio-control.hpp"
 
-/**
- * System audio control through WASAPI endpoint volume, acting on the default render device.
- */
 class WasapiAudioControl : public AbstractAudioControl {
 public:
   QString id() const override;

--- a/src/server/src/services/audio-control/windows/wasapi-audio-control.hpp
+++ b/src/server/src/services/audio-control/windows/wasapi-audio-control.hpp
@@ -1,7 +1,10 @@
 #pragma once
-#include "../abstract-audio-control.hpp"
+#include "services/audio-control/abstract-audio-control.hpp"
 
-class CoreAudioControl : public AbstractAudioControl {
+/**
+ * System audio control through WASAPI endpoint volume, acting on the default render device.
+ */
+class WasapiAudioControl : public AbstractAudioControl {
 public:
   QString id() const override;
 

--- a/src/server/src/services/media-control/abstract-media-control.hpp
+++ b/src/server/src/services/media-control/abstract-media-control.hpp
@@ -12,6 +12,8 @@ struct MediaPlayer {
   QString id;
   /// Name of the program owning the player, e.g. "Spotify".
   QString identity;
+  /// Raw key of the owning app for `AppService::find`, e.g. a desktop entry or an AppUserModelId.
+  QString appId;
   QString title;
   QString artist;
   PlaybackStatus status = PlaybackStatus::Stopped;

--- a/src/server/src/services/media-control/abstract-media-control.hpp
+++ b/src/server/src/services/media-control/abstract-media-control.hpp
@@ -12,7 +12,6 @@ struct MediaPlayer {
   QString id;
   /// Name of the program owning the player, e.g. "Spotify".
   QString identity;
-  /// Raw key of the owning app for `AppService::find`, e.g. a desktop entry or an AppUserModelId.
   QString appId;
   QString title;
   QString artist;

--- a/src/server/src/services/media-control/media-control-service.hpp
+++ b/src/server/src/services/media-control/media-control-service.hpp
@@ -3,6 +3,8 @@
 #include "services/media-control/abstract-media-control.hpp"
 #ifdef Q_OS_LINUX
 #include "services/media-control/mpris/mpris-media-control.hpp"
+#elif defined(Q_OS_WIN)
+#include "services/media-control/windows/windows-media-control.hpp"
 #else
 #include "services/media-control/dummy-media-control.hpp"
 #endif
@@ -14,6 +16,8 @@ public:
   MediaControlService() {
 #ifdef Q_OS_LINUX
     m_backend = std::make_unique<MprisMediaControl>();
+#elif defined(Q_OS_WIN)
+    m_backend = std::make_unique<WindowsMediaControl>();
 #else
     m_backend = std::make_unique<DummyMediaControl>();
 #endif

--- a/src/server/src/services/media-control/mpris/mpris-media-control.cpp
+++ b/src/server/src/services/media-control/mpris/mpris-media-control.cpp
@@ -123,6 +123,7 @@ std::optional<MediaPlayer> MprisMediaControl::queryPlayer(const QString &service
     if (auto identity = root->value("Identity").toString(); !identity.isEmpty()) {
       player.identity = std::move(identity);
     }
+    player.appId = root->value("DesktopEntry").toString();
   }
 
   return player;

--- a/src/server/src/services/media-control/windows/windows-media-control.cpp
+++ b/src/server/src/services/media-control/windows/windows-media-control.cpp
@@ -55,8 +55,7 @@ struct WindowsMediaControl::Impl {
                    << fromHString(e.message());
         return;
       }
-      sessionsRevoker =
-          manager.SessionsChanged(winrt::auto_revoke, [this](auto &&, auto &&) { refresh(); });
+      sessionsRevoker = manager.SessionsChanged(winrt::auto_revoke, [this](auto &&, auto &&) { refresh(); });
       refresh();
     });
   }
@@ -110,9 +109,8 @@ struct WindowsMediaControl::Impl {
 
   std::optional<Session> find(const QString &playerId) const {
     std::lock_guard lock(cacheMutex);
-    const auto it = std::ranges::find_if(entries, [&](const Entry &e) {
-      return fromHString(e.session.SourceAppUserModelId()) == playerId;
-    });
+    const auto it = std::ranges::find_if(
+        entries, [&](const Entry &e) { return fromHString(e.session.SourceAppUserModelId()) == playerId; });
     if (it == entries.end()) return std::nullopt;
     return it->session;
   }

--- a/src/server/src/services/media-control/windows/windows-media-control.cpp
+++ b/src/server/src/services/media-control/windows/windows-media-control.cpp
@@ -1,0 +1,163 @@
+#include "windows-media-control.hpp"
+#include <algorithm>
+#include <mutex>
+#include <thread>
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.Media.Control.h>
+#include <QDebug>
+#include <QFileInfo>
+
+using namespace winrt::Windows::Media::Control;
+using Session = GlobalSystemMediaTransportControlsSession;
+using SessionManager = GlobalSystemMediaTransportControlsSessionManager;
+
+namespace {
+
+PlaybackStatus toStatus(GlobalSystemMediaTransportControlsSessionPlaybackStatus status) {
+  switch (status) {
+  case GlobalSystemMediaTransportControlsSessionPlaybackStatus::Playing:
+    return PlaybackStatus::Playing;
+  case GlobalSystemMediaTransportControlsSessionPlaybackStatus::Paused:
+    return PlaybackStatus::Paused;
+  default:
+    return PlaybackStatus::Stopped;
+  }
+}
+
+// Packaged apps report "Publisher.App_hash!Entry", classic ones usually just "app.exe" or a custom id.
+QString identityFor(const QString &aumid) {
+  if (auto bang = aumid.lastIndexOf('!'); bang != -1) return aumid.mid(bang + 1);
+  if (aumid.endsWith(".exe", Qt::CaseInsensitive)) return QFileInfo(aumid).completeBaseName();
+  return aumid;
+}
+
+QString fromHString(const winrt::hstring &s) { return QString::fromWCharArray(s.c_str(), s.size()); }
+
+} // namespace
+
+struct WindowsMediaControl::Impl {
+  struct Entry {
+    Session session;
+    Session::PlaybackInfoChanged_revoker playbackRevoker;
+    Session::MediaPropertiesChanged_revoker propertiesRevoker;
+  };
+
+  explicit Impl(WindowsMediaControl *owner) : owner(owner) {}
+
+  void start() {
+    initThread = std::thread([this] {
+      winrt::init_apartment(winrt::apartment_type::multi_threaded);
+      try {
+        manager = SessionManager::RequestAsync().get();
+      } catch (const winrt::hresult_error &e) {
+        qWarning() << "media session manager unavailable, media control will not work:"
+                   << fromHString(e.message());
+        return;
+      }
+      sessionsRevoker =
+          manager.SessionsChanged(winrt::auto_revoke, [this](auto &&, auto &&) { refresh(); });
+      refresh();
+    });
+  }
+
+  void stop() {
+    if (initThread.joinable()) initThread.join();
+    sessionsRevoker.revoke();
+    std::scoped_lock lock(refreshMutex, cacheMutex);
+    entries.clear();
+  }
+
+  // Runs on WinRT threads: blocking on the async property fetch is fine there.
+  void refresh() {
+    std::lock_guard refreshLock(refreshMutex);
+    std::vector<MediaPlayer> players;
+    std::vector<Entry> fresh;
+
+    for (const auto &session : manager.GetSessions()) {
+      MediaPlayer player{.id = fromHString(session.SourceAppUserModelId())};
+      player.identity = identityFor(player.id);
+
+      const auto info = session.GetPlaybackInfo();
+      player.status = toStatus(info.PlaybackStatus());
+      player.canGoNext = info.Controls().IsNextEnabled();
+      player.canGoPrevious = info.Controls().IsPreviousEnabled();
+
+      try {
+        const auto props = session.TryGetMediaPropertiesAsync().get();
+        player.title = fromHString(props.Title());
+        player.artist = fromHString(props.Artist());
+      } catch (const winrt::hresult_error &) {
+        // the player went away mid-query, the sessions changed event will follow
+      }
+
+      auto onChange = [this](auto &&, auto &&) { refresh(); };
+      fresh.push_back({.session = session,
+                       .playbackRevoker = session.PlaybackInfoChanged(winrt::auto_revoke, onChange),
+                       .propertiesRevoker = session.MediaPropertiesChanged(winrt::auto_revoke, onChange)});
+      players.emplace_back(std::move(player));
+    }
+
+    {
+      std::lock_guard cacheLock(cacheMutex);
+      cache = std::move(players);
+      entries = std::move(fresh);
+    }
+
+    QMetaObject::invokeMethod(owner, [owner = owner] { emit owner->playersChanged(); }, Qt::QueuedConnection);
+  }
+
+  std::optional<Session> find(const QString &playerId) const {
+    std::lock_guard lock(cacheMutex);
+    const auto it = std::ranges::find_if(entries, [&](const Entry &e) {
+      return fromHString(e.session.SourceAppUserModelId()) == playerId;
+    });
+    if (it == entries.end()) return std::nullopt;
+    return it->session;
+  }
+
+  WindowsMediaControl *owner;
+  std::thread initThread;
+  SessionManager manager{nullptr};
+  SessionManager::SessionsChanged_revoker sessionsRevoker;
+  std::mutex refreshMutex;
+  mutable std::mutex cacheMutex;
+  std::vector<MediaPlayer> cache;
+  std::vector<Entry> entries;
+};
+
+WindowsMediaControl::WindowsMediaControl() : m_impl(std::make_unique<Impl>(this)) { m_impl->start(); }
+
+WindowsMediaControl::~WindowsMediaControl() { m_impl->stop(); }
+
+QString WindowsMediaControl::id() const { return "smtc"; }
+
+std::vector<MediaPlayer> WindowsMediaControl::players() const {
+  std::lock_guard lock(m_impl->cacheMutex);
+  return m_impl->cache;
+}
+
+// The async results are dropped on purpose: waiting on them would block the UI thread.
+bool WindowsMediaControl::playPause(const QString &playerId) {
+  auto session = m_impl->find(playerId);
+  if (!session) return false;
+  session->TryTogglePlayPauseAsync();
+  setLastPlayerId(playerId);
+  return true;
+}
+
+bool WindowsMediaControl::next(const QString &playerId) {
+  auto session = m_impl->find(playerId);
+  if (!session) return false;
+  session->TrySkipNextAsync();
+  setLastPlayerId(playerId);
+  return true;
+}
+
+bool WindowsMediaControl::previous(const QString &playerId) {
+  auto session = m_impl->find(playerId);
+  if (!session) return false;
+  session->TrySkipPreviousAsync();
+  setLastPlayerId(playerId);
+  return true;
+}

--- a/src/server/src/services/media-control/windows/windows-media-control.cpp
+++ b/src/server/src/services/media-control/windows/windows-media-control.cpp
@@ -77,6 +77,7 @@ struct WindowsMediaControl::Impl {
     for (const auto &session : manager.GetSessions()) {
       MediaPlayer player{.id = fromHString(session.SourceAppUserModelId())};
       player.identity = identityFor(player.id);
+      player.appId = player.id;
 
       const auto info = session.GetPlaybackInfo();
       player.status = toStatus(info.PlaybackStatus());

--- a/src/server/src/services/media-control/windows/windows-media-control.cpp
+++ b/src/server/src/services/media-control/windows/windows-media-control.cpp
@@ -25,7 +25,6 @@ PlaybackStatus toStatus(GlobalSystemMediaTransportControlsSessionPlaybackStatus 
   }
 }
 
-// Packaged apps report "Publisher.App_hash!Entry", classic ones usually just "app.exe" or a custom id.
 QString identityFor(const QString &aumid) {
   if (auto bang = aumid.lastIndexOf('!'); bang != -1) return aumid.mid(bang + 1);
   if (aumid.endsWith(".exe", Qt::CaseInsensitive)) return QFileInfo(aumid).completeBaseName();
@@ -67,7 +66,6 @@ struct WindowsMediaControl::Impl {
     entries.clear();
   }
 
-  // Runs on WinRT threads: blocking on the async property fetch is fine there.
   void refresh() {
     std::lock_guard refreshLock(refreshMutex);
     std::vector<MediaPlayer> players;
@@ -87,9 +85,7 @@ struct WindowsMediaControl::Impl {
         const auto props = session.TryGetMediaPropertiesAsync().get();
         player.title = fromHString(props.Title());
         player.artist = fromHString(props.Artist());
-      } catch (const winrt::hresult_error &) {
-        // the player went away mid-query, the sessions changed event will follow
-      }
+      } catch (const winrt::hresult_error &) {}
 
       auto onChange = [this](auto &&, auto &&) { refresh(); };
       fresh.push_back({.session = session,
@@ -136,7 +132,6 @@ std::vector<MediaPlayer> WindowsMediaControl::players() const {
   return m_impl->cache;
 }
 
-// The async results are dropped on purpose: waiting on them would block the UI thread.
 bool WindowsMediaControl::playPause(const QString &playerId) {
   auto session = m_impl->find(playerId);
   if (!session) return false;

--- a/src/server/src/services/media-control/windows/windows-media-control.hpp
+++ b/src/server/src/services/media-control/windows/windows-media-control.hpp
@@ -1,0 +1,27 @@
+#pragma once
+#include <memory>
+#include "services/media-control/abstract-media-control.hpp"
+
+/**
+ * Media control through the system media transport controls, the same sessions the Windows
+ * media flyout shows. Players are identified by their AppUserModelId.
+ */
+class WindowsMediaControl : public AbstractMediaControl {
+  Q_OBJECT
+
+public:
+  WindowsMediaControl();
+  ~WindowsMediaControl() override;
+
+  QString id() const override;
+
+  std::vector<MediaPlayer> players() const override;
+
+  bool playPause(const QString &playerId) override;
+  bool next(const QString &playerId) override;
+  bool previous(const QString &playerId) override;
+
+private:
+  struct Impl;
+  std::unique_ptr<Impl> m_impl;
+};

--- a/src/server/src/services/media-control/windows/windows-media-control.hpp
+++ b/src/server/src/services/media-control/windows/windows-media-control.hpp
@@ -2,10 +2,6 @@
 #include <memory>
 #include "services/media-control/abstract-media-control.hpp"
 
-/**
- * Media control through the system media transport controls, the same sessions the Windows
- * media flyout shows. Players are identified by their AppUserModelId.
- */
 class WindowsMediaControl : public AbstractMediaControl {
   Q_OBJECT
 


### PR DESCRIPTION
Implement audio and media control on Windows.

- Use `WASPI` for volume control.
- Use `GlobalSystemMediaTransportControlsSessionManager` for media control



Also links media source to the corresponding application, if possible.