### PR TITLE
feat(linux): add GitHub token support to installer to avoid rate limi…

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -163,7 +163,11 @@ get_latest_release_info() {
 	local api_url="https://api.github.com/repos/$REPO/releases/latest"
 
 	local response
-	response=$(curl -s "$api_url")
+	if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+		response=$(curl -s --header "Authorization: Bearer $GITHUB_TOKEN" "$api_url")
+	else
+		response=$(curl -s "$api_url")
+	fi
 
 	local tag_name
 	tag_name=$(echo "$response" | jq -r '.tag_name')
@@ -591,11 +595,13 @@ show_usage() {
 	echo "Options:"
 	echo "  --prefix PATH    Installation prefix (default: /usr/local)"
 	echo "  --appimage PATH  Install from a local AppImage instead of downloading the latest release"
+	echo "  --token TOKEN    GitHub token for the release API call (avoids rate limiting)"
 	echo "  --uninstall      Uninstall Vicinae"
 	echo "  --help, -h       Show this help message"
 	echo ""
 	echo "Environment variables:"
 	echo "  PREFIX         Installation prefix (overridden by --prefix)"
+	echo "  GITHUB_TOKEN   GitHub token for the release API call (overridden by --token)"
 	echo ""
 	echo "Without options, the script will install or update Vicinae to the latest version."
 	echo ""
@@ -603,6 +609,7 @@ show_usage() {
 	echo "  $0                           # Install to /usr/local (requires sudo)"
 	echo "  $0 --prefix ~/.local         # Install to ~/.local (user install)"
 	echo "  PREFIX=/opt/vicinae $0       # Install to /opt/vicinae"
+	echo "  GITHUB_TOKEN=ghp_xxx $0      # Use a GitHub token (avoids API rate limiting)"
 }
 
 # we need the script stored on disk to re-execute it with privilege elevation, if needed.
@@ -659,6 +666,15 @@ main() {
 			THEMES_DIR="$PREFIX/share/vicinae/themes"
 			APPLICATIONS_DIR="$PREFIX/share/applications"
 			SYSTEMD_USER_DIR="$PREFIX/lib/systemd/user"
+			shift 2
+			;;
+		--token)
+			if [[ -z "${2:-}" ]]; then
+				echo "Error: --token requires a GitHub token argument"
+				show_usage
+				exit 1
+			fi
+			export GITHUB_TOKEN="$2"
 			shift 2
 			;;
 		--uninstall)


### PR DESCRIPTION
   ## Description

   The installer fetches the latest release from the GitHub API without
   authentication, which is subject to GitHub's unauthenticated rate limit
   (60 requests/hour per IP). This can make the installer fail with
   "Failed to fetch latest version" on networks with many users or when the
   script is run repeatedly.

   This PR adds optional GitHub token support to `scripts/install.sh` so
   users can authenticate API requests and avoid rate limiting.

   ## Changes

   - New `--token TOKEN` option (exported as `GITHUB_TOKEN`; takes
     precedence over the environment variable).
   - `GITHUB_TOKEN` environment variable is now honored directly, so the
     token can also be provided without putting it on the command line.
   - When a token is set, the release API call includes an
     `Authorization: Bearer <token>` header. Without a token, behavior is
     unchanged (unauthenticated request).
   - Updated `--help` output (options, environment variables, examples).

   ## Usage

   ```bash
   # Command-line flag
   curl -fsSL https://vicinae.com/install | bash -s -- --token ghp_xxx

   # Environment variable (keeps the token out of the command line)
   GITHUB_TOKEN=ghp_xxx curl -fsSL https://vicinae.com/install | bash
   ```

   ## Testing

   - `bash -n scripts/install.sh` passes; `--help` output verified.
   - Verified the `Authorization: Bearer` header is sent with a local echo
     server and against the live GitHub API (invalid token returns 401,
     anonymous request returns 200).
   - Verified `--token` requires an argument and errors out cleanly.

   ## Notes

   - When installation requires privilege escalation, the re-executed
     command replays the original arguments, so a token passed via
     `--token` may briefly appear in the process list. Users concerned
     about this should prefer the `GITHUB_TOKEN` environment variable.
   - A token is only needed for the release metadata API call; the AppImage
     itself is downloaded from the public release CDN, which is not rate
     limited.