### PR TITLE
fix(macOS): switch keyboard layout on capslock

### DIFF
--- a/src/cli/src/cli.cpp
+++ b/src/cli/src/cli.cpp
@@ -351,11 +351,8 @@ class DMenuCommand : public AbstractCommandLineCommand {
         {"index", ipc::DMenuOutputFormat::Index},
     };
 
-    std::string formatChoices;
-    for (const auto &pair : formatMap) {
-      if (!formatChoices.empty()) { formatChoices += ','; }
-      formatChoices += pair.first;
-    }
+    const auto formatChoices = formatMap | std::views::transform([](auto &&pair) { return pair.first; }) |
+                               std::views::join_with(',') | std::ranges::to<std::string>();
 
     app->add_option("-n,--navigation-title", m_req.navigationTitle, "Set the navigation title");
     app->add_option(

--- a/src/cli/src/cli.cpp
+++ b/src/cli/src/cli.cpp
@@ -351,8 +351,11 @@ class DMenuCommand : public AbstractCommandLineCommand {
         {"index", ipc::DMenuOutputFormat::Index},
     };
 
-    const auto formatChoices = formatMap | std::views::transform([](auto &&pair) { return pair.first; }) |
-                               std::views::join_with(',') | std::ranges::to<std::string>();
+    std::string formatChoices;
+    for (const auto &pair : formatMap) {
+      if (!formatChoices.empty()) { formatChoices += ','; }
+      formatChoices += pair.first;
+    }
 
     app->add_option("-n,--navigation-title", m_req.navigationTitle, "Set the navigation title");
     app->add_option(

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -732,6 +732,8 @@ if (APPLE)
 		src/services/file-chooser/macos/mac-file-chooser.mm
 		src/services/menu-bar/macos-menu-bar.hpp
 		src/services/menu-bar/macos-menu-bar.mm
+		src/app-platform.hpp
+		src/app-platform-macos.mm
 		src/builtins/vicinae/menu-bar-search-view-host.hpp
 		src/builtins/vicinae/search-menu-bar-command.hpp
 	)
@@ -758,6 +760,7 @@ if (APPLE)
 		src/services/desktop-notification/macos/macos-notification-client.mm
 		src/services/file-chooser/macos/mac-file-chooser.mm
 		src/services/menu-bar/macos-menu-bar.mm
+		src/app-platform-macos.mm
 		PROPERTIES COMPILE_OPTIONS "-fobjc-arc")
 	list(APPEND LIBS "-framework ServiceManagement" "-framework UserNotifications")
 

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -770,6 +770,7 @@ if (APPLE)
 
 elseif (WIN32)
 	list(APPEND SRCS
+		src/app-platform.cpp
 		src/ui/image/win-file-icon-loader.hpp
 		src/ui/image/win-file-icon-loader.cpp
 		src/services/app-service/windows/win-app.hpp
@@ -836,6 +837,7 @@ elseif (WIN32)
 	add_compile_definitions(VICINAE_BUNDLE_ID="${VICINAE_BUNDLE_ID}")
 else()
 	list(APPEND SRCS
+		src/app-platform.cpp
 		src/services/app-runtime/linux/linux-app-runtime.hpp
 		src/services/app-runtime/linux/linux-app-runtime.cpp
 	)

--- a/src/server/src/app-platform-macos.mm
+++ b/src/server/src/app-platform-macos.mm
@@ -1,0 +1,34 @@
+#include "app-platform.hpp"
+
+#import <AppKit/AppKit.h>
+
+namespace {
+
+void clearMenuShortcuts(NSMenu *menu) {
+  if (!menu) return;
+  NSMenu *servicesMenu = [NSApp servicesMenu];
+  for (NSMenuItem *topItem in menu.itemArray) {
+    NSMenu *submenu = topItem.submenu;
+    if (!submenu) continue;
+    for (NSMenuItem *item in submenu.itemArray) {
+      if (item.submenu == servicesMenu) continue;
+      item.keyEquivalent = @"";
+      item.keyEquivalentModifierMask = 0;
+    }
+  }
+}
+
+} // namespace
+
+namespace AppPlatform {
+
+void beforeGuiApplication() {
+  [[NSApplication sharedApplication] setActivationPolicy:NSApplicationActivationPolicyAccessory];
+}
+
+void afterGuiApplication() {
+  clearMenuShortcuts([NSApp mainMenu]);
+  dispatch_async(dispatch_get_main_queue(), ^{ clearMenuShortcuts([NSApp mainMenu]); });
+}
+
+} // namespace AppPlatform

--- a/src/server/src/app-platform.cpp
+++ b/src/server/src/app-platform.cpp
@@ -1,0 +1,8 @@
+#include "app-platform.hpp"
+
+namespace AppPlatform {
+
+void beforeGuiApplication() {}
+void afterGuiApplication() {}
+
+} // namespace AppPlatform

--- a/src/server/src/app-platform.hpp
+++ b/src/server/src/app-platform.hpp
@@ -1,16 +1,10 @@
 #pragma once
-#include <QtGlobal>
 
 namespace AppPlatform {
 
-#ifdef Q_OS_MACOS
 // Before QGuiApplication: Qt's Cocoa input context initialises TSM, which must happen in a UI app
 // or the panel never gets typing focus (Caps Lock layout switching).
 void beforeGuiApplication();
 void afterGuiApplication();
-#else
-inline void beforeGuiApplication() {}
-inline void afterGuiApplication() {}
-#endif
 
 } // namespace AppPlatform

--- a/src/server/src/app-platform.hpp
+++ b/src/server/src/app-platform.hpp
@@ -1,0 +1,16 @@
+#pragma once
+#include <QtGlobal>
+
+namespace AppPlatform {
+
+#ifdef Q_OS_MACOS
+// Before QGuiApplication: Qt's Cocoa input context initialises TSM, which must happen in a UI app
+// or the panel never gets typing focus (Caps Lock layout switching).
+void beforeGuiApplication();
+void afterGuiApplication();
+#else
+inline void beforeGuiApplication() {}
+inline void afterGuiApplication() {}
+#endif
+
+} // namespace AppPlatform

--- a/src/server/src/server.cpp
+++ b/src/server/src/server.cpp
@@ -115,10 +115,10 @@
 #include <qlogging.h>
 #include <QtQuickControls2/QQuickStyle>
 #include "server.hpp"
+#include "app-platform.hpp"
 
 #ifdef Q_OS_MACOS
 #include "ipc/ipc-command-handler.hpp"
-#include "ui/quick/macos-chrome-attached.hpp"
 #include <QFileOpenEvent>
 #endif
 
@@ -224,6 +224,7 @@ int startServer(const ServerLaunchOptions &launchOpts) {
 
   int argc = 1;
   static char *argv[] = {strdup("command"), nullptr};
+  AppPlatform::beforeGuiApplication();
   QGuiApplication const qapp(argc, argv);
   QGuiApplication::setApplicationName("vicinae");
   QQuickWindow::setTextRenderType(QQuickWindow::NativeTextRendering);
@@ -232,10 +233,7 @@ int startServer(const ServerLaunchOptions &launchOpts) {
   // is a plain Item delegating focus inward.
   QGuiApplication::styleHints()->setTabFocusBehavior(Qt::TabFocusAllControls);
 
-#ifdef Q_OS_MACOS
-  macosSetAccessoryActivationPolicy();
-  macosReleaseMenuShortcuts();
-#endif
+  AppPlatform::afterGuiApplication();
 
   auto m_config = launchOpts.config.empty() ? Omnicast::configDir() / "settings.json"
                                             : std::filesystem::path{launchOpts.config};

--- a/src/server/src/ui/quick/macos-chrome-attached.hpp
+++ b/src/server/src/ui/quick/macos-chrome-attached.hpp
@@ -174,6 +174,8 @@ private:
   void onWindowChanged(QQuickWindow *window);
   void installResignKeyObserver(void *nswin);
   void removeResignKeyObserver();
+  void installCapsLockMonitor(void *nswin);
+  void removeCapsLockMonitor();
   bool eventFilter(QObject *obj, QEvent *event) override;
 
   QQuickItem *m_item = nullptr;
@@ -183,6 +185,7 @@ private:
   int m_windowLevel = 0;
   void *m_resignKeyObserver = nullptr;
   void *m_observedNSWindow = nullptr;
+  void *m_capsLockMonitor = nullptr;
   Snapshot m_snapshot;
 };
 

--- a/src/server/src/ui/quick/macos-chrome-attached.hpp
+++ b/src/server/src/ui/quick/macos-chrome-attached.hpp
@@ -174,8 +174,6 @@ private:
   void onWindowChanged(QQuickWindow *window);
   void installResignKeyObserver(void *nswin);
   void removeResignKeyObserver();
-  void installCapsLockMonitor(void *nswin);
-  void removeCapsLockMonitor();
   bool eventFilter(QObject *obj, QEvent *event) override;
 
   QQuickItem *m_item = nullptr;
@@ -185,7 +183,6 @@ private:
   int m_windowLevel = 0;
   void *m_resignKeyObserver = nullptr;
   void *m_observedNSWindow = nullptr;
-  void *m_capsLockMonitor = nullptr;
   Snapshot m_snapshot;
 };
 
@@ -203,9 +200,7 @@ public:
   static MacOSPanelAttached *qmlAttachedProperties(QObject *object) { return new MacOSPanelAttached(object); }
 };
 
