### PR TITLE
feat(global-shortcuts): add press-and-hold support

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -869,6 +869,8 @@ list(APPEND SRCS
 	src/services/global-shortcuts/global-shortcut-backend-factory.cpp
 	src/services/global-shortcuts/global-shortcut-service.hpp
 	src/services/global-shortcuts/global-shortcut-service.cpp
+	src/services/global-shortcuts/config-global-shortcuts.hpp
+	src/services/global-shortcuts/config-global-shortcuts.cpp
 )
 
 if (NOT WIN32)

--- a/src/server/src/command/command.hpp
+++ b/src/server/src/command/command.hpp
@@ -8,7 +8,6 @@
 #include "common/entrypoint.hpp"
 
 class View;
-struct ApplicationContext;
 struct LaunchProps;
 
 class AbstractCmd {
@@ -30,7 +29,7 @@ public:
   virtual bool isFallback() const { return false; }
   virtual void preferenceValuesChanged(const QJsonObject &) const {}
   virtual bool isInternal() const { return false; }
-  virtual void shortcutReleased(const ApplicationContext *) const {}
+  virtual void shortcutReleased() const {}
 
   /**
    * Optional override of the navigation title that is to be shown when

--- a/src/server/src/command/command.hpp
+++ b/src/server/src/command/command.hpp
@@ -8,6 +8,7 @@
 #include "common/entrypoint.hpp"
 
 class View;
+struct ApplicationContext;
 struct LaunchProps;
 
 class AbstractCmd {
@@ -29,6 +30,7 @@ public:
   virtual bool isFallback() const { return false; }
   virtual void preferenceValuesChanged(const QJsonObject &) const {}
   virtual bool isInternal() const { return false; }
+  virtual void shortcutReleased(const ApplicationContext *) const {}
 
   /**
    * Optional override of the navigation title that is to be shown when

--- a/src/server/src/command/preference.hpp
+++ b/src/server/src/command/preference.hpp
@@ -14,6 +14,7 @@ public:
     std::optional<QString> label;
   };
   struct AppPickerData {};
+  struct ShortcutData {};
   struct FilePickerData {
     bool multiple = false;
     // Paths that are always part of the effective set but are not part of the stored
@@ -35,7 +36,7 @@ public:
 
 private:
   using Data = std::variant<UnknownData, TextData, PasswordData, CheckboxData, DropdownData, FilePickerData,
-                            DirectoryPickerData, AppPickerData>;
+                            DirectoryPickerData, AppPickerData, ShortcutData>;
   QString m_name;
   QString m_title;
   QString m_description;
@@ -53,6 +54,7 @@ public:
   }
   static Preference makeText(const QString &id) { return {id, TextData{}}; }
   static Preference makePassword(const QString &id) { return {id, PasswordData{}}; }
+  static Preference makeShortcut(const QString &id) { return {id, ShortcutData{}}; }
   static Preference makeDropdown(const QString &id, const std::vector<DropdownData::Option> &options = {}) {
     return {id, DropdownData{options}};
   }

--- a/src/server/src/navigation-controller.cpp
+++ b/src/server/src/navigation-controller.cpp
@@ -639,6 +639,13 @@ bool NavigationController::activateEntrypoint(const EntrypointId &id,
   return true;
 }
 
+void NavigationController::releaseEntrypoint(const EntrypointId &id) {
+  const auto *entrypoint = m_ctx.services->rootItemManager()->findItemById(id);
+  if (auto *ext = dynamic_cast<const CommandRootItem *>(entrypoint)) {
+    ext->command()->shortcutReleased(&m_ctx);
+  }
+}
+
 void NavigationController::launch(const std::shared_ptr<AbstractCmd> &cmd) {
   launch(cmd, LaunchProps{.arguments = completionValues()});
 }

--- a/src/server/src/navigation-controller.cpp
+++ b/src/server/src/navigation-controller.cpp
@@ -641,9 +641,7 @@ bool NavigationController::activateEntrypoint(const EntrypointId &id,
 
 void NavigationController::releaseEntrypoint(const EntrypointId &id) {
   const auto *entrypoint = m_ctx.services->rootItemManager()->findItemById(id);
-  if (auto *ext = dynamic_cast<const CommandRootItem *>(entrypoint)) {
-    ext->command()->shortcutReleased(&m_ctx);
-  }
+  if (auto *ext = dynamic_cast<const CommandRootItem *>(entrypoint)) { ext->command()->shortcutReleased(); }
 }
 
 void NavigationController::launch(const std::shared_ptr<AbstractCmd> &cmd) {

--- a/src/server/src/navigation-controller.hpp
+++ b/src/server/src/navigation-controller.hpp
@@ -225,6 +225,7 @@ public:
   void launch(const std::shared_ptr<AbstractCmd> &cmd, const ArgumentValues &arguments);
   void launch(const std::shared_ptr<AbstractCmd> &cmd, const LaunchProps &props);
   bool activateEntrypoint(const EntrypointId &id, const ActivateEntrypointOptions &options = {});
+  void releaseEntrypoint(const EntrypointId &id);
 
   const AbstractCmd *activeCommand() const;
   CommandFrame *activeFrame() const { return m_frames.back().get(); }

--- a/src/server/src/server.cpp
+++ b/src/server/src/server.cpp
@@ -69,6 +69,7 @@
 #include "services/wallpaper/wallpaper-manager.hpp"
 #include "services/app-runtime/app-runtime.hpp"
 #include "services/snippet/snippet-service.hpp"
+#include "services/global-shortcuts/config-global-shortcuts.hpp"
 #include "services/global-shortcuts/global-shortcut-service.hpp"
 #include "services/global-shortcuts/global-shortcut-backend-factory.hpp"
 #ifdef Q_OS_LINUX
@@ -304,8 +305,8 @@ int startServer(const ServerLaunchOptions &launchOpts) {
                                                        std::move(platformPaste));
     auto fontService = std::make_unique<FontService>();
     auto rootItemManager = std::make_unique<RootItemManager>(*configService, *localStorage);
-    auto globalShortcutService = std::make_unique<GlobalShortcutService>(
-        *configService, *rootItemManager, *appRuntime, createGlobalShortcutBackend());
+    auto globalShortcutService =
+        std::make_unique<GlobalShortcutService>(*configService, *appRuntime, createGlobalShortcutBackend());
     auto shortcutService =
         std::make_unique<ShortcutService>(Omnicast::dataDir() / "shortcuts" / "shortcuts.json", omniDb.get());
     auto toastService = std::make_unique<ToastService>();
@@ -624,11 +625,11 @@ int startServer(const ServerLaunchOptions &launchOpts) {
 
   QObject::connect(cfgService, &config::Manager::configChanged, configChanged);
 
+  std::unique_ptr<ConfigGlobalShortcuts> configGlobalShortcuts;
+
   if (auto *globalShortcuts = ServiceRegistry::instance()->globalShortcuts()) {
-    QObject::connect(globalShortcuts, &GlobalShortcutService::toggleLauncherRequested,
-                     [&ctx](quint64) { ctx.navigation->toggleWindow(); });
-    QObject::connect(globalShortcuts, &GlobalShortcutService::commandActivated,
-                     [&ctx](const EntrypointId &id, quint64) { ctx.navigation->activateEntrypoint(id); });
+    configGlobalShortcuts = std::make_unique<ConfigGlobalShortcuts>(
+        *globalShortcuts, *cfgService, *ServiceRegistry::instance()->rootItemManager(), *ctx.navigation);
   }
 
   QIcon::setFallbackSearchPaths(Environment::fallbackIconSearchPaths());

--- a/src/server/src/services/global-shortcuts/abstract-global-shortcut-backend.hpp
+++ b/src/server/src/services/global-shortcuts/abstract-global-shortcut-backend.hpp
@@ -18,6 +18,7 @@ class AbstractGlobalShortcutBackend : public QObject {
 
 signals:
   void shortcutActivated(const QString &id, quint64 timestamp);
+  void shortcutReleased(const QString &id, quint64 timestamp);
   void ready();
   void keyCaptured(int key, int modifiers, bool down);
 

--- a/src/server/src/services/global-shortcuts/config-global-shortcuts.cpp
+++ b/src/server/src/services/global-shortcuts/config-global-shortcuts.cpp
@@ -1,0 +1,50 @@
+#include "services/global-shortcuts/config-global-shortcuts.hpp"
+#include <utility>
+#include "config/config.hpp"
+#include "navigation-controller.hpp"
+#include "services/root-item-manager/root-item-manager.hpp"
+
+ConfigGlobalShortcuts::ConfigGlobalShortcuts(GlobalShortcutService &service, config::Manager &config,
+                                             RootItemManager &rootItemManager,
+                                             NavigationController &navigation)
+    : m_service(service), m_config(config), m_rootItemManager(rootItemManager), m_navigation(navigation) {
+  connect(&m_config, &config::Manager::configChanged, this, &ConfigGlobalShortcuts::apply);
+  apply();
+}
+
+void ConfigGlobalShortcuts::apply() {
+  const config::ConfigValue &cfg = m_config.value();
+
+  std::vector<GlobalShortcutHandle> next;
+  next.reserve(m_handles.size() + 1);
+
+  if (cfg.globalShortcuts.toggle && !cfg.globalShortcuts.toggle->empty()) {
+    const auto id = QString::fromUtf8(TOGGLE_ID);
+    next.emplace_back(m_service.bind(id, {.trigger = Keyboard::Shortcut::fromString(
+                                              QString::fromStdString(*cfg.globalShortcuts.toggle)),
+                                          .description = tr("Toggle Vicinae"),
+                                          .onActivated = [this] { m_navigation.toggleWindow(); }}));
+  }
+
+  for (const auto &[provider, providerData] : cfg.providers) {
+    for (const auto &[entrypoint, item] : providerData.entrypoints) {
+      if (!item.shortcut || item.shortcut->empty()) { continue; }
+      if (item.enabled.has_value() && !*item.enabled) { continue; }
+
+      EntrypointId eid{provider, entrypoint};
+      const auto id = QString::fromStdString(eid);
+      next.emplace_back(m_service.bind(
+          id, {.trigger = Keyboard::Shortcut::fromString(QString::fromStdString(*item.shortcut)),
+               .description = describeCommand(eid),
+               .onActivated = [this, eid] { m_navigation.activateEntrypoint(eid); },
+               .onReleased = [this, eid] { m_navigation.releaseEntrypoint(eid); }}));
+    }
+  }
+
+  m_handles = std::move(next);
+}
+
+QString ConfigGlobalShortcuts::describeCommand(const EntrypointId &id) const {
+  if (auto meta = m_rootItemManager.itemMetadata(id); meta.item) { return meta.item->title(); }
+  return QString::fromStdString(id);
+}

--- a/src/server/src/services/global-shortcuts/config-global-shortcuts.cpp
+++ b/src/server/src/services/global-shortcuts/config-global-shortcuts.cpp
@@ -20,10 +20,10 @@ void ConfigGlobalShortcuts::apply() {
 
   if (cfg.globalShortcuts.toggle && !cfg.globalShortcuts.toggle->empty()) {
     const auto id = QString::fromUtf8(TOGGLE_ID);
-    next.emplace_back(m_service.bind(id, {.trigger = Keyboard::Shortcut::fromString(
-                                              QString::fromStdString(*cfg.globalShortcuts.toggle)),
-                                          .description = tr("Toggle Vicinae"),
-                                          .onActivated = [this] { m_navigation.toggleWindow(); }}));
+    next.emplace_back(m_service.bind(
+        id, {.trigger = Keyboard::Shortcut::fromString(QString::fromStdString(*cfg.globalShortcuts.toggle)),
+             .description = tr("Toggle Vicinae"),
+             .onActivated = [this] { m_navigation.toggleWindow(); }}));
   }
 
   for (const auto &[provider, providerData] : cfg.providers) {

--- a/src/server/src/services/global-shortcuts/config-global-shortcuts.hpp
+++ b/src/server/src/services/global-shortcuts/config-global-shortcuts.hpp
@@ -1,0 +1,39 @@
+#pragma once
+#include <vector>
+#include <QObject>
+#include "common/entrypoint.hpp"
+#include "services/global-shortcuts/global-shortcut-service.hpp"
+
+namespace config {
+class Manager;
+}
+
+class NavigationController;
+class RootItemManager;
+
+/**
+ * Projects the global shortcuts declared in the config onto the GlobalShortcutService. Config is the
+ * single source of truth: per-command shortcuts live in `providers[*].entrypoints[*].shortcut`,
+ * app-level ones (the launcher toggle, ...) in `globalShortcuts`. The internal `keybinds` map is NOT
+ * global and is deliberately ignored here.
+ */
+class ConfigGlobalShortcuts : public QObject {
+  Q_OBJECT
+
+public:
+  // Non-command global shortcuts are prefixed with '@' to avoid colliding with entrypoint ids.
+  static constexpr const char *TOGGLE_ID = "@toggle-launcher";
+
+  ConfigGlobalShortcuts(GlobalShortcutService &service, config::Manager &config,
+                        RootItemManager &rootItemManager, NavigationController &navigation);
+
+private:
+  void apply();
+  QString describeCommand(const EntrypointId &id) const;
+
+  GlobalShortcutService &m_service;
+  config::Manager &m_config;
+  RootItemManager &m_rootItemManager;
+  NavigationController &m_navigation;
+  std::vector<GlobalShortcutHandle> m_handles;
+};

--- a/src/server/src/services/global-shortcuts/global-shortcut-service.cpp
+++ b/src/server/src/services/global-shortcuts/global-shortcut-service.cpp
@@ -1,32 +1,71 @@
 #include "services/global-shortcuts/global-shortcut-service.hpp"
-#include "common/types.hpp"
-#include "config/config.hpp"
-#include "services/app-runtime/app-runtime.hpp"
-#include "services/root-item-manager/root-item-manager.hpp"
 #include <algorithm>
 #include <utility>
+#include "config/config.hpp"
+#include "services/app-runtime/app-runtime.hpp"
 
-GlobalShortcutService::GlobalShortcutService(config::Manager &config, RootItemManager &rootItemManager,
-                                             AppRuntime &appRuntime,
+GlobalShortcutHandle::GlobalShortcutHandle(GlobalShortcutService *service, QString id, std::uint64_t serial)
+    : m_service(service), m_id(std::move(id)), m_serial(serial) {}
+
+GlobalShortcutHandle::GlobalShortcutHandle(GlobalShortcutHandle &&other) noexcept
+    : m_service(std::exchange(other.m_service, nullptr)), m_id(std::exchange(other.m_id, {})),
+      m_serial(std::exchange(other.m_serial, 0)) {}
+
+GlobalShortcutHandle &GlobalShortcutHandle::operator=(GlobalShortcutHandle &&other) noexcept {
+  if (this != &other) {
+    reset();
+    m_service = std::exchange(other.m_service, nullptr);
+    m_id = std::exchange(other.m_id, {});
+    m_serial = std::exchange(other.m_serial, 0);
+  }
+  return *this;
+}
+
+GlobalShortcutHandle::~GlobalShortcutHandle() { reset(); }
+
+void GlobalShortcutHandle::reset() {
+  if (m_service) { m_service->release(m_id, m_serial); }
+  m_service = nullptr;
+  m_id.clear();
+  m_serial = 0;
+}
+
+GlobalShortcutService::GlobalShortcutService(config::Manager &config, AppRuntime &appRuntime,
                                              std::unique_ptr<AbstractGlobalShortcutBackend> backend)
-    : m_config(config), m_rootItemManager(rootItemManager), m_appRuntime(appRuntime),
-      m_backend(std::move(backend)) {
+    : m_config(config), m_appRuntime(appRuntime), m_backend(std::move(backend)) {
   connect(m_backend.get(), &AbstractGlobalShortcutBackend::shortcutActivated, this,
-          &GlobalShortcutService::onActivated);
+          [this](const QString &id, quint64) { onActivated(id); });
+  connect(m_backend.get(), &AbstractGlobalShortcutBackend::shortcutReleased, this,
+          [this](const QString &id, quint64) { onReleased(id); });
   // `ready` may be re-emitted after a backend reset, in which case every binding is replayed
   connect(m_backend.get(), &AbstractGlobalShortcutBackend::ready, this, [this] {
-    m_appliedTriggers.clear();
-    m_actions.clear();
+    m_applied.clear();
+    releaseHeld();
     reconcile();
   });
-  connect(&m_config, &config::Manager::configChanged, this, [this] {
-    updateInhibition();
-    reconcile();
-  });
+  connect(&m_config, &config::Manager::configChanged, this, &GlobalShortcutService::updateInhibition);
   connect(&m_appRuntime, &AppRuntime::frontmostAppChanged, this, &GlobalShortcutService::updateInhibition);
 
   m_inhibited = computeInhibited();
   m_backend->start();
+}
+
+GlobalShortcutHandle GlobalShortcutService::bind(const QString &id, Binding binding) {
+  if (!binding.trigger.isValid()) {
+    qWarning() << "Refusing to bind global shortcut" << id << "with an invalid trigger";
+    return {};
+  }
+
+  const auto serial = m_nextSerial++;
+  m_bindings.insert_or_assign(id, Entry{.binding = std::move(binding), .serial = serial});
+  reconcile();
+  return {this, id, serial};
+}
+
+void GlobalShortcutService::release(const QString &id, std::uint64_t serial) {
+  auto it = m_bindings.find(id);
+  if (it == m_bindings.end() || it->second.serial != serial) { return; }
+  m_bindings.erase(it);
   reconcile();
 }
 
@@ -36,11 +75,26 @@ void GlobalShortcutService::setCapturing(bool capturing) {
   m_backend->setCapturing(capturing);
 
   if (capturing) {
-    m_backend->unbindAll();
-    m_appliedTriggers.clear();
-    m_actions.clear();
+    unbindAll();
   } else {
     reconcile();
+  }
+}
+
+void GlobalShortcutService::unbindAll() {
+  m_backend->unbindAll();
+  m_applied.clear();
+  releaseHeld();
+}
+
+void GlobalShortcutService::releaseHeld() {
+  std::vector<QString> held;
+  held.reserve(m_bindings.size());
+  for (const auto &[id, entry] : m_bindings) {
+    if (entry.held) { held.emplace_back(id); }
+  }
+  for (const auto &id : held) {
+    onReleased(id);
   }
 }
 
@@ -48,57 +102,27 @@ void GlobalShortcutService::reconcile() {
   if (m_capturing || m_inhibited) { return; }
   if (!isSupported()) { return; }
 
-  const config::ConfigValue &cfg = m_config.value();
-
-  std::unordered_map<QString, Desired> desired;
-
-  if (cfg.globalShortcuts.toggle && !cfg.globalShortcuts.toggle->empty()) {
-    desired.emplace(QString::fromUtf8(TOGGLE_ID),
-                    Desired{.trigger = QString::fromStdString(*cfg.globalShortcuts.toggle),
-                            .description = tr("Toggle Vicinae"),
-                            .action = ToggleLauncherWindow{}});
-  }
-
-  for (const auto &[provider, providerData] : cfg.providers) {
-    for (const auto &[entrypoint, item] : providerData.entrypoints) {
-      if (!item.shortcut || item.shortcut->empty()) { continue; }
-      if (item.enabled.has_value() && !*item.enabled) { continue; }
-
-      EntrypointId eid{provider, entrypoint};
-      desired.emplace(QString::fromStdString(eid), Desired{.trigger = QString::fromStdString(*item.shortcut),
-                                                           .description = describeCommand(eid),
-                                                           .action = RunCommand{eid}});
-    }
-  }
-
-  for (auto it = m_appliedTriggers.begin(); it != m_appliedTriggers.end();) {
-    auto desiredIt = desired.find(it->first);
-    if (desiredIt == desired.end() || desiredIt->second.trigger != it->second) {
+  for (auto it = m_applied.begin(); it != m_applied.end();) {
+    auto desired = m_bindings.find(it->first);
+    if (desired == m_bindings.end() || desired->second.binding.trigger != it->second) {
       m_backend->unbindShortcut(it->first);
-      m_actions.erase(it->first);
-      it = m_appliedTriggers.erase(it);
+      it = m_applied.erase(it);
     } else {
       ++it;
     }
   }
 
-  for (const auto &[id, entry] : desired) {
-    if (auto it = m_appliedTriggers.find(id); it != m_appliedTriggers.end() && it->second == entry.trigger) {
-      continue;
-    }
+  for (const auto &[id, entry] : m_bindings) {
+    if (m_applied.contains(id)) { continue; }
 
-    auto shortcut = Keyboard::Shortcut::fromString(entry.trigger);
+    const auto &binding = entry.binding;
+    auto bound =
+        m_backend->bindShortcut({.id = id, .trigger = binding.trigger, .description = binding.description});
+    m_applied.emplace(id, binding.trigger);
 
-    if (!shortcut.isValid()) { continue; }
-
-    auto bound = m_backend->bindShortcut({.id = id, .trigger = shortcut, .description = entry.description});
-    m_appliedTriggers[id] = entry.trigger;
-
-    if (bound) {
-      m_actions[id] = entry.action;
-    } else {
-      m_actions.erase(id);
-      qWarning() << "Failed to bind global shortcut" << id << "(" << entry.trigger << "):" << bound.error();
+    if (!bound) {
+      qWarning() << "Failed to bind global shortcut" << id << "(" << binding.trigger.toString()
+                 << "):" << bound.error();
     }
   }
 }
@@ -115,11 +139,6 @@ std::optional<QString> GlobalShortcutService::probeBind(const Keyboard::Shortcut
   return std::nullopt;
 }
 
-QString GlobalShortcutService::describeCommand(const EntrypointId &id) const {
-  if (auto meta = m_rootItemManager.itemMetadata(id); meta.item) { return meta.item->title(); }
-  return QString::fromStdString(id);
-}
-
 void GlobalShortcutService::updateInhibition() {
   const bool inhibited = computeInhibited();
   if (inhibited == m_inhibited) { return; }
@@ -128,9 +147,7 @@ void GlobalShortcutService::updateInhibition() {
   if (m_capturing) { return; }
 
   if (inhibited) {
-    m_backend->unbindAll();
-    m_appliedTriggers.clear();
-    m_actions.clear();
+    unbindAll();
   } else {
     reconcile();
   }
@@ -147,38 +164,34 @@ bool GlobalShortcutService::computeInhibited() const {
   return std::ranges::contains(apps, id);
 }
 
-void GlobalShortcutService::onActivated(const QString &id, quint64 timestamp) {
-  if (auto it = m_actions.find(id); it != m_actions.end()) {
-    match(
-        it->second, [&](const RunCommand &cmd) { emit commandActivated(cmd.id, timestamp); },
-        [&](const ToggleLauncherWindow &launcher) { emit toggleLauncherRequested(timestamp); });
+void GlobalShortcutService::onActivated(const QString &id) {
+  auto it = m_bindings.find(id);
+  if (it == m_bindings.end()) { return; }
+
+  auto &entry = it->second;
+  if (entry.binding.onReleased) {
+    if (entry.held) { return; }
+    entry.held = true;
   }
+
+  if (auto handler = entry.binding.onActivated) { handler(); }
+}
+
+void GlobalShortcutService::onReleased(const QString &id) {
+  auto it = m_bindings.find(id);
+  if (it == m_bindings.end() || !it->second.held) { return; }
+
+  it->second.held = false;
+  if (auto handler = it->second.binding.onReleased) { handler(); }
 }
 
 std::optional<QString> GlobalShortcutService::findConflict(const Keyboard::Shortcut &shortcut,
                                                            const QString &excludeId) const {
   if (!isSupported()) { return std::nullopt; }
 
-  const config::ConfigValue &cfg = m_config.value();
-  const auto matches = [&](const std::string &trigger) {
-    return Keyboard::Shortcut::fromString(QString::fromStdString(trigger)) == shortcut;
-  };
-
-  if (excludeId != QString::fromUtf8(TOGGLE_ID) && cfg.globalShortcuts.toggle &&
-      !cfg.globalShortcuts.toggle->empty() && matches(*cfg.globalShortcuts.toggle)) {
-    return tr("the launcher hotkey");
-  }
-
-  for (const auto &[provider, providerData] : cfg.providers) {
-    for (const auto &[entrypoint, item] : providerData.entrypoints) {
-      if (!item.shortcut || item.shortcut->empty()) { continue; }
-
-      EntrypointId eid{provider, entrypoint};
-      if (QString::fromStdString(eid) == excludeId || !matches(*item.shortcut)) { continue; }
-
-      if (auto meta = m_rootItemManager.itemMetadata(eid); meta.item) { return meta.item->title(); }
-      return tr("another command");
-    }
+  for (const auto &[id, entry] : m_bindings) {
+    if (id == excludeId || entry.binding.trigger != shortcut) { continue; }
+    return entry.binding.description.isEmpty() ? id : entry.binding.description;
   }
 
   return std::nullopt;

--- a/src/server/src/services/global-shortcuts/global-shortcut-service.hpp
+++ b/src/server/src/services/global-shortcuts/global-shortcut-service.hpp
@@ -1,8 +1,11 @@
 #pragma once
+#include <cstdint>
+#include <functional>
 #include <memory>
+#include <optional>
 #include <unordered_map>
 #include <QObject>
-#include "common/entrypoint.hpp"
+#include <QPointer>
 #include "services/global-shortcuts/abstract-global-shortcut-backend.hpp"
 
 namespace config {
@@ -10,69 +13,85 @@ class Manager;
 }
 
 class AppRuntime;
-class RootItemManager;
+class GlobalShortcutService;
 
-/**
- * Projects the global shortcuts declared in the config onto the provided backend, and dispatches
- * activations to actions. Config is the single source of truth: there is no separate storage.
- * Per-command shortcuts live in `providers[*].entrypoints[*].shortcut`, app-level ones (the
- * launcher toggle, ...) in `globalShortcuts`. The internal `keybinds` map is NOT global and is
- * deliberately ignored here.
- */
+class GlobalShortcutHandle {
+public:
+  GlobalShortcutHandle() = default;
+  GlobalShortcutHandle(const GlobalShortcutHandle &) = delete;
+  GlobalShortcutHandle &operator=(const GlobalShortcutHandle &) = delete;
+  GlobalShortcutHandle(GlobalShortcutHandle &&other) noexcept;
+  GlobalShortcutHandle &operator=(GlobalShortcutHandle &&other) noexcept;
+  ~GlobalShortcutHandle();
+
+  void reset();
+
+private:
+  friend class GlobalShortcutService;
+
+  GlobalShortcutHandle(GlobalShortcutService *service, QString id, std::uint64_t serial);
+
+  QPointer<GlobalShortcutService> m_service;
+  QString m_id;
+  std::uint64_t m_serial = 0;
+};
+
+// Registry of desired bindings projected onto the platform backend.
 class GlobalShortcutService : public QObject {
   Q_OBJECT
 
-signals:
-  void toggleLauncherRequested(quint64 timestamp);
-  void commandActivated(const EntrypointId &id, quint64 timestamp);
-
 public:
-  // Non-command global shortcuts are prefixed with '@' to avoid colliding with entrypoint ids.
-  static constexpr const char *TOGGLE_ID = "@toggle-launcher";
+  using Handler = std::function<void()>;
 
-  GlobalShortcutService(config::Manager &config, RootItemManager &rootItemManager, AppRuntime &appRuntime,
+  struct Binding {
+    Keyboard::Shortcut trigger;
+    QString description;
+    Handler onActivated;
+    Handler onReleased;
+  };
+
+  GlobalShortcutService(config::Manager &config, AppRuntime &appRuntime,
                         std::unique_ptr<AbstractGlobalShortcutBackend> backend);
 
   AbstractGlobalShortcutBackend *backend() const { return m_backend.get(); }
   bool isSupported() const { return m_backend && m_backend->isSupported(); }
 
-  // Display name of the global shortcut already using `shortcut` (excluding `excludeId`), or nullopt.
+  [[nodiscard]] GlobalShortcutHandle bind(const QString &id, Binding binding);
+
+  // Description of the registered binding already using `shortcut` (excluding `excludeId`), or nullopt.
   // Always nullopt when the backend is unsupported (inert shortcuts can't actually conflict).
   std::optional<QString> findConflict(const Keyboard::Shortcut &shortcut, const QString &excludeId) const;
 
   std::optional<QString> probeBind(const Keyboard::Shortcut &shortcut);
 
   // Suspends all global binds while the in-app recorder captures (so it doesn't hijack the keystroke),
-  // then rebinds from config on release.
+  // then replays them on release.
   void setCapturing(bool capturing);
 
 private:
-  struct RunCommand {
-    EntrypointId id;
+  friend class GlobalShortcutHandle;
+
+  struct Entry {
+    Binding binding;
+    std::uint64_t serial;
+    bool held = false;
   };
 
-  struct ToggleLauncherWindow {};
-
-  using Action = std::variant<RunCommand, ToggleLauncherWindow>;
-
-  struct Desired {
-    QString trigger;
-    QString description;
-    Action action;
-  };
-
+  void release(const QString &id, std::uint64_t serial);
   void reconcile();
-  void onActivated(const QString &id, quint64 timestamp);
-  QString describeCommand(const EntrypointId &id) const;
+  void unbindAll();
+  void onActivated(const QString &id);
+  void onReleased(const QString &id);
+  void releaseHeld();
   void updateInhibition();
   bool computeInhibited() const;
 
   config::Manager &m_config;
-  RootItemManager &m_rootItemManager;
   AppRuntime &m_appRuntime;
   std::unique_ptr<AbstractGlobalShortcutBackend> m_backend;
-  std::unordered_map<QString, Action> m_actions;
-  std::unordered_map<QString, QString> m_appliedTriggers;
+  std::unordered_map<QString, Entry> m_bindings;
+  std::unordered_map<QString, Keyboard::Shortcut> m_applied;
+  std::uint64_t m_nextSerial = 1;
   bool m_capturing = false;
   bool m_inhibited = false;
 };

--- a/src/server/src/services/global-shortcuts/macos-global-shortcut-backend.cpp
+++ b/src/server/src/services/global-shortcuts/macos-global-shortcut-backend.cpp
@@ -2,6 +2,7 @@
 #include "keyboard/keyboard-macos.hpp"
 
 #include <algorithm>
+#include <array>
 #include <QChar>
 #include <QDebug>
 
@@ -38,7 +39,8 @@ OSStatus hotKeyHandler(EventHandlerCallRef, EventRef event, void *userData) {
   if (hotKeyId.signature != HOT_KEY_SIGNATURE) { return eventNotHandledErr; }
 
   const auto timestamp = static_cast<quint64>(GetEventTime(event) * 1000.0);
-  static_cast<MacOSGlobalShortcutBackend *>(userData)->handleHotKey(hotKeyId.id, timestamp);
+  const bool released = GetEventKind(event) == kEventHotKeyReleased;
+  static_cast<MacOSGlobalShortcutBackend *>(userData)->handleHotKey(hotKeyId.id, timestamp, released);
   return noErr;
 }
 
@@ -106,9 +108,12 @@ void MacOSGlobalShortcutBackend::refreshLayout() {
 bool MacOSGlobalShortcutBackend::startCarbonHandler() {
   if (m_hotKeyHandler) { return true; }
 
-  const EventTypeSpec spec{.eventClass = kEventClassKeyboard, .eventKind = kEventHotKeyPressed};
+  const auto specs = std::to_array<EventTypeSpec>({
+      {.eventClass = kEventClassKeyboard, .eventKind = kEventHotKeyPressed},
+      {.eventClass = kEventClassKeyboard, .eventKind = kEventHotKeyReleased},
+  });
   EventHandlerRef handler = nullptr;
-  if (InstallApplicationEventHandler(&hotKeyHandler, 1, &spec, this, &handler) != noErr) {
+  if (InstallApplicationEventHandler(&hotKeyHandler, specs.size(), specs.data(), this, &handler) != noErr) {
     qWarning() << "MacOSGlobalShortcutBackend: failed to install Carbon hot key handler";
     return false;
   }
@@ -179,13 +184,17 @@ void MacOSGlobalShortcutBackend::unregisterCarbonHotKey(Binding &binding) {
   binding.hotKeyRef = nullptr;
 }
 
-void MacOSGlobalShortcutBackend::handleHotKey(uint32_t carbonId, quint64 timestamp) {
+void MacOSGlobalShortcutBackend::handleHotKey(uint32_t carbonId, quint64 timestamp, bool released) {
   const auto it = std::ranges::find_if(m_bindings, [&](const Binding &binding) {
     return binding.carbonId == carbonId && binding.hotKeyRef != nullptr;
   });
   if (it == m_bindings.end()) { return; }
 
-  emit shortcutActivated(it->id, timestamp);
+  if (released) {
+    emit shortcutReleased(it->id, timestamp);
+  } else {
+    emit shortcutActivated(it->id, timestamp);
+  }
 }
 
 std::expected<void, QString> MacOSGlobalShortcutBackend::bindShortcut(const GlobalShortcutRequest &request) {

--- a/src/server/src/services/global-shortcuts/macos-global-shortcut-backend.hpp
+++ b/src/server/src/services/global-shortcuts/macos-global-shortcut-backend.hpp
@@ -26,7 +26,7 @@ public:
   void unbindAll() override;
 
   // called on the main thread by the Carbon hot key handler
-  void handleHotKey(uint32_t carbonId, quint64 timestamp);
+  void handleHotKey(uint32_t carbonId, quint64 timestamp, bool released);
 
   // called on the main thread when the keyboard layout changes
   void refreshLayout();

--- a/src/server/src/services/global-shortcuts/vicinae-hotkey-global-shortcut-backend.cpp
+++ b/src/server/src/services/global-shortcuts/vicinae-hotkey-global-shortcut-backend.cpp
@@ -61,6 +61,10 @@ void VicinaeHotkeyGlobalShortcutBackend::Hotkey::vicinae_hotkey_v1_pressed(uint3
   emit m_backend->shortcutActivated(m_id, time);
 }
 
+void VicinaeHotkeyGlobalShortcutBackend::Hotkey::vicinae_hotkey_v1_released(uint32_t, uint32_t time) {
+  emit m_backend->shortcutReleased(m_id, time);
+}
+
 VicinaeHotkeyGlobalShortcutBackend::~VicinaeHotkeyGlobalShortcutBackend() { unbindAll(); }
 
 QString VicinaeHotkeyGlobalShortcutBackend::id() const { return "vicinae-hotkey"; }

--- a/src/server/src/services/global-shortcuts/vicinae-hotkey-global-shortcut-backend.hpp
+++ b/src/server/src/services/global-shortcuts/vicinae-hotkey-global-shortcut-backend.hpp
@@ -45,6 +45,7 @@ private:
     void vicinae_hotkey_v1_denied(uint32_t reason, const QString &message) override;
     void vicinae_hotkey_v1_revoked(uint32_t reason, const QString &message) override;
     void vicinae_hotkey_v1_pressed(uint32_t serial, uint32_t time) override;
+    void vicinae_hotkey_v1_released(uint32_t serial, uint32_t time) override;
 
   private:
     VicinaeHotkeyGlobalShortcutBackend *m_backend;

--- a/src/server/src/services/global-shortcuts/windows-global-shortcut-backend.cpp
+++ b/src/server/src/services/global-shortcuts/windows-global-shortcut-backend.cpp
@@ -216,6 +216,11 @@ void WindowsGlobalShortcutBackend::activate(const QString &id) {
       this, [this, id]() { emit shortcutActivated(id, GetTickCount64()); }, Qt::QueuedConnection);
 }
 
+void WindowsGlobalShortcutBackend::release(const QString &id) {
+  QMetaObject::invokeMethod(
+      this, [this, id]() { emit shortcutReleased(id, GetTickCount64()); }, Qt::QueuedConnection);
+}
+
 bool WindowsGlobalShortcutBackend::dispatchKey(unsigned int vk, unsigned int mods, bool down) {
   std::scoped_lock lock(m_targetsMutex);
 
@@ -238,7 +243,10 @@ bool WindowsGlobalShortcutBackend::dispatchKey(unsigned int vk, unsigned int mod
     if (!down) {
       // eat the key up of an eaten key down: some apps act on release (e.g. a
       // focused browser button activates on space key up)
-      if (target.down) { eaten = true; }
+      if (target.down) {
+        eaten = true;
+        release(target.id);
+      }
       target.down = false;
       continue;
     }
@@ -264,6 +272,7 @@ bool WindowsGlobalShortcutBackend::dispatchModifier(unsigned int mods, bool down
     if (!modBitForVk(target.vk) || target.mods != m_chord) continue;
     if (m_chord & MOD_WIN) { suppressStartMenu(); }
     activate(target.id);
+    release(target.id);
     m_chord = CHORD_BROKEN;
     break;
   }

--- a/src/server/src/services/global-shortcuts/windows-global-shortcut-backend.hpp
+++ b/src/server/src/services/global-shortcuts/windows-global-shortcut-backend.hpp
@@ -35,6 +35,7 @@ private:
 
   bool dispatchModifier(unsigned int mods, bool down);
   void activate(const QString &id);
+  void release(const QString &id);
 
   std::mutex m_targetsMutex;
   std::vector<HookTarget> m_targets;

--- a/src/server/src/services/global-shortcuts/x11-global-shortcut-backend.cpp
+++ b/src/server/src/services/global-shortcuts/x11-global-shortcut-backend.cpp
@@ -4,6 +4,12 @@
 #include <QSocketNotifier>
 #include <qlogging.h>
 #include <xcb/xproto.h>
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+// xkb.h names a struct field `explicit`, which a C++ compiler rejects
+#define explicit explicit_
+#include <xcb/xkb.h>
+#undef explicit
+// NOLINTEND(cppcoreguidelines-macro-usage)
 #include <xkbcommon/xkbcommon-keysyms.h>
 
 namespace {
@@ -53,6 +59,7 @@ bool X11GlobalShortcutBackend::start() {
   m_root = m_screen->root;
   m_keysyms = xcb_key_symbols_alloc(m_connection);
   computeLockMasks();
+  enableDetectableAutoRepeat();
 
   int const fd = xcb_get_file_descriptor(m_connection);
   m_notifier = new QSocketNotifier(fd, QSocketNotifier::Read, this);
@@ -60,6 +67,24 @@ bool X11GlobalShortcutBackend::start() {
 
   emit ready();
   return true;
+}
+
+void X11GlobalShortcutBackend::enableDetectableAutoRepeat() {
+  CPtr<xcb_xkb_use_extension_reply_t> ext(xcb_xkb_use_extension_reply(
+      m_connection, xcb_xkb_use_extension(m_connection, XCB_XKB_MAJOR_VERSION, XCB_XKB_MINOR_VERSION),
+      nullptr));
+  if (!ext || !ext->supported) {
+    qWarning() << "X11GlobalShortcutBackend: XKB unavailable, hold shortcuts may misfire on auto-repeat";
+    return;
+  }
+
+  constexpr uint32_t FLAG = XCB_XKB_PER_CLIENT_FLAG_DETECTABLE_AUTO_REPEAT;
+  CPtr<xcb_xkb_per_client_flags_reply_t> reply(xcb_xkb_per_client_flags_reply(
+      m_connection, xcb_xkb_per_client_flags(m_connection, XCB_XKB_ID_USE_CORE_KBD, FLAG, FLAG, 0, 0, 0),
+      nullptr));
+  if (!reply || !(reply->value & FLAG)) {
+    qWarning() << "X11GlobalShortcutBackend: detectable auto-repeat refused, hold shortcuts may misfire";
+  }
 }
 
 void X11GlobalShortcutBackend::computeLockMasks() {
@@ -205,7 +230,10 @@ void X11GlobalShortcutBackend::drainEvents() {
       uint16_t const mods = key->state & MODIFIER_BITS;
       auto it =
           std::ranges::find_if(m_binds, [&](auto &&b) { return b.keycode == key->detail && b.mods == mods; });
-      if (it != m_binds.end()) { emit shortcutActivated(it->id, key->time); }
+      if (it != m_binds.end()) {
+        it->held = true;
+        emit shortcutActivated(it->id, key->time);
+      }
       break;
     }
     case XCB_KEY_RELEASE: {
@@ -213,6 +241,12 @@ void X11GlobalShortcutBackend::drainEvents() {
       m_lastReleaseCode = key->detail;
       m_lastReleaseTime = key->time;
       m_lastReleaseValid = true;
+
+      auto it = std::ranges::find_if(m_binds, [&](auto &&b) { return b.held && b.keycode == key->detail; });
+      if (it != m_binds.end()) {
+        it->held = false;
+        emit shortcutReleased(it->id, key->time);
+      }
       break;
     }
     case XCB_MAPPING_NOTIFY: {

--- a/src/server/src/services/global-shortcuts/x11-global-shortcut-backend.hpp
+++ b/src/server/src/services/global-shortcuts/x11-global-shortcut-backend.hpp
@@ -37,12 +37,14 @@ private:
     xcb_keysym_t keysym;
     xcb_keycode_t keycode;
     uint16_t mods;
+    bool held = false;
   };
 
   std::expected<void, QString> grab(xcb_keycode_t keycode, uint16_t mods);
   void ungrab(xcb_keycode_t keycode, uint16_t mods);
   void regrabAll();
   void computeLockMasks();
+  void enableDetectableAutoRepeat();
   uint16_t modMaskForKeysym(xcb_keysym_t keysym) const;
 
   xcb_connection_t *m_connection = nullptr;

--- a/src/server/src/services/global-shortcuts/xx-hotkey-global-shortcut-backend.cpp
+++ b/src/server/src/services/global-shortcuts/xx-hotkey-global-shortcut-backend.cpp
@@ -82,6 +82,10 @@ void XxHotkeyGlobalShortcutBackend::Hotkey::xx_hotkey_v1_triggered(uint32_t seri
   emit m_backend->shortcutActivated(m_id, time);
 }
 
+void XxHotkeyGlobalShortcutBackend::Hotkey::xx_hotkey_v1_released(uint32_t, uint32_t time) {
+  emit m_backend->shortcutReleased(m_id, time);
+}
+
 XxHotkeyGlobalShortcutBackend::XxHotkeyGlobalShortcutBackend() {
   if (m_manager.isActive()) m_manager.set_app_id(Omnicast::APP_ID);
 }

--- a/src/server/src/services/global-shortcuts/xx-hotkey-global-shortcut-backend.hpp
+++ b/src/server/src/services/global-shortcuts/xx-hotkey-global-shortcut-backend.hpp
@@ -64,6 +64,7 @@ private:
     void xx_hotkey_v1_denied(uint32_t reason, const QString &message) override;
     void xx_hotkey_v1_revoked(const QString &message) override;
     void xx_hotkey_v1_triggered(uint32_t serial, uint32_t time) override;
+    void xx_hotkey_v1_released(uint32_t serial, uint32_t time) override;
 
   private:
     XxHotkeyGlobalShortcutBackend *m_backend;

--- a/src/server/src/ui/bridges/global-shortcut-bridge.hpp
+++ b/src/server/src/ui/bridges/global-shortcut-bridge.hpp
@@ -3,6 +3,7 @@
 #include <QObject>
 #include "keyboard/keyboard.hpp"
 #include "service-registry.hpp"
+#include "services/global-shortcuts/config-global-shortcuts.hpp"
 #include "services/global-shortcuts/global-shortcut-service.hpp"
 #include "ui/settings/shortcut-conflict.hpp"
 
@@ -31,7 +32,7 @@ public:
     }
   }
 
-  QString toggleId() const { return QString::fromUtf8(GlobalShortcutService::TOGGLE_ID); }
+  QString toggleId() const { return QString::fromUtf8(ConfigGlobalShortcuts::TOGGLE_ID); }
 
   // Suspends global binds while a recorder captures so it doesn't hijack the keystroke; rebinds on
   // release.

--- a/src/server/src/ui/qml/settings/SettingsPreferenceForm.qml
+++ b/src/server/src/ui/qml/settings/SettingsPreferenceForm.qml
@@ -50,6 +50,8 @@ ColumnLayout {
             case "filepicker":
             case "directorypicker":
                 return filepickerComp;
+            case "shortcut":
+                return Platform.supports("globalShortcuts") ? shortcutComp : null;
             default:
                 return null;
             }
@@ -136,6 +138,27 @@ ColumnLayout {
                 readOnly: field.host.readOnly
                 currentItem: field.host.currentDropdownItem
                 onActivated: item => root.prefModel.setFieldValue(field.host.index, item.id)
+            }
+        }
+    }
+
+    Component {
+        id: shortcutComp
+        SettingsRow {
+            id: field
+            readonly property FieldHost host: parent as FieldHost
+            label: field.host.label
+            description: field.host.description
+            controlWidth: root.fieldControlWidth
+            showSeparator: field.host.index < settingsRepeater.count - 1
+
+            ShortcutField {
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                bordered: false
+                shortcut: field.host.value != null ? String(field.host.value) : ""
+                onAccepted: shortcut => root.prefModel.setFieldValue(field.host.index, shortcut)
+                onCleared: root.prefModel.setFieldValue(field.host.index, "")
             }
         }
     }

--- a/src/server/src/ui/settings/preference-form-model.cpp
+++ b/src/server/src/ui/settings/preference-form-model.cpp
@@ -90,6 +90,8 @@ static QString preferenceType(const Preference &p) {
           return QStringLiteral("filepicker");
         else if constexpr (std::is_same_v<T, Preference::DirectoryPickerData>)
           return QStringLiteral("directorypicker");
+        else if constexpr (std::is_same_v<T, Preference::ShortcutData>)
+          return QStringLiteral("shortcut");
         else
           return QStringLiteral("text");
       },


### PR DESCRIPTION
Refactor of the global shortcut service to allow support for press-and-hold global shortcuts. Commands that can make use of press-and-hold (e.g the upcoming dictation command) can leverage this in order to implement it seamlessly, without needing an additional preference.

This PR also adds a new shortcut preference type, although it is not directly used here.