### PR TITLE
feat(windows): adaptative popup placement

### DIFF
--- a/src/server/src/qml/completion-model.cpp
+++ b/src/server/src/qml/completion-model.cpp
@@ -1,6 +1,7 @@
 #include "completion-model.hpp"
 #include "fuzzy/fuzzy-searchable.hpp"
 #include "services/navigation/list-navigation.hpp"
+#include <algorithm>
 #include <utility>
 
 template <> struct fuzzy::FuzzySearchable<CompletionModel::Item> {
@@ -153,6 +154,11 @@ QVariantMap CompletionModel::itemDataAt(int index) const {
 int CompletionModel::rowCount(const QModelIndex &parent) const {
   if (parent.isValid()) return 0;
   return static_cast<int>(m_flat.size());
+}
+
+int CompletionModel::sectionCount() const {
+  return static_cast<int>(std::count_if(m_flat.begin(), m_flat.end(),
+                                        [](const auto &f) { return f.kind == FlatItem::SectionHeader; }));
 }
 
 QVariant CompletionModel::data(const QModelIndex &index, int role) const {

--- a/src/server/src/qml/completion-model.hpp
+++ b/src/server/src/qml/completion-model.hpp
@@ -11,6 +11,7 @@ class CompletionModel : public QAbstractListModel {
   QML_ELEMENT
 
   Q_PROPERTY(int count READ rowCount NOTIFY countChanged)
+  Q_PROPERTY(int sectionCount READ sectionCount NOTIFY countChanged)
 
 public:
   enum Role {
@@ -34,6 +35,7 @@ public:
   Q_INVOKABLE QVariantMap itemDataAt(int index) const;
 
   int rowCount(const QModelIndex &parent = {}) const override;
+  int sectionCount() const;
   QVariant data(const QModelIndex &index, int role) const override;
   QHash<int, QByteArray> roleNames() const override;
 

--- a/src/server/src/qml/qml/CompletionPopup.qml
+++ b/src/server/src/qml/qml/CompletionPopup.qml
@@ -19,6 +19,43 @@ Popup {
 
     popupType: nativePanel && Platform.supports("nativePanels") ? Popup.Window : Popup.Item
 
+    // In-scene popups can't extend past the window, so the popup opens below
+    // `anchorItem`, flips above it when that side has more room, and caps its
+    // list to whatever fits on the chosen side.
+    property Item anchorItem: parent
+    property int anchorGap: 4
+    property int maxListHeight: showFilter ? 300 : 200
+
+    readonly property int itemRowHeight: 30
+    readonly property int sectionRowHeight: 24
+    readonly property int filterRowHeight: 28
+    readonly property int filterRowMargin: 4
+    readonly property int windowEdgeMargin: 8
+    readonly property int minListHeight: 60
+
+    property bool _above: false
+    property real _listCap: maxListHeight
+    readonly property real _chromeHeight: topPadding + bottomPadding + (showFilter ? filterRowHeight + filterRowMargin : 0)
+
+    y: _above ? -height - anchorGap : (anchorItem ? anchorItem.height + anchorGap : 0)
+
+    function _updatePlacement() {
+        _above = false;
+        _listCap = maxListHeight;
+        const win = content.hostWindow;
+        if (popupType !== Popup.Item || !anchorItem || !win)
+            return;
+        const pad = (win.shadowPadding ?? 0) + windowEdgeMargin;
+        const anchorTop = anchorItem.mapToItem(null, 0, 0).y;
+        const below = win.height - pad - (anchorTop + anchorItem.height + anchorGap);
+        const above = anchorTop - anchorGap - pad;
+        const sections = _model.sectionCount;
+        const natural = sections * sectionRowHeight + (count - sections) * itemRowHeight;
+        const wanted = Math.min(natural, maxListHeight) + _chromeHeight;
+        _above = wanted > below && above > below;
+        _listCap = Math.max(minListHeight, Math.min(maxListHeight, (_above ? above : below) - _chromeHeight));
+    }
+
     readonly property int count: _model.count
     readonly property bool hasSelection: _highlightedIndex >= 0
 
@@ -51,10 +88,15 @@ Popup {
     onSectionsChanged: if (sections.length > 0)
         internalModel.setSections(sections)
 
-    onOpened: {
+    onAboutToShow: {
         if (showFilter) {
             filterField.text = "";
             _model.setFilter("");
+        }
+        _updatePlacement();
+    }
+    onOpened: {
+        if (showFilter) {
             _highlightCurrentOrFirst();
             filterField.forceActiveFocus();
         }
@@ -120,13 +162,16 @@ Popup {
     }
 
     contentItem: ColumnLayout {
+        id: content
         spacing: 0
+
+        readonly property var hostWindow: Window.window
 
         Item {
             visible: root.showFilter
             Layout.fillWidth: true
-            Layout.preferredHeight: 28
-            Layout.bottomMargin: 4
+            Layout.preferredHeight: root.filterRowHeight
+            Layout.bottomMargin: root.filterRowMargin
 
             RowLayout {
                 anchors.fill: parent
@@ -196,7 +241,7 @@ Popup {
         ListView {
             id: completionList
             Layout.fillWidth: true
-            Layout.preferredHeight: Math.min(contentHeight, root.showFilter ? 300 : 200)
+            Layout.preferredHeight: Math.min(contentHeight, root._listCap)
             model: root._model
             clip: true
             boundsBehavior: Flickable.StopAtBounds
@@ -235,7 +280,7 @@ Popup {
                     anchors.right: parent.right
                     anchors.leftMargin: 8
                     anchors.rightMargin: 8
-                    height: visible ? 24 : 0
+                    height: visible ? root.sectionRowHeight : 0
 
                     Text {
                         text: del.title
@@ -250,7 +295,7 @@ Popup {
                     visible: del.itemType === "item"
                     anchors.left: parent.left
                     anchors.right: parent.right
-                    height: visible ? 30 : 0
+                    height: visible ? root.itemRowHeight : 0
 
                     SourceBlendRect {
                         anchors.fill: parent

--- a/src/server/src/qml/qml/PlaceholderCompleter.qml
+++ b/src/server/src/qml/qml/PlaceholderCompleter.qml
@@ -64,7 +64,6 @@ Item {
         nativePanel: true
         focus: false
         x: 0
-        y: root.height + 4
         width: Math.max(200, root.width)
         items: root.completions
 

--- a/src/server/src/qml/qml/SearchableDropdown.qml
+++ b/src/server/src/qml/qml/SearchableDropdown.qml
@@ -118,23 +118,12 @@ Item {
         // PopupPlacement anchor; x/y only apply on other platforms.
         PopupPlacement.alignment: root.compact ? Qt.AlignRight : Qt.AlignLeft
         x: root.popupX()
-        y: triggerButton.height + 4
         width: Math.max(compact ? 200 : 250, root.width)
         focus: true
         sections: root.items
         model: root.model
         showFilter: true
         currentItemId: root.currentItem ? root.currentItem.id : ""
-
-        background: Rectangle {
-            readonly property bool csd: completionPopup.popupType === Popup.Item || Platform.supports("clientSideDecorations")
-            readonly property real bgOpacity: completionPopup.popupType === Popup.Window ? Config.popupOpacity : 1
-            radius: csd ? Math.min(Config.borderRounding, 15) : 0
-            color: Qt.rgba(Theme.popoverBackground.r, Theme.popoverBackground.g, Theme.popoverBackground.b, bgOpacity)
-            border.color: Config.withAlpha(Theme.popoverBorder, bgOpacity)
-            border.width: csd ? 1 : 0
-            PopupMaterial {}
-        }
 
         onClosed: {
             root._closedTime = Date.now();

--- a/src/server/src/qml/qml/ViciToolTip.qml
+++ b/src/server/src/qml/qml/ViciToolTip.qml
@@ -15,13 +15,8 @@ ToolTip {
         font.pointSize: Theme.smallerFontSize
     }
 
-    background: Rectangle {
-        readonly property bool csd: root.popupType === Popup.Item || Platform.supports("clientSideDecorations")
-        readonly property real bgOpacity: root.popupType === Popup.Window ? Config.popupOpacity : 1
-        radius: csd ? Math.min(Config.borderRounding, 15) : 0
-        color: Qt.rgba(Theme.popoverBackground.r, Theme.popoverBackground.g, Theme.popoverBackground.b, bgOpacity)
-        border.color: Config.withAlpha(Theme.popoverBorder, bgOpacity)
-        border.width: csd ? 1 : 0
+    background: PopoverBackground {
+        popup: root
         PopupMaterial {}
     }
 }


### PR DESCRIPTION
On Windows we use in-scene popups instead of native windows because it doesn't work very well, especially when frequent resizing (e.g while searching, as we do always) is a requirement.

Because of this limitation, the popups cannot extend outside the main Vicinae window, so we need to adapt popup placement to display it either above or below the anchor, depending on the free space available.