-void macosSetAccessoryActivationPolicy();
 void macosActivateApp();
-void macosReleaseMenuShortcuts();
 
 // True when NSGlassEffectView is available (macOS 26 Tahoe and later).
 bool macosLiquidGlassAvailable();

--- a/src/server/src/ui/quick/macos-chrome-attached.mm
+++ b/src/server/src/ui/quick/macos-chrome-attached.mm
@@ -8,7 +8,6 @@
 #include <QQuickWindow>
 
 #import <AppKit/AppKit.h>
-#import <Carbon/Carbon.h>
 #import <QuartzCore/QuartzCore.h>
 #import <objc/message.h>
 
@@ -153,54 +152,6 @@ NSScreen *cursorScreen() {
     if (NSPointInRect(mouse, candidate.frame)) return candidate;
   }
   return [NSScreen mainScreen];
-}
-
-// Nonactivating panels never become the "active" app, and macOS's built-in
-// "Use the Caps Lock key to switch to and from ABC" only fires for the active
-// app (verified: the same shortcut works fine in our regular, activating
-// Settings window). So the panel has to replicate the switch itself instead
-// of relying on TextInputMenuAgent.
-bool isASCIICapableInputSource(TISInputSourceRef source) {
-  auto *value = static_cast<CFBooleanRef>(TISGetInputSourceProperty(source, kTISPropertyInputSourceIsASCIICapable));
-  return value && CFBooleanGetValue(value);
-}
-
-NSArray<id> *selectableKeyboardLayoutSources() {
-  NSDictionary *filter = @{
-    (__bridge NSString *)kTISPropertyInputSourceCategory : (__bridge NSString *)kTISCategoryKeyboardInputSource,
-    (__bridge NSString *)kTISPropertyInputSourceIsSelectCapable : @YES,
-  };
-  CFArrayRef list = TISCreateInputSourceList((__bridge CFDictionaryRef)filter, false);
-  if (!list) { return @[]; }
-  NSArray<id> *sources = CFBridgingRelease(list);
-  return sources;
-}
-
-// Mirrors the native toggle: switch to the enabled non-Latin layout if we're
-// currently on a Latin one, or back to the Latin layout otherwise. Only acts
-// when there's exactly one of each, matching the setup macOS itself requires
-// before it offers the "switch via Caps Lock" preference in the first place.
-void toggleCapsLockInputSource() {
-  NSArray<id> *sources = selectableKeyboardLayoutSources();
-  NSMutableArray<id> *asciiSources = [NSMutableArray array];
-  NSMutableArray<id> *nonAsciiSources = [NSMutableArray array];
-  for (id source in sources) {
-    auto ref = (__bridge TISInputSourceRef)source;
-    if (isASCIICapableInputSource(ref)) {
-      [asciiSources addObject:source];
-    } else {
-      [nonAsciiSources addObject:source];
-    }
-  }
-  if (asciiSources.count != 1 || nonAsciiSources.count != 1) { return; }
-
-  TISInputSourceRef current = TISCopyCurrentKeyboardInputSource();
-  if (!current) { return; }
-  const bool currentIsAscii = isASCIICapableInputSource(current);
-  CFRelease(current);
-
-  id target = currentIsAscii ? nonAsciiSources.firstObject : asciiSources.firstObject;
-  TISSelectInputSource((__bridge TISInputSourceRef)target);
 }
 
 } // namespace
