### PR TITLE
feat(windows): clipboard fallback to get text selection

### DIFF
--- a/src/server/src/qml/launcher-window-platform.cpp
+++ b/src/server/src/qml/launcher-window-platform.cpp
@@ -1,5 +1,6 @@
 #include "launcher-window-platform.hpp"
 #include "services/global-shortcuts/windows-global-shortcut-backend.hpp"
+#include "services/selection/windows-selection-service.hpp"
 #include <windows.h>
 
 namespace LauncherWindowPlatform {
@@ -32,5 +33,7 @@ void suppressHeldKeyReleases() {
     if (GetAsyncKeyState(static_cast<int>(vk)) < 0) { WindowsGlobalShortcutBackend::suppressNextKeyUp(vk); }
   }
 }
+
+bool foregroundLent() { return WindowsSelectionService::isLendingForeground(); }
 
 } // namespace LauncherWindowPlatform

--- a/src/server/src/qml/launcher-window-platform.hpp
+++ b/src/server/src/qml/launcher-window-platform.hpp
@@ -21,9 +21,13 @@ void grantForeground();
 // Called right before hiding: the release of keys still held (escape, return,
 // the hotkey key) would otherwise leak to the window regaining foreground.
 void suppressHeldKeyReleases();
+// The selection service lends the foreground to the target app to send it a copy
+// chord; the deactivation that causes is not user focus loss.
+bool foregroundLent();
 #else
 inline void grantForeground() {}
 inline void suppressHeldKeyReleases() {}
+inline bool foregroundLent() { return false; }
 #endif
 
 } // namespace LauncherWindowPlatform

