### PR TITLE
fix(install): put user units where systemd looks for them

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,12 +11,23 @@ SYSTEMD_SERVICE_NAME="vicinae.service"
 # Installation prefix - can be overridden via environment or --prefix flag
 PREFIX="${PREFIX:-/usr/local}"
 
+# systemd searches a fixed set of user unit directories. "$PREFIX/lib/systemd/user"
+# is one of them for /usr and /usr/local, but not for a prefix under $HOME, where
+# the XDG data directory is the one it looks at.
+resolve_systemd_user_dir() {
+	if [[ "$PREFIX" == "$HOME" || "$PREFIX" == "$HOME"/* ]]; then
+		echo "${XDG_DATA_HOME:-$HOME/.local/share}/systemd/user"
+	else
+		echo "$PREFIX/lib/systemd/user"
+	fi
+}
+
 # Derived paths based on PREFIX
 INSTALL_DIR="$PREFIX/lib/vicinae"
 BIN_DIR="$PREFIX/bin"
 THEMES_DIR="$PREFIX/share/vicinae/themes"
 APPLICATIONS_DIR="$PREFIX/share/applications"
-SYSTEMD_USER_DIR="$PREFIX/lib/systemd/user"
+SYSTEMD_USER_DIR="$(resolve_systemd_user_dir)"
 
 VICINAE_SCRIPT_PATH="$TEMP_DIR/vicinae-install-script.sh"
 SCRIPT_DOWNLOAD_URL="https://vicinae.com/install"
@@ -665,7 +676,7 @@ main() {
 			BIN_DIR="$PREFIX/bin"
 			THEMES_DIR="$PREFIX/share/vicinae/themes"
 			APPLICATIONS_DIR="$PREFIX/share/applications"
-			SYSTEMD_USER_DIR="$PREFIX/lib/systemd/user"
+			SYSTEMD_USER_DIR="$(resolve_systemd_user_dir)"
 			shift 2
 			;;
 		--token)


### PR DESCRIPTION
After a rootless install (`--prefix` under `$HOME`), the server never starts at login.

`vicinae.service` is written to `$PREFIX/lib/systemd/user`, which is not one of the directories systemd searches for user units, so the installer reports success while the unit stays invisible:

```
$ curl -fsSL https://vicinae.com/install | bash -s -- --prefix ~/.local
🎉 Vicinae v0.28.1 has been successfully installed!
$ systemctl --user list-unit-files 'vicinae*'
0 unit files listed.
```

`$PREFIX/lib/systemd/user` is right for `/usr` and `/usr/local`. For a prefix under `$HOME` the searched location is `${XDG_DATA_HOME:-$HOME/.local/share}/systemd/user`, per `systemd-analyze --user unit-paths`.

Tested on Ubuntu 26.04, GNOME 50, systemd 259 (259.5-0ubuntu3.4):

| PREFIX | resolves to | |
|---|---|---|
| `/usr/local` | `/usr/local/lib/systemd/user` | unchanged |
| `/usr` | `/usr/lib/systemd/user` | unchanged |
| `/opt/vicinae` | `/opt/vicinae/lib/systemd/user` | unchanged |
| `~/.local` | `~/.local/share/systemd/user` | fixed |
| `~/.local` + `XDG_DATA_HOME` | `$XDG_DATA_HOME/systemd/user` | fixed |

Not handled: an install made at the old path is not migrated, so `--uninstall` leaves a stale unit for anyone who already used a `$HOME` prefix. Happy to add that if you want it in scope.

Assisted by Claude (Opus 5); reviewed and tested locally.