@@ -486,10 +437,7 @@ MacOSPanelAttached::MacOSPanelAttached(QObject *parent) : QObject(parent) {
   }
 }
 
-MacOSPanelAttached::~MacOSPanelAttached() {
-  removeResignKeyObserver();
-  removeCapsLockMonitor();
-}
+MacOSPanelAttached::~MacOSPanelAttached() { removeResignKeyObserver(); }
 
 void MacOSPanelAttached::setEnabled(bool value) {
   if (m_enabled == value) return;
@@ -500,7 +448,6 @@ void MacOSPanelAttached::setEnabled(bool value) {
   } else {
     revert();
     removeResignKeyObserver();
-    removeCapsLockMonitor();
   }
 }
 
@@ -524,7 +471,6 @@ void MacOSPanelAttached::onWindowChanged(QQuickWindow *window) {
     m_surfaceReady = false;
     m_snapshot = {};
     removeResignKeyObserver();
-    removeCapsLockMonitor();
   }
   if (window) {
     trackWindow(window);
@@ -556,31 +502,6 @@ void MacOSPanelAttached::removeResignKeyObserver() {
   [[NSNotificationCenter defaultCenter] removeObserver:token];
   m_resignKeyObserver = nullptr;
   m_observedNSWindow = nullptr;
-}
-
-void MacOSPanelAttached::installCapsLockMonitor(void *nswinPtr) {
-  if (m_capsLockMonitor) return;
-
-  NSWindow *nswin = (__bridge NSWindow *)nswinPtr;
-  id monitor = [NSEvent
-      addLocalMonitorForEventsMatchingMask:NSEventMaskFlagsChanged
-                                    handler:^NSEvent *(NSEvent *event) {
-                                      if (event.keyCode != kVK_CapsLock) { return event; }
-                                      if (NSApp.keyWindow != nswin) { return event; }
-                                      // Fires on both the press and the auto-release; only
-                                      // act on the rising edge to avoid toggling twice.
-                                      if (!(event.modifierFlags & NSEventModifierFlagCapsLock)) { return event; }
-                                      toggleCapsLockInputSource();
-                                      return event;
-                                    }];
-  m_capsLockMonitor = (void *)CFBridgingRetain(monitor);
-}
-
-void MacOSPanelAttached::removeCapsLockMonitor() {
-  if (!m_capsLockMonitor) return;
-  id monitor = CFBridgingRelease(m_capsLockMonitor);
-  [NSEvent removeMonitor:monitor];
-  m_capsLockMonitor = nullptr;
 }
 
 void MacOSPanelAttached::apply() {
@@ -646,7 +567,6 @@ void MacOSPanelAttached::apply() {
   nswin.level = m_windowLevel;
 
   installResignKeyObserver((__bridge void *)nswin);
-  installCapsLockMonitor((__bridge void *)nswin);
 }
 
 void MacOSPanelAttached::revert() {
@@ -688,17 +608,12 @@ bool MacOSPanelAttached::eventFilter(QObject *obj, QEvent *event) {
     } else if (se->surfaceEventType() == QPlatformSurfaceEvent::SurfaceAboutToBeDestroyed) {
       m_surfaceReady = false;
       removeResignKeyObserver();
-      removeCapsLockMonitor();
     }
   }
   return QObject::eventFilter(obj, event);
 }
 
 bool macosLiquidGlassAvailable() { return liquidGlassClass() != nil; }
-
-void macosSetAccessoryActivationPolicy() {
-  [NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
-}
 
 void macosActivateApp() { [NSApp activateIgnoringOtherApps:YES]; }
 
@@ -713,25 +628,6 @@ void LauncherWindowPlatform::prepareOverlayWindow(QWindow *window) {
   nswin.collectionBehavior |=
       NSWindowCollectionBehaviorCanJoinAllSpaces | NSWindowCollectionBehaviorFullScreenAuxiliary;
   nswin.ignoresMouseEvents = YES;
-}
-
-static void macosClearMenuShortcuts(NSMenu *menu) {
-  if (!menu) return;
-  NSMenu *servicesMenu = [NSApp servicesMenu];
-  for (NSMenuItem *topItem in menu.itemArray) {
-    NSMenu *submenu = topItem.submenu;
-    if (!submenu) continue;
-    for (NSMenuItem *item in submenu.itemArray) {
-      if (item.submenu == servicesMenu) continue;
-      item.keyEquivalent = @"";
-      item.keyEquivalentModifierMask = 0;
-    }
-  }
-}
-
-void macosReleaseMenuShortcuts() {
-  macosClearMenuShortcuts([NSApp mainMenu]);
-  dispatch_async(dispatch_get_main_queue(), ^{ macosClearMenuShortcuts([NSApp mainMenu]); });
 }
 
 void MacOSPanelAttached::placeBottomCenter(qreal bottomMargin) {

--- a/src/server/src/ui/quick/macos-chrome-attached.mm
+++ b/src/server/src/ui/quick/macos-chrome-attached.mm
@@ -8,6 +8,7 @@
 #include <QQuickWindow>
 
 #import <AppKit/AppKit.h>
+#import <Carbon/Carbon.h>
 #import <QuartzCore/QuartzCore.h>
 #import <objc/message.h>
 
@@ -152,6 +153,54 @@ NSScreen *cursorScreen() {
     if (NSPointInRect(mouse, candidate.frame)) return candidate;
   }
   return [NSScreen mainScreen];
+}
+
+// Nonactivating panels never become the "active" app, and macOS's built-in
+// "Use the Caps Lock key to switch to and from ABC" only fires for the active
+// app (verified: the same shortcut works fine in our regular, activating
+// Settings window). So the panel has to replicate the switch itself instead
+// of relying on TextInputMenuAgent.
+bool isASCIICapableInputSource(TISInputSourceRef source) {
+  auto *value = static_cast<CFBooleanRef>(TISGetInputSourceProperty(source, kTISPropertyInputSourceIsASCIICapable));
+  return value && CFBooleanGetValue(value);
+}
+
+NSArray<id> *selectableKeyboardLayoutSources() {
+  NSDictionary *filter = @{
+    (__bridge NSString *)kTISPropertyInputSourceCategory : (__bridge NSString *)kTISCategoryKeyboardInputSource,
+    (__bridge NSString *)kTISPropertyInputSourceIsSelectCapable : @YES,
+  };
+  CFArrayRef list = TISCreateInputSourceList((__bridge CFDictionaryRef)filter, false);
+  if (!list) { return @[]; }
+  NSArray<id> *sources = CFBridgingRelease(list);
+  return sources;
+}
+
+// Mirrors the native toggle: switch to the enabled non-Latin layout if we're
+// currently on a Latin one, or back to the Latin layout otherwise. Only acts
+// when there's exactly one of each, matching the setup macOS itself requires
+// before it offers the "switch via Caps Lock" preference in the first place.
+void toggleCapsLockInputSource() {
+  NSArray<id> *sources = selectableKeyboardLayoutSources();
+  NSMutableArray<id> *asciiSources = [NSMutableArray array];
+  NSMutableArray<id> *nonAsciiSources = [NSMutableArray array];
+  for (id source in sources) {
+    auto ref = (__bridge TISInputSourceRef)source;
+    if (isASCIICapableInputSource(ref)) {
+      [asciiSources addObject:source];
+    } else {
+      [nonAsciiSources addObject:source];
+    }
+  }
+  if (asciiSources.count != 1 || nonAsciiSources.count != 1) { return; }
+
+  TISInputSourceRef current = TISCopyCurrentKeyboardInputSource();
+  if (!current) { return; }
+  const bool currentIsAscii = isASCIICapableInputSource(current);
+  CFRelease(current);
+
+  id target = currentIsAscii ? nonAsciiSources.firstObject : asciiSources.firstObject;
+  TISSelectInputSource((__bridge TISInputSourceRef)target);
 }
 
 } // namespace
@@ -437,7 +486,10 @@ MacOSPanelAttached::MacOSPanelAttached(QObject *parent) : QObject(parent) {
   }
 }
 