--- a/src/server/src/qml/launcher-window.cpp
+++ b/src/server/src/qml/launcher-window.cpp
@@ -141,8 +141,8 @@ LauncherWindow::LauncherWindow(ApplicationContext &ctx, QObject *parent)
   if (m_window) {
     nav->setWindow(m_window);
     connect(m_window, &QQuickWindow::activeChanged, this, [this]() {
-      // losing focus to our own file dialog is not user focus loss
-      if (m_pendingLauncherFileChoice) return;
+      // losing focus to our own file dialog or to a selection capture is not user focus loss
+      if (m_pendingLauncherFileChoice || LauncherWindowPlatform::foregroundLent()) return;
       m_ctx.navigation->setWindowActivated(m_window->isActive());
     });
     m_window->installEventFilter(this);

--- a/src/server/src/server.cpp
+++ b/src/server/src/server.cpp
@@ -285,8 +285,8 @@ int startServer(const ServerLaunchOptions &launchOpts) {
 #elif defined(Q_OS_WIN)
     auto snippetServer = std::make_unique<WindowsSnippetServer>();
     auto platformPaste = std::unique_ptr<AbstractPasteService>(std::make_unique<WindowsPasteService>());
-    auto selectionService =
-        std::unique_ptr<AbstractSelectionService>(std::make_unique<WindowsSelectionService>());
+    auto selectionService = std::unique_ptr<AbstractSelectionService>(
+        std::make_unique<WindowsSelectionService>(*clipboardManager, *windowManager));
 #else
     auto snippetServer = std::make_unique<NullSnippetServer>();
     auto platformPaste = std::unique_ptr<AbstractPasteService>(std::make_unique<DummyPasteService>());

--- a/src/server/src/services/selection/windows-selection-service.cpp
+++ b/src/server/src/services/selection/windows-selection-service.cpp
@@ -1,10 +1,22 @@
 #include "windows-selection-service.hpp"
+#include "services/clipboard/clipboard-service.hpp"
+#include "services/window-manager/window-manager.hpp"
+#include "services/window-manager/windows/windows-window.hpp"
+#include "utils/scoped-com.hpp"
+#include <QClipboard>
+#include <QGuiApplication>
+#include <QMimeData>
+#include <QPromise>
+#include <QTimer>
+#include <QtLogging>
+#include <chrono>
+#include <memory>
+#include <vector>
 #include <windows.h>
 #include <objbase.h>
 #include <oleauto.h>
 #include <uiautomation.h>
 #include <wrl/client.h>
-#include "utils/scoped-com.hpp"
 
 using Microsoft::WRL::ComPtr;
 
@@ -12,16 +24,38 @@ namespace {
 
 using Result = AbstractSelectionService::Result;
 
-HWND g_lastForeground = nullptr;
+constexpr int COPY_POLL_INTERVAL_MS = 10;
+constexpr int COPY_TIMEOUT_MS = 1000;
+constexpr int HANDOFF_TIMEOUT_MS = 400;
+constexpr UINT WM_COPY_TIMEOUT_MS = 50;
+constexpr int MAX_ANCESTOR_WALK = 32;
+constexpr auto FOREGROUND_LEASE_GRACE = std::chrono::milliseconds(1000);
+constexpr ULONG_PTR VICINAE_INJECT_TAG = 0x7669636e; // 'vicn'
+constexpr WORD START_MENU_SUPPRESS_VK = 0xFF;
+constexpr WORD MODIFIERS[] = {VK_LCONTROL, VK_RCONTROL, VK_LSHIFT, VK_RSHIFT,
+                              VK_LMENU,    VK_RMENU,    VK_LWIN,   VK_RWIN};
 
-void CALLBACK foregroundChanged(HWINEVENTHOOK, DWORD, HWND hwnd, LONG, LONG, DWORD, DWORD) {
-  if (!hwnd) return;
+std::chrono::steady_clock::time_point g_foregroundLentAt{};
+
+QFuture<Result> ready(Result result) { return QtFuture::makeReadyValueFuture<Result>(std::move(result)); }
+
+QFuture<Result> fail(const QString &error) { return ready(std::unexpected(error)); }
+
+Result noSelection() { return std::unexpected(QStringLiteral("Unable to get selected text")); }
+
+bool isOurs(HWND hwnd) {
   DWORD pid = 0;
   GetWindowThreadProcessId(hwnd, &pid);
-  if (pid && pid != GetCurrentProcessId()) g_lastForeground = hwnd;
+  return pid == GetCurrentProcessId();
 }
 
-QString textFromPattern(IUIAutomationTextPattern *pattern) {
+QString selectionText(IUIAutomationElement *element) {
+  ComPtr<IUnknown> unknown;
+  if (FAILED(element->GetCurrentPattern(UIA_TextPatternId, &unknown)) || !unknown) return {};
+
+  ComPtr<IUIAutomationTextPattern> pattern;
+  if (FAILED(unknown.As(&pattern)) || !pattern) return {};
+
   ComPtr<IUIAutomationTextRangeArray> ranges;
   if (FAILED(pattern->GetSelection(&ranges)) || !ranges) return {};
 
@@ -43,17 +77,51 @@ QString textFromPattern(IUIAutomationTextPattern *pattern) {
   return text;
 }
 
-QString textFromElement(IUIAutomationElement *element) {
-  ComPtr<IUnknown> unknown;
-  if (FAILED(element->GetCurrentPattern(UIA_TextPatternId, &unknown)) || !unknown) return {};
+ComPtr<IUIAutomationCondition> boolCondition(IUIAutomation *automation, PROPERTYID property) {
+  VARIANT value;
+  value.vt = VT_BOOL;
+  value.boolVal = VARIANT_TRUE;
 
-  ComPtr<IUIAutomationTextPattern> pattern;
-  if (FAILED(unknown.As(&pattern)) || !pattern) return {};
-
-  return textFromPattern(pattern.Get());
+  ComPtr<IUIAutomationCondition> condition;
+  if (FAILED(automation->CreatePropertyCondition(property, value, &condition))) return nullptr;
+  return condition;
 }
 
-QString selectedTextFromWindow(HWND foreground) {
+QString selectionFromAncestry(IUIAutomation *automation, IUIAutomationElement *start) {
+  ComPtr<IUIAutomationTreeWalker> walker;
+  if (FAILED(automation->get_RawViewWalker(&walker)) || !walker) return selectionText(start);
+
+  ComPtr<IUIAutomationElement> current = start;
+  for (int depth = 0; current && depth < MAX_ANCESTOR_WALK; ++depth) {
+    if (QString text = selectionText(current.Get()); !text.isEmpty()) return text;
+
+    ComPtr<IUIAutomationElement> parent;
+    if (FAILED(walker->GetParentElement(current.Get(), &parent))) break;
+    current = parent;
+  }
+
+  return {};
+}
+
+HWND focusedWindow(HWND foreground) {
+  GUITHREADINFO info{};
+  info.cbSize = sizeof(GUITHREADINFO);
+  DWORD thread = GetWindowThreadProcessId(foreground, nullptr);
+  if (thread && GetGUIThreadInfo(thread, &info) && info.hwndFocus) return info.hwndFocus;
+  return foreground;
+}
+
+// foreground alone is not enough: a browser reports foreground before its content window takes keyboard
+// focus, and a chord sent in that gap is dropped
+bool targetHasKeyboardFocus(HWND target) {
+  if (GetForegroundWindow() != target) return false;
+  GUITHREADINFO info{};
+  info.cbSize = sizeof(GUITHREADINFO);
+  DWORD thread = GetWindowThreadProcessId(target, nullptr);
+  return thread && GetGUIThreadInfo(thread, &info) && info.hwndFocus != nullptr;
+}
+
+QString uiaSelectedText(HWND focus) {
   ScopedCom com;
   ComPtr<IUIAutomation> automation;
   if (FAILED(
@@ -62,59 +130,214 @@ QString selectedTextFromWindow(HWND foreground) {
     return {};
   }
 
-  // GetFocusedElement would resolve to the launcher; ask the target thread for its focused control
-  GUITHREADINFO info{};
-  info.cbSize = sizeof(GUITHREADINFO);
-  DWORD thread = GetWindowThreadProcessId(foreground, nullptr);
-  HWND focus = (thread && GetGUIThreadInfo(thread, &info) && info.hwndFocus) ? info.hwndFocus : foreground;
-
   ComPtr<IUIAutomationElement> element;
   if (FAILED(automation->ElementFromHandle(focus, &element)) || !element) return {};
 
-  if (QString text = textFromElement(element.Get()); !text.isEmpty()) return text;
-
-  VARIANT focusedValue;
-  focusedValue.vt = VT_BOOL;
-  focusedValue.boolVal = VARIANT_TRUE;
-
-  ComPtr<IUIAutomationCondition> condition;
-  if (FAILED(automation->CreatePropertyCondition(UIA_HasKeyboardFocusPropertyId, focusedValue, &condition)) ||
-      !condition) {
-    return {};
+  // GetFocusedElement would resolve to the launcher, not the target
+  ComPtr<IUIAutomationElement> start = element;
+  if (auto condition = boolCondition(automation.Get(), UIA_HasKeyboardFocusPropertyId)) {
+    ComPtr<IUIAutomationElement> deepest;
+    if (SUCCEEDED(element->FindFirst(TreeScope_Subtree, condition.Get(), &deepest)) && deepest)
+      start = deepest;
   }
 
-  ComPtr<IUIAutomationElement> focused;
-  if (FAILED(element->FindFirst(TreeScope_Subtree, condition.Get(), &focused)) || !focused) return {};
-
-  return textFromElement(focused.Get());
+  return selectionFromAncestry(automation.Get(), start.Get());
 }
+
+INPUT keyInput(WORD vk, bool down) {
+  INPUT in{};
+  in.type = INPUT_KEYBOARD;
+  in.ki.wVk = vk;
+  in.ki.wScan = static_cast<WORD>(MapVirtualKeyW(vk, MAPVK_VK_TO_VSC));
+  in.ki.dwFlags = down ? 0 : KEYEVENTF_KEYUP;
+  in.ki.dwExtraInfo = VICINAE_INJECT_TAG;
+  return in;
+}
+
+// modifiers still held from the triggering chord would turn ctrl+c into something else
+void sendCopyChord() {
+  std::vector<INPUT> inputs;
+  std::vector<WORD> held;
+
+  for (WORD vk : MODIFIERS) {
+    if (GetAsyncKeyState(vk) < 0) {
+      held.push_back(vk);
+      inputs.push_back(keyInput(vk, false));
+    }
+  }
+
+  inputs.push_back(keyInput(VK_CONTROL, true));
+  inputs.push_back(keyInput('C', true));
+  inputs.push_back(keyInput('C', false));
+  inputs.push_back(keyInput(VK_CONTROL, false));
+
+  for (WORD vk : held) {
+    inputs.push_back(keyInput(vk, true));
+  }
+  // a re-pressed win key would otherwise open the start menu on its physical release
+  inputs.push_back(keyInput(START_MENU_SUPPRESS_VK, false));
+
+  SendInput(static_cast<UINT>(inputs.size()), inputs.data(), sizeof(INPUT));
+}
+
+HWND lendForeground(HWND target) {
+  HWND current = GetForegroundWindow();
+  if (current == target) return nullptr;
+
+  g_foregroundLentAt = std::chrono::steady_clock::now();
+  SetForegroundWindow(target);
+  return isOurs(current) ? current : nullptr;
+}
+
+void reclaimForeground(HWND launcher) {
+  // the system only grants foreground to the process that last received input
+  INPUT input{};
+  input.type = INPUT_MOUSE;
+  SendInput(1, &input, sizeof(input));
+  SetForegroundWindow(launcher);
+  g_foregroundLentAt = std::chrono::steady_clock::now();
+}
+
+std::unique_ptr<QMimeData> snapshotClipboard() {
+  auto copy = std::make_unique<QMimeData>();
+  const QMimeData *mime = QGuiApplication::clipboard()->mimeData();
+  if (!mime) return copy;
+
+  for (const QString &format : mime->formats()) {
+    copy->setData(format, mime->data(format));
+  }
+
+  return copy;
+}
+
+struct CopyState {
+  DWORD sequence = 0;
+  std::unique_ptr<QMimeData> snapshot;
+  HWND target = nullptr;
+  HWND launcher = nullptr;
+  int elapsed = 0;
+  int readyAt = -1;
+  int chordSentAt = -1;
+  const char *tier = "wm_copy";
+};
 
 } // namespace
 
-WindowsSelectionService::WindowsSelectionService() {
-  g_lastForeground = GetForegroundWindow();
-  m_hook = SetWinEventHook(EVENT_SYSTEM_FOREGROUND, EVENT_SYSTEM_FOREGROUND, nullptr, foregroundChanged, 0, 0,
-                           WINEVENT_OUTOFCONTEXT | WINEVENT_SKIPOWNPROCESS);
-}
+WindowsSelectionService::WindowsSelectionService(ClipboardService &clipboard, WindowManager &wm)
+    : m_clipboard(clipboard), m_wm(wm) {}
 
-WindowsSelectionService::~WindowsSelectionService() {
-  if (m_hook) UnhookWinEvent(static_cast<HWINEVENTHOOK>(m_hook));
+bool WindowsSelectionService::isLendingForeground() {
+  return std::chrono::steady_clock::now() - g_foregroundLentAt < FOREGROUND_LEASE_GRACE;
 }
 
 QFuture<Result> WindowsSelectionService::selectedText() {
-  HWND target = g_lastForeground;
-
-  if (!target || !IsWindow(target)) {
-    return QtFuture::makeReadyValueFuture<Result>(
-        std::unexpected(QStringLiteral("Unable to get selected text")));
+  auto window = m_wm.getFocusedWindow();
+  if (!window) {
+    qInfo() << "selection: no remembered target window";
+    return ready(noSelection());
   }
 
-  QString text = selectedTextFromWindow(target);
+  HWND target = static_cast<const Win::Window &>(*window).hwnd();
+  if (!IsWindow(target)) {
+    qInfo() << "selection: remembered window is gone" << window->title();
+    return ready(noSelection());
+  }
+  if (m_copying) return fail(QStringLiteral("A selection capture is already in progress"));
 
-  if (text.isEmpty()) {
-    return QtFuture::makeReadyValueFuture<Result>(
-        std::unexpected(QStringLiteral("Unable to get selected text")));
+  HWND focus = focusedWindow(target);
+  qInfo().nospace() << "selection: target " << window->title() << " (class=" << window->wmClass()
+                    << ", focus hwnd=" << focus << ")";
+
+  if (QString text = uiaSelectedText(focus); !text.isEmpty()) {
+    qInfo() << "selection: uia hit," << text.size() << "chars";
+    return ready(std::move(text));
   }
 
-  return QtFuture::makeReadyValueFuture<Result>(std::move(text));
+  return copyFromTarget(target, focus);
+}
+
+QFuture<Result> WindowsSelectionService::copyFromTarget(void *target, void *focus) {
+  auto state = std::make_shared<CopyState>();
+  state->target = static_cast<HWND>(target);
+  state->sequence = GetClipboardSequenceNumber();
+  state->snapshot = snapshotClipboard();
+
+  // classic edit controls copy on request without needing the foreground
+  SendMessageTimeoutW(static_cast<HWND>(focus), WM_COPY, 0, 0, SMTO_ABORTIFHUNG | SMTO_BLOCK,
+                      WM_COPY_TIMEOUT_MS, nullptr);
+
+  if (GetClipboardSequenceNumber() != state->sequence) {
+    state->chordSentAt = 0;
+  } else {
+    state->launcher = lendForeground(state->target);
+    state->tier = "ctrl_c";
+  }
+
+  m_copying = true;
+
+  auto promise = std::make_shared<QPromise<Result>>();
+  promise->start();
+
+  auto *timer = new QTimer(this);
+  timer->setInterval(COPY_POLL_INTERVAL_MS);
+
+  connect(timer, &QTimer::timeout, this, [this, timer, promise, state]() {
+    state->elapsed += COPY_POLL_INTERVAL_MS;
+
+    const auto finish = [&](Result result) {
+      timer->deleteLater();
+      if (state->launcher) reclaimForeground(state->launcher);
+      m_copying = false;
+      promise->addResult(std::move(result));
+      promise->finish();
+    };
+
+    // activation is async: send the chord only once the target actually holds keyboard focus, otherwise it
+    // arrives before the app is ready and is dropped
+    if (state->chordSentAt < 0) {
+      if (state->readyAt < 0) {
+        if (targetHasKeyboardFocus(state->target)) {
+          state->readyAt = state->elapsed;
+        } else if (state->elapsed >= HANDOFF_TIMEOUT_MS) {
+          qWarning() << "selection: target never took keyboard focus, foreground" << GetForegroundWindow();
+          finish(noSelection());
+        }
+        return;
+      }
+
+      state->sequence = GetClipboardSequenceNumber();
+      sendCopyChord();
+      state->chordSentAt = state->elapsed;
+      return;
+    }
+
+    const int sinceChord = state->elapsed - state->chordSentAt;
+    const bool timedOut = sinceChord >= COPY_TIMEOUT_MS;
+
+    if (GetClipboardSequenceNumber() == state->sequence) {
+      if (!timedOut) return;
+      qInfo() << "selection:" << state->tier << "clipboard unchanged after" << sinceChord << "ms";
+      finish(noSelection());
+      return;
+    }
+
+    QString text = QGuiApplication::clipboard()->text();
+    if (text.isEmpty() && !timedOut) return;
+
+    // transient so neither we nor the system re-index what was already on the clipboard
+    m_clipboard.copyQMimeData(state->snapshot.release(), {.transient = true});
+
+    if (text.isEmpty()) {
+      qInfo() << "selection:" << state->tier << "clipboard changed but holds no text after" << sinceChord
+              << "ms";
+      finish(noSelection());
+    } else {
+      qInfo() << "selection:" << state->tier << "hit," << text.size() << "chars after" << sinceChord
+              << "ms, ready" << state->readyAt << "ms";
+      finish(std::move(text));
+    }
+  });
+  timer->start();
+
+  return promise->future();
 }

--- a/src/server/src/services/selection/windows-selection-service.hpp
+++ b/src/server/src/services/selection/windows-selection-service.hpp
@@ -1,13 +1,25 @@
 #pragma once
 #include "services/selection/abstract-selection-service.hpp"
+#include <QObject>
 
-class WindowsSelectionService : public AbstractSelectionService {
+class ClipboardService;
+class WindowManager;
+
+class WindowsSelectionService : public QObject, public AbstractSelectionService {
+  Q_OBJECT
+
 public:
-  WindowsSelectionService();
-  ~WindowsSelectionService() override;
+  WindowsSelectionService(ClipboardService &clipboard, WindowManager &wm);
 
   QFuture<Result> selectedText() override;
 
+  // true shortly after the foreground was lent to the target app for a copy chord
+  static bool isLendingForeground();
+
 private:
-  void *m_hook = nullptr;
+  QFuture<Result> copyFromTarget(void *target, void *focus);
+
+  ClipboardService &m_clipboard;
+  WindowManager &m_wm;
+  bool m_copying = false;
 };


### PR DESCRIPTION
Sometimes we can't reliably get the text using the accessibility API, so we issue a transient clipboard copy to try to get the selected text.