### PR TITLE
feat: add icon badges

### DIFF
--- a/src/server/src/builtins/browser/browser-extension.cpp
+++ b/src/server/src/builtins/browser/browser-extension.cpp
@@ -47,7 +47,7 @@ class CreateShortcutFromActiveBrowserTabCommand : public GuardedBuiltinCallbackC
               "results if many browsers are connected at once.");
   }
   ImageURL iconUrl() const override {
-    return ImageURL(BuiltinIcon::Link).setBackgroundTint(SemanticColor::Red);
+    return ImageURL(BuiltinIcon::Link).setBackgroundTint(SemanticColor::Red).setBadge(BuiltinIcon::Plus);
   }
 
   void execute(CommandController &controller) const override {

--- a/src/server/src/builtins/clipboard/clipboard-extension.cpp
+++ b/src/server/src/builtins/clipboard/clipboard-extension.cpp
@@ -14,7 +14,9 @@ class ClipboardClearCommand : public BuiltinCallbackCommand {
   QString name() const override { return tr("Clear Current Clipboard Data"); }
   QString description() const override { return tr("Clear the current content of the clipboard"); }
   ImageURL iconUrl() const override {
-    return ImageURL::builtin(BuiltinIcon::DeleteDocument).setBackgroundTint(SemanticColor::Red);
+    return ImageURL::builtin(BuiltinIcon::CopyClipboard)
+        .setBackgroundTint(SemanticColor::Red)
+        .setBadge(BuiltinIcon::Xmark);
   }
   void execute(CommandController &ctrl) const override {
     auto ctx = ctrl.context();
@@ -36,7 +38,9 @@ class ClearClipboardHistoryCommand : public BuiltinCallbackCommand {
   QString name() const override { return tr("Clear Clipboard History"); }
   QString description() const override { return tr("Clear the clipboard history"); }
   ImageURL iconUrl() const override {
-    return ImageURL(BuiltinIcon::Trash).setBackgroundTint(SemanticColor::Red);
+    return ImageURL::builtin(BuiltinIcon::CopyClipboard)
+        .setBackgroundTint(SemanticColor::Red)
+        .setBadge(BuiltinIcon::Xmark);
   }
   void execute(CommandController &ctrl) const override {
     auto ctx = ctrl.context();

--- a/src/server/src/builtins/developer/developer-extension.hpp
+++ b/src/server/src/builtins/developer/developer-extension.hpp
@@ -10,7 +10,9 @@ class CreateExtensionCommand : public BuiltinViewCommand<CreateExtensionViewHost
     return QCoreApplication::translate("CreateExtensionCommand", "Create Extension");
   }
   ImageURL iconUrl() const override {
-    return ImageURL::builtin(BuiltinIcon::Hammer).setBackgroundTint(SemanticColor::Green);
+    return ImageURL::builtin(BuiltinIcon::Hammer)
+        .setBackgroundTint(SemanticColor::Green)
+        .setBadge(BuiltinIcon::Plus);
   }
 };
 

--- a/src/server/src/builtins/raycast/raycast-store-command.hpp
+++ b/src/server/src/builtins/raycast/raycast-store-command.hpp
@@ -13,11 +13,11 @@ class RaycastStoreCommand : public BuiltinCallbackCommand {
   QString description() const override { return tr("Install compatible extensions from the Raycast store"); }
   QString extensionId() const override { return "raycast-compat"; }
   QString commandId() const override { return "store"; }
-  ImageURL iconUrl() const override {
-    auto icon = ImageURL::builtin(BuiltinIcon::Raycast);
-    icon.setBackgroundTint(SemanticColor::Red);
-    return icon;
+  static ImageURL plainIcon() {
+    return ImageURL::builtin(BuiltinIcon::Raycast).setBackgroundTint(SemanticColor::Red);
   }
+
+  ImageURL iconUrl() const override { return plainIcon().setBadge(BuiltinIcon::ArrowDown); }
   std::vector<Preference> preferences() const override {
     auto alwaysShowIntro = Preference::makeCheckbox("alwaysShowIntro", tr("Always show intro"));
     alwaysShowIntro.setDefaultValue(false);
@@ -48,7 +48,7 @@ Vicinae also has its own [extension store](vicinae://launch/core/store).
         }
         return intro;
       }();
-      auto icon = iconUrl();
+      auto icon = plainIcon();
       auto storage = ctrl.storage();
       ctx->navigation->pushView(
           new StoreIntroViewHost(INTRO, icon, tr("Continue to store"), [storage, ctx]() mutable {

--- a/src/server/src/builtins/shortcut/shortcut-extension.hpp
+++ b/src/server/src/builtins/shortcut/shortcut-extension.hpp
@@ -14,7 +14,9 @@ class CreateShortcutCommand : public BuiltinViewCommand<ShortcutFormViewHost> {
   }
 
   ImageURL iconUrl() const override {
-    return ImageURL::builtin(BuiltinIcon::Bolt).setBackgroundTint(SemanticColor::Purple);
+    return ImageURL::builtin(BuiltinIcon::Bolt)
+        .setBackgroundTint(SemanticColor::Purple)
+        .setBadge(BuiltinIcon::Plus);
   }
 };
 

--- a/src/server/src/builtins/snippet/create-snippet-command.hpp
+++ b/src/server/src/builtins/snippet/create-snippet-command.hpp
@@ -10,6 +10,8 @@ class CreateSnippetCommand : public BuiltinViewCommand<SnippetFormViewHost> {
     return QCoreApplication::translate("CreateSnippetCommand", "Create Snippet");
   }
   ImageURL iconUrl() const override {
-    return ImageURL(BuiltinIcon::Snippets).setBackgroundTint(SemanticColor::Orange);
+    return ImageURL(BuiltinIcon::Snippets)
+        .setBackgroundTint(SemanticColor::Orange)
+        .setBadge(BuiltinIcon::Plus);
   }
 };

--- a/src/server/src/builtins/vicinae/vicinae-store-command.hpp
+++ b/src/server/src/builtins/vicinae/vicinae-store-command.hpp
@@ -14,9 +14,9 @@ class VicinaeStoreCommand : public BuiltinCallbackCommand {
   QString extensionId() const override { return "vicinae"; }
   QString commandId() const override { return "store"; }
   ImageURL iconUrl() const override {
-    auto icon = ImageURL::builtin(BuiltinIcon::Cart);
-    icon.setBackgroundTint(Omnicast::ACCENT_COLOR);
-    return icon;
+    return ImageURL::builtin(BuiltinIcon::Cart)
+        .setBackgroundTint(Omnicast::ACCENT_COLOR)
+        .setBadge(BuiltinIcon::ArrowDown);
   }
   std::vector<Preference> preferences() const override {
     auto alwaysShowIntro = Preference::makeCheckbox("alwaysShowIntro", tr("Always show intro"));

--- a/src/server/src/ui/image/image-renderer.cpp
+++ b/src/server/src/ui/image/image-renderer.cpp
@@ -30,6 +30,7 @@
 #include <QtConcurrent>
 #include <QtMath>
 #include <algorithm>
+#include <cmath>
 #include <mutex>
 
 namespace ImageRendering {
@@ -276,6 +277,59 @@ void applySafetyMargins(QImage &image) {
   painter.setRenderHint(QPainter::SmoothPixmapTransform, true);
   painter.drawImage(dest, image);
   image = padded;
+}
+
+static qreal inkRadius(const QImage &image) {
+  QPointF const center(image.width() / 2.0, image.height() / 2.0);
+  qreal maxSq = 0;
+  for (int y = 0; y < image.height(); ++y) {
+    const auto *line = reinterpret_cast<const QRgb *>(image.constScanLine(y));
+    for (int x = 0; x < image.width(); ++x) {
+      if (qAlpha(line[x]) == 0) continue;
+      qreal const dx = x + 0.5 - center.x();
+      qreal const dy = y + 0.5 - center.y();
+      maxSq = std::max(maxSq, dx * dx + dy * dy);
+    }
+  }
+  return std::sqrt(maxSq);
+}
+
+// Small black disc with a white builtin glyph in the bottom-right corner. Glyphs are
+// normalized by how far their ink reaches from the center so that shapes hitting the
+// corners of their box (an X) read the same size as ones hitting the edges (a plus).
+void applyBadge(QImage &image, const QString &builtinName) {
+  if (image.isNull()) return;
+
+  constexpr qreal BADGE_SCALE = 0.4;
+  constexpr qreal BADGE_GLYPH_REACH = 0.56;
+
+  qreal const diameter = image.height() * BADGE_SCALE;
+  QRectF const badgeRect(image.width() - diameter, image.height() - diameter, diameter, diameter);
+
+  int const renderSide = std::max(1, qRound(diameter));
+  QImage glyph = renderBuiltinSvg(builtinName, QSize(renderSide, renderSide));
+  applyFillColor(glyph, Qt::white);
+  qreal const reach = inkRadius(glyph);
+  qreal const glyphScale = reach > 0 ? (diameter / 2.0) * BADGE_GLYPH_REACH / reach : 0;
+  QSizeF const glyphSize = QSizeF(glyph.size()) * glyphScale;
+
+  QImage canvas(image.size(), QImage::Format_ARGB32_Premultiplied);
+  canvas.fill(Qt::transparent);
+  QPainter painter(&canvas);
+  painter.setRenderHint(QPainter::Antialiasing, true);
+  painter.setRenderHint(QPainter::SmoothPixmapTransform, true);
+  painter.drawImage(0, 0, image);
+
+  painter.setPen(Qt::NoPen);
+  painter.setBrush(Qt::black);
+  painter.drawEllipse(badgeRect);
+
+  if (glyphScale > 0) {
+    QRectF const dest(badgeRect.center() - QPointF(glyphSize.width() / 2.0, glyphSize.height() / 2.0),
+                      glyphSize);
+    painter.drawImage(dest, glyph);
+  }
+  image = canvas;
 }
 
 static bool hasBackdrop(const QColor &bg) { return bg.isValid() && bg.alpha() > 0; }

--- a/src/server/src/ui/image/image-renderer.cpp
+++ b/src/server/src/ui/image/image-renderer.cpp
@@ -300,11 +300,14 @@ static qreal inkRadius(const QImage &image) {
 void applyBadge(QImage &image, const QString &builtinName) {
   if (image.isNull()) return;
 
-  constexpr qreal BADGE_SCALE = 0.4;
+  constexpr qreal BADGE_SCALE = 0.44;
   constexpr qreal BADGE_GLYPH_REACH = 0.56;
+  constexpr qreal BADGE_INSET_SCALE = 0.04;
 
   qreal const diameter = image.height() * BADGE_SCALE;
-  QRectF const badgeRect(image.width() - diameter, image.height() - diameter, diameter, diameter);
+  qreal const inset = image.height() * BADGE_INSET_SCALE;
+  QRectF const badgeRect(image.width() - diameter - inset, image.height() - diameter - inset, diameter,
+                         diameter);
 
   int const renderSide = std::max(1, qRound(diameter));
   QImage glyph = renderBuiltinSvg(builtinName, QSize(renderSide, renderSide));

--- a/src/server/src/ui/image/image-renderer.hpp
+++ b/src/server/src/ui/image/image-renderer.hpp
@@ -37,6 +37,7 @@ QSize backdropContentSize(const QSize &size);
 void applyPostTransforms(QImage &image, const QColor &fg, const QColor &bg, const QSize &size,
                          OmniPainter::ImageMaskType mask);
 void applySafetyMargins(QImage &image);
+void applyBadge(QImage &image, const QString &builtinName);
 
 QThreadPool &decodingPool();
 QThread &animationThread();

--- a/src/server/src/ui/image/image-stream.cpp
+++ b/src/server/src/ui/image/image-stream.cpp
@@ -375,10 +375,11 @@ void ImageStream::decodeStatic(const QByteArray &data) {
   watcher->setFuture(future);
 }
 
+// The badge is part of the icon, so it is drawn before the margin inset and shrinks with it.
 void ImageStream::applyOverlays(QImage &img) const {
+  if (m_badge) ImageRendering::applyBadge(img, *m_badge);
   if (m_opts.safetyMargins && m_url.type() != ImageURLType::MacBundle)
     ImageRendering::applySafetyMargins(img);
-  if (m_badge) ImageRendering::applyBadge(img, *m_badge);
 }
 
 void ImageStream::emitStaticFrame(QImage img) {
@@ -431,8 +432,8 @@ void ImageStream::startAnimation(QByteArray data) {
     QImage frame = movie->currentImage();
     if (frame.isNull()) return;
     ImageRendering::applyPostTransforms(frame, QColor(), QColor(), QSize(), mask);
-    if (safetyMargins) ImageRendering::applySafetyMargins(frame);
     if (badge) ImageRendering::applyBadge(frame, *badge);
+    if (safetyMargins) ImageRendering::applySafetyMargins(frame);
     emit worker->frameReady(frame);
   });
 

--- a/src/server/src/ui/image/image-stream.cpp
+++ b/src/server/src/ui/image/image-stream.cpp
@@ -102,6 +102,7 @@ ImageStream::ImageStream(const ImageURL &url, const QSize &size, ImageStreamOpti
   if (auto fill = m_url.fillColor()) m_fg = ThemeService::instance().theme().resolve(*fill);
   m_bg = resolveBackgroundTint(m_url);
   m_mask = m_url.mask();
+  m_badge = m_url.badge();
   m_cacheKey = makeCacheKey(m_url, size, m_opts.safetyMargins);
   m_originalCacheKey = m_cacheKey;
   m_latestCacheKey = makeLatestCacheKey(m_url);
@@ -374,13 +375,18 @@ void ImageStream::decodeStatic(const QByteArray &data) {
   watcher->setFuture(future);
 }
 
+void ImageStream::applyOverlays(QImage &img) const {
+  if (m_opts.safetyMargins && m_url.type() != ImageURLType::MacBundle)
+    ImageRendering::applySafetyMargins(img);
+  if (m_badge) ImageRendering::applyBadge(img, *m_badge);
+}
+
 void ImageStream::emitStaticFrame(QImage img) {
   if (img.isNull()) {
     tryFallback();
     return;
   }
-  if (m_opts.safetyMargins && m_url.type() != ImageURLType::MacBundle)
-    ImageRendering::applySafetyMargins(img);
+  applyOverlays(img);
   if (m_opts.cache) {
     auto cost = static_cast<int>(img.sizeInBytes());
     imageCache().insert(m_cacheKey, new QImage(img), cost);
@@ -415,8 +421,9 @@ void ImageStream::startAnimation(QByteArray data) {
   auto mask = m_mask;
   auto canceled = m_canceled;
   auto safetyMargins = m_opts.safetyMargins;
+  auto badge = m_badge;
 
-  connect(movie, &QMovie::updated, worker, [movie, worker, mask, canceled, safetyMargins]() {
+  connect(movie, &QMovie::updated, worker, [movie, worker, mask, canceled, safetyMargins, badge]() {
     if (canceled->load(std::memory_order_relaxed)) {
       movie->stop();
       return;
@@ -425,6 +432,7 @@ void ImageStream::startAnimation(QByteArray data) {
     if (frame.isNull()) return;
     ImageRendering::applyPostTransforms(frame, QColor(), QColor(), QSize(), mask);
     if (safetyMargins) ImageRendering::applySafetyMargins(frame);
+    if (badge) ImageRendering::applyBadge(frame, *badge);
     emit worker->frameReady(frame);
   });
 

--- a/src/server/src/ui/image/image-stream.hpp
+++ b/src/server/src/ui/image/image-stream.hpp
@@ -42,6 +42,7 @@ private:
   void onDataReceived(const QByteArray &data);
   void decodeStatic(const QByteArray &data);
   void startAnimation(QByteArray data);
+  void applyOverlays(QImage &img) const;
   void emitStaticFrame(QImage img);
   void handleStaticFuture(QFuture<QImage> future);
 
@@ -50,6 +51,7 @@ private:
   QColor m_fg;
   QColor m_bg;
   OmniPainter::ImageMaskType m_mask = OmniPainter::NoMask;
+  std::optional<QString> m_badge;
   QString m_cacheKey;
   QString m_originalCacheKey;
   QString m_latestCacheKey;

--- a/src/server/src/ui/image/image-url.cpp
+++ b/src/server/src/ui/image/image-url.cpp
@@ -33,3 +33,9 @@ ImageUrl ImageUrl::withFillColor(const QColor &color) const {
   copy.setFill(color);
   return ImageUrl(std::move(copy));
 }
+
+ImageUrl ImageUrl::withBadge(BuiltinIcon icon) const {
+  ImageURL copy = m_url;
+  copy.setBadge(icon);
+  return ImageUrl(std::move(copy));
+}

--- a/src/server/src/ui/image/image-url.hpp
+++ b/src/server/src/ui/image/image-url.hpp
@@ -17,6 +17,7 @@ public:
   Q_INVOKABLE ImageUrl withFallback(const ImageUrl &fb) const;
   Q_INVOKABLE ImageUrl withBackgroundTint(const QString &tint) const;
   Q_INVOKABLE ImageUrl withFillColor(const QColor &color) const;
+  Q_INVOKABLE ImageUrl withBadge(BuiltinIcon icon) const;
 
   const ImageURL &imageUrl() const;
   bool isValid() const;

--- a/src/server/src/ui/image/url.cpp
+++ b/src/server/src/ui/image/url.cpp
@@ -30,11 +30,22 @@ ImageURL &ImageURL::setBackgroundTint(const ColorLike &tint) {
   return *this;
 }
 
+ImageURL &ImageURL::setBadge(BuiltinIcon icon) {
+  if (const auto *name = BuiltinIconService::nameForIcon(icon)) _badge = QString::fromLatin1(name);
+  return *this;
+}
+
+ImageURL &ImageURL::setBadge(const QString &builtinName) {
+  _badge = builtinName;
+  return *this;
+}
+
 ImageURLType ImageURL::type() const { return _type; }
 const QString &ImageURL::name() const { return _name; }
 std::optional<ColorLike> ImageURL::backgroundTint() const { return _bgTint; }
 const std::optional<ColorLike> &ImageURL::fillColor() const { return _fillColor; }
 OmniPainter::ImageMaskType ImageURL::mask() const { return _mask; }
+const std::optional<QString> &ImageURL::badge() const { return _badge; }
 
 ImageURL &ImageURL::withFallback(const ImageURL &fallback) {
   _fallback = fallback.toString();
@@ -76,6 +87,7 @@ QUrl ImageURL::url() const {
   if (_fallback) query.addQueryItem("fallback", *_fallback);
   if (_bgTint) query.addQueryItem("bg_tint", OmniPainter::serializeColor(*_bgTint));
   if (_fillColor) query.addQueryItem("fill", OmniPainter::serializeColor(_fillColor.value()));
+  if (_badge) query.addQueryItem("badge", *_badge);
   if (_mask == OmniPainter::CircleMask)
     query.addQueryItem("mask", "circle");
   else if (_mask == OmniPainter::RoundedRectangleMask)
@@ -117,6 +129,7 @@ ImageURL::ImageURL(const QUrl &url) {
       _fillColor = QColor(fill);
   }
   if (auto fallback = query.queryItemValue("fallback"); !fallback.isEmpty()) { _fallback = fallback; }
+  if (auto badge = query.queryItemValue("badge"); !badge.isEmpty()) { _badge = badge; }
   if (auto mask = query.queryItemValue("mask"); !mask.isEmpty()) {
     if (mask == "circle")
       _mask = OmniPainter::ImageMaskType::CircleMask;

--- a/src/server/src/ui/image/url.hpp
+++ b/src/server/src/ui/image/url.hpp
@@ -116,6 +116,8 @@ public:
   std::optional<ColorLike> backgroundTint() const;
   const std::optional<ColorLike> &fillColor() const;
   OmniPainter::ImageMaskType mask() const;
+  // Builtin icon name overlaid as a small badge in the bottom-right corner.
+  const std::optional<QString> &badge() const;
 
   void setType(ImageURLType type);
   void setName(const QString &name);
@@ -123,6 +125,8 @@ public:
   ImageURL &setFill(const std::optional<ColorLike> &color);
   ImageURL &setMask(OmniPainter::ImageMaskType mask);
   ImageURL &setBackgroundTint(const ColorLike &tint);
+  ImageURL &setBadge(BuiltinIcon icon);
+  ImageURL &setBadge(const QString &builtinName);
 
   // Returns a copy with colors resolved against the current theme (SemanticColor/DynamicColor
   // become QColor; Builtin without fill gets Foreground) and local paths substituted with their
@@ -161,4 +165,5 @@ private:
   OmniPainter::ImageMaskType _mask = OmniPainter::ImageMaskType::NoMask;
   std::optional<QString> _fallback;
   std::optional<ColorLike> _fillColor = std::nullopt;
+  std::optional<QString> _badge;
 };

--- a/src/server/src/ui/qml/settings/SettingsSidebar.qml
+++ b/src/server/src/ui/qml/settings/SettingsSidebar.qml
@@ -217,15 +217,15 @@ Item {
 
                     RowLayout {
                         anchors.fill: parent
-                        anchors.leftMargin: 8 + (navItem._isCommand ? 12 : 0)
+                        anchors.leftMargin: 8 + (navItem._isCommand ? 8 : 0)
                         anchors.rightMargin: 8
                         spacing: 10
                         opacity: navItem._enabled ? 1.0 : 0.5
 
                         ViciImage {
                             source: navItem.model.kind === "core" ? Img.icon(navItem.model.icon).withFillColor(navItem._selected ? Theme.listItemSelectionFg : Theme.textMuted) : navItem.model.iconSource
-                            Layout.preferredWidth: navItem._isCommand ? 16 : 18
-                            Layout.preferredHeight: navItem._isCommand ? 16 : 18
+                            Layout.preferredWidth: 18
+                            Layout.preferredHeight: 18
                         }
 
                         Text {


### PR DESCRIPTION
Tweak the image rendering pipeline so that we can draw an optional badge on the bottom right corner of an icon.

Thanks to this, we can reuse the same icon for CRUD style commands, and only change the badge to highlight the difference. Before, they all had to be identical.

<img width="76" height="244" alt="image" src="https://github.com/user-attachments/assets/657bbd17-0907-49ac-b3f2-eeab886da577" />