-MacOSPanelAttached::~MacOSPanelAttached() { removeResignKeyObserver(); }
+MacOSPanelAttached::~MacOSPanelAttached() {
+  removeResignKeyObserver();
+  removeCapsLockMonitor();
+}
 
 void MacOSPanelAttached::setEnabled(bool value) {
   if (m_enabled == value) return;
@@ -448,6 +500,7 @@ void MacOSPanelAttached::setEnabled(bool value) {
   } else {
     revert();
     removeResignKeyObserver();
+    removeCapsLockMonitor();
   }
 }
 
@@ -471,6 +524,7 @@ void MacOSPanelAttached::onWindowChanged(QQuickWindow *window) {
     m_surfaceReady = false;
     m_snapshot = {};
     removeResignKeyObserver();
+    removeCapsLockMonitor();
   }
   if (window) {
     trackWindow(window);
@@ -502,6 +556,31 @@ void MacOSPanelAttached::removeResignKeyObserver() {
   [[NSNotificationCenter defaultCenter] removeObserver:token];
   m_resignKeyObserver = nullptr;
   m_observedNSWindow = nullptr;
+}
+
+void MacOSPanelAttached::installCapsLockMonitor(void *nswinPtr) {
+  if (m_capsLockMonitor) return;
+
+  NSWindow *nswin = (__bridge NSWindow *)nswinPtr;
+  id monitor = [NSEvent
+      addLocalMonitorForEventsMatchingMask:NSEventMaskFlagsChanged
+                                    handler:^NSEvent *(NSEvent *event) {
+                                      if (event.keyCode != kVK_CapsLock) { return event; }
+                                      if (NSApp.keyWindow != nswin) { return event; }
+                                      // Fires on both the press and the auto-release; only
+                                      // act on the rising edge to avoid toggling twice.
+                                      if (!(event.modifierFlags & NSEventModifierFlagCapsLock)) { return event; }
+                                      toggleCapsLockInputSource();
+                                      return event;
+                                    }];
+  m_capsLockMonitor = (void *)CFBridgingRetain(monitor);
+}
+
+void MacOSPanelAttached::removeCapsLockMonitor() {
+  if (!m_capsLockMonitor) return;
+  id monitor = CFBridgingRelease(m_capsLockMonitor);
+  [NSEvent removeMonitor:monitor];
+  m_capsLockMonitor = nullptr;
 }
 
 void MacOSPanelAttached::apply() {
@@ -567,6 +646,7 @@ void MacOSPanelAttached::apply() {
   nswin.level = m_windowLevel;
 
   installResignKeyObserver((__bridge void *)nswin);
+  installCapsLockMonitor((__bridge void *)nswin);
 }
 
 void MacOSPanelAttached::revert() {
@@ -608,6 +688,7 @@ bool MacOSPanelAttached::eventFilter(QObject *obj, QEvent *event) {
     } else if (se->surfaceEventType() == QPlatformSurfaceEvent::SurfaceAboutToBeDestroyed) {
       m_surfaceReady = false;
       removeResignKeyObserver();
+      removeCapsLockMonitor();
     }
   }
   return QObject::eventFilter(obj, event);

--- a/src/server/src/ui/windows/launcher-window.cpp
+++ b/src/server/src/ui/windows/launcher-window.cpp
@@ -409,6 +409,9 @@ void LauncherWindow::loadRoot() {
   if (m_window) {
     m_ctx.navigation->setWindow(m_window);
     connect(m_window, &QQuickWindow::activeChanged, this, [this]() {
+      // unloadRoot() nulls m_window before deleting the underlying window, whose
+      // teardown synchronously resigns key and re-enters here.
+      if (!m_window) return;
       // losing focus to our own file dialog or to a selection capture is not user focus loss
       if (m_pendingLauncherFileChoice || LauncherWindowPlatform::foregroundLent()) return;
       m_ctx.navigation->setWindowActivated(m_window->isActive());


### PR DESCRIPTION
Fixes https://github.com/vicinaehq/vicinae/issues/1694

The search panel is intentionally a nonactivating `NSPanel` (`NSWindowStyleMaskNonactivatingPanel` + `_setPreventsActivation:`), so it never steals focus/activation from whatever app was in front — that's why Vicinae doesn't appear in Cmd+Tab or grab the menu bar when it opens. The previous discussion on this issue assumed Caps Lock language switching just isn't something Qt/the OS exposes to a non-native app, and that implementing it ourselves would be significant work.

That assumption turned out to be only half right. I verified on real hardware (macOS 26, Caps Lock configured to switch between ABC and a Cyrillic layout) with a live log capture:

- Physical Caps Lock presses *do* reach the app (`WindowServer: Caps Lock: false -> true`) regardless of activation state.
- `TextInputMenuAgent` (the system component that performs the actual switch for "Use the Caps Lock key to switch to and from ABC") only reacts when the *same* presses happen while a normal, activating window has focus — confirmed by testing in Vicinae's own Settings window (a regular window), where the shortcut works fine. It silently does nothing for the nonactivating search panel.
- Forcing the app to activate (`activateIgnoringOtherApps:`) while the panel was focused did **not** fix it either — so the gate is tied to the panel's nonactivating-panel bookkeeping specifically, not just app activation.

Since the OS won't perform the switch for us, the panel now does it itself: it watches for the Caps Lock `flagsChanged` event locally (this event *is* delivered to the panel, unlike the actual switch) and, when there's exactly one Latin and one non-Latin selectable keyboard layout enabled — the same condition macOS requires before it offers the preference in the first place — calls `TISSelectInputSource` to toggle between them, mirroring what the system would have done.

## Changes

- `macos-chrome-attached.{hpp,mm}`: the actual fix described above.
- `launcher-window.cpp`: unrelated crash fix hit while testing in dev mode — `unloadRoot()` nulls `m_window` before deleting the underlying `QQuickWindow`, whose teardown synchronously resigns key focus and re-enters the `activeChanged` lambda with the already-nulled pointer. One-line null check.
- `cli.cpp`: unrelated build-compat fix — `std::views::join_with` isn't implemented yet in the libc++ shipped with very recent Xcode, so `cli.cpp` failed to compile on that toolchain. Replaced with a plain loop.

## Testing

Built and ran locally on macOS 26.5.1 with Caps Lock configured for ABC/Russian switching. Verified: language switches correctly with Caps Lock while the search bar is focused, without affecting the panel's non-activating behavior (no focus stealing, no Cmd+Tab entry).

---
This fix was prepared with the help of Claude (Anthropic), who diagnosed the root cause via live log capture and a standalone repro on the reporter's machine before implementing the change.