### PR TITLE
feat(macOS): add entitlements for events and calendar automation

### DIFF
--- a/extra/Info.plist.in
+++ b/extra/Info.plist.in
@@ -51,6 +51,16 @@
 	<string>NSApplication</string>
 	<key>NSAppleEventsUsageDescription</key>
 	<string>Vicinae uses Apple Events to perform system power actions such as restart, shut down, and log out.</string>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>Vicinae extensions can read and manage your calendar events.</string>
+	<key>NSCalendarsUsageDescription</key>
+	<string>Vicinae extensions can read and manage your calendar events.</string>
+	<key>NSRemindersFullAccessUsageDescription</key>
+	<string>Vicinae extensions can read and manage your reminders.</string>
+	<key>NSRemindersUsageDescription</key>
+	<string>Vicinae extensions can read and manage your reminders.</string>
+	<key>NSContactsUsageDescription</key>
+	<string>Vicinae extensions can read your contacts.</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © Vicinae contributors. Licensed under GPL-3.0.</string>
 </dict>

--- a/extra/Vicinae.entitlements
+++ b/extra/Vicinae.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist versin="1.0">
+<dict>
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
+	<key>com.apple.security.personal-information.calendars</key>
+	<true/>
+	<key>com.apple.security.personal-information.addressbook</key>
+	<true/>
+</dict>
+</plist>

--- a/scripts/macdeploy.sh
+++ b/scripts/macdeploy.sh
@@ -184,13 +184,31 @@ strip -x "$BUNDLE/Contents/MacOS/Vicinae" "$BUNDLE/Contents/MacOS/vicinae-cli" \
       "$BUNDLE/Contents/MacOS/vicinae-browser-link"
 
 echo "==> signing bundle"
-sign_args=(--force --deep --sign "$SIGN_IDENTITY")
+sign_args=(--force --sign "$SIGN_IDENTITY")
 
 if [[ "$SIGN_IDENTITY" != "-" ]]; then
   sign_args+=(--options runtime --timestamp)
 fi
 
-codesign "${sign_args[@]}" "$BUNDLE" 2>&1 | tail -3
+sign() {
+  local out
+  if ! out="$(codesign "${sign_args[@]}" "$@" 2>&1)"; then
+    echo "$out" >&2
+    return 1
+  fi
+}
+
+# Signed inside out: nested code first, then the app itself with its
+# entitlements. `codesign --deep --entitlements` would stamp the app's
+# entitlements onto every nested framework, plugin and helper.
+while IFS= read -r -d '' item; do
+  sign "$item"
+done < <(find "$BUNDLE/Contents" -type f \( -name "*.dylib" -o -name "*.so" \) -print0)
+while IFS= read -r -d '' item; do
+  sign "$item"
+done < <(find "$BUNDLE/Contents/Frameworks" -maxdepth 1 -name "*.framework" -print0)
+sign "$BUNDLE/Contents/MacOS/vicinae-cli" "$BUNDLE/Contents/MacOS/vicinae-browser-link"
+sign --entitlements "$SRC_DIR/extra/Vicinae.entitlements" "$BUNDLE"
 
 echo "==> audit"
 fail=0

--- a/scripts/verify-dmg.sh
+++ b/scripts/verify-dmg.sh
@@ -71,6 +71,24 @@ if [[ "$fail" -ne 0 ]]; then
   exit 1
 fi
 
+echo "==> entitlements"
+ENTITLEMENTS="$(codesign -d --entitlements - --xml "$APP" 2>/dev/null)"
+for key in com.apple.security.automation.apple-events \
+           com.apple.security.personal-information.calendars \
+           com.apple.security.personal-information.addressbook; do
+  if ! grep -qF "<key>$key</key>" <<<"$ENTITLEMENTS"; then
+    echo "verify-dmg.sh: app is missing entitlement $key" >&2
+    exit 1
+  fi
+done
+for key in NSAppleEventsUsageDescription NSCalendarsFullAccessUsageDescription \
+           NSRemindersFullAccessUsageDescription NSContactsUsageDescription; do
+  if ! /usr/libexec/PlistBuddy -c "Print :$key" "$APP/Contents/Info.plist" >/dev/null 2>&1; then
+    echo "verify-dmg.sh: Info.plist is missing $key" >&2
+    exit 1
+  fi
+done
+
 echo "==> image format plugins"
 for plugin in qicns qwebp qtiff qmacheif qgif qico qjpeg qsvg; do
   if [[ ! -f "$APP/Contents/PlugIns/imageformats/lib$plugin.dylib" ]]; then


### PR DESCRIPTION
Some extensions may call Swift helpers that access macOS APIs that do require specific entitlements.

In general we are interested in calendar automation or apple events.

This will also allow us to integrate with these in the future if we want to.

fixes #1922