### PR TITLE
fix(i18n): translate tray menu

### DIFF
--- a/src/server/src/services/tray/linux/tray-service-linux.cpp
+++ b/src/server/src/services/tray/linux/tray-service-linux.cpp
@@ -231,21 +231,21 @@ QString TrayServiceLinux::entryLabel(const MenuEntry &entry) const {
   using Kind = MenuEntry::Kind;
   switch (entry.kind) {
   case Kind::Toggle:
-    return tr("Toggle Vicinae");
+    return toggleLabel();
   case Kind::Version:
     return m_version.isEmpty() ? QStringLiteral("Vicinae") : QStringLiteral("Vicinae %1").arg(m_version);
   case Kind::About:
-    return tr("About Vicinae");
+    return aboutLabel();
   case Kind::Settings:
-    return tr("Settings…");
+    return settingsLabel();
   case Kind::Sponsor:
-    return tr("Sponsor Vicinae");
+    return sponsorLabel();
   case Kind::Discord:
-    return tr("Join the Discord");
+    return discordLabel();
   case Kind::Follow:
-    return tr("Follow on X");
+    return followLabel();
   case Kind::Quit:
-    return tr("Quit Vicinae");
+    return quitLabel();
   case Kind::Separator:
     return {};
   }

--- a/src/server/src/services/tray/macos/tray-service-macos.mm
+++ b/src/server/src/services/tray/macos/tray-service-macos.mm
@@ -87,7 +87,7 @@ TrayServiceMacOS::TrayServiceMacOS(QObject *parent) : TrayService(parent), m_imp
 
   NSMenu *menu = [[NSMenu alloc] init];
 
-  NSMenuItem *toggleItem = [[NSMenuItem alloc] initWithTitle:@"Toggle Vicinae"
+  NSMenuItem *toggleItem = [[NSMenuItem alloc] initWithTitle:toggleLabel().toNSString()
                                                       action:@selector(toggle:)
                                                keyEquivalent:@""];
   toggleItem.target = m_impl->target;
@@ -98,20 +98,20 @@ TrayServiceMacOS::TrayServiceMacOS(QObject *parent) : TrayService(parent), m_imp
 
   [menu addItem:[NSMenuItem separatorItem]];
 
-  NSMenuItem *aboutItem = [[NSMenuItem alloc] initWithTitle:@"About Vicinae"
+  NSMenuItem *aboutItem = [[NSMenuItem alloc] initWithTitle:aboutLabel().toNSString()
                                                      action:@selector(openAbout:)
                                               keyEquivalent:@""];
   aboutItem.target = m_impl->target;
   [menu addItem:aboutItem];
 
-  m_impl->checkForUpdatesItem = [[NSMenuItem alloc] initWithTitle:@"Check for Updates…"
+  m_impl->checkForUpdatesItem = [[NSMenuItem alloc] initWithTitle:checkForUpdatesLabel().toNSString()
                                                            action:@selector(checkForUpdates:)
                                                     keyEquivalent:@""];
   m_impl->checkForUpdatesItem.target = m_impl->target;
   m_impl->checkForUpdatesItem.hidden = YES;
   [menu addItem:m_impl->checkForUpdatesItem];
 
-  NSMenuItem *prefsItem = [[NSMenuItem alloc] initWithTitle:@"Preferences…"
+  NSMenuItem *prefsItem = [[NSMenuItem alloc] initWithTitle:preferencesLabel().toNSString()
                                                      action:@selector(openPreferences:)
                                               keyEquivalent:@","];
   prefsItem.keyEquivalentModifierMask = NSEventModifierFlagCommand;
@@ -120,19 +120,19 @@ TrayServiceMacOS::TrayServiceMacOS(QObject *parent) : TrayService(parent), m_imp
 
   [menu addItem:[NSMenuItem separatorItem]];
 
-  NSMenuItem *sponsorItem = [[NSMenuItem alloc] initWithTitle:@"Sponsor Vicinae"
+  NSMenuItem *sponsorItem = [[NSMenuItem alloc] initWithTitle:sponsorLabel().toNSString()
                                                        action:@selector(openSponsor:)
                                                 keyEquivalent:@""];
   sponsorItem.target = m_impl->target;
   [menu addItem:sponsorItem];
 
-  NSMenuItem *discordItem = [[NSMenuItem alloc] initWithTitle:@"Join the Discord"
+  NSMenuItem *discordItem = [[NSMenuItem alloc] initWithTitle:discordLabel().toNSString()
                                                        action:@selector(openDiscord:)
                                                 keyEquivalent:@""];
   discordItem.target = m_impl->target;
   [menu addItem:discordItem];
 
-  NSMenuItem *followItem = [[NSMenuItem alloc] initWithTitle:@"Follow on X"
+  NSMenuItem *followItem = [[NSMenuItem alloc] initWithTitle:followLabel().toNSString()
                                                       action:@selector(openFollow:)
                                                keyEquivalent:@""];
   followItem.target = m_impl->target;
@@ -140,7 +140,7 @@ TrayServiceMacOS::TrayServiceMacOS(QObject *parent) : TrayService(parent), m_imp
 
   [menu addItem:[NSMenuItem separatorItem]];
 
-  NSMenuItem *quitItem = [[NSMenuItem alloc] initWithTitle:@"Quit Vicinae"
+  NSMenuItem *quitItem = [[NSMenuItem alloc] initWithTitle:quitLabel().toNSString()
                                                     action:@selector(quit:)
                                              keyEquivalent:@""];
   quitItem.target = m_impl->target;
@@ -167,9 +167,9 @@ void TrayServiceMacOS::setAvailableUpdate(const QString &tag) {
   if (!m_impl->checkForUpdatesItem) return;
 
   if (tag.isEmpty()) {
-    m_impl->checkForUpdatesItem.title = @"Check for Updates…";
+    m_impl->checkForUpdatesItem.title = checkForUpdatesLabel().toNSString();
   } else {
-    m_impl->checkForUpdatesItem.title = [NSString stringWithFormat:@"Update Available: %@", tag.toNSString()];
+    m_impl->checkForUpdatesItem.title = updateAvailableLabel(tag).toNSString();
   }
 }
 

--- a/src/server/src/services/tray/tray-service.cpp
+++ b/src/server/src/services/tray/tray-service.cpp
@@ -7,6 +7,26 @@
 #include "services/tray/linux/tray-service-linux.hpp"
 #endif
 
+QString TrayService::toggleLabel() { return tr("Toggle Vicinae"); }
+
+QString TrayService::aboutLabel() { return tr("About Vicinae"); }
+
+QString TrayService::checkForUpdatesLabel() { return tr("Check for Updates…"); }
+
+QString TrayService::updateAvailableLabel(const QString &tag) { return tr("Update Available: %1").arg(tag); }
+
+QString TrayService::settingsLabel() { return tr("Settings…"); }
+
+QString TrayService::preferencesLabel() { return tr("Preferences…"); }
+
+QString TrayService::sponsorLabel() { return tr("Sponsor Vicinae"); }
+
+QString TrayService::discordLabel() { return tr("Join the Discord"); }
+
+QString TrayService::followLabel() { return tr("Follow on X"); }
+
+QString TrayService::quitLabel() { return tr("Quit Vicinae"); }
+
 std::unique_ptr<TrayService> createTrayService() {
 #ifdef Q_OS_MACOS
   return std::make_unique<TrayServiceMacOS>();

--- a/src/server/src/services/tray/tray-service.hpp
+++ b/src/server/src/services/tray/tray-service.hpp
@@ -21,6 +21,17 @@ public:
   explicit TrayService(QObject *parent = nullptr) : QObject(parent) {}
   ~TrayService() override = default;
 
+  static QString toggleLabel();
+  static QString aboutLabel();
+  static QString checkForUpdatesLabel();
+  static QString updateAvailableLabel(const QString &tag);
+  static QString settingsLabel();
+  static QString preferencesLabel();
+  static QString sponsorLabel();
+  static QString discordLabel();
+  static QString followLabel();
+  static QString quitLabel();
+
   virtual void setVersion(const QString &version) = 0;
   virtual void setCheckForUpdatesVisible(bool visible) = 0;
   virtual void setAvailableUpdate(const QString &tag) = 0;

--- a/src/server/src/services/tray/windows/tray-service-windows.cpp
+++ b/src/server/src/services/tray/windows/tray-service-windows.cpp
@@ -157,23 +157,23 @@ struct TrayServiceWindows::Impl {
       return;
     }
 
-    appendMenuItem(menu, MF_STRING, COMMAND_TOGGLE, owner.tr("Toggle Vicinae"));
+    appendMenuItem(menu, MF_STRING, COMMAND_TOGGLE, TrayService::toggleLabel());
     appendMenuItem(menu, MF_STRING | MF_DISABLED, 0,
                    version.isEmpty() ? QStringLiteral("Vicinae") : QStringLiteral("Vicinae %1").arg(version));
     AppendMenuW(menu, MF_SEPARATOR, 0, nullptr);
-    appendMenuItem(menu, MF_STRING, COMMAND_ABOUT, owner.tr("About Vicinae"));
+    appendMenuItem(menu, MF_STRING, COMMAND_ABOUT, TrayService::aboutLabel());
     if (checkForUpdatesVisible) {
       appendMenuItem(menu, MF_STRING, COMMAND_CHECK_FOR_UPDATES,
-                     availableUpdate.isEmpty() ? owner.tr("Check for Updates…")
-                                               : owner.tr("Update Available: %1").arg(availableUpdate));
+                     availableUpdate.isEmpty() ? TrayService::checkForUpdatesLabel()
+                                               : TrayService::updateAvailableLabel(availableUpdate));
     }
-    appendMenuItem(menu, MF_STRING, COMMAND_SETTINGS, owner.tr("Settings…"));
+    appendMenuItem(menu, MF_STRING, COMMAND_SETTINGS, TrayService::settingsLabel());
     AppendMenuW(menu, MF_SEPARATOR, 0, nullptr);
-    appendMenuItem(menu, MF_STRING, COMMAND_SPONSOR, owner.tr("Sponsor Vicinae"));
-    appendMenuItem(menu, MF_STRING, COMMAND_DISCORD, owner.tr("Join the Discord"));
-    appendMenuItem(menu, MF_STRING, COMMAND_FOLLOW, owner.tr("Follow on X"));
+    appendMenuItem(menu, MF_STRING, COMMAND_SPONSOR, TrayService::sponsorLabel());
+    appendMenuItem(menu, MF_STRING, COMMAND_DISCORD, TrayService::discordLabel());
+    appendMenuItem(menu, MF_STRING, COMMAND_FOLLOW, TrayService::followLabel());
     AppendMenuW(menu, MF_SEPARATOR, 0, nullptr);
-    appendMenuItem(menu, MF_STRING, COMMAND_QUIT, owner.tr("Quit Vicinae"));
+    appendMenuItem(menu, MF_STRING, COMMAND_QUIT, TrayService::quitLabel());
 
     POINT cursor{};
     GetCursorPos(&cursor);

--- a/src/server/translations/vicinae_de.ts
+++ b/src/server/translations/vicinae_de.ts
@@ -7225,4 +7225,47 @@ Wenn Sie Ihre eigene Erweiterung erstellen möchten, werfen Sie einen Blick auf 
         <translation>Desktop %1</translation>
     </message>
 </context>
+<context>
+    <name>TrayService</name>
+    <message>
+        <source>Toggle Vicinae</source>
+        <translation>Vicinae ein-/ausblenden</translation>
+    </message>
+    <message>
+        <source>About Vicinae</source>
+        <translation>Über Vicinae</translation>
+    </message>
+    <message>
+        <source>Check for Updates…</source>
+        <translation>Nach Updates suchen…</translation>
+    </message>
+    <message>
+        <source>Update Available: %1</source>
+        <translation>Update verfügbar: %1</translation>
+    </message>
+    <message>
+        <source>Settings…</source>
+        <translation>Einstellungen…</translation>
+    </message>
+    <message>
+        <source>Preferences…</source>
+        <translation>Einstellungen…</translation>
+    </message>
+    <message>
+        <source>Sponsor Vicinae</source>
+        <translation>Vicinae unterstützen</translation>
+    </message>
+    <message>
+        <source>Join the Discord</source>
+        <translation>Discord-Server beitreten</translation>
+    </message>
+    <message>
+        <source>Follow on X</source>
+        <translation>Auf X folgen</translation>
+    </message>
+    <message>
+        <source>Quit Vicinae</source>
+        <translation>Vicinae beenden</translation>
+    </message>
+</context>
 </TS>


### PR DESCRIPTION
## Summary

- centralize tray menu labels in a shared `TrayService` translation context
- use translated labels across Linux, Windows, and macOS tray implementations
- add complete German translations for the tray menu

## Verification

- `lrelease src/server/translations/vicinae_de.ts -qm /tmp/vicinae_de.qm` (1,225 finished, 0 unfinished)
- `git diff --check`

