### PR TITLE
fix: image copy on Windows

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -767,6 +767,8 @@ elseif (WIN32)
 		src/services/global-shortcuts/windows-global-shortcut-backend.cpp
 		src/services/clipboard/windows/windows-clipboard-server.hpp
 		src/services/clipboard/windows/windows-clipboard-server.cpp
+		src/services/clipboard/windows/windows-image-mime.hpp
+		src/services/clipboard/windows/windows-image-mime.cpp
 		src/services/tray/windows/tray-service-windows.hpp
 		src/services/tray/windows/tray-service-windows.cpp
 		src/services/paste/windows-paste-service.hpp

--- a/src/server/src/services/clipboard/windows/windows-clipboard-server.cpp
+++ b/src/server/src/services/clipboard/windows/windows-clipboard-server.cpp
@@ -5,6 +5,7 @@
 #include <appmodel.h>
 
 #include "windows-clipboard-server.hpp"
+#include "windows-image-mime.hpp"
 #include "services/clipboard/clipboard-mime.hpp"
 
 namespace {
@@ -17,6 +18,13 @@ bool isDwordZero(const QByteArray &data) {
   return data.size() >= 4 && qFromLittleEndian<quint32>(data.constData()) == 0;
 }
 } // namespace
+
+WindowsClipboardServer::WindowsClipboardServer() {
+  // the converter registers itself with the windows QPA plugin on construction
+  if (isActivatable()) m_imageMime = std::make_unique<WindowsImageMime>();
+}
+
+WindowsClipboardServer::~WindowsClipboardServer() = default;
 
 bool WindowsClipboardServer::start() {
   connect(QGuiApplication::clipboard(), &QClipboard::dataChanged, this, [this]() { handleChange(false); });

--- a/src/server/src/services/clipboard/windows/windows-clipboard-server.hpp
+++ b/src/server/src/services/clipboard/windows/windows-clipboard-server.hpp
@@ -1,11 +1,17 @@
 #pragma once
 
+#include <memory>
 #include "services/clipboard/clipboard-server.hpp"
+
+class WindowsImageMime;
 
 class WindowsClipboardServer : public AbstractClipboardServer {
   Q_OBJECT
 
 public:
+  WindowsClipboardServer();
+  ~WindowsClipboardServer() override;
+
   QString id() const override { return "windows"; }
   bool isActivatable() const override { return QGuiApplication::platformName() == "windows"; }
   bool isAlive() const override { return true; }
@@ -14,6 +20,8 @@ public:
 
 private:
   static constexpr int RETRY_DELAY_MS = 100;
+
+  std::unique_ptr<WindowsImageMime> m_imageMime;
 
   bool writeClipboard(QMimeData *data, const Clipboard::CopyOptions &options) override;
   void handleChange(bool isRetry);

--- a/src/server/src/services/clipboard/windows/windows-image-mime.cpp
+++ b/src/server/src/services/clipboard/windows/windows-image-mime.cpp
@@ -1,0 +1,99 @@
+#include <windows.h>
+#include <ole2.h>
+#include <cstring>
+
+#include <QBuffer>
+#include <QImage>
+#include <QImageWriter>
+#include <QMimeData>
+#include <QVariant>
+
+#include "windows-image-mime.hpp"
+
+namespace {
+constexpr qsizetype BMP_FILE_HEADER_SIZE = 14;
+
+FORMATETC formatEtc(CLIPFORMAT cf) { return {cf, nullptr, DVASPECT_CONTENT, -1, TYMED_HGLOBAL}; }
+
+bool setHGlobal(STGMEDIUM *pmedium, const QByteArray &data) {
+  HGLOBAL hglobal = GlobalAlloc(GMEM_MOVEABLE, data.size());
+  if (!hglobal) return false;
+
+  void *dst = GlobalLock(hglobal);
+  if (!dst) {
+    GlobalFree(hglobal);
+    return false;
+  }
+  std::memcpy(dst, data.constData(), data.size());
+  GlobalUnlock(hglobal);
+
+  pmedium->tymed = TYMED_HGLOBAL;
+  pmedium->hGlobal = hglobal;
+  pmedium->pUnkForRelease = nullptr;
+  return true;
+}
+
+QByteArray getHGlobal(IDataObject *obj, CLIPFORMAT cf) {
+  FORMATETC fmt = formatEtc(cf);
+  STGMEDIUM medium{};
+  if (FAILED(obj->GetData(&fmt, &medium))) return {};
+
+  QByteArray data;
+  if (medium.tymed == TYMED_HGLOBAL) {
+    if (const void *src = GlobalLock(medium.hGlobal)) {
+      data = QByteArray(static_cast<const char *>(src), static_cast<qsizetype>(GlobalSize(medium.hGlobal)));
+      GlobalUnlock(medium.hGlobal);
+    }
+  }
+  ReleaseStgMedium(&medium);
+  return data;
+}
+
+// CF_DIB is a BMP file without its file header
+QByteArray dibFromPng(const QByteArray &png) {
+  QImage const image = QImage::fromData(png);
+  if (image.isNull()) return {};
+
+  QByteArray bmp;
+  QBuffer buf(&bmp);
+  buf.open(QIODevice::WriteOnly);
+  QImageWriter writer(&buf, "BMP");
+  if (!writer.write(image)) return {};
+  return bmp.mid(BMP_FILE_HEADER_SIZE);
+}
+} // namespace
+
+WindowsImageMime::WindowsImageMime() : m_pngFormat(RegisterClipboardFormatW(L"PNG")) {}
+
+QString WindowsImageMime::mimeForFormat(const FORMATETC &formatetc) const {
+  return formatetc.cfFormat == m_pngFormat ? QString(PNG_MIME) : QString();
+}
+
+bool WindowsImageMime::canConvertToMime(const QString &mimeType, IDataObject *pDataObj) const {
+  if (mimeType != PNG_MIME) return false;
+  FORMATETC fmt = formatEtc(static_cast<CLIPFORMAT>(m_pngFormat));
+  return pDataObj->QueryGetData(&fmt) == S_OK;
+}
+
+QVariant WindowsImageMime::convertToMime(const QString &mimeType, IDataObject *pDataObj, QMetaType) const {
+  if (!canConvertToMime(mimeType, pDataObj)) return {};
+  return getHGlobal(pDataObj, static_cast<CLIPFORMAT>(m_pngFormat));
+}
+
+QList<FORMATETC> WindowsImageMime::formatsForMime(const QString &mimeType, const QMimeData *) const {
+  if (mimeType != PNG_MIME) return {};
+  return {formatEtc(static_cast<CLIPFORMAT>(m_pngFormat)), formatEtc(CF_DIB)};
+}
+
+bool WindowsImageMime::canConvertFromMime(const FORMATETC &formatetc, const QMimeData *mimeData) const {
+  const bool known = formatetc.cfFormat == m_pngFormat || formatetc.cfFormat == CF_DIB;
+  return known && (formatetc.tymed & TYMED_HGLOBAL) && mimeData->hasFormat(PNG_MIME);
+}
+
+bool WindowsImageMime::convertFromMime(const FORMATETC &formatetc, const QMimeData *mimeData,
+                                       STGMEDIUM *pmedium) const {
+  if (!canConvertFromMime(formatetc, mimeData)) return false;
+  const QByteArray png = mimeData->data(PNG_MIME);
+  const QByteArray out = formatetc.cfFormat == CF_DIB ? dibFromPng(png) : png;
+  return !out.isEmpty() && setHGlobal(pmedium, out);
+}

--- a/src/server/src/services/clipboard/windows/windows-image-mime.hpp
+++ b/src/server/src/services/clipboard/windows/windows-image-mime.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <QtGui/qwindowsmimeconverter.h>
+
+// image/png <-> "PNG" as raw bytes
+// CF_DIB is rendered only when a consumer asks for it
+class WindowsImageMime : public QWindowsMimeConverter {
+public:
+  WindowsImageMime();
+
+  bool canConvertFromMime(const FORMATETC &formatetc, const QMimeData *mimeData) const override;
+  bool convertFromMime(const FORMATETC &formatetc, const QMimeData *mimeData,
+                       STGMEDIUM *pmedium) const override;
+  QList<FORMATETC> formatsForMime(const QString &mimeType, const QMimeData *mimeData) const override;
+  bool canConvertToMime(const QString &mimeType, IDataObject *pDataObj) const override;
+  QVariant convertToMime(const QString &mimeType, IDataObject *pDataObj,
+                         QMetaType preferredType) const override;
+  QString mimeForFormat(const FORMATETC &formatetc) const override;
+
+private:
+  static constexpr const char *PNG_MIME = "image/png";
+
+  const unsigned m_pngFormat;
+};


### PR DESCRIPTION
Image copied back from clipboard history was set using the raw image/png mime type which Windows doesn't understand. We provide a custom Windows mime converter for QT so that image gets properly served as PNG format, and also handle CF_DIB (bitmap)