### PR TITLE
build(appimage): embed GitHub release update information

### DIFF
--- a/.github/workflows/build-appimage.yaml
+++ b/.github/workflows/build-appimage.yaml
@@ -59,6 +59,8 @@ jobs:
 
       - name: Make AppImage
         run: |
+          apt-get update
+          apt-get install -y zsync
           chmod +x ./scripts/mkappimage.sh
           ./scripts/mkappimage.sh "${INSTALL_DIR}" AppDir
 
@@ -66,6 +68,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Vicinae-${{ matrix.target.deploy_arch }}-${{ github.sha }}.AppImage
-          path: "*.AppImage"
+          path: |
+            *.AppImage
+            *.AppImage.zsync
           if-no-files-found: error
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,8 @@ jobs:
 
       - name: Make AppImage
         run: |
+          apt-get update
+          apt-get install -y zsync
           chmod +x ./scripts/mkappimage.sh
           ./scripts/mkappimage.sh "${INSTALL_DIR}" "${APP_DIR}"
 
@@ -170,7 +172,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: vicinae-appimage-${{ matrix.target.arch }}
-          path: "*.AppImage"
+          path: |
+            *.AppImage
+            *.AppImage.zsync
           retention-days: 7
           if-no-files-found: error
           overwrite: true

--- a/extra/vicinae.desktop
+++ b/extra/vicinae.desktop
@@ -11,6 +11,7 @@ NoDisplay=false
 Actions=open;close;toggle
 StartupWMClass=vicinae
 StartupNotify=false
+X-AppImage-Homepage=https://github.com/vicinaehq/vicinae
 
 [Desktop Action open]
 Name=Open Vicinae Window

--- a/scripts/mkappimage.sh
+++ b/scripts/mkappimage.sh
@@ -53,6 +53,19 @@ for bin in $APPDIR/usr/libexec/vicinae/*; do
 	EXECUTABLE_ARGS+=(--executable $bin)
 done
 
+# AppImage managers (AppManager, AppImageUpdate, Gear Lever) read this from
+# the .upd_info ELF section. Without it, users have to paste the GitHub URL
+# by hand. The glob must match linuxdeploy's output name, e.g.
+# Vicinae-x86_64.AppImage.zsync. Always point at vicinaehq/vicinae so a
+# rebuild from a fork still updates from official releases.
+ARCH=$(uname -m)
+export LDAI_UPDATE_INFORMATION="gh-releases-zsync|vicinaehq|vicinae|latest|*${ARCH}.AppImage.zsync"
+export UPDATE_INFORMATION="$LDAI_UPDATE_INFORMATION"
+
+if ! command -v zsyncmake >/dev/null 2>&1; then
+	echo "warning: zsyncmake not found; the AppImage will embed update info but no .zsync sidecar will be generated" >&2
+fi
+
 linuxdeploy --appdir $APPDIR "${EXECUTABLE_ARGS[@]}" \
 	--library "$LIBSECRET" \
 	--desktop-file $APPDIR/usr/share/applications/vicinae.desktop \


### PR DESCRIPTION
## Intent

AppImage managers (AppManager, AppImageUpdate, Gear Lever) should pick up Vicinae's GitHub release URL automatically. Today they cannot, because the AppImage does not ship the metadata those tools look for.

## Problem

On install, AppManager fills **Update Link** / **Web Page** from:

1. the `.upd_info` ELF section (`gh-releases-zsync|owner|repo|latest|*.AppImage.zsync`)
2. `X-AppImage-Homepage` on the desktop file

We set neither. Tagged releases also do not publish a `.zsync` sidecar, so even a hand-pasted GitHub URL cannot do delta updates.

## Change

- `scripts/mkappimage.sh` tells linuxdeploy to embed `gh-releases-zsync|vicinaehq|vicinae|latest|*$ARCH.AppImage.zsync`. The repo is hardcoded so a rebuild from a fork still updates from official releases.
- `extra/vicinae.desktop` sets `X-AppImage-Homepage=https://github.com/vicinaehq/vicinae` (this is what AppManager shows as **Web Page**).
- Release and PR AppImage workflows install `zsync` (the pack image does not have `zsyncmake`) and upload `*.AppImage.zsync` next to the image.

After the next tagged release, installing the AppImage in AppManager should pre-fill Update Link and Web Page to `https://github.com/vicinaehq/vicinae`.

## Notes

I did not set `LINUXDEPLOY_OUTPUT_VERSION` / `LDAI_VERSION`. linuxdeploy would then rename the artifact from `Vicinae-x86_64.AppImage` to `Vicinae-<version>-x86_64.AppImage`, which would change the published asset names